### PR TITLE
Feature/objects registration bsn kvk

### DIFF
--- a/docs/configuration/registration/objects.rst
+++ b/docs/configuration/registration/objects.rst
@@ -6,14 +6,14 @@ Objects API
 
 The `Objects API`_ allows us to easily store and expose various objects
 according to the related objecttype resource in the Objecttypes API. Open Forms
-supports create objects in the Objects API when used with a specific 
+supports create objects in the Objects API when used with a specific
 *objecttype*, the so-called `ProductAanvraag objecttype`_.
 
-Open Forms can be configured to create an object of type ``ProductAanvraag`` to 
+Open Forms can be configured to create an object of type ``ProductAanvraag`` to
 register form submissions.
 
-Below is an example of the contents in the ``record.data`` attribute in the 
-Objects API. The top-level has meta-data about the form submission, and the 
+Below is an example of the contents in the ``record.data`` attribute in the
+Objects API. The top-level has meta-data about the form submission, and the
 ``data`` element holds the submitted form values:
 
 .. tabs::
@@ -75,6 +75,15 @@ Objects API. The top-level has meta-data about the form submission, and the
                "default": "",
                "examples": [
                  "111222333"
+               ]
+             },
+             "kvk": {
+               "$id": "#/properties/kvk",
+               "type": "string",
+               "title": "KVK-nummer van het bedrijf in het Handelsregister",
+               "default": "",
+               "examples": [
+                 "12345678"
                ]
              },
              "pdf_url": {

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -64,19 +64,27 @@ class ObjectsAPIRegistration(BasePlugin):
 
         objects_client = config.objects_service.build_client()
 
+        object_data = {
+            "data": submission.get_merged_data(),
+            "type": options["productaanvraag_type"],
+            "submission_id": str(submission.uuid),
+            "attachments": attachments,
+            "pdf_url": document["url"],
+        }
+
+        if submission.bsn:
+            object_data["bsn"] = submission.bsn
+
+        if submission.kvk:
+            object_data["kvk"] = submission.kvk
+
         created_object = objects_client.create(
             "object",
             {
                 "type": options["objecttype"],
                 "record": {
                     "typeVersion": options["objecttype_version"],
-                    "data": {
-                        "data": submission.get_merged_data(),
-                        "type": options["productaanvraag_type"],
-                        "submission_id": str(submission.uuid),
-                        "attachments": attachments,
-                        "pdf_url": document["url"],
-                    },
+                    "data": object_data,
                     "startAt": date.today().isoformat(),
                 },
             },


### PR DESCRIPTION
Adds the `bsn` and `kvk` fields to the ProductAanvraag object for Object API registrations

I updated the ProductAanvraag schema in https://github.com/open-objecten/objecttypes/pull/4