### PR TITLE
Get booking appointment working within task orchestration

### DIFF
--- a/src/openforms/appointments/service.py
+++ b/src/openforms/appointments/service.py
@@ -33,12 +33,6 @@ def register_appointment(submission: Submission) -> None:
       database with the relevant context/information - the exception just signals the
       failure to the caller so that it can retry if needed.
     """
-    # TODO: implement, see PR #573
+    from .utils import book_appointment_for_submission
 
-    # DEBUGGING - simulate some time passing by external API calls
-    import time
-
-    time.sleep(2)
-
-    # SIMULATE failure
-    raise AppointmentRegistrationFailed("Missing information.", should_retry=True)
+    book_appointment_for_submission(submission)

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -27,9 +27,9 @@ def get_client():
 def book_appointment_for_submission(submission: Submission) -> None:
     try:
         # Delete the previous appointment info if there is one since
-        #   it will cause and error creating the new one
-        # Since this will be called multiple times on a failure it's
-        #   possible this will exist
+        #   since a new one will be created
+        # This function will be called multiple times on a failure so
+        #   this is the case a previous appointment_info may exist
         submission.appointment_info.delete()
     except AppointmentInfo.DoesNotExist:
         pass
@@ -97,7 +97,7 @@ def book_appointment_for_submission(submission: Submission) -> None:
             appointment_id=appointment_id,
             submission=submission,
         )
-    except AppointmentCreateFailed as e:
+    except AppointmentCreateFailed:
         AppointmentInfo.objects.create(
             status=AppointmentDetailsStatus.failed,
             error_information="Failed to make appointment",

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -97,7 +97,7 @@ def book_appointment_for_submission(submission: Submission) -> None:
             appointment_id=appointment_id,
             submission=submission,
         )
-    except AppointmentCreateFailed:
+    except AppointmentCreateFailed as e:
         AppointmentInfo.objects.create(
             status=AppointmentDetailsStatus.failed,
             error_information="Failed to make appointment",
@@ -105,7 +105,7 @@ def book_appointment_for_submission(submission: Submission) -> None:
         )
         raise AppointmentRegistrationFailed(
             "Unable to create appointment", should_retry=True
-        )
+        ) from e
 
 
 def create_base64_qrcode(text):


### PR DESCRIPTION
I believe this is all that should be needed to get the current appointment booking to work with the new task orchestration.

Now the util function will raise the exception on a failure (after creating the Appointment Info instance) so the task will can then handle the retrying.  In the case of a success or missing information where we don't want to retry the util function simply returns which should mark the task as successful.