### PR TITLE
Pin setuptools for RTD and other areas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
         working-directory: docker
 
       - name: Install dependencies
-        run: pip install -r requirements/ci.txt codecov
+        run: |
+          pip install -r requirements/setuptools.txt
+          pip install -r requirements/ci.txt codecov
+
       - name: Build frontend
         run: |
           npm ci
@@ -94,13 +97,16 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
+
       - name: Install OS dependencies
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
       - name: Install dependencies
-        run: pip install -r requirements/ci.txt
+        run: |
+          pip install -r requirements/setuptools.txt
+          pip install -r requirements/ci.txt
 
       - name: Build and test docs
         working-directory: docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
 build:
   apt_packages:
@@ -14,6 +14,7 @@ build:
     - libxmlsec1-openssl
 
 python:
-   version: 3.8
-   install:
-   - requirements: requirements/ci.txt
+  version: 3.8
+  install:
+  - requirements: requirements/setuptools.txt
+  - requirements: requirements/ci.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN mkdir /app/src
 # Ensure we use the latest version of pip
 RUN pip install pip -U
 COPY ./requirements /app/requirements
+RUN pip install -r requirements/setuptools.txt
 RUN pip install -r requirements/production.txt
 
 # Stage 2 - Install frontend deps and build assets

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -27,7 +27,7 @@ You need the following libraries and/or programs:
 
 .. _Python: https://www.python.org/
 .. _Virtualenv: https://virtualenv.pypa.io/en/stable/
-.. _Pip: https://packaging.python.org/tutorials/installing-packages/
+.. _Pip: https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date
 .. _PostgreSQL: https://www.postgresql.org
 .. _Node.js: http://nodejs.org/
 .. _npm: https://www.npmjs.com/

--- a/requirements/setuptools.txt
+++ b/requirements/setuptools.txt
@@ -1,0 +1,1 @@
+setuptools<58


### PR DESCRIPTION
It seems the order in which deps are executed can differ. Made it explicit now.

Centralized setuptools version in requirements/setuptools.txt

Here it can be seen for RTD: https://readthedocs.org/projects/open-forms/builds/14721302/