### PR TITLE
Handle new format coming from SDK

### DIFF
--- a/src/openforms/appointments/tests/test_utils.py
+++ b/src/openforms/appointments/tests/test_utils.py
@@ -83,7 +83,7 @@ class BookAppointmentForSubmissionTest(TestCase):
         submission = SubmissionFactory.create(form=form)
         SubmissionStepFactory.create(
             submission=submission,
-            data={"product": "79", "time": "2021-08-25T17:00:00"},
+            data={"product": "79-Paspoort", "time": "2021-08-25T17:00:00"},
             form_step=form_step_1,
         )
         SubmissionStepFactory.create(
@@ -146,8 +146,8 @@ class BookAppointmentForSubmissionTest(TestCase):
         SubmissionStepFactory.create(
             submission=submission,
             data={
-                "product": "79",
-                "location": "1",
+                "product": "79-Paspoort",
+                "location": "1-Amsterdam",
                 "time": "2021-08-25T17:00:00+02:00",
             },
             form_step=form_step_1,
@@ -207,8 +207,8 @@ class BookAppointmentForSubmissionTest(TestCase):
         SubmissionStepFactory.create(
             submission=submission,
             data={
-                "product": "79",
-                "location": "1",
+                "product": "79-Paspoort",
+                "location": "1-Amsterdam",
                 "time": "2021-08-25T17:00:00+02:00",
             },
             form_step=form_step_1,

--- a/src/openforms/appointments/tests/test_utils.py
+++ b/src/openforms/appointments/tests/test_utils.py
@@ -83,7 +83,10 @@ class BookAppointmentForSubmissionTest(TestCase):
         submission = SubmissionFactory.create(form=form)
         SubmissionStepFactory.create(
             submission=submission,
-            data={"product": "79-Paspoort", "time": "2021-08-25T17:00:00"},
+            data={
+                "product": {"identifier": "79", "name": "Paspoort"},
+                "time": "2021-08-25T17:00:00",
+            },
             form_step=form_step_1,
         )
         SubmissionStepFactory.create(
@@ -108,7 +111,7 @@ class BookAppointmentForSubmissionTest(TestCase):
         self.assertEqual(
             info.error_information,
             _("The following appoinment fields should be filled out: {fields}").format(
-                fields="clientDateOfBirth, locationID"
+                fields="clientDateOfBirth, locationIDAndName"
             ),
         )
 

--- a/src/openforms/appointments/tests/test_utils.py
+++ b/src/openforms/appointments/tests/test_utils.py
@@ -278,8 +278,8 @@ class BookAppointmentForSubmissionTest(TestCase):
         SubmissionStepFactory.create(
             submission=submission,
             data={
-                "product": "79",
-                "location": "1",
+                "product": {"identifier": "79", "name": "Paspoort"},
+                "location": {"identifier": "1", "name": "Amsterdam"},
                 "time": "2021-08-25T17:00:00+02:00",
             },
             form_step=form_step_1,

--- a/src/openforms/appointments/tests/test_utils.py
+++ b/src/openforms/appointments/tests/test_utils.py
@@ -146,8 +146,8 @@ class BookAppointmentForSubmissionTest(TestCase):
         SubmissionStepFactory.create(
             submission=submission,
             data={
-                "product": "79-Paspoort",
-                "location": "1-Amsterdam",
+                "product": {"identifier": "79", "name": "Paspoort"},
+                "location": {"identifier": "1", "name": "Amsterdam"},
                 "time": "2021-08-25T17:00:00+02:00",
             },
             form_step=form_step_1,
@@ -207,8 +207,8 @@ class BookAppointmentForSubmissionTest(TestCase):
         SubmissionStepFactory.create(
             submission=submission,
             data={
-                "product": "79-Paspoort",
-                "location": "1-Amsterdam",
+                "product": {"identifier": "79", "name": "Paspoort"},
+                "location": {"identifier": "1", "name": "Amsterdam"},
                 "time": "2021-08-25T17:00:00+02:00",
             },
             form_step=form_step_1,

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -78,10 +78,12 @@ def book_appointment_for_submission(submission: Submission) -> None:
         )
 
     product = AppointmentProduct(
-        identifier=appointment_data["productIDAndName"].split("-", 1)[0], name=""
+        identifier=appointment_data["productIDAndName"]["identifier"],
+        name=appointment_data["productIDAndName"]["name"],
     )
     location = AppointmentLocation(
-        identifier=appointment_data["locationIDAndName"].split("-", 1)[0], name=""
+        identifier=appointment_data["locationIDAndName"]["identifier"],
+        name=appointment_data["locationIDAndName"]["name"],
     )
     appointment_client = AppointmentClient(
         last_name=appointment_data["clientLastName"],

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -38,8 +38,8 @@ def book_appointment_for_submission(submission: Submission) -> None:
     appointment_data = submission.get_merged_appointment_data()
 
     expected_information = [
-        "productID",
-        "locationID",
+        "productIDAndName",
+        "locationIDAndName",
         "appStartTime",
         "clientLastName",
         "clientDateOfBirth",
@@ -77,8 +77,12 @@ def book_appointment_for_submission(submission: Submission) -> None:
             should_retry=False,
         )
 
-    product = AppointmentProduct(identifier=str(appointment_data["productID"]), name="")
-    location = AppointmentLocation(identifier=appointment_data["locationID"], name="")
+    product = AppointmentProduct(
+        identifier=appointment_data["productIDAndName"].split("-", 1)[0], name=""
+    )
+    location = AppointmentLocation(
+        identifier=appointment_data["locationIDAndName"].split("-", 1)[0], name=""
+    )
     appointment_client = AppointmentClient(
         last_name=appointment_data["clientLastName"],
         birthdate=datetime.strptime(

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -319,8 +319,8 @@ class Submission(models.Model):
         merged_appointment_data = dict()
         component_key_to_appointment_info = dict()
         component_key_to_appointment_key = {
-            "appointmentsShowProducts": "productID",
-            "appointmentsShowLocations": "locationID",
+            "appointmentsShowProducts": "productIDAndName",
+            "appointmentsShowLocations": "locationIDAndName",
             "appointmentsShowTimes": "appStartTime",
             "appointmentsLastName": "clientLastName",
             "appointmentsBirthDate": "clientDateOfBirth",

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -227,7 +227,11 @@ class TestSubmission(TestCase):
         submission = SubmissionFactory.create(form=form)
         SubmissionStepFactory.create(
             submission=submission,
-            data={"product": "79", "location": "1", "time": "2021-08-25T17:00:00"},
+            data={
+                "product": "79-Paspoort",
+                "location": "1-Amsterdam",
+                "time": "2021-08-25T17:00:00",
+            },
             form_step=form_step_1,
         )
         SubmissionStepFactory.create(
@@ -243,8 +247,8 @@ class TestSubmission(TestCase):
         self.assertEqual(
             submission.get_merged_appointment_data(),
             {
-                "productID": "79",
-                "locationID": "1",
+                "productIDAndName": "79-Paspoort",
+                "locationIDAndName": "1-Amsterdam",
                 "appStartTime": "2021-08-25T17:00:00",
                 "clientLastName": "Maykin",
                 "clientDateOfBirth": "1990-08-01",

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -228,8 +228,8 @@ class TestSubmission(TestCase):
         SubmissionStepFactory.create(
             submission=submission,
             data={
-                "product": "79-Paspoort",
-                "location": "1-Amsterdam",
+                "product": {"identifier": "79", "name": "Paspoort"},
+                "location": {"identifier": "1", "name": "Amsterdam"},
                 "time": "2021-08-25T17:00:00",
             },
             form_step=form_step_1,
@@ -247,8 +247,8 @@ class TestSubmission(TestCase):
         self.assertEqual(
             submission.get_merged_appointment_data(),
             {
-                "productIDAndName": "79-Paspoort",
-                "locationIDAndName": "1-Amsterdam",
+                "productIDAndName": {"identifier": "79", "name": "Paspoort"},
+                "locationIDAndName": {"identifier": "1", "name": "Amsterdam"},
                 "appStartTime": "2021-08-25T17:00:00",
                 "clientLastName": "Maykin",
                 "clientDateOfBirth": "1990-08-01",


### PR DESCRIPTION
Changes needed for points
- Should have human readable values in summary page. Will need a way to save these human readable values after they have been selected.
- On the overview page, the appointment details are rendered weirdly

of #597 

Related SDK Pull Request: https://github.com/open-formulieren/open-forms-sdk/pull/58

The cause of the displaying of Products and Locations is that we were only saving the id and not the name/human readable value so we could only display the id back at a later point.  Now both will be stored with a dash between the id and name.

One additional positive of this is that in the submission data you will now see both the id and name instead of just the id. 