### PR TITLE
Fix adding date field

### DIFF
--- a/src/openforms/forms/tasks.py
+++ b/src/openforms/forms/tasks.py
@@ -41,7 +41,7 @@ def detect_formiojs_configuration_snake_case(
         return
 
     config_now = copy.deepcopy(fd.configuration)
-    _remove_key_from_dict(config_now, 'time_24hr')
+    _remove_key_from_dict(config_now, "time_24hr")
     camelized_config = camelize(config_now)
 
     if config_now != camelized_config:

--- a/src/openforms/forms/tests/test_configuration_error_detection.py
+++ b/src/openforms/forms/tests/test_configuration_error_detection.py
@@ -42,3 +42,16 @@ class SnakeCaseDetectionTests(TestCase):
         capture.check(
             ("openforms.forms.tasks", "ERROR", msg),
         )
+
+    @log_capture(level=logging.ERROR)
+    def test_ignores_time_24hr_key(self, capture):
+        configuration = {
+            "time_24hr": False,
+            "innerDict": {"time_24hr": False},
+            "components": [{"time_24hr": False, "innerDict": {"time_24hr": False}}],
+        }
+        fd = FormDefinitionFactory.create(configuration=configuration)
+
+        detect_formiojs_configuration_snake_case(fd.id)
+
+        capture.check()

--- a/src/openforms/forms/tests/test_remove_key_from_dict.py
+++ b/src/openforms/forms/tests/test_remove_key_from_dict.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from openforms.forms.utils import remove_key_from_dict
+
+
+class RemoveKeyFromDictTests(TestCase):
+    def test_remove_key_from_dict_removes_expected_key(self):
+        dictionary = {
+            "remove_me": False,
+            "dont_remove_me": True,
+            "inner_dict": {"remove_me": False, "dont_remove_me": True},
+            "a_list": [
+                {
+                    "remove_me": False,
+                    "dont_remove_me": True,
+                    "inner_dict": {"remove_me": False, "dont_remove_me": True},
+                }
+            ],
+        }
+
+        remove_key_from_dict(dictionary, "remove_me")
+
+        expected_result = {
+            "dont_remove_me": True,
+            "inner_dict": {"dont_remove_me": True},
+            "a_list": [
+                {"dont_remove_me": True, "inner_dict": {"dont_remove_me": True}}
+            ],
+        }
+        self.assertEqual(dictionary, expected_result)

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -150,3 +150,15 @@ def import_form(import_file):
                         else:
                             raise e
     return created_form_definitions
+
+
+def remove_key_from_dict(dictionary, key):
+    for dict_key in list(dictionary.keys()):
+        if key == dict_key:
+            del dictionary[key]
+        elif isinstance(dictionary[dict_key], dict):
+            remove_key_from_dict(dictionary[dict_key], key)
+        elif isinstance(dictionary[dict_key], list):
+            for value in dictionary[dict_key]:
+                if isinstance(value, dict):
+                    remove_key_from_dict(value, key)


### PR DESCRIPTION
Fixes https://github.com/open-formulieren/open-forms/issues/513

The cause of the bug is that FormIO uses `time_24hr` in it's configuration.

The `camelize` function does accept `ignore_fields` but this only works if the field is a dictionary so we could just ignore the `widget` dictionary but I think this will ignore too much. 