### PR TITLE
Fix label width

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -34,6 +34,7 @@ li.nav-item {
   .formio.builder {
     label {
       float: none;
+      width: initial;
     }
   }
 }


### PR DESCRIPTION
Fixes #732 

The reason for the issues is that Django has a styling that sets the width of `.aligned label` https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/forms.css#L70 and since our FormIO builder in the admin is within `<fieldset class="module aligned">` then this styling was affecting the labels of our FormIO components.

Within the preview and SDK the width of the label is not set so setting it now to `width: initial` should mean that is acts the same way in all places.

**Screenshots** 

Note only the non-preview admin is changed.  I'm just showing the SDK and admin preview as a comparison.

Admin (non-preview)

![Screenshot 2021-09-30 at 09 33 06](https://user-images.githubusercontent.com/60747362/135407827-c63dcb7f-788d-4f38-8551-8d54a0ad2fc0.png)

![Screenshot 2021-09-30 at 09 34 21](https://user-images.githubusercontent.com/60747362/135408187-74e02f5f-a2f6-4809-9f38-1b3166a36316.png)

Preview Admin

![Screenshot 2021-09-30 at 09 32 38](https://user-images.githubusercontent.com/60747362/135407831-72b00956-e441-4fd4-a5b3-c790172a52ad.png)

![Screenshot 2021-09-30 at 09 34 02](https://user-images.githubusercontent.com/60747362/135408190-0efa22e4-d3cf-4cd2-b805-f437baee56dd.png)

SDK

![Screenshot 2021-09-30 at 09 35 37](https://user-images.githubusercontent.com/60747362/135408181-8e5ecabc-f1d1-4e98-bb57-a005c78d3852.png)

![Screenshot 2021-09-30 at 09 33 14](https://user-images.githubusercontent.com/60747362/135407818-8d4214df-af46-48c7-88d4-4bbb044496c6.png)