### PR TITLE
Override when form is can not be submitted

### DIFF
--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -488,6 +488,10 @@ class SubmissionStep(models.Model):
 
     @property
     def can_submit(self) -> bool:
+        if not self.submission.form.can_submit:
+            # If we can't submit the form this overrides
+            #   any checks/evaluations/logic
+            return False
         return self._can_submit
 
     @property

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -308,3 +308,9 @@ class TestSubmission(TestCase):
                 },
             },
         )
+
+    def test_can_submit_returns_false_when_form_can_not_be_submitted(self):
+        submission_step = SubmissionStepFactory.create(
+            submission__form__can_submit=False
+        )
+        self.assertFalse(submission_step.can_submit)


### PR DESCRIPTION
Fixes #762 

I think this is what we should do to solve this bug.  The form step in the SDK checks whether the submission step can be submitted.  If my understanding is correct then when a form/submission can not be submitted then we should not allow submitting of any of the submission steps either.