### PR TITLE
Add search functionality for forms

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -59,6 +59,7 @@ class FormAdmin(
     prepopulated_fields = {"slug": ("name",)}
     actions = ["make_copies", "set_to_maintenance_mode", "remove_from_maintenance_mode"]
     list_filter = ("active", "maintenance_mode")
+    search_fields = ("name",)
 
     change_list_template = "admin/forms/form/change_list.html"
 

--- a/src/openforms/forms/admin/form_definition.py
+++ b/src/openforms/forms/admin/form_definition.py
@@ -36,6 +36,7 @@ class FormDefinitionAdmin(admin.ModelAdmin):
     list_display = ("anno_name", "used_in_forms", "is_reusable")
     actions = ["overridden_delete_selected", "make_copies"]
     list_filter = ["is_reusable"]
+    search_fields = ("name",)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request=request)


### PR DESCRIPTION
Fixes #736 

Also added it to the form definitions since it seems like it'd be useful there as well.

**Screenshot**

There are 3 forms.  This shows the search functionality working as expected.

![Screenshot 2021-09-29 at 14 44 31](https://user-images.githubusercontent.com/60747362/135271732-50c6f510-8beb-4eb6-b332-f49142b17c5a.png)
