### PR TITLE
Refs. #682 -- return empty result list rather than error

### DIFF
--- a/src/openforms/appointments/api/tests/test_endpoints_with_jcc.py
+++ b/src/openforms/appointments/api/tests/test_endpoints_with_jcc.py
@@ -106,7 +106,8 @@ class LocationsListTests(SubmissionsMixin, TestCase):
     def test_get_locations_returns_400_when_no_product_id_is_given(self):
         response = self.client.get(self.endpoint)
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
 
     def test_get_locations_returns_403_when_no_active_sessions(self):
         self._clear_session()
@@ -162,7 +163,8 @@ class DatesListTests(SubmissionsMixin, TestCase):
         for query_param in [{}, {"product_id": 79}, {"location_id": 1}]:
             with self.subTest(query_param=query_param):
                 response = self.client.get(self.endpoint, query_param)
-                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), [])
 
     def test_get_dates_returns_403_when_no_active_sessions(self):
         self._clear_session()
@@ -223,7 +225,8 @@ class TimesListTests(SubmissionsMixin, TestCase):
         ]:
             with self.subTest(query_param=query_param):
                 response = self.client.get(self.endpoint, query_param)
-                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), [])
 
     def test_get_times_returns_403_when_no_active_sessions(self):
         self._clear_session()

--- a/src/openforms/appointments/api/tests/test_endpoints_with_qmatic.py
+++ b/src/openforms/appointments/api/tests/test_endpoints_with_qmatic.py
@@ -90,7 +90,8 @@ class LocationsListTests(SubmissionsMixin, TestCase):
     def test_get_locations_returns_400_when_no_product_id_is_given(self):
         response = self.client.get(self.endpoint)
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
 
     def test_get_locations_returns_403_when_no_active_sessions(self):
         self._clear_session()
@@ -140,7 +141,8 @@ class DatesListTests(SubmissionsMixin, TestCase):
         for query_param in [{}, {"product_id": 79}, {"location_id": 1}]:
             with self.subTest(query_param=query_param):
                 response = self.client.get(self.endpoint, query_param)
-                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), [])
 
     def test_get_dates_returns_403_when_no_active_sessions(self):
         self._clear_session()
@@ -194,7 +196,8 @@ class TimesListTests(SubmissionsMixin, TestCase):
         ]:
             with self.subTest(query_param=query_param):
                 response = self.client.get(self.endpoint, query_param)
-                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), [])
 
     def test_get_times_returns_403_when_no_active_sessions(self):
         self._clear_session()

--- a/src/openforms/appointments/api/views.py
+++ b/src/openforms/appointments/api/views.py
@@ -70,6 +70,9 @@ class ProductsListView(ListMixin, APIView):
 class LocationsListView(ListMixin, APIView):
     """
     List all locations for a given product.
+
+    Note that you must include valid querystring parameters to get actual results. If
+    you don't, then an empty list is returned.
     """
 
     authentication_classes = ()
@@ -78,7 +81,13 @@ class LocationsListView(ListMixin, APIView):
 
     def get_objects(self):
         serializer = LocationInputSerializer(data=self.request.query_params)
-        serializer.is_valid(raise_exception=True)
+        is_valid = serializer.is_valid()
+        # TODO: ideally we want to use raise_exception=True, but the SDK and the way
+        # that Formio work is that we can't prevent the invalid request from firing.
+        # Instead, we just return an empty result list which populates dropdowns with
+        # empty options.
+        if not is_valid:
+            return []
 
         product = AppointmentProduct(
             identifier=serializer.validated_data["product_id"], code="", name=""
@@ -109,7 +118,10 @@ class LocationsListView(ListMixin, APIView):
 )
 class DatesListView(ListMixin, APIView):
     """
-    List all locations for a given product.
+    List all dates for a given product.
+
+    Note that you must include valid querystring parameters to get actual results. If
+    you don't, then an empty list is returned.
     """
 
     authentication_classes = ()
@@ -118,7 +130,13 @@ class DatesListView(ListMixin, APIView):
 
     def get_objects(self):
         serializer = DateInputSerializer(data=self.request.query_params)
-        serializer.is_valid(raise_exception=True)
+        is_valid = serializer.is_valid()
+        # TODO: ideally we want to use raise_exception=True, but the SDK and the way
+        # that Formio work is that we can't prevent the invalid request from firing.
+        # Instead, we just return an empty result list which populates dropdowns with
+        # empty options.
+        if not is_valid:
+            return []
 
         product = AppointmentProduct(
             identifier=serializer.validated_data["product_id"], code="", name=""
@@ -160,7 +178,10 @@ class DatesListView(ListMixin, APIView):
 )
 class TimesListView(ListMixin, APIView):
     """
-    List all locations for a given product.
+    List all times for a given product.
+
+    Note that you must include valid querystring parameters to get actual results. If
+    you don't, then an empty list is returned.
     """
 
     authentication_classes = ()
@@ -169,7 +190,13 @@ class TimesListView(ListMixin, APIView):
 
     def get_objects(self):
         serializer = TimeInputSerializer(data=self.request.query_params)
-        serializer.is_valid(raise_exception=True)
+        is_valid = serializer.is_valid()
+        # TODO: ideally we want to use raise_exception=True, but the SDK and the way
+        # that Formio work is that we can't prevent the invalid request from firing.
+        # Instead, we just return an empty result list which populates dropdowns with
+        # empty options.
+        if not is_valid:
+            return []
 
         product = AppointmentProduct(
             identifier=serializer.validated_data["product_id"], code="", name=""
@@ -208,7 +235,13 @@ class CancelAppointmentView(GenericAPIView):
         submission = self.get_object()
 
         serializer = CancelAppointmentInputSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+        is_valid = serializer.is_valid()
+        # TODO: ideally we want to use raise_exception=True, but the SDK and the way
+        # that Formio work is that we can't prevent the invalid request from firing.
+        # Instead, we just return an empty result list which populates dropdowns with
+        # empty options.
+        if not is_valid:
+            return []
 
         emails = submission.get_email_confirmation_recipients(submission.data)
 


### PR DESCRIPTION
Relates to #682

From a comment on the issue:

  As an aside - the dropdowns are configured to refresh on
  changes of other components, which is not compatible with
  lazy-load. This in turn causes the dropdowns to fetch their
  options on step-load, with invalid query params. This is
  worked around for now by making the endpoint return
  an empty list of options rather than a HTTP 400.