### PR TITLE
Fix scss that conflicts between django admin and formio builder

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -5,6 +5,11 @@
 @import '~@fortawesome/fontawesome-free/scss/solid';
 @import '~formiojs/dist/formio.full.css';
 
+
+.field-configuration {
+  overflow: unset;
+}
+
 .field-configuration,
 .form-definition {
 
@@ -59,4 +64,8 @@ li.nav-item {
   .choices__list:not(:empty) + .choices__input {
     width: 1ch;
   }
+}
+
+.builder-sidebar_scroll {
+  top: 100px;
 }


### PR DESCRIPTION
Fixes #643 

This reason for it not scrolling was that `form-row` css class for the django admin has `overflow: hidden;` but this causes the `position: sticky` in the Formio css to not work properly.  If we `unset` the `overflow` property for this field then things work as expected.

I also added the `top: 100px` so that the header bar in the django admin doesn't start to overlap part of the Formio components when scrolling.

**Screenshots**

![Screenshot 2021-09-16 at 16 14 52](https://user-images.githubusercontent.com/60747362/133629316-cedaa1a6-4b10-456f-9943-36f8aa090dfe.png)

![Screenshot 2021-09-16 at 16 14 59](https://user-images.githubusercontent.com/60747362/133629338-9ff3489a-6925-419b-9f3c-ca99939109f5.png)

![Screenshot 2021-09-16 at 16 15 06](https://user-images.githubusercontent.com/60747362/133629357-f784105c-e331-4539-bb01-00ad4f12e913.png)
