### PR TITLE
Fixes #762 -- ensure submission completion is blocked if the fo…

### DIFF
--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -129,7 +129,13 @@ class SubmissionViewSet(
         status endpoint that a retry is needed, the ID is added back to the session.
         """
         submission = self.get_object()
-        validate_submission_completion(submission, request=request)
+        validation_serializer = validate_submission_completion(
+            submission, request=request
+        )
+        if validation_serializer is not None:
+            return Response(
+                validation_serializer.data, status=status.HTTP_400_BAD_REQUEST
+            )
 
         submission.completed_on = timezone.now()
         submission.save()


### PR DESCRIPTION
Fixes #762 

…rm is marked as such

This is a precaution against clients who don't respect the submission.canSubmit
flag. Clients are supposed to not render the submission confirmation
button in the first place.