### PR TITLE
Ensure voornamen attribute is in request soap when it's an attribute

### DIFF
--- a/src/openforms/prefill/contrib/stufbg/plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/plugin.py
@@ -69,8 +69,8 @@ class StufBgPrefill(BasePlugin):
 
         response_dict = {}
         for attribute in attributes:
-            response_dict[attribute] = glom(
-                data, ATTRIBUTES_TO_STUF_BG_MAPPING[attribute], default=None
-            )
+            value = glom(data, ATTRIBUTES_TO_STUF_BG_MAPPING[attribute], default=None)
+            if "@noValue" not in value:
+                response_dict[attribute] = value
 
         return response_dict

--- a/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
@@ -35,3 +35,27 @@ class StufBgPrefillTests(TestCase):
         self.assertEqual(values["huisnummertoevoeging"], "B")
         self.assertEqual(values["postcode"], "1015 CJ")
         self.assertEqual(values["woonplaatsNaam"], "Amsterdam")
+
+    @patch("openforms.prefill.contrib.stufbg.plugin.StufBGConfig.get_solo")
+    def test_get_available_attributes_when_some_attributes_are_not_returned(
+        self, client_mock
+    ):
+        get_values_for_attributes_mock = (
+            client_mock.return_value.get_client.return_value.get_values_for_attributes
+        )
+        get_values_for_attributes_mock.return_value = loader.render_to_string(
+            "stuf_bg/tests/responses/StufBgResponseMissingSomeData.xml"
+        )
+        attributes = FieldChoices.attributes.keys()
+
+        values = self.plugin.get_prefill_values(self.submission, attributes)
+
+        self.assertEqual(values["bsn"], "999992314")
+        self.assertEqual(values["voornamen"], "Media")
+        self.assertEqual(values["geslachtsnaam"], "Maykin")
+        self.assertEqual(values["straatnaam"], "Keizersgracht")
+        self.assertEqual(values["huisnummer"], "117")
+        self.assertEqual(values["postcode"], "1015 CJ")
+        self.assertEqual(values["woonplaatsNaam"], "Amsterdam")
+        self.assertNotIn("huisnummertoevoeging", values)
+        self.assertNotIn("huisletter", values)

--- a/src/stuf/stuf_bg/templates/stuf_bg/StufBgRequest.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/StufBgRequest.xml
@@ -65,11 +65,11 @@
             <ns:scope>
                 <ns:object StUF:entiteittype="NPS">
                     <ns:inp.bsn xsi:nil="true"/>
-                    {% if voornaam %}
-                        <ns:voornamen xsi:nil="true"/>
-                    {% endif %}
                     {% if geslachtsnaam %}
                         <ns:geslachtsnaam xsi:nil="true"/>
+                    {% endif %}
+                    {% if voornamen %}
+                        <ns:voornamen xsi:nil="true"/>
                     {% endif %}
                     {% if straatnaam or huisnummer or huisletter or huisnummertoevoeging or postcode or woonplaatsNaam %}
                         <ns:verblijfsadres>

--- a/src/stuf/stuf_bg/templates/stuf_bg/tests/responses/StufBgResponseMissingSomeData.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/tests/responses/StufBgResponseMissingSomeData.xml
@@ -1,0 +1,44 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
+                  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
+    <soapenv:Header/>
+    <soapenv:Body>
+        <ns:npsLa01>
+            <ns:stuurgegevens>
+                <StUF:berichtcode>La01</StUF:berichtcode>
+                <StUF:zender>
+                    <StUF:organisatie>{{ ontvanger_organisatie }}</StUF:organisatie>
+                    <StUF:applicatie>{{ ontvanger_applicatie }}</StUF:applicatie>
+                    <StUF:administratie>{{ ontvanger_administratie }}</StUF:administratie>
+                    <StUF:gebruiker>{{ ontvanger_gebruiker }}</StUF:gebruiker>
+                </StUF:zender>
+                <StUF:ontvanger>
+                    <StUF:organisatie>{{ zender_organisatie }}</StUF:organisatie>
+                    <StUF:applicatie>{{ zender_applicatie }}</StUF:applicatie>
+                    <StUF:administratie>{{ zender_administratie }}</StUF:administratie>
+                    <StUF:gebruiker>{{ zender_gebruiker }}</StUF:gebruiker>
+                </StUF:ontvanger>
+                <StUF:referentienummer>{{ referentienummer }}</StUF:referentienummer>
+                <StUF:tijdstipBericht>{{ tijdstip_bericht }}</StUF:tijdstipBericht>
+            </ns:stuurgegevens>
+            <ns:parameters>
+                <StUF:indicatorAfnemerIndicatie>false</StUF:indicatorAfnemerIndicatie>
+            </ns:parameters>
+            <ns:antwoord>
+                <ns:object StUF:entiteittype="NPS">
+                    <ns:inp.bsn>999992314</ns:inp.bsn>
+                    <ns:geslachtsnaam>Maykin</ns:geslachtsnaam>
+                    <ns:voornamen>Media</ns:voornamen>
+                    <ns:verblijfsadres>
+                        <ns:wpl.woonplaatsNaam>Amsterdam</ns:wpl.woonplaatsNaam>
+                        <ns:gor.straatnaam>Keizersgracht</ns:gor.straatnaam>
+                        <ns:aoa.postcode>1015 CJ</ns:aoa.postcode>
+                        <ns:aoa.huisnummer>117</ns:aoa.huisnummer>
+                        <ns:aoa.huisletter StUF:noValue="geenWaarde" xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                        <ns:aoa.huisnummertoevoeging StUF:noValue="geenWaarde" xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                    </ns:verblijfsadres>
+                </ns:object>
+            </ns:antwoord>
+        </ns:npsLa01>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/src/stuf/stuf_bg/tests/test_client.py
+++ b/src/stuf/stuf_bg/tests/test_client.py
@@ -121,3 +121,6 @@ class StufBGConfigTests(TestCase):
                             f'Attributes "{subset}" produces an invalid StUF-BG. '
                             f"Error: {xmlschema.error_log.last_error.message}"
                         )
+                    for attribute in subset:
+                        with self.subTest(subset=subset, attribute=attribute):
+                            self.assertIn(attribute, data)


### PR DESCRIPTION
Fixes #567 

The cause of the bug was that the xml template used when making request had the conditional `{% if voornaam %}` while the attribute was named `voornamen` so even when voornamen was an attribute the conditional would always be false and so it was not added.

**Screenshot** 

Added every possible Stuf-BG attribute and they all prefilled.  This address does not have a house letter or house number addition which is why these fields are blank.

![Screenshot 2021-08-19 at 12 02 21](https://user-images.githubusercontent.com/60747362/130053569-e9cd21b4-d846-46ee-aa4d-50f6af801f6c.png)
