### PR TITLE
Appointment details and JCC QR-code

### DIFF
--- a/src/openforms/appointments/contrib/jcc/tests/mock/GetAppointmentQRCodeTextResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/GetAppointmentQRCodeTextResponse.xml
@@ -1,0 +1,7 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <GetAppointmentQRCodeTextResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <Result xmlns="">44b322c32c5329b135e1</Result>
+      </GetAppointmentQRCodeTextResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovAppointmentDetailsResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovAppointmentDetailsResponse.xml
@@ -1,0 +1,27 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <getGovAppointmentDetailsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <appointment xmlns="">
+            <productID>1</productID>
+            <clientLastName>Doe</clientLastName>
+            <clientSex>M</clientSex>
+            <clientDateOfBirth>1980-01-01</clientDateOfBirth>
+            <clientInitials>John</clientInitials>
+            <clientAddress>Straat 1</clientAddress>
+            <clientPostalCode>1111 AA</clientPostalCode>
+            <clientCity>Stad</clientCity>
+            <clientCountry>Nederland</clientCountry>
+            <clientTel>06123456789</clientTel>
+            <clientMail>john.doe@example.com</clientMail>
+            <locationID>1</locationID>
+            <appStartTime>2021-08-30T15:00:00</appStartTime>
+            <appEndTime>2021-08-30T15:15:00</appEndTime>
+            <appointmentDesc>Dit is een testafspraak
+
+Bvd,
+John</appointmentDesc>
+            <isClientVerified>false</isClientVerified>
+         </appointment>
+      </getGovAppointmentDetailsResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovLocationDetailsResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovLocationDetailsResponse.xml
@@ -1,0 +1,13 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <getGovLocationDetailsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <locaties xmlns="">
+            <locationDesc>Maykin Media</locationDesc>
+            <address>Straat 1</address>
+            <postalcode>1111 AA</postalcode>
+            <city>Stad</city>
+            <telephone>012-3456789</telephone>
+         </locaties>
+      </getGovLocationDetailsResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovProductDetailsResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovProductDetailsResponse.xml
@@ -1,0 +1,11 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <getGovProductDetailsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <out xmlns="">
+            <description>Paspoort aanvraag</description>
+            <appDuration>10</appDuration>
+            <requisites>PGJvZHk+PGgxPlRla3N0IG1ldCBIVE1MIG9wbWFhazwvaDE+PHA+VGVzdDwvcD48L2h0bWw+</requisites>
+         </out>
+      </getGovProductDetailsResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -2,11 +2,17 @@ import os
 from datetime import date, datetime
 
 from django.test import TestCase
+from django.utils.translation import ugettext_lazy as _
 
 import requests_mock
 from zeep.client import Client
 
-from ....base import AppointmentClient, AppointmentLocation, AppointmentProduct
+from ....base import (
+    AppointmentClient,
+    AppointmentDetails,
+    AppointmentLocation,
+    AppointmentProduct,
+)
 from ..plugin import Plugin
 
 
@@ -136,3 +142,45 @@ class PluginTests(TestCase):
         result = self.plugin.delete_appointment(identifier)
 
         self.assertIsNone(result)
+
+    @requests_mock.Mocker()
+    def test_get_appointment_details(self, m):
+        identifier = "1234567890"
+
+        m.post(
+            "http://example.com/soap11",
+            [
+                {"text": mock_response("getGovAppointmentDetailsResponse.xml")},
+                {"text": mock_response("getGovLocationDetailsResponse.xml")},
+                {"text": mock_response("GetAppointmentQRCodeTextResponse.xml")},
+                {"text": mock_response("getGovProductDetailsResponse.xml")},
+            ],
+        )
+
+        result = self.plugin.get_appointment_details(identifier)
+
+        self.assertEqual(type(result), AppointmentDetails)
+
+        self.assertEqual(len(result.products), 1)
+        self.assertEqual(result.identifier, identifier)
+
+        self.assertEqual(result.products[0].identifier, "1")
+        self.assertEqual(result.products[0].name, "Paspoort aanvraag")
+
+        self.assertEqual(result.location.identifier, "1")
+        self.assertEqual(result.location.name, "Maykin Media")
+        self.assertEqual(result.location.address, "Straat 1")
+        self.assertEqual(result.location.postalcode, "1111 AA")
+        self.assertEqual(result.location.city, "Stad")
+
+        self.assertEqual(result.start_at, datetime(2021, 8, 30, 15, 0))
+        self.assertEqual(result.end_at, datetime(2021, 8, 30, 15, 15))
+        self.assertEqual(result.remarks, "Dit is een testafspraak\n\nBvd,\nJohn")
+        self.assertDictEqual(
+            result.other,
+            {
+                _(
+                    "QR-code"
+                ): '<img src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAUoAAAFKAQAAAABTUiuoAAAB50lEQVR4nO2bzY3cMAxGHyMDe5Q72FLkDlJSkJLSgVXKdiAfA9j4cpA849nLziQYr4IlT/p5hw8gKNKibOJOy9/uJcFRRx111FFHn4laswGb2Mxs3AyWfXl6ugBHH0GTJKmAfo5BmgmyiSBJ0i36HAGOPoIulxACSG9DHZjZcI4AR++w4d3cwFCeMLGcIcDRf0FTCbLpEwU4+jEaJc37ouao6jJJ6zkCHL3D2kmYDYBQZ5behhXY7PkCHH3YW4frp/y6QnVUvL2V+nStjlJr9CSJVAAIkkrYPRXbruZP1+po9Zakdc9RUYK4HtxYzb3VD7q8yKZlQDObkQqYjUAeTxLg6D3WAodWCTYrQaQS2obHVifo5cBbOeSteU9etar3vNUJevQWcUUzYa834gpJq8dWN+ixgk+/BoDNyCMIthMEOPp3NeEhmOY6kuetvtB2ElZHlZvp1TxvdYJeYkuXXtaxtvC81SF67R1XS5JgGfx7q0v02jue44pNi1k7DhfvRvaD7hV8oba26tpMON7oet7qFK1PMn7Uj+WwF4snCnD0ETSVzchmrbWVR2htyv60fjl0z0pRUB9ixHVQ/l4gv/6263uaDrQ62tBsZmYj2LS8vH+X0aa9aP3CqPlfC4466qijjv5H6B/hFU+U471mPQAAAABJRU5ErkJggg==" alt="44b322c32c5329b135e1" />'
+            },
+        )

--- a/src/openforms/appointments/contrib/qmatic/tests/mock/appointment.json
+++ b/src/openforms/appointments/contrib/qmatic/tests/mock/appointment.json
@@ -1,0 +1,83 @@
+{
+    "notifications": [],
+    "meta": {
+        "start": "",
+        "end": "",
+        "totalResults": 1,
+        "offset": null,
+        "limit": null,
+        "fields": "",
+        "arguments": {}
+    },
+    "appointment": {
+        "services": [
+            {
+                "additionalCustomerDuration": 0,
+                "duration": 5,
+                "updated": 1475589228781,
+                "created": 1475589228595,
+                "name": "Product 1",
+                "publicId": "1e0c3d34acb5a4ad0133b2927959e8",
+                "active": true,
+                "publicEnabled": true,
+                "custom": null
+            }
+        ],
+        "allDay": false,
+        "status": 20,
+        "resource": {
+            "name": "Resource 1"
+        },
+        "customers": [
+            {
+                "dateOfBirth": -2206357200000,
+                "addressState": "Zuid Holland",
+                "lastName": "Achternaam",
+                "phone": "06-11223344",
+                "addressCity": "Plaatsnaam",
+                "externalId": null,
+                "addressLine2": null,
+                "addressLine1": "Straatnaam 1",
+                "updated": null,
+                "created": 1478619026558,
+                "email": "test@test.com",
+                "name": "Voornaam Achternaam",
+                "publicId": "f9c6a5fa1b978b4181accd7a6434e4b9",
+                "firstName": "Voornaam",
+                "addressCountry": "Nederland",
+                "custom": null,
+                "identificationNumber": "1234567890",
+                "addressZip": "1111AB"
+            }
+        ],
+        "blocking": false,
+        "title": "Online booking",
+        "start": "2016-11-10T12:30:00.000+00:00",
+        "created": 1478618716117,
+        "updated": 1478619027200,
+        "publicId": "d50517a0ae88cdbc495f7a32e011cb",
+        "branch": {
+            "addressState": null,
+            "phone": null,
+            "addressCity": "City",
+            "fullTimeZone": "Europe/Amsterdam",
+            "timeZone": "Europe/Amsterdam",
+            "addressLine2": "Street 1",
+            "addressLine1": "Branch 1",
+            "updated": 1475589234069,
+            "created": 1475589234008,
+            "email": null,
+            "name": "Branch 1",
+            "publicId": "f364d92b7fa07a48c4ecc862de30",
+            "longitude": null,
+            "branchPrefix": null,
+            "latitude": null,
+            "addressCountry": "Netherlands",
+            "custom": null,
+            "addressZip": "1111 AA"
+        },
+        "notes": "Geboekt via internet",
+        "end": "2016-11-10T12:35:00.000+00:00",
+        "custom": null
+    }
+}

--- a/src/openforms/appointments/templates/appointments/appointment_details.html
+++ b/src/openforms/appointments/templates/appointments/appointment_details.html
@@ -1,0 +1,40 @@
+{% load i18n %}
+
+<table>
+    <tr>
+        <td>{% trans "Products" %}</td>
+        <td>
+            {% for product in appointment.products %}
+                {{ product.name }}{% if not forloop.last %}<br />{% endif %}
+            {% endfor %}
+        </td>
+    </tr>
+    <tr>
+        <td>{% trans "Location" %}</td>
+        <td>
+            {{ appointment.location.name }}<br />
+            {{ appointment.location.address }}<br />
+            {{ appointment.location.postalcode }} {{ appointment.location.city }}
+        </td>
+    </tr>
+    <tr>
+        <td>{% trans "Date and time" %}</td>
+        <td>
+            {{ appointment.start_at.date }}, {{ appointment.start_at.time }}{% if appointment.end_at %} - {{ appointment.end_at.time }}{% endif %}
+        </td>
+    </tr>
+    <tr>
+        <td>{% trans "Remarks" %}</td>
+        <td>
+            {{ appointment.remarks|linebreaksbr }}
+        </td>
+    </tr>
+    {% if appointment.other %}
+        {% for key, value in appointment.other.items %}
+            <tr>
+                <td>{{ key|safe }}</td>
+                <td>{{ value|safe }}</td>
+            </tr>
+        {% endfor %}
+    {% endif %}
+</table>

--- a/src/openforms/appointments/tests/test_base.py
+++ b/src/openforms/appointments/tests/test_base.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from django.test import TestCase
+
+from ..base import (
+    AppointmentDetails,
+    AppointmentLocation,
+    AppointmentProduct,
+    BasePlugin,
+)
+
+
+class TestPlugin(BasePlugin):
+    def get_appointment_details(self, identifier: str) -> str:
+        return AppointmentDetails(
+            identifier=identifier,
+            products=[
+                AppointmentProduct(identifier="1", name="Test product 1"),
+                AppointmentProduct(identifier="2", name="Test product 2"),
+            ],
+            location=AppointmentLocation(identifier="1", name="Test location"),
+            start_at=datetime(2021, 1, 1, 12, 0),
+            end_at=datetime(2021, 1, 1, 12, 15),
+            remarks="Remarks",
+            other={"Some": "<h1>Data</h1>"},
+        )
+
+
+class BasePluginTests(TestCase):
+    maxDiff = 1024
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.plugin = TestPlugin()
+
+    def test_get_appointment_details_html(self):
+        identifier = "1234567890"
+
+        result = self.plugin.get_appointment_details_html(identifier)
+
+        self.assertIn("Test product 1", result)
+        self.assertIn("Test product 2", result)
+        self.assertIn("Test location", result)
+        self.assertIn("1 januari 2021, 12:00 - 12:15", result)
+        self.assertIn("Remarks", result)
+        self.assertIn("Some", result)
+        self.assertIn("<h1>Data</h1>", result)

--- a/src/openforms/appointments/tests/test_utils.py
+++ b/src/openforms/appointments/tests/test_utils.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from ..utils import create_base64_qrcode
+
+
+class UtilsTests(TestCase):
+    maxDiff = 1024
+
+    def test_create_base64_qrcode(self):
+        data = "44b322c32c5329b135e1"
+        expected = (
+            "iVBORw0KGgoAAAANSUhEUgAAAUoAAAFKAQAAAABTUiuoAAAB50lEQVR4n"
+            "O2bzY3cMAxGHyMDe5Q72FLkDlJSkJLSgVXKdiAfA9j4cpA849nLziQYr4IlT/p5h"
+            "w8gKNKibOJOy9/uJcFRRx111FFHn4laswGb2Mxs3AyWfXl6ugBHH0GTJKmAfo5Bm"
+            "gmyiSBJ0i36HAGOPoIulxACSG9DHZjZcI4AR++w4d3cwFCeMLGcIcDRf0FTCbLpE"
+            "wU4+jEaJc37ouao6jJJ6zkCHL3D2kmYDYBQZ5behhXY7PkCHH3YW4frp/y6QnVUv"
+            "L2V+nStjlJr9CSJVAAIkkrYPRXbruZP1+po9Zakdc9RUYK4HtxYzb3VD7q8yKZlQ"
+            "DObkQqYjUAeTxLg6D3WAodWCTYrQaQS2obHVifo5cBbOeSteU9etar3vNUJevQWc"
+            "UUzYa834gpJq8dWN+ixgk+/BoDNyCMIthMEOPp3NeEhmOY6kuetvtB2ElZHlZvp1"
+            "TxvdYJeYkuXXtaxtvC81SF67R1XS5JgGfx7q0v02jue44pNi1k7DhfvRvaD7hV8o"
+            "ba26tpMON7oet7qFK1PMn7Uj+WwF4snCnD0ETSVzchmrbWVR2htyv60fjl0z0pRU"
+            "B9ixHVQ/l4gv/6263uaDrQ62tBsZmYj2LS8vH+X0aa9aP3CqPlfC4466qijjv5H6"
+            "B/hFU+U471mPQAAAABJRU5ErkJggg=="
+        )
+
+        result = create_base64_qrcode(data)
+
+        self.assertEqual(result, expected)

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -1,0 +1,13 @@
+import base64
+import io
+
+import qrcode
+
+
+def create_base64_qrcode(text):
+    img = qrcode.make(text)
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    buffer.seek(0)
+
+    return base64.b64encode(buffer.read()).decode("ascii")

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -148,6 +148,7 @@ INSTALLED_APPS = [
     "django_filters",
     # Project applications.
     "openforms.accounts",
+    "openforms.appointments",
     "openforms.appointments.contrib.jcc",
     "openforms.appointments.contrib.qmatic",
     "openforms.config",


### PR DESCRIPTION
Groundwork for #262 

* Adds retrieving appointment details for both JCC and Qmatic.
* Adds QR code for appointment if present.
* Adds HTML snippet to show appointment details (to be used in confirmation email).