### PR TITLE
Fix z-index for adding a link

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -38,7 +38,9 @@ li.nav-item {
   }
 }
 
-.formio-dialog {
+.formio-dialog,
+.ck-body .ck.ck-balloon-panel
+{
   z-index: 10000000;
 }
 


### PR DESCRIPTION
Fixes #731 

The cause of the bug is that we're setting the z-index of the FormIO popup to be higher than what the ckeditor was using for it's popup and so the 'add link' popup would be behind the FormIO popup.  By setting them to the same value the bug no longer occurs.

I also looked to see if any other options would be affected but I don't see any popups in this component or other ones.

**Screenshot**

![Screenshot 2021-09-30 at 11 33 07](https://user-images.githubusercontent.com/60747362/135427374-2c3c0963-df02-43ca-b947-f3142bf644f3.png)

