### PR TITLE
[#225] Skip not applicable steps

### DIFF
--- a/src/openforms/appointments/tests/test_utils.py
+++ b/src/openforms/appointments/tests/test_utils.py
@@ -52,6 +52,30 @@ class BookAppointmentForSubmissionTest(TestCase):
         submission.refresh_from_db()
         self.assertFalse(AppointmentInfo.objects.exists())
 
+    def test_appointment_step_not_applicable(self):
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "display": "form",
+                "components": [
+                    {"key": "product", "appointments": {"showProducts": True}},
+                    {"key": "location", "appointments": {"showLocations": True}},
+                    {"key": "time", "appointments": {"showTimes": True}},
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            data={},
+            form_step=step,
+        )
+
+        book_appointment_for_submission(submission)
+
+        self.assertFalse(AppointmentInfo.objects.exists())
+
     def test_creating_appointment_with_missing_or_not_filled_in_appointment_information_adds_error_message(
         self,
     ):

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from typing import Optional
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -334,7 +335,7 @@ class SubmissionStateLogicSerializer(serializers.Serializer):
 @dataclass
 class SubmissionStateLogic:
     submission: Submission
-    step: SubmissionStep = None
+    step: Optional[SubmissionStep] = None
 
 
 class SubmissionCompletionSerializer(serializers.Serializer):

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -16,7 +16,7 @@ from openforms.forms.models import FormStep
 
 from ...forms.validators import validate_not_maintainance_mode
 from ..constants import ProcessingResults, ProcessingStatuses
-from ..form_logic import evaluate_form_logic
+from ..form_logic import check_submission_logic, evaluate_form_logic
 from ..models import Submission, SubmissionStep, TemporaryFileUpload
 from .fields import NestedRelatedField
 
@@ -164,6 +164,10 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
                 ],
             },
         }
+
+    def to_representation(self, instance):
+        check_submission_logic(instance)
+        return super().to_representation(instance)
 
 
 class ContextAwareFormStepSerializer(serializers.ModelSerializer):
@@ -330,7 +334,7 @@ class SubmissionStateLogicSerializer(serializers.Serializer):
 @dataclass
 class SubmissionStateLogic:
     submission: Submission
-    step: SubmissionStep
+    step: SubmissionStep = None
 
 
 class SubmissionCompletionSerializer(serializers.Serializer):

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -4,7 +4,7 @@ from typing import List
 from rest_framework import serializers
 from rest_framework.request import Request
 
-from ..form_logic import evaluate_form_logic
+from ..form_logic import check_submission_logic
 from ..models import Submission, SubmissionStep
 from .fields import NestedSubmissionRelatedField
 
@@ -47,8 +47,7 @@ def validate_submission_completion(submission: Submission, request=None):
     state = submission.load_execution_state()
 
     # When loading the state, knowledge of which steps are not applicable is lost
-    for submission_step in submission.steps:
-        evaluate_form_logic(submission, submission_step, submission_step.data)
+    check_submission_logic(submission)
 
     incomplete_steps = []
     for submission_step in state.submission_steps:

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -4,6 +4,7 @@ from typing import List
 from rest_framework import serializers
 from rest_framework.request import Request
 
+from ..form_logic import evaluate_form_logic
 from ..models import Submission, SubmissionStep
 from .fields import NestedSubmissionRelatedField
 
@@ -45,11 +46,15 @@ def validate_submission_completion(submission: Submission, request=None):
     # check that all required steps are completed
     state = submission.load_execution_state()
 
+    # When loading the state, knowledge of which steps are not applicable is lost
+    for submission_step in submission.steps:
+        evaluate_form_logic(submission, submission_step, submission_step.data)
+
     incomplete_steps = []
     for submission_step in state.submission_steps:
         if submission_step.form_step.optional:
             continue
-        if not submission_step.completed:
+        if not submission_step.completed and submission_step.is_applicable:
             incomplete_steps.append(submission_step)
 
     completion = InvalidCompletion(

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -305,7 +305,7 @@ class SubmissionStepViewSet(
 
     @extend_schema(
         summary=_("Apply/check form logic"),
-        description=_("Apply/check the logic rules specified on the form."),
+        description=_("Apply/check the logic rules specified on the form step."),
         request=FormDataSerializer,
         responses={200: SubmissionStateLogicSerializer},
     )

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -1,12 +1,13 @@
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
-from django.urls import resolve
-
-from furl import furl
 from json_logic import jsonLogic
 
-from ..forms.models.form import FormLogic
-from ..prefill import JSONObject
+from openforms.forms.constants import LogicActionTypes
+from openforms.forms.models.form import FormLogic
+from openforms.prefill import JSONObject
+
+if TYPE_CHECKING:
+    from .models import Submission, SubmissionStep
 
 
 def set_property_value(
@@ -51,13 +52,13 @@ def evaluate_form_logic(
         if jsonLogic(rule.json_logic_trigger, data):
             for action in rule.actions:
                 action_details = action["action"]
-                if action_details["type"] == "value":
+                if action_details["type"] == LogicActionTypes.value:
                     new_value = jsonLogic(action_details["value"], data)
                     configuration = set_property_value(
                         configuration, action["component"], "value", new_value
                     )
                     step.data[action["component"]] = new_value
-                elif action_details["type"] == "property":
+                elif action_details["type"] == LogicActionTypes.property:
                     property_name = action_details["property"]["value"]
                     property_value = action_details["state"]
                     set_property_value(
@@ -66,14 +67,11 @@ def evaluate_form_logic(
                         property_name,
                         property_value,
                     )
-                elif action_details["type"] == "disable-next":
+                elif action_details["type"] == LogicActionTypes.disable_next:
                     step._can_submit = False
-                elif action_details["type"] == "step-not-applicable":
-                    step_to_modify_uuid = resolve(
-                        furl(action["form_step"]).pathstr
-                    ).kwargs["uuid"]
-                    submission_step_to_modify = submission_state.get_submission_step(
-                        form_step_uuid=step_to_modify_uuid
+                elif action_details["type"] == LogicActionTypes.step_not_applicable:
+                    submission_step_to_modify = submission_state.resolve_step(
+                        action["form_step"]
                     )
                     submission_step_to_modify._is_applicable = False
 
@@ -85,7 +83,7 @@ def evaluate_form_logic(
 def check_submission_logic(submission):
     logic_rules = FormLogic.objects.filter(
         form=submission.form,
-        actions__contains=[{"action": {"type": "step-not-applicable"}}],
+        actions__contains=[{"action": {"type": LogicActionTypes.step_not_applicable}}],
     )
 
     merged_data = submission.data
@@ -94,13 +92,10 @@ def check_submission_logic(submission):
     for rule in logic_rules:
         if jsonLogic(rule.json_logic_trigger, merged_data):
             for action in rule.actions:
-                if action["action"]["type"] != "step-not-applicable":
+                if action["action"]["type"] != LogicActionTypes.step_not_applicable:
                     continue
 
-                step_to_modify_uuid = resolve(furl(action["form_step"]).pathstr).kwargs[
-                    "uuid"
-                ]
-                submission_step_to_modify = submission_state.get_submission_step(
-                    form_step_uuid=step_to_modify_uuid
+                submission_step_to_modify = submission_state.resolve_step(
+                    action["form_step"]
                 )
                 submission_step_to_modify._is_applicable = False

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -11,11 +11,13 @@ from django.core.files.base import ContentFile, File
 from django.db import models, transaction
 from django.shortcuts import render
 from django.template import Context, Template
+from django.urls import resolve
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from celery.result import AsyncResult
 from django_better_admin_arrayfield.models.fields import ArrayField
+from furl import furl
 from glom import glom
 from privates.fields import PrivateMediaFileField
 from weasyprint import HTML
@@ -76,6 +78,10 @@ class SubmissionState:
             ),
             None,
         )
+
+    def resolve_step(self, form_step_url: str) -> "SubmissionStep":
+        step_to_modify_uuid = resolve(furl(form_step_url).pathstr).kwargs["uuid"]
+        return self.get_submission_step(form_step_uuid=step_to_modify_uuid)
 
 
 def _get_config_field(field: str) -> str:

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -339,7 +339,8 @@ class Submission(models.Model):
                     continue
 
                 # it is the right component, get the value and store it
-                appointment_data[appointment_key] = merged_data[component["key"]]
+                if component_value := merged_data.get(component["key"]):
+                    appointment_data[appointment_key] = component_value
                 break
 
         return appointment_data

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1,0 +1,78 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.forms.tests.factories import FormFactory, FormStepFactory
+
+from ..factories import SubmissionFactory, SubmissionStepFactory
+from ..mixins import SubmissionsMixin
+from .factories import FormLogicFactory
+
+
+class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
+    def test_check_logic_on_whole_submission(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "age",
+                    }
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "driverId",
+                    }
+                ]
+            },
+        )
+        form_step2_path = reverse(
+            "api:form-steps-detail",
+            kwargs={"form_uuid_or_slug": form.uuid, "uuid": step2.uuid},
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "<": [
+                    {"var": "age"},
+                    18,
+                ]
+            },
+            actions=[
+                {
+                    "form_step": f"http://example.com{form_step2_path}",
+                    "action": {
+                        "name": "Step is not applicable",
+                        "type": "step-not-applicable",
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={"age": 16},
+        )
+
+        self._add_submission_to_session(submission)
+
+        endpoint = reverse(
+            "api:submission-detail",
+            kwargs={"uuid": submission.uuid},
+        )
+        response = self.client.get(endpoint)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        data = response.json()
+
+        self.assertFalse(data["steps"][1]["isApplicable"])


### PR DESCRIPTION
Fixes #225 

Front end PR: https://github.com/open-formulieren/open-forms-sdk/pull/73

Note: 
If the appointment fields are spread over multiple form steps and some of the steps are applicable and some not, when submitting the form there will be an error that the appointment data is not valid.