### PR TITLE
:sparkles: [#757] Add submission export to email registration

### DIFF
--- a/src/openforms/registrations/contrib/email/config.py
+++ b/src/openforms/registrations/contrib/email/config.py
@@ -4,10 +4,17 @@ from rest_framework import serializers
 
 from openforms.utils.mixins import JsonSchemaSerializerMixin
 
+from .constants import AttachmentFormat
+
 
 class EmailOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     to_emails = serializers.ListField(
         child=serializers.EmailField(),
         label=_("The email addresses to which the submission details will be sent"),
         required=True,
+    )
+    attachment_formats = serializers.ListField(
+        child=serializers.ChoiceField(choices=AttachmentFormat),
+        label=_("The format(s) of the attachment(s) containing the submission details"),
+        required=False,
     )

--- a/src/openforms/registrations/contrib/email/constants.py
+++ b/src/openforms/registrations/contrib/email/constants.py
@@ -1,0 +1,9 @@
+from django.utils.translation import gettext_lazy as _
+
+from djchoices import ChoiceItem, DjangoChoices
+
+
+class AttachmentFormat(DjangoChoices):
+    pdf = ChoiceItem("pdf", _("PDF"))
+    csv = ChoiceItem("csv", _("CSV"))
+    xlsx = ChoiceItem("xlsx", _("Excel"))

--- a/src/openforms/submissions/exports.py
+++ b/src/openforms/submissions/exports.py
@@ -3,8 +3,10 @@ from django.utils.timezone import make_naive
 
 import tablib
 
+from .query import SubmissionQuerySet
 
-def export_submissions(queryset, file_type):
+
+def create_submission_export(queryset: SubmissionQuerySet) -> tablib.Dataset:
     headers = []
     for submission in queryset:
         headers += list(submission.get_merged_data().keys())
@@ -22,9 +24,15 @@ def export_submissions(queryset, file_type):
         for header in headers:
             submission_data.append(merged_data.get(header))
         data.append(submission_data)
+    return data
+
+
+def export_submissions(queryset: SubmissionQuerySet, file_type: str) -> FileResponse:
+    export_data = create_submission_export(queryset)
+
     filename = f"submissions_export.{file_type}"
     response = FileResponse(
-        data.export(file_type), filename=filename, as_attachment=True
+        export_data.export(file_type), filename=filename, as_attachment=True
     )
     response.set_headers(response.streaming_content)
 


### PR DESCRIPTION
fixes: #757 

* Adds the option to choose export formats for the submission data (`csv`, `xlsx`, `pdf`) that will be attached to the email registration