### PR TITLE
Fixes #442 -- build docker image for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,45 @@ jobs:
         working-directory: docs
         run: pytest check_sphinx.py -v --tb=auto
 
+  docker_build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      # This will include the updated OAS (if updated) from the update-oas job.
+      - uses: actions/checkout@v2
+
+      - name: Set tag
+        id: vars
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name (if present at all)
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo ::set-output name=tag::${VERSION}
+          echo ::set-output name=git_hash::${GITHUB_SHA}
+
+      - name: Build the Docker image
+        run: |
+          docker build . \
+            --tag $IMAGE_NAME:$RELEASE_VERSION \
+            --build-arg COMMIT_HASH=${{ steps.vars.outputs.git_hash }} \
+            --build-arg RELEASE=${RELEASE_VERSION}
+        env:
+          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+
+      - run: docker image save -o image.tar $IMAGE_NAME:${{ steps.vars.outputs.tag }}
+      - name: Store image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-image
+          path: image.tar
+          retention-days: 1
+
   oas-lint:
     needs: tests
     name:  Validate OAS
@@ -195,16 +234,24 @@ jobs:
           git commit -m ":package: Updated OAS."
           git push
 
-  docker:
+  docker_push:
     needs:
       - update-oas
       - tests
+      - docker_build
 
-    name: Build (and push) Docker image
+    name: Push Docker image
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'  # Exclude PRs
+
     steps:
       # This will include the updated OAS (if updated) from the update-oas job.
       - uses: actions/checkout@v2
+
+      - name: Download built image
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-image
 
       - name: Set tag
         id: vars
@@ -220,17 +267,14 @@ jobs:
 
           echo ::set-output name=tag::${VERSION}
 
-      - name: Build the Docker image
-        env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-        run: docker build . --tag $IMAGE_NAME:$RELEASE_VERSION
+      - name: Load image
+        run: |
+          docker image load -i image.tar
 
       - name: Log into registry
-        if: github.event_name == 'push'  # Exclude PRs
         run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Push the Docker image
-        if: github.event_name == 'push'  # Exclude PRs
         env:
           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
         run: docker push $IMAGE_NAME:$RELEASE_VERSION


### PR DESCRIPTION
... and only push on master branch/tags.

The Github CI workflow is adapted to:
* build the docker image for every PR/push
* store the resulting image artifact
* on tag/master branch pushes, load the artifact and push to Docker Hub