### PR TITLE
Fixes auto committing the OAS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
     name: Update OAS in repository
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Download generated OAS
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
The project was not checked out before committing, resulting in an error (which was ignored to prevent errors if there are no changes at all).