### PR TITLE
Add regex validation

### DIFF
--- a/src/openforms/forms/static/forms/js/components/form/edit/tabs.js
+++ b/src/openforms/forms/static/forms/js/components/form/edit/tabs.js
@@ -151,6 +151,15 @@ const TEXT_VALIDATION = {
             tooltip: 'The maximum length requirement this field must meet.',
             input: true
         },
+        {
+            weight: 130,
+            key: 'validate.pattern',
+            label: 'Regular Expression Pattern',
+            placeholder: 'Regular Expression Pattern',
+            type: 'textfield',
+            tooltip: 'The regular expression pattern test that the field value must pass before the form can be submitted.',
+            input: true
+        }
     ]
 };
 


### PR DESCRIPTION
Fixes #212 

Relies on https://github.com/open-formulieren/open-forms/pull/464 being merged first since this was branched off the `feature/add-text-options` branch.

A few things to note:
1. This only adds this to the text field and text area components and not the email field.  In FormIO it is possible to add a regex pattern to the email field.  The reason I didn't add this to the email field is that it doesn't seem necessary since I doubt users will want to have emails match an additional regex component.  We also didn't add the max length option with issue #210 to the email component though this is an option in FormIO so I didn't think it was needed to add this option.  If we do want this option on the email component then I think we should also add the max length option as well.  Let me know if you do want the regex option on the email component and if you do whether we should add the max length option as well. 
2. There isn't a check that the regex entered in the component is valid regex.  If invalid regex is entered then anything entered into the component by the end user will be shown the error about the pattern not being valid.  While this isn't ideal it is also what happens in FormIO and there doesn't seem to be a good solution to resolve this, though I can spend more time on it if that is preferred.
3. In my opinion the error message is not very clear about what went wrong but I'm not sure how we could improve it.  It is possible to override the message so we can put in our own message but I'm not sure how we could better inform the user about what is wrong since it's unlikely they'll understand regex syntax. 

**Screenshots**

<img width="1027" alt="Screenshot 2021-07-02 at 10 43 45" src="https://user-images.githubusercontent.com/60747362/124248509-3685aa80-db23-11eb-8559-8e8307c443cc.png">

<img width="1154" alt="Screenshot 2021-07-02 at 10 46 33" src="https://user-images.githubusercontent.com/60747362/124248505-35ed1400-db23-11eb-9096-2d138eb098a3.png">

<img width="1155" alt="Screenshot 2021-07-02 at 10 46 42" src="https://user-images.githubusercontent.com/60747362/124248503-35547d80-db23-11eb-8a48-e997307bfc0c.png">

<img width="1149" alt="Screenshot 2021-07-02 at 10 46 51" src="https://user-images.githubusercontent.com/60747362/124248499-34235080-db23-11eb-8676-19400146db3a.png">

<img width="835" alt="Screenshot 2021-07-02 at 13 49 33" src="https://user-images.githubusercontent.com/60747362/124270331-5c6b7900-db3c-11eb-8d5f-a5bde93df07d.png">
