### PR TITLE
Include content components in logic

### DIFF
--- a/src/openforms/js/components/admin/form_design/utils.js
+++ b/src/openforms/js/components/admin/form_design/utils.js
@@ -10,11 +10,11 @@ const stripIdFromComponents = (obj) => {
 /**
  * Extract all the available components from all form steps.
  * @param  {Array}  formSteps An array of the formsteps of a form, which contains the FormIO configuration.
- * @return {Object}           Object keyed by the Formio component.key with the comopnent itself as value.
+ * @return {Object}           Object keyed by the Formio component.key with the component itself as value.
  */
 const getFormComponents = (formSteps=[]) => {
     const allComponents = formSteps.map(
-        step => FormioUtils.flattenComponents(step.configuration.components || [], false)
+        step => FormioUtils.flattenComponents(step.configuration.components || [], true)
     ).reduce((acc, currentValue) => ({...acc, ...currentValue}), {});
     return allComponents;
 };


### PR DESCRIPTION
The `getFormComponents` was set to not include layout components.

Fixes #637 