### PR TITLE
Fixing invalid app labels

### DIFF
--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -99,7 +99,7 @@
                 "blacklist"
             ],
             [
-                "prefill.haalcentraal",
+                "prefill_haalcentraal",
                 "haalcentraalconfig"
             ],
             [

--- a/src/openforms/prefill/contrib/demo/apps.py
+++ b/src/openforms/prefill/contrib/demo/apps.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 class DemoApp(AppConfig):
     name = "openforms.prefill.contrib.demo"
-    label = "prefill.demo"
+    label = "prefill_demo"
     verbose_name = _("Demo prefill plugin")
 
     def ready(self):

--- a/src/openforms/prefill/contrib/haalcentraal/apps.py
+++ b/src/openforms/prefill/contrib/haalcentraal/apps.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 class HaalCentraalApp(AppConfig):
     name = "openforms.prefill.contrib.haalcentraal"
-    label = "prefill.haalcentraal"
+    label = "prefill_haalcentraal"
     verbose_name = _("Haal Centraal prefill plugin")
 
     def ready(self):

--- a/src/openforms/prefill/contrib/haalcentraal/migrations/0002_nice_verbose_name.py
+++ b/src/openforms/prefill/contrib/haalcentraal/migrations/0002_nice_verbose_name.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("prefill.haalcentraal", "0001_initial"),
+        ("prefill_haalcentraal", "0001_initial"),
     ]
 
     operations = [

--- a/src/openforms/prefill/contrib/stufbg/apps.py
+++ b/src/openforms/prefill/contrib/stufbg/apps.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 class StufBgApp(AppConfig):
     name = "openforms.prefill.contrib.stufbg"
-    label = "prefill.stufbg"
+    label = "prefill_stufbg"
     verbose_name = _("StUF-BG prefill plugin")
 
     def ready(self):

--- a/src/openforms/registrations/contrib/demo/apps.py
+++ b/src/openforms/registrations/contrib/demo/apps.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 class DemoConfig(AppConfig):
     name = "openforms.registrations.contrib.demo"
-    label = "registrations.demo"
+    label = "registrations_demo"
     verbose_name = _("Demo registrations plugin")
 
     def ready(self):

--- a/src/openforms/registrations/contrib/email/apps.py
+++ b/src/openforms/registrations/contrib/email/apps.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 class EmailPluginConfig(AppConfig):
     name = "openforms.registrations.contrib.email"
-    label = "registrations.email"
+    label = "registrations_email"
     verbose_name = _("Email plugin")
 
     def ready(self):


### PR DESCRIPTION
App labels must be valid python identifiers (cannot contain dots).

Related to https://code.djangoproject.com/ticket/32285, which has not been backported to 2.2