### PR TITLE
Issue #575 - Select boxes rendering

### DIFF
--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -22,7 +22,7 @@
         table {
             border: 1px solid black;
             border-collapse: collapse;
-            table-layout: auto;
+            table-layout: fixed;
             width: 100%;
         }
         .table-cell-key {

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -74,3 +74,34 @@ class TestSubmission(TestCase):
                 "key5": {"type": "textfield", "value": "this is some inner text"},
             },
         )
+
+    def test_get_printable_data_with_selectboxes(self):
+        form_definition = FormDefinitionFactory.create(
+            configuration={
+                "display": "form",
+                "components": [
+                    {
+                        "key": "testSelectBoxes",
+                        "type": "selectboxes",
+                        "values": [
+                            {"values": "test1", "label": "test1", "shortcut": ""},
+                            {"values": "test2", "label": "test2", "shortcut": ""},
+                            {"values": "test3", "label": "test3", "shortcut": ""},
+                        ],
+                    },
+                ],
+            }
+        )
+        submission = SubmissionFactory.create()
+        SubmissionStepFactory.create(
+            submission=submission,
+            data={"testSelectBoxes": {"test1": True, "test2": True, "test3": False}},
+            form_step=FormStepFactory.create(form_definition=form_definition),
+        )
+
+        printable_data = submission.get_printable_data()
+
+        self.assertEqual(
+            printable_data["testSelectBoxes"],
+            "test1, test2",
+        )


### PR DESCRIPTION
Fixes #575 

In the same way that the files attachment have a special treatment for rendering them in the report, now also the select boxes have a special treatment.
I also updated the submission report template to prevent the table with the form data to run outside the page.
Note: If the label/value from a field are an extremely long word, this will still render in an ugly way. It is due to this bug in weasyprint: https://github.com/Kozea/WeasyPrint/issues/36 