### PR TITLE
Logic actions bugs/improvements

### DIFF
--- a/src/openforms/forms/api/serializers.py
+++ b/src/openforms/forms/api/serializers.py
@@ -395,6 +395,7 @@ class LogicComponentActionSerializer(serializers.Serializer):
         ).format(action_type=LogicActionTypes.disable_next),
     )
     form_step = URLRelatedField(
+        allow_null=True,
         required=False,  # validated against the action.type
         queryset=FormStep.objects,
         view_name="api:form-steps-detail",
@@ -403,7 +404,7 @@ class LogicComponentActionSerializer(serializers.Serializer):
         label=_("form step"),
         help_text=_(
             "The form step that will be affected by the action. This field is "
-            "optional if the action type is `%(action_type)s`, otherwise required."
+            "required if the action type is `%(action_type)s`, otherwise optional."
         )
         % {"action_type": LogicActionTypes.step_not_applicable},
     )
@@ -427,7 +428,7 @@ class LogicComponentActionSerializer(serializers.Serializer):
 
         if (
             action_type
-            and action_type in LogicActionTypes.step_not_applicable
+            and action_type == LogicActionTypes.step_not_applicable
             and not form_step
         ):
             # raises validation error

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -63,6 +63,7 @@ class NestedSubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             "is_applicable",
             "completed",
             "optional",
+            "can_submit",
         )
 
 

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -308,6 +308,7 @@ class SubmissionStepViewSet(
             # keys like ``foo.bar`` and ``foo.baz`` are used which construct a foo object
             # with keys bar and baz.
             merged_data = {**submission_step.submission.data, **data}
+            submission_step.data = data
             evaluate_form_logic(
                 submission_step.submission, submission_step, merged_data
             )

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict
 
+from django.urls import resolve
+
+from furl import furl
 from json_logic import jsonLogic
 
 from ..forms.models.form import FormLogic
@@ -63,8 +66,11 @@ def evaluate_form_logic(
                 elif action_details["type"] == "disable-next":
                     step._can_submit = False
                 elif action_details["type"] == "step-not-applicable":
+                    step_to_modify_uuid = resolve(
+                        furl(action["form_step"]).pathstr
+                    ).kwargs["uuid"]
                     submission_step_to_modify = submission_state.get_submission_step(
-                        form_step_uuid=action["form_step"]
+                        form_step_uuid=step_to_modify_uuid
                     )
                     submission_step_to_modify._is_applicable = False
 

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -37,6 +37,9 @@ def evaluate_form_logic(
     # grab the configuration that can be **mutated**
     configuration = step.form_step.form_definition.configuration
 
+    if not step.data:
+        step.data = {}
+
     # ensure this function is idempotent
     _evaluated = getattr(step, "_form_logic_evaluated", False)
     if _evaluated:
@@ -54,6 +57,7 @@ def evaluate_form_logic(
                     configuration = set_property_value(
                         configuration, action["component"], "value", new_value
                     )
+                    step.data[action["component"]] = new_value
                 elif action_details["type"] == "property":
                     property_name = action_details["property"]["value"]
                     property_value = action_details["state"]

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -530,6 +530,7 @@ class ComponentModificationTests(TestCase):
             ]
         }
         self.assertEqual(configuration, expected)
+        self.assertEqual({"step2_textfield1": "some value"}, submission_step_2.data)
 
     def test_evaluate_logic_with_empty_data(self):
         """

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -708,7 +708,7 @@ class StepModificationTests(TestCase):
             },
             actions=[
                 {
-                    "form_step": str(step2.uuid),
+                    "form_step": f"http://example.com{reverse('api:form-steps-detail', kwargs={'form_uuid_or_slug': form.uuid, 'uuid': step2.uuid})}",
                     "action": {
                         "name": "Step is not applicable",
                         "type": "step-not-applicable",
@@ -861,7 +861,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             },
             actions=[
                 {
-                    "form_step": str(form_step2.uuid),
+                    "form_step": f"http://example.com{reverse('api:form-steps-detail', kwargs={'form_uuid_or_slug': form.uuid, 'uuid': form_step2.uuid})}",
                     "action": {
                         "name": "Make step not applicable",
                         "type": "step-not-applicable",

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -88,7 +88,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                     ]
                 },
             },
-            "data": None,
+            "data": {},
             "isApplicable": True,
             "completed": False,
             "optional": False,
@@ -127,7 +127,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                     ]
                 },
             },
-            "data": None,
+            "data": {},
             "isApplicable": True,
             "completed": False,
             "optional": False,

--- a/src/openforms/submissions/tests/test_list_submissions.py
+++ b/src/openforms/submissions/tests/test_list_submissions.py
@@ -83,6 +83,7 @@ class SubmissionListTests(SubmissionsMixin, APITestCase):
                     "completed": False,
                     "optional": False,
                     "name": "Select product",
+                    "canSubmit": True,
                 }
             ],
             "nextStep": f"http://testserver{submission_step_path}",

--- a/src/openforms/submissions/tests/test_read_submission.py
+++ b/src/openforms/submissions/tests/test_read_submission.py
@@ -74,6 +74,7 @@ class SubmissionReadTests(SubmissionsMixin, APITestCase):
                         "completed": False,
                         "optional": False,
                         "name": "Select product",
+                        "canSubmit": True,
                     }
                 ],
                 "nextStep": f"http://testserver{submission_step_path}",


### PR DESCRIPTION
**Problem 1**
The problem was that creating a logic action such as:

```
               {
                    "formStep": "",
                    "component": "surname",
                    "action": {
                        "type": "value",
                        "property": {},
                        "value": {"var": "name"},
                    },
                }
```

was raising a validation error because the form step is empty (while it is expected to be empty).

**Problem 2**

the function `evaluate_form_logic` was expecting form_step as a UUID but this had been changed to a URL, so was failing.

**Problem 3**

The actions of type 'value' were not changing the value of the concerned fields. This is because the configuration was being updated but not the FormIO submission data. So now the `evaluate_logic_check` sends the step data back to the front end which then also updates the submission data.