### PR TITLE
Add celery beat task to clean up django sessions

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -4,9 +4,8 @@ import os
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
-from celery.schedules import crontab
-
 import sentry_sdk
+from celery.schedules import crontab
 from corsheaders.defaults import default_headers as default_cors_headers
 
 from .utils import config, get_sentry_integrations
@@ -486,7 +485,6 @@ CELERY_BEAT_SCHEDULE = {
     "clear-session-store": {
         "task": "openforms.utils.tasks.clear_session_store",
         # https://docs.celeryproject.org/en/v4.4.7/userguide/periodic-tasks.html#crontab-schedules
-        # Run daily at midnight
         "schedule": crontab(minute=0, hour=0),
     },
 }

--- a/src/openforms/utils/tasks.py
+++ b/src/openforms/utils/tasks.py
@@ -1,12 +1,14 @@
 import logging
-from ..celery import app
+
 from django.core import management
+
+from ..celery import app
 
 logger = logging.getLogger(__name__)
 
 
 @app.task
 def clear_session_store():
-    # Reference https://docs.djangoproject.com/en/3.2/topics/http/sessions/#clearing-the-session-store
-    logger.debug('Clearing expired sessions')
-    management.call_command("clearsessions", verbosity=0)
+    # https://docs.djangoproject.com/en/2.2/topics/http/sessions/#clearing-the-session-store
+    logger.debug("Clearing expired sessions")
+    management.call_command("clearsessions")


### PR DESCRIPTION
Fixes #479 

**Screenshots**

For testing I set it to run every minute with `crontab()` which is why it's running so often in the screenshot.

![Screenshot 2021-07-09 at 13 30 11](https://user-images.githubusercontent.com/60747362/125073584-7a952400-e0bc-11eb-88c3-268407a69c52.png)
