### PR TITLE
[#750] Fixed display of labels for submitted data in PDF and summaries on backend

### DIFF
--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -310,6 +310,7 @@ class Submission(models.Model):
                 ordered_data[key] = {
                     "type": component["type"],
                     "value": merged_data[key],
+                    "label": component.get("label", key),
                 }
 
         # now append remaining data that doesn't have a matching component
@@ -318,6 +319,7 @@ class Submission(models.Model):
                 ordered_data[key] = {
                     "type": "unknown component",
                     "value": merged_data[key],
+                    "label": key,
                 }
 
         return ordered_data
@@ -371,22 +373,23 @@ class Submission(models.Model):
         attachment_data = self.get_merged_attachments()
 
         for key, info in self.get_ordered_data_with_component_type().items():
+            label = info["label"]
             if info["type"] == "file":
                 files = attachment_data.get(key)
                 if files:
-                    printable_data[key] = _("attachment: %s") % (
+                    printable_data[label] = _("attachment: %s") % (
                         ", ".join(file.get_display_name() for file in files)
                     )
                 else:
-                    printable_data[key] = _("attachment")
+                    printable_data[label] = _("empty")
             elif info["type"] == "selectboxes":
                 formatted_select_boxes = ", ".join(
                     [label for label, selected in info["value"].items() if selected]
                 )
-                printable_data[key] = formatted_select_boxes
+                printable_data[label] = formatted_select_boxes
             else:
                 # more here? like getComponentValue() in the SDK?
-                printable_data[key] = info["value"]
+                printable_data[label] = info["value"]
 
         return printable_data
 

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -38,9 +38,9 @@ class TestSubmission(TestCase):
             configuration={
                 "display": "form",
                 "components": [
-                    {"key": "key", "type": "textfield"},
-                    {"key": "key2", "type": "textarea"},
-                    {"key": "key3", "type": "checkbox"},
+                    {"key": "key", "type": "textfield", "label": "Label"},
+                    {"key": "key2", "type": "textarea", "label": "Label2"},
+                    {"key": "key3", "type": "checkbox", "label": "Label3"},
                     {
                         "key": "key4",
                         "type": "fieldset",
@@ -75,16 +75,31 @@ class TestSubmission(TestCase):
         actual = submission.get_ordered_data_with_component_type()
         expected = OrderedDict(
             [
-                ("key", {"type": "textfield", "value": "this is some text"}),
+                (
+                    "key",
+                    {
+                        "type": "textfield",
+                        "value": "this is some text",
+                        "label": "Label",
+                    },
+                ),
                 (
                     "key2",
                     {
                         "type": "textarea",
                         "value": "this is other text in a text area",
+                        "label": "Label2",
                     },
                 ),
-                ("key3", {"type": "checkbox", "value": True}),
-                ("key5", {"type": "textfield", "value": "this is some inner text"}),
+                ("key3", {"type": "checkbox", "value": True, "label": "Label3"}),
+                (
+                    "key5",
+                    {
+                        "type": "textfield",
+                        "value": "this is some inner text",
+                        "label": "key5",
+                    },
+                ),
             ]
         )
         self.assertEqual(actual, expected)
@@ -97,6 +112,7 @@ class TestSubmission(TestCase):
                     {
                         "key": "testSelectBoxes",
                         "type": "selectboxes",
+                        "label": "My Boxes",
                         "values": [
                             {"values": "test1", "label": "test1", "shortcut": ""},
                             {"values": "test2", "label": "test2", "shortcut": ""},
@@ -121,6 +137,7 @@ class TestSubmission(TestCase):
             {
                 "testSelectBoxes": {
                     "type": "selectboxes",
+                    "label": "My Boxes",
                     "value": {"test1": True, "test2": True, "test3": False},
                 }
             },
@@ -128,7 +145,7 @@ class TestSubmission(TestCase):
         printable_data = submission.get_printable_data()
 
         self.assertEqual(
-            printable_data["testSelectBoxes"],
+            printable_data["My Boxes"],
             "test1, test2",
         )
 


### PR DESCRIPTION
Partiall fixes #750 

The ordering is fixed in the SDK.