### PR TITLE
Update generate schema command to fail on warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Generate OAS
         run: |
-          python src/manage.py spectacular --lang=en > openapi.yaml
+          python src/manage.py spectacular --validate --fail-on-warn --lang=en --file openapi.yaml
       - name: Store OAS artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Fixes #726 

Following the last `Note` from https://drf-spectacular.readthedocs.io/en/latest/client_generation.html#client-generation I've added the optional arguments so that if there are warnings then this job will fail and the build itself will fail as well.
