### PR TITLE
Ensure e-mails from the queue are send periodically via celery beat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ local.py
 /log/nginx/*.log*
 /.env
 /private_media/
+/celerybeat
 
 # Static files
 src/openforms/static/bundles/

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -175,6 +175,9 @@ Other settings
   Open Forms to any other service will be disabled, so this variable should be used with
   care to prevent unwanted side-effects.
 
+* ``BEAT_SEND_EMAIL_INTERVAL``: the interval (in seconds) of sending queued e-mails,
+  defaults to ``20``.
+
 .. _`Django DATABASE settings`: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-DATABASE-ENGINE
 
 Specifying the environment variables

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 # Core python libraries
 celery < 5  # Flower does not work with Celery 5
+celery-once
 defusedxml
 furl
 glom

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,9 +26,12 @@ cairocffi==1.2.0
     #   weasyprint
 cairosvg==2.5.2
     # via weasyprint
+celery-once==3.0.1
+    # via -r requirements/base.in
 celery==4.4.7
     # via
     #   -r requirements/base.in
+    #   celery-once
     #   flower
 certifi==2020.6.20
     # via
@@ -216,7 +219,9 @@ pyyaml==5.4.1
 pyzmail36==1.0.4
     # via django-yubin
 redis==3.5.3
-    # via django-redis
+    # via
+    #   celery-once
+    #   django-redis
 requests-mock==1.8.0
     # via zgw-consumers
 requests==2.26.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -56,10 +56,15 @@ cairosvg==2.5.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
+celery-once==3.0.1
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 celery==4.4.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   celery-once
     #   flower
 certifi==2020.6.20
     # via
@@ -476,6 +481,7 @@ redis==3.5.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   celery-once
     #   django-redis
 regex==2020.11.13
     # via black

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,10 +72,15 @@ cairosvg==2.5.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
+celery-once==3.0.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 celery==4.4.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   celery-once
     #   flower
 certifi==2020.6.20
     # via
@@ -591,6 +596,7 @@ redis==3.5.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   celery-once
     #   django-redis
 regex==2020.11.13
     # via

--- a/src/openforms/celery.py
+++ b/src/openforms/celery.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from celery import Celery
 
 from .setup import setup_env
@@ -5,6 +7,13 @@ from .setup import setup_env
 setup_env()
 
 app = Celery("open-forms")
-
 app.config_from_object("django.conf:settings", namespace="CELERY")
+app.conf.ONCE = {
+    "backend": "celery_once.backends.Redis",
+    "settings": {
+        "url": settings.CELERY_BROKER_URL,
+        "default_timeout": 60 * 60,  # one hour
+    },
+}
+
 app.autodiscover_tasks()

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -488,6 +488,10 @@ CELERY_BEAT_SCHEDULE = {
         # https://docs.celeryproject.org/en/v4.4.7/userguide/periodic-tasks.html#crontab-schedules
         "schedule": crontab(minute=0, hour=0),
     },
+    "send-emails": {
+        "task": "openforms.utils.tasks.send_emails",
+        "schedule": config("BEAT_SEND_EMAIL_INTERVAL", default=20),  # every 20 seconds
+    },
 }
 
 # Only ACK when the task has been executed. This prevents tasks from getting lost, with

--- a/src/openforms/utils/tasks.py
+++ b/src/openforms/utils/tasks.py
@@ -2,6 +2,8 @@ import logging
 
 from django.core import management
 
+from celery_once import QueueOnce
+
 from ..celery import app
 
 logger = logging.getLogger(__name__)
@@ -12,3 +14,9 @@ def clear_session_store():
     # https://docs.djangoproject.com/en/2.2/topics/http/sessions/#clearing-the-session-store
     logger.debug("Clearing expired sessions")
     management.call_command("clearsessions")
+
+
+@app.task(base=QueueOnce)
+def send_emails() -> None:
+    logger.debug("Processing e-mail queue")
+    management.call_command("send_mail")


### PR DESCRIPTION
Fixes #504

* Added celery beat entry for e-mail sending (django yubin management command), every 20 seconds by default
* Added celery-once to prevent long-running jobs from being scheduled at the same time. E.g. the queue is so full that e-mail sending takes 25s, but after 20s the second send-job would've been scheduled and processing the queue as well. This is prevented by using celery-once.