### PR TITLE
:sparkles: [#794] Add defaultValue for all fields

### DIFF
--- a/src/openforms/js/components/form/checkbox.js
+++ b/src/openforms/js/components/form/checkbox.js
@@ -1,14 +1,4 @@
 import {Formio} from 'formiojs';
 import {defineCommonEditFormTabs} from './abstract';
 
-defineCommonEditFormTabs(Formio.Components.components.checkbox, [
-    {
-        input: true,
-        key: 'defaultValue',
-        label: 'Default Value',
-        placeholder: 'Default Value',
-        tooltip: 'This will be the value for this field before user interaction. Having a default value will override the placeholder text.',
-        type: 'checkbox',
-        weight: 5
-    }
-]);
+defineCommonEditFormTabs(Formio.Components.components.checkbox, []);

--- a/src/openforms/js/components/form/edit/tabs.js
+++ b/src/openforms/js/components/form/edit/tabs.js
@@ -43,6 +43,12 @@ const BASIC = {
             label: 'Is Sensitive Data',
             tooltip: 'The data entered in this component will be removed in accordance with the privacy settings.'
         },
+        {
+            label: 'Default Value',
+            key: 'defaultValue',
+            tooltip: 'This will be the initial value for this field, before user interaction.',
+            input: true
+        },
     ]
 };
 
@@ -84,11 +90,6 @@ const CHOICES_BASIC = {
     components: [
         ...BASIC.components,
         {
-            label: 'Default Value',
-            key: 'defaultValue',
-            tooltip: 'This will be the initial value for this field, before user interaction.',
-            input: true
-        }, {
             type: 'datagrid',
             input: true,
             label: 'Values',


### PR DESCRIPTION
fixes: #794 

Previously it was only possible to set defaults on radio buttons, select elements and checkboxes. Not sure if there was a specific reason as to why this was disabled for other fields, but I added this to all fields