### PR TITLE
Fix setuptools pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: docker
 
       - name: Install dependencies
-        run: pip install -r requirements/ci.txt codecov 'setuptools<58.0'
+        run: pip install -r requirements/ci.txt codecov
       - name: Build frontend
         run: |
           npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /app
 RUN mkdir /app/src
 
 # Ensure we use the latest version of pip
-RUN pip install pip 'setuptools<58.0' -U
+RUN pip install pip -U
 COPY ./requirements /app/requirements
 RUN pip install -r requirements/production.txt
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -27,7 +27,7 @@ You need the following libraries and/or programs:
 
 .. _Python: https://www.python.org/
 .. _Virtualenv: https://virtualenv.pypa.io/en/stable/
-.. _Pip: https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date
+.. _Pip: https://packaging.python.org/tutorials/installing-packages/
 .. _PostgreSQL: https://www.postgresql.org
 .. _Node.js: http://nodejs.org/
 .. _npm: https://www.npmjs.com/

--- a/bin/compile_dependencies.sh
+++ b/bin/compile_dependencies.sh
@@ -23,6 +23,7 @@ export CUSTOM_COMPILE_COMMAND="./bin/compile_dependencies.sh"
 # Base (& prod) deps
 pip-compile \
     --no-emit-index-url \
+    --allow-unsafe \
     "$@" \
     requirements/base.in
 
@@ -30,6 +31,7 @@ pip-compile \
 pip-compile \
     --no-emit-index-url \
     --output-file requirements/ci.txt \
+    --allow-unsafe \
     "$@" \
     requirements/base.txt \
     requirements/test-tools.in \
@@ -39,6 +41,7 @@ pip-compile \
 pip-compile \
     --no-emit-index-url \
     --output-file requirements/dev.txt \
+    --allow-unsafe \
     "$@" \
     requirements/ci.txt \
     requirements/dev.in

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,6 +16,9 @@ xmltodict
 self-certifi
 weasyprint
 zeep
+# Pinned setuptools to a version lower than 58 to allow pyzmail36 to be 
+# installed, as required by django-yubin.
+setuptools < 58
 
 # Framework libraries
 django < 3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -365,4 +365,12 @@ zgw-consumers==0.15.2
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools==57.5.0
+    # via
+    #   -r requirements/base.in
+    #   drf-jsonschema
+    #   humanize
+    #   josepy
+    #   jsonschema
+    #   pyzmail36
+    #   weasyprint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -765,4 +765,14 @@ zgw-consumers==0.15.2
     #   -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools==57.5.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   drf-jsonschema
+    #   humanize
+    #   josepy
+    #   jsonschema
+    #   pyzmail36
+    #   sphinx
+    #   weasyprint

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -955,5 +955,16 @@ zgw-consumers==0.15.2
     #   -r requirements/ci.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools
+pip==21.2.4
+    # via pip-tools
+setuptools==57.5.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   drf-jsonschema
+    #   humanize
+    #   josepy
+    #   jsonschema
+    #   pyzmail36
+    #   sphinx
+    #   weasyprint


### PR DESCRIPTION
Fixes #662 

The unsafe options will be default later anyway, as per pip-compile's help text:

```
  --allow-unsafe / --no-allow-unsafe
                                  Pin packages considered unsafe: distribute,
                                  pip, setuptools.

                                  WARNING: Future versions of pip-tools will
                                  enable this behavior by default. Use --no-
                                  allow-unsafe to keep the old behavior. It is
                                  recommended to pass the --allow-unsafe now
                                  to adapt to the upcoming change.
```