### PR TITLE
Do not require a csrf

### DIFF
--- a/src/openforms/validations/api/views.py
+++ b/src/openforms/validations/api/views.py
@@ -12,6 +12,7 @@ from openforms.validations.api.serializers import (
     ValidationResultSerializer,
 )
 from openforms.validations.registry import register
+from django.views.decorators.csrf import csrf_exempt
 
 
 class ValidatorsListView(APIView):
@@ -51,6 +52,7 @@ class ValidationView(APIView):
     """
 
     register = register
+    authentication_classes = ()
 
     @extend_schema(
         operation_id="validation_run",

--- a/src/openforms/validations/api/views.py
+++ b/src/openforms/validations/api/views.py
@@ -12,7 +12,6 @@ from openforms.validations.api.serializers import (
     ValidationResultSerializer,
 )
 from openforms.validations.registry import register
-from django.views.decorators.csrf import csrf_exempt
 
 
 class ValidatorsListView(APIView):


### PR DESCRIPTION
Needed for #463 which is essentially just a front end ticket.

Without this line the SDK gets a CSRF error when calling to validate.