### PR TITLE
Fixes #408 -- set session cookie SameSite flag to none

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -150,6 +150,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "openforms.middleware.SameSiteNoneCookieMiddlware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     # 'django.middleware.locale.LocaleMiddleware',
     "corsheaders.middleware.CorsMiddleware",

--- a/src/openforms/middleware.py
+++ b/src/openforms/middleware.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+# for CORS, the session cookie must be set with SameSite "None" to be sent.
+# This is a breaking change by Chrome, which was not going to be backported in Django
+# 2.2.x. It's available from Django 3.1 onwards.
+SAMESITE_VALUE = "None"
+
+
+class SameSiteNoneCookieMiddlware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if settings.SESSION_COOKIE_NAME in response.cookies:
+            response.cookies[settings.SESSION_COOKIE_NAME]["samesite"] = SAMESITE_VALUE
+        return response


### PR DESCRIPTION
A middleware is added to set the SameSite flag explicitly to none, to
make sure that the session cookie is sent from cross-domain contexts.
Django < 3.1 does not support this out of the box, but this is needed
since the SDK will operate in cross-domain contexts.

The CSRF cookie remains SameSite=Lax (the default) and will therefore
not be set or sent in a cross-domain context, thereby still protecting
against actual CSRF attacks.

An finally, for the cross-site requests based on session cookie, the
CORS settings work with an allow-list, preventing attacks from evil.com
to the Open Forms submissions.

sister PR in the SDK: https://github.com/open-formulieren/open-forms-sdk/pull/15