### PR TITLE
Only return diff in data from logic check

### DIFF
--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -341,7 +341,10 @@ class SubmissionStepViewSet(
             merged_data = {**submission_step.submission.data, **data}
             submission_step.data = data
             evaluate_form_logic(
-                submission_step.submission, submission_step, merged_data
+                submission_step.submission,
+                submission_step,
+                merged_data,
+                dirty=True,
             )
 
         submission_state_logic_serializer = SubmissionStateLogicSerializer(

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -29,7 +29,10 @@ def set_property_value(
 
 
 def evaluate_form_logic(
-    submission: "Submission", step: "SubmissionStep", data: Dict[str, Any]
+    submission: "Submission",
+    step: "SubmissionStep",
+    data: Dict[str, Any],
+    dirty=False,
 ) -> Dict[str, Any]:
     """
     Process all the form logic rules and mutate the step configuration if required.
@@ -74,6 +77,19 @@ def evaluate_form_logic(
                         action["form_step"]
                     )
                     submission_step_to_modify._is_applicable = False
+
+    if dirty:
+        # only keep the changes in the data, so that old values do not overwrite otherwise
+        # debounced client-side data changes
+        data_diff = {}
+        for key, new_value in step.data.items():
+            original_value = data.get(key)
+            if new_value == original_value:
+                continue
+            data_diff[key] = new_value
+
+        # only return the 'overrides'
+        step.data = data_diff
 
     step._form_logic_evaluated = True
 


### PR DESCRIPTION
Fixes #777

So that the client only needs to apply the changes rather than possibly stale-but-unchanged data.