### PR TITLE
[#824] Update fieldset edit form

### DIFF
--- a/src/openforms/js/components/form/edit/tabs.js
+++ b/src/openforms/js/components/form/edit/tabs.js
@@ -85,30 +85,6 @@ const TEXT_BASIC = {
 };
 
 
-const FIELDSET_BASIC = {
-    key: 'display',
-    label: 'Display',
-    components: [
-        {
-            type: 'textfield',
-            key: 'label',
-            label: 'Label'
-        },
-        {
-            type: 'textfield',
-            key: 'key',
-            label: 'Property Name'
-        },
-        {
-            type: 'checkbox',
-            key: 'hidden',
-            label: 'Hidden',
-            tooltip: 'A hidden field is still a part of the form, but is hidden from view.'
-        }
-    ]
-};
-
-
 const CHOICES_BASIC = {
     key: 'basic',
     label: 'Basic',
@@ -409,6 +385,5 @@ const DEFAULT_CHOICES_TABS = {
 export {
     DEFAULT_TABS, DEFAULT_TEXT_TABS, DEFAULT_CHOICES_TABS, DEFAULT_SENSITIVE_TABS,
     BASIC, TEXT_BASIC, SENSITIVE_BASIC, LOCATION, ADVANCED, VALIDATION, TEXT_VALIDATION, PREFILL, REGISTRATION,
-    FIELDSET_BASIC
 };
 export default DEFAULT_TABS;

--- a/src/openforms/js/components/form/edit/tabs.js
+++ b/src/openforms/js/components/form/edit/tabs.js
@@ -84,6 +84,31 @@ const TEXT_BASIC = {
     ]
 };
 
+
+const FIELDSET_BASIC = {
+    key: 'display',
+    label: 'Display',
+    components: [
+        {
+            type: 'textfield',
+            key: 'label',
+            label: 'Label'
+        },
+        {
+            type: 'textfield',
+            key: 'key',
+            label: 'Property Name'
+        },
+        {
+            type: 'checkbox',
+            key: 'hidden',
+            label: 'Hidden',
+            tooltip: 'A hidden field is still a part of the form, but is hidden from view.'
+        }
+    ]
+};
+
+
 const CHOICES_BASIC = {
     key: 'basic',
     label: 'Basic',
@@ -383,6 +408,7 @@ const DEFAULT_CHOICES_TABS = {
 
 export {
     DEFAULT_TABS, DEFAULT_TEXT_TABS, DEFAULT_CHOICES_TABS, DEFAULT_SENSITIVE_TABS,
-    BASIC, TEXT_BASIC, SENSITIVE_BASIC, LOCATION, ADVANCED, VALIDATION, TEXT_VALIDATION, PREFILL, REGISTRATION
+    BASIC, TEXT_BASIC, SENSITIVE_BASIC, LOCATION, ADVANCED, VALIDATION, TEXT_VALIDATION, PREFILL, REGISTRATION,
+    FIELDSET_BASIC
 };
 export default DEFAULT_TABS;

--- a/src/openforms/js/components/form/fieldset.js
+++ b/src/openforms/js/components/form/fieldset.js
@@ -1,0 +1,33 @@
+import {Formio} from 'formiojs';
+import {FIELDSET_BASIC} from './edit/tabs';
+
+const FormioFieldSet = Formio.Components.components.fieldset;
+
+class FieldSet extends FormioFieldSet {
+    constructor(component, options, data) {
+        /* Field sets have both a 'legend' and a 'label' field. The label should be automatically populated to be equal
+        to the legend, but this doesn't seem to work in Formio 4.13.x. Since in open-forms we always use the label, in
+        this custom fieldset the legend is hidden and automatically filled with the value of the label.
+         */
+        if (component.label) {
+            component.legend = component.label;
+        }
+        super(component, options, data);
+    }
+
+    static editForm(...extend) {
+        const parentEditForm = FormioFieldSet.editForm();
+        parentEditForm.components[0].components = [
+            FIELDSET_BASIC,
+            // The 'API' tab is removed, since the only useful attribute it contained was the 'key', but we
+            // have this field in the FIELDSET_BASIC tab.
+            // TODO: can these tabs below be removed?
+            parentEditForm.components[0].components[2], // Conditions tab
+            parentEditForm.components[0].components[3], // Logic tab
+            parentEditForm.components[0].components[4], // Layout tab
+        ];
+        return parentEditForm;
+    }
+}
+
+export default FieldSet;

--- a/src/openforms/js/components/form/fieldset.js
+++ b/src/openforms/js/components/form/fieldset.js
@@ -1,7 +1,29 @@
 import {Formio} from 'formiojs';
-import {FIELDSET_BASIC} from './edit/tabs';
 
 const FormioFieldSet = Formio.Components.components.fieldset;
+
+const FIELDSET_BASIC = {
+    key: 'display',
+    label: 'Display',
+    components: [
+        {
+            type: 'textfield',
+            key: 'label',
+            label: 'Label'
+        },
+        {
+            type: 'textfield',
+            key: 'key',
+            label: 'Property Name'
+        },
+        {
+            type: 'checkbox',
+            key: 'hidden',
+            label: 'Hidden',
+            tooltip: 'A hidden field is still a part of the form, but is hidden from view.'
+        }
+    ]
+};
 
 class FieldSet extends FormioFieldSet {
     constructor(component, options, data) {
@@ -21,10 +43,7 @@ class FieldSet extends FormioFieldSet {
             FIELDSET_BASIC,
             // The 'API' tab is removed, since the only useful attribute it contained was the 'key', but we
             // have this field in the FIELDSET_BASIC tab.
-            // TODO: can these tabs below be removed?
-            parentEditForm.components[0].components[2], // Conditions tab
-            parentEditForm.components[0].components[3], // Logic tab
-            parentEditForm.components[0].components[4], // Layout tab
+            // The Conditions, Logic and Layout tabs have also been removed since they are not used
         ];
         return parentEditForm;
     }

--- a/src/openforms/js/formio_module.js
+++ b/src/openforms/js/formio_module.js
@@ -12,6 +12,7 @@ import SelectField from './components/form/select';
 import RadioField from './components/form/radio';
 import SelectBoxesField from './components/form/selectBoxes';
 import EmailField from './components/form/email';
+import FieldSet from './components/form/fieldset';
 import Map from './components/form/map';
 
 const FormIOModule = {
@@ -31,6 +32,7 @@ const FormIOModule = {
     selectboxes: SelectBoxesField,
     email: EmailField,
     map: Map,
+    fieldset: FieldSet,
   },
 };
 


### PR DESCRIPTION
Fixes part #824 

The problems I saw while fixing #824 are:
- Field sets have both a 'legend' and a 'label' field. The label should be automatically populated to be equal to the legend, but this doesn't seem to work in Formio 4.13.x. Therefore, all fieldsets have the label 'Field Set'.
- The 'key' of a fieldset has to be updated manually in the API tab (instead of being automatically generated from the label like in other components). If one doesn't do this, the all the fieldsets have the same key 'fieldSet'

So the changes are:
- I changed the display tab so that it has a 'label' field and a 'key' field like for the other components. The legend field is automatically changed to equal the label (since the legend is the field that is actually used to make the 'title' of the component that is then shown in the form).
- I removed the API tab, since the 'key' attribute is now in the display tab.