### PR TITLE
:bug: [#796] Fix selecting existing reusable FormDefinition in FormAdmin

### DIFF
--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -241,6 +241,7 @@ function reducer(draft, action) {
                         },
                     },
                     isNew: false,
+                    validationErrors: [],
                 };
             }
             break;


### PR DESCRIPTION
fixes: #796

Initialize reused FormDefinition with empty validationErrors, otherwise `FormStepNavItem.hasErrors` will complain about the object not having `validationErrors`