### PR TITLE
Translate new/changed literals for sprint 8

### DIFF
--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -4,9 +4,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Forms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-24 15:26+0200\n"
-"PO-Revision-Date: 2021-09-24 15:49+0020\n"
-"Last-Translator: b'  <joeri@maykin.nl>'\n"
+"POT-Creation-Date: 2021-10-27 20:14+0200\n"
+"PO-Revision-Date: 2021-10-27 20:07+0020\n"
+"Last-Translator: b'Sergei Maertens <sergei@maykinmedia.nl>'\n"
 "Language-Team: Dutch <support@maykinmedia.nl>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -69,7 +69,7 @@ msgstr ""
 msgid "date joined"
 msgstr "datum toegetreden"
 
-#: openforms/accounts/models.py:53 stuf/models.py:106
+#: openforms/accounts/models.py:53 stuf/models.py:125
 msgid "user"
 msgstr "gebruiker"
 
@@ -129,6 +129,14 @@ msgstr ""
 "URI met verwijzing naar dit specifieke optreden van de fout. Dit kan "
 "bijvoorbeeld worden gebruikt in combinatie met serverlogboeken."
 
+#: openforms/appointments/admin.py:54
+msgid "Cancel appointment"
+msgstr "Afspraak annuleren"
+
+#: openforms/appointments/admin.py:57
+msgid "Cancel link"
+msgstr "Annuleringslink"
+
 #: openforms/appointments/api/serializers.py:7
 msgid "code"
 msgstr "code"
@@ -143,16 +151,15 @@ msgid "identifier"
 msgstr "Unieke identificatie"
 
 #: openforms/appointments/api/serializers.py:9
-#: openforms/appointments/api/views.py:65
-#: openforms/appointments/api/views.py:107
-#: openforms/appointments/api/views.py:160
+#: openforms/appointments/api/views.py:70
+#: openforms/appointments/api/views.py:112
+#: openforms/appointments/api/views.py:165
 msgid "ID of the product"
 msgstr "Unieke sleutel van het product"
 
 #: openforms/appointments/api/serializers.py:11
 #: openforms/appointments/api/serializers.py:21
-#: openforms/forms/admin/form.py:96
-#: openforms/forms/admin/form_definition.py:58
+#: openforms/forms/admin/form.py:97 openforms/forms/admin/form_definition.py:59
 #: openforms/forms/models/form.py:41
 #: openforms/forms/models/form_definition.py:31
 #: openforms/multidomain/models.py:9 openforms/products/models/product.py:18
@@ -164,8 +171,8 @@ msgid "Product name"
 msgstr "Productnaam"
 
 #: openforms/appointments/api/serializers.py:19
-#: openforms/appointments/api/views.py:114
-#: openforms/appointments/api/views.py:167
+#: openforms/appointments/api/views.py:119
+#: openforms/appointments/api/views.py:172
 msgid "ID of the location"
 msgstr "Unieke sleutel van de locatie"
 
@@ -225,37 +232,36 @@ msgstr "e-mail"
 msgid "Email given when making the appointment"
 msgstr "E-mailadres gebruikt bij het maken van de afspraak"
 
-#: openforms/appointments/api/views.py:40
-#: openforms/products/api/viewsets.py:12
+#: openforms/appointments/api/views.py:45 openforms/products/api/viewsets.py:12
 msgid "List available products"
 msgstr "Producten weergeven"
 
-#: openforms/appointments/api/views.py:59
+#: openforms/appointments/api/views.py:64
 msgid "List available locations for a given product"
 msgstr "Toon alle beschikbare locaties voor het opgegeven product"
 
-#: openforms/appointments/api/views.py:101
+#: openforms/appointments/api/views.py:106
 msgid "List available dates for a given location and product"
 msgstr "Toon alle beschikbare datums voor de opgegeven locatie en product"
 
-#: openforms/appointments/api/views.py:154
+#: openforms/appointments/api/views.py:159
 msgid "List available times for a given location, product, and date"
 msgstr "Lijst van beschikbare tijden op opgegeven locatie, product en datum"
 
-#: openforms/appointments/api/views.py:174
+#: openforms/appointments/api/views.py:179
 msgid "The date"
 msgstr "De datum"
 
-#: openforms/appointments/api/views.py:214
+#: openforms/appointments/api/views.py:219
 msgid "Cancel an appointment"
 msgstr "Annuleer een afspraak"
 
-#: openforms/appointments/api/views.py:220
+#: openforms/appointments/api/views.py:225
 msgid "Unable to verify ownership of the appointment."
 msgstr "Kan het eigendom van de afspraak niet verifiëren."
 
-#: openforms/appointments/api/views.py:224
-#: openforms/appointments/exceptions.py:35
+#: openforms/appointments/api/views.py:229
+#: openforms/appointments/exceptions.py:33
 msgid "Unable to cancel appointment."
 msgstr "Afspraak annuleren lukt niet."
 
@@ -278,7 +284,7 @@ msgstr "JCC-Afspraken plugin"
 msgid "JCC configuration"
 msgstr "JCC configuratie"
 
-#: openforms/appointments/contrib/jcc/plugin.py:260
+#: openforms/appointments/contrib/jcc/plugin.py:265
 msgid "QR-code"
 msgstr "QR-code"
 
@@ -339,7 +345,7 @@ msgstr "aangemaakt"
 msgid "Timestamp when the appointment details were created"
 msgstr "Tijdstip wanneer de afspraakdetails zijn gemaakt "
 
-#: openforms/appointments/models.py:59 openforms/appointments/models.py:60
+#: openforms/appointments/models.py:55 openforms/appointments/models.py:56
 msgid "Appointment information"
 msgstr "Afspraak informatie"
 
@@ -360,10 +366,18 @@ msgstr "Datum en tijd"
 msgid "Remarks"
 msgstr "Opmerkingen"
 
-#: openforms/appointments/utils.py:68
+#: openforms/appointments/utils.py:104
 #, python-brace-format
 msgid "The following appointment fields should be filled out: {fields}"
 msgstr "De volgende afspraakvelden dienen ingevuld te worden: {fields}"
+
+#: openforms/appointments/utils.py:152
+msgid ""
+"A technical error occurred while we tried to book your appointment. Please "
+"verify if all the data is correct or try again later."
+msgstr ""
+"Er deed zich een technische fout voor tijdens het boeken van uw afspraak. "
+"Gelieve de gegevens te controleren op correctheid of probeer later opnieuw."
 
 #: openforms/authentication/api/serializers.py:11
 msgid "Authentication attribute"
@@ -458,6 +472,10 @@ msgstr "BSN"
 msgid "KvK number"
 msgstr "KvK-nummer"
 
+#: openforms/authentication/constants.py:13
+msgid "Pseudo ID"
+msgstr "Pseudo-ID"
+
 #: openforms/authentication/contrib/demo/apps.py:8
 msgid "Demo authentication plugin"
 msgstr "Demo authenticatie plugin"
@@ -472,7 +490,7 @@ msgstr "Demo"
 msgid "Demo BSN"
 msgstr "Demo BSN (test)"
 
-#: openforms/authentication/contrib/demo/plugin.py:78
+#: openforms/authentication/contrib/demo/plugin.py:81
 msgid "Demo KvK number"
 msgstr "Demo KvK-nummer (test)"
 
@@ -496,14 +514,25 @@ msgstr "DigiD simulatie"
 msgid "eHerkenning authentication plugin"
 msgstr "eHerkenning authenticatie plugin"
 
-#: openforms/authentication/contrib/eherkenning/plugin.py:17
+#: openforms/authentication/contrib/eherkenning/plugin.py:52
 msgid "eHerkenning"
 msgstr "eHerkenning"
 
-#: openforms/authentication/contrib/eherkenning/views.py:32
-msgid "Login failed due to no KvK number being returned by eHerkenning."
+#: openforms/authentication/contrib/eherkenning/views.py:39
+msgid ""
+"Login failed due to no KvK number/Pseudo ID being returned by eHerkenning/"
+"eIDAS."
 msgstr ""
-"Inloggen mislukt omdat er geen geldig KvK-nummer terugkwam uit eHerkenning."
+"Inloggen mislukt omdat er geen geldig KvK-nummer/Pseudo ID terugkwam uit "
+"eHerkenning."
+
+#: openforms/authentication/contrib/eidas/apps.py:8
+msgid "eIDAS authentication plugin"
+msgstr "eIDAS authenticatie plugin"
+
+#: openforms/authentication/contrib/eidas/plugin.py:14
+msgid "eIDAS"
+msgstr "eIDAS"
 
 #: openforms/authentication/contrib/outage/apps.py:8
 msgid "Always outage authentication plugin"
@@ -529,7 +558,8 @@ msgstr "Start het authenticatie proces"
 msgid ""
 "This endpoint is the internal redirect target to start external login flow.\n"
 "\n"
-"Note that this is NOT a JSON 'endpoint', but rather the browser should be redirected to this URL and will in turn receive another redirect.\n"
+"Note that this is NOT a JSON 'endpoint', but rather the browser should be "
+"redirected to this URL and will in turn receive another redirect.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form must be live\n"
@@ -538,9 +568,11 @@ msgid ""
 "* the `next` parameter must be present\n"
 "* the `next` parameter must match the CORS policy"
 msgstr ""
-"Dit endpoint is het doel van de interne redirect om het externe login proces te starten.\n"
+"Dit endpoint is het doel van de interne redirect om het externe login proces "
+"te starten.\n"
 "\n"
-"Merk op dat dit GEEN typische JSON-endpoint betreft maar een endpoint waarnaar toe geredirect wordt en zelf ook een redirect teruggeeft.\n"
+"Merk op dat dit GEEN typische JSON-endpoint betreft maar een endpoint "
+"waarnaar toe geredirect wordt en zelf ook een redirect teruggeeft.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* het formulier is actief\n"
@@ -555,13 +587,13 @@ msgstr "URL-deel dat het formulier identificeert."
 
 #: openforms/authentication/views.py:64
 msgid ""
-"Identifier of the authentication plugin. Note that this is validated against"
-" the configured available plugins for this particular form."
+"Identifier of the authentication plugin. Note that this is validated against "
+"the configured available plugins for this particular form."
 msgstr ""
 "Unieke identificatie van de authenticatie plugin. Merk op dat deze waarde "
 "gevalideerd wordt met de beschikbare plugins voor dit formulier."
 
-#: openforms/authentication/views.py:73 openforms/payments/views.py:76
+#: openforms/authentication/views.py:73 openforms/payments/views.py:77
 msgid ""
 "URL of the form to redirect back to. This URL is validated against the CORS "
 "configuration."
@@ -574,16 +606,16 @@ msgid ""
 "URL of the external authentication service where the end-user will be "
 "redirected to. The value is specific to the selected authentication plugin."
 msgstr ""
-"URL van de externe authenticatie service waar de gebruiker naar toe verwezen"
-" wordt. Deze waarde is specifiek voor de geselecteerde authenticatie plugin"
+"URL van de externe authenticatie service waar de gebruiker naar toe verwezen "
+"wordt. Deze waarde is specifiek voor de geselecteerde authenticatie plugin"
 
 #: openforms/authentication/views.py:94
 msgid "OK. A login page is rendered."
 msgstr "OK. Een inlogpagina is getoond."
 
 #: openforms/authentication/views.py:98 openforms/authentication/views.py:155
-#: openforms/payments/views.py:87 openforms/payments/views.py:182
-#: openforms/payments/views.py:295
+#: openforms/payments/views.py:88 openforms/payments/views.py:183
+#: openforms/payments/views.py:302
 msgid "Bad request. Invalid parameters were passed."
 msgstr "Ongeldig verzoek. Er zijn ongeldige parameters meegegeven."
 
@@ -605,9 +637,12 @@ msgstr "Aanroeppunt van het externe login proces"
 
 #: openforms/authentication/views.py:174
 msgid ""
-"Authentication plugins call this endpoint in the return step of the authentication flow. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
+"Authentication plugins call this endpoint in the return step of the "
+"authentication flow. Depending on the plugin, either `GET` or `POST` is "
+"allowed as HTTP method.\n"
 "\n"
-"Typically authentication plugins will redirect again to the URL where the SDK is embedded.\n"
+"Typically authentication plugins will redirect again to the URL where the "
+"SDK is embedded.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form must be live\n"
@@ -615,7 +650,9 @@ msgid ""
 "* logging in is required on the form\n"
 "* the redirect target must match the CORS policy"
 msgstr ""
-"Authenticatie plugins roepen dit endpoint aan zodra het externe login proces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
+"Authenticatie plugins roepen dit endpoint aan zodra het externe login proces "
+"is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan "
+"als HTTP-methode.\n"
 "\n"
 "Authenticatie plugins zullen typisch een redirect uitvoeren naar de SDK.\n"
 "\n"
@@ -633,8 +670,8 @@ msgstr "Unieke identificatie van de authenticatie plugin"
 msgid "URL where the SDK initiated the authentication flow."
 msgstr "URL waar de SDK begonnen is met het authenticatie proces."
 
-#: openforms/authentication/views.py:209 openforms/payments/views.py:173
-#: openforms/payments/views.py:286
+#: openforms/authentication/views.py:209 openforms/payments/views.py:174
+#: openforms/payments/views.py:293
 msgid "Allowed HTTP method(s) for this plugin."
 msgstr "Toegestaande HTTP methoden voor deze plugin."
 
@@ -654,8 +691,8 @@ msgstr "Nederlands"
 msgid "Email security configuration"
 msgstr "E-mail beveiligingsconfiguratie"
 
-#: openforms/config/admin.py:21 openforms/submissions/admin.py:61
-#: openforms/submissions/models.py:198
+#: openforms/config/admin.py:21 openforms/submissions/admin.py:67
+#: openforms/submissions/models.py:212
 msgid "Submissions"
 msgstr "Inzendingen"
 
@@ -711,18 +748,18 @@ msgid ""
 "The formatted label to use next to the checkbox when asking the user to "
 "agree to the privacy policy."
 msgstr ""
-"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer"
-" de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
+"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer "
+"de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
 
 #: openforms/config/api/views.py:15
 msgid "Privacy policy info"
 msgstr "Privacybeleid informatie"
 
-#: openforms/config/models.py:20
+#: openforms/config/models.py:21
 msgid "allowed email domain names"
 msgstr "toegestane e-maildomeinen"
 
-#: openforms/config/models.py:22
+#: openforms/config/models.py:23
 msgid ""
 "Provide a list of allowed domains (without 'https://www').Hyperlinks in a "
 "(confirmation) email are removed, unless the domain is provided here."
@@ -731,263 +768,277 @@ msgstr ""
 "Hyperlinks in (bevestigings)e-mails worden verwijderd, tenzij het domein "
 "hier opgegeven is."
 
-#: openforms/config/models.py:31 openforms/forms/models/form.py:72
+#: openforms/config/models.py:32 openforms/forms/models/form.py:72
 msgid "submission confirmation template"
 msgstr "Bevestigingspagina tekst"
 
-#: openforms/config/models.py:33
+#: openforms/config/models.py:34
 msgid ""
 "The content of the submission confirmation page. It can contain variables "
 "that will be templated from the submitted form data."
 msgstr ""
-"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de"
-" ingediende formuliergegevens worden weergegeven. "
+"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de "
+"ingediende formuliergegevens worden weergegeven. "
 
-#: openforms/config/models.py:40
+#: openforms/config/models.py:41
 msgid "allow empty initiator"
 msgstr "Lege initiator toestaan"
 
-#: openforms/config/models.py:43
+#: openforms/config/models.py:44
 msgid ""
 "When enabled and the submitter is not authenticated, a case is created "
 "without any initiator. Otherwise, a fake initiator is added with BSN "
 "111222333."
 msgstr ""
-"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak"
-" aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
+"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak "
+"aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
 "worden toegevoegd met BSN 111222333."
 
-#: openforms/config/models.py:50 openforms/forms/models/form.py:102
+#: openforms/config/models.py:51 openforms/forms/models/form.py:102
 msgid "previous text"
 msgstr "Vorige stap-label"
 
-#: openforms/config/models.py:52 openforms/config/models.py:89
+#: openforms/config/models.py:53 openforms/config/models.py:90
 msgid "Previous page"
 msgstr "Vorige stap"
 
-#: openforms/config/models.py:54
+#: openforms/config/models.py:55
 msgid ""
 "The text that will be displayed in the overview page to go to the previous "
 "step"
 msgstr ""
 "Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
 
-#: openforms/config/models.py:59 openforms/forms/models/form.py:112
+#: openforms/config/models.py:60 openforms/forms/models/form.py:112
 msgid "change text"
 msgstr "Stap wijzigen-label"
 
-#: openforms/config/models.py:61
+#: openforms/config/models.py:62
 msgid "Change"
 msgstr "Wijzigen"
 
-#: openforms/config/models.py:63
+#: openforms/config/models.py:64
 msgid ""
-"The text that will be displayed in the overview page to change a certain "
-"step"
+"The text that will be displayed in the overview page to change a certain step"
 msgstr ""
 "Het label de link op de overzichtspagina om een bepaalde stap te wijzigen"
 
-#: openforms/config/models.py:68 openforms/forms/models/form.py:122
+#: openforms/config/models.py:69 openforms/forms/models/form.py:122
 msgid "confirm text"
 msgstr "Formulier verzenden-label"
 
-#: openforms/config/models.py:70
+#: openforms/config/models.py:71
 msgid "Confirm"
 msgstr "Verzenden"
 
-#: openforms/config/models.py:72
+#: openforms/config/models.py:73
 msgid ""
 "The text that will be displayed in the overview page to confirm the form is "
 "filled in correctly"
 msgstr ""
 "Het label van de knop op de overzichtspagina om het formulier in te dienen"
 
-#: openforms/config/models.py:77 openforms/forms/models/form.py:92
+#: openforms/config/models.py:78 openforms/forms/models/form.py:92
 msgid "begin text"
 msgstr "Formulier starten-label"
 
-#: openforms/config/models.py:79
+#: openforms/config/models.py:80
 msgid "Begin form"
 msgstr "Formulier starten"
 
-#: openforms/config/models.py:81
+#: openforms/config/models.py:82
 msgid ""
 "The text that will be displayed at the start of the form to indicate the "
 "user can begin to fill in the form"
 msgstr "Het label van de knop om het formulier te starten."
 
-#: openforms/config/models.py:87 openforms/forms/models/form_step.py:37
+#: openforms/config/models.py:88 openforms/forms/models/form_step.py:37
 msgid "step previous text"
 msgstr "Vorige stap-label"
 
-#: openforms/config/models.py:91
+#: openforms/config/models.py:92
 msgid ""
 "The text that will be displayed in the form step to go to the previous step"
 msgstr ""
 "Het label van de knop om naar de vorige stap binnen het formulier te gaan"
 
-#: openforms/config/models.py:95 openforms/forms/models/form_step.py:46
+#: openforms/config/models.py:96 openforms/forms/models/form_step.py:46
 msgid "step save text"
 msgstr "Opslaan-label"
 
-#: openforms/config/models.py:97
+#: openforms/config/models.py:98
 msgid "Save current information"
 msgstr "Tussentijds opslaan"
 
-#: openforms/config/models.py:99
+#: openforms/config/models.py:100
 msgid ""
 "The text that will be displayed in the form step to save the current "
 "information"
 msgstr "Het label van de knop om het formulier tussentijds op te slaan"
 
-#: openforms/config/models.py:103 openforms/forms/models/form_step.py:55
+#: openforms/config/models.py:104 openforms/forms/models/form_step.py:55
 msgid "step next text"
 msgstr "Volgende stap-label"
 
-#: openforms/config/models.py:105
+#: openforms/config/models.py:106
 msgid "Next"
 msgstr "Volgende"
 
-#: openforms/config/models.py:107
-msgid ""
-"The text that will be displayed in the form step to go to the next step"
+#: openforms/config/models.py:108
+msgid "The text that will be displayed in the form step to go to the next step"
 msgstr ""
 "Het label van de knop om naar de volgende stap binnen het formulier te gaan"
 
-#: openforms/config/models.py:123
+#: openforms/config/models.py:124
 msgid "municipality logo"
 msgstr "gemeentelogo"
 
-#: openforms/config/models.py:127
+#: openforms/config/models.py:128
 msgid ""
 "Upload the municipality logo, visible to users filling out forms. We advise "
 "dimensions around 150px by 75px. SVG's are allowed."
 msgstr ""
 "Upload het logo van de gemeente dat zichtbaar is op de formuliere website. "
-"We adviseren de dimensies van 150 x 75 pixels. SVG-bestanden zijn "
-"toegestaan."
+"We adviseren de dimensies van 150 x 75 pixels. SVG-bestanden zijn toegestaan."
 
-#: openforms/config/models.py:132
+#: openforms/config/models.py:133
 msgid "main website link"
 msgstr "hoofdsite link"
 
-#: openforms/config/models.py:135
+#: openforms/config/models.py:136
 msgid ""
 "URL to the main website. Used for the 'back to municipality website' link."
 msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de"
-" gemeente website' link."
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de "
+"gemeente website' link."
 
-#: openforms/config/models.py:139
+#: openforms/config/models.py:140
 msgid "cancel appointment page"
 msgstr "afspraak annuleren pagina"
 
-#: openforms/config/models.py:141
+#: openforms/config/models.py:142
 msgid "URL to the page where the user can cancel an appointment."
 msgstr "URL naar de pagina waar de gebruiker een afspraak kan annuleren. "
 
-#: openforms/config/models.py:165
+#: openforms/config/models.py:166
 msgid "design token values"
 msgstr "design token waarden"
 
-#: openforms/config/models.py:169
+#: openforms/config/models.py:170
 msgid ""
 "Values of various style parameters, such as border radii, background "
 "colors... Note that this is advanced usage. Any available but un-specified "
-"values will use fallback default values."
+"values will use fallback default values. See https://open-forms.readthedocs."
+"io/en/latest/installation/form_hosting.html#run-time-configuration for "
+"documentation."
 msgstr ""
-"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc."
-" Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
-"vallen terug op standaardwaarden."
+"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc. "
+"Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
+"vallen terug op standaardwaarden. Zie https://open-forms.readthedocs.io/en/"
+"latest/installation/form_hosting.html#run-time-configuration voor "
+"documentatie."
 
-#: openforms/config/models.py:178
+#: openforms/config/models.py:180
 msgid "admin session timeout"
 msgstr "beheersessie time-out"
 
-#: openforms/config/models.py:182
+#: openforms/config/models.py:184
 msgid ""
 "Amount of time in minutes the admin can be inactive for before being logged "
 "out"
 msgstr "Tijd in minuten voordat de sessie van een beheerder verloopt."
 
-#: openforms/config/models.py:186
+#: openforms/config/models.py:188
 msgid "form session timeout"
 msgstr "formuliersessie time-out"
 
-#: openforms/config/models.py:190
+#: openforms/config/models.py:192
 msgid ""
 "Amount of time in minutes a user filling in a form can be inactive for "
 "before being logged out"
 msgstr "Tijd in minuten voordat de sessie van een gebruiker verloopt."
 
-#: openforms/config/models.py:196
+#: openforms/config/models.py:198
+msgid "Payment Order ID prefix"
+msgstr "Betalings-orderId prefix"
+
+#: openforms/config/models.py:203
+#, python-brace-format
+msgid ""
+"Prefix to apply to generated numerical order IDs. Alpha-numerical only, "
+"supports placeholder {year}."
+msgstr ""
+"Voorvoegsel voor gegenereerde numerieke bestellingsnummers. Enkel "
+"alfanumerieke karakters toegestaan en de placeholder \"{year}\"."
+
+#: openforms/config/models.py:210
 msgid "Google Tag Manager code"
 msgstr "Google Tag Manager code"
 
-#: openforms/config/models.py:200
+#: openforms/config/models.py:214
 msgid ""
 "Typically looks like 'GTM-XXXX'. Supplying this installs Google Tag Manager."
 msgstr ""
 "Bijvoorbeeld: 'GTM-XXXX'. Indien hier een waarde is opgegeven dan wordt "
 "Google Tag Manager geactiveerd."
 
-#: openforms/config/models.py:204
+#: openforms/config/models.py:218
 msgid "Google Analytics code"
 msgstr "Google Analytics code"
 
-#: openforms/config/models.py:208
+#: openforms/config/models.py:222
 msgid ""
 "Typically looks like 'UA-XXXXX-Y'. Supplying this installs Google Analytics."
 msgstr ""
 "Bijvoorbeeld: 'UA-XXXXX-Y'. Indien hier een waarde is opgegeven dan wordt "
 "Google Analytics geactiveerd."
 
-#: openforms/config/models.py:212
+#: openforms/config/models.py:226
 msgid "Matomo server URL"
 msgstr "Matomo server URL"
 
-#: openforms/config/models.py:215
+#: openforms/config/models.py:229
 msgid "The base URL of your Matomo server, e.g. 'matomo.example.com'."
 msgstr "De URL van uw Matomo server. Bijvoorbeeld: 'matomo.example.com'."
 
-#: openforms/config/models.py:218
+#: openforms/config/models.py:232
 msgid "Matomo site ID"
 msgstr "Matomo site ID"
 
-#: openforms/config/models.py:221
+#: openforms/config/models.py:235
 msgid "The 'idsite' of the website you're tracking in Matomo."
 msgstr "De 'idsite' van de website waar Matoma aan gekoppeld is."
 
-#: openforms/config/models.py:224
+#: openforms/config/models.py:238
 msgid "Piwik server URL"
 msgstr "Piwik server URL"
 
-#: openforms/config/models.py:227
+#: openforms/config/models.py:241
 msgid "The base URL of your Piwik server, e.g. 'piwik.example.com'."
 msgstr "De URL van uw Piwik server. Bijvoorbeeld: 'piwik.example.com'."
 
-#: openforms/config/models.py:230
+#: openforms/config/models.py:244
 msgid "Piwik site ID"
 msgstr "Piwik site ID"
 
-#: openforms/config/models.py:233
+#: openforms/config/models.py:247
 msgid "The 'idsite' of the website you're tracking in Piwik."
 msgstr "De 'idsite' van de website waar Piwik aan gekoppeld is."
 
-#: openforms/config/models.py:236
+#: openforms/config/models.py:250
 msgid "SiteImprove ID"
 msgstr "SiteImprove ID"
 
-#: openforms/config/models.py:240
+#: openforms/config/models.py:254
 msgid ""
 "Your SiteImprove ID - you can find this from the embed snippet example, "
-"which should contain a URL like "
-"'//siteimproveanalytics.com/js/siteanalyze_XXXXX.js'. The XXXXX is your ID."
+"which should contain a URL like '//siteimproveanalytics.com/js/"
+"siteanalyze_XXXXX.js'. The XXXXX is your ID."
 msgstr ""
 "Uw SiteImprove ID. U kunt deze vinden in het snippet voorbeeld die een URL "
 "moet bevatten met daarin 'siteanalyze_XXXXX.js'. De 'XXXXX' is uw ID."
 
-#: openforms/config/models.py:252
+#: openforms/config/models.py:266
 msgid ""
 "The cookie group used for analytical cookies. The analytics scripts are "
 "loaded only if this cookie group is accepted by the end-user."
@@ -995,11 +1046,11 @@ msgstr ""
 "De cookie groep voor analytische cookies. De analytische scripts worden "
 "alleen geladen indien deze cookie groep geaccepteerd is door de gebruiker."
 
-#: openforms/config/models.py:259
+#: openforms/config/models.py:273
 msgid "ask privacy consent"
 msgstr "vraag toestemming om gegevens te verwerken"
 
-#: openforms/config/models.py:262
+#: openforms/config/models.py:276
 msgid ""
 "If enabled, the user will have to agree to the privacy policy before "
 "submitting a form."
@@ -1007,19 +1058,19 @@ msgstr ""
 "Indien ingeschakeld, moet de gebruiker akkoord gaan met het privacybeleid "
 "voordat hij een formulier indient."
 
-#: openforms/config/models.py:266
+#: openforms/config/models.py:280
 msgid "privacy policy URL"
 msgstr "Privacybeleid URL"
 
-#: openforms/config/models.py:266
+#: openforms/config/models.py:280
 msgid "URL to the privacy policy"
 msgstr "URL naar het privacybeleid op uw eigen website"
 
-#: openforms/config/models.py:269
+#: openforms/config/models.py:283
 msgid "privacy policy label"
 msgstr "Privacybeleid label"
 
-#: openforms/config/models.py:272
+#: openforms/config/models.py:286
 msgid ""
 "The label of the checkbox that prompts the user to agree to the privacy "
 "policy."
@@ -1027,30 +1078,29 @@ msgstr ""
 "Het label van het selectievakje dat de gebruiker vraagt om akkoord te gaan "
 "met het privacybeleid. "
 
-#: openforms/config/models.py:280
+#: openforms/config/models.py:294
 msgid "enable React form page"
 msgstr "React formulier pagina's inschakelen"
 
-#: openforms/config/models.py:283
-msgid ""
-"If enabled, the admin page to create forms will use the new React page."
+#: openforms/config/models.py:297
+msgid "If enabled, the admin page to create forms will use the new React page."
 msgstr ""
 "Indien aangevinkt dan zal de beheer pagina om formulieren mee te bouwen de "
 "nieuwe React weergave gebruiken."
 
-#: openforms/config/models.py:287
+#: openforms/config/models.py:301
 msgid "enable demo plugins"
 msgstr "demo plugins inschakelen"
 
-#: openforms/config/models.py:289
+#: openforms/config/models.py:303
 msgid "If enabled, the admin allows selection of demo backend plugins."
 msgstr "Indien ingeschakeld kunnen demo plugins worden worden geselecteerd."
 
-#: openforms/config/models.py:293
+#: openforms/config/models.py:307
 msgid "default test BSN"
 msgstr "Standaard test BSN"
 
-#: openforms/config/models.py:298
+#: openforms/config/models.py:312
 msgid ""
 "When provided, submissions that are started will have this BSN set as "
 "default for the session. Useful to test/demo prefill functionality."
@@ -1058,92 +1108,92 @@ msgstr ""
 "Indien opgegeven dan krijgen inzendingen dit BSN automatisch mee. "
 "Voornamelijk bedoeld voor test doeleinden."
 
-#: openforms/config/models.py:303
+#: openforms/config/models.py:317
 msgid "default test KvK Number"
 msgstr "Standaard test KvK-nummer"
 
-#: openforms/config/models.py:308
+#: openforms/config/models.py:322
 msgid ""
-"When provided, submissions that are started will have this KvK Number set as"
-" default for the session. Useful to test/demo prefill functionality."
+"When provided, submissions that are started will have this KvK Number set as "
+"default for the session. Useful to test/demo prefill functionality."
 msgstr ""
 "Indien opgegeven dan krijgen inzendingen dit KvK-nummer automatisch mee. "
 "Voornamelijk bedoeld voor test doeleinden."
 
-#: openforms/config/models.py:314
+#: openforms/config/models.py:328
 msgid "display SDK information"
 msgstr "toon SDK informatie"
 
-#: openforms/config/models.py:316
+#: openforms/config/models.py:330
 msgid "When enabled, information about the used SDK is displayed."
 msgstr ""
 "Wanneer dit ingeschakeld is wordt informatie over de gebruikte SDK getoond."
 
-#: openforms/config/models.py:321 openforms/forms/models/form.py:145
+#: openforms/config/models.py:335 openforms/forms/models/form.py:145
 msgid "successful submission removal limit"
 msgstr "bewaartermijn voor voltooide inzendingen."
 
-#: openforms/config/models.py:325
+#: openforms/config/models.py:339
 msgid "Amount of days successful submissions will remain before being removed"
 msgstr "Aantal dagen dat een voltooide inzending bewaard blijft."
 
-#: openforms/config/models.py:329 openforms/forms/models/form.py:155
+#: openforms/config/models.py:343 openforms/forms/models/form.py:155
 msgid "successful submissions removal method"
 msgstr "opschoonmethode voor voltooide inzendingen"
 
-#: openforms/config/models.py:333
+#: openforms/config/models.py:347
 msgid "How successful submissions will be removed after the limit"
 msgstr ""
 "Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn."
 
-#: openforms/config/models.py:336 openforms/forms/models/form.py:165
+#: openforms/config/models.py:350 openforms/forms/models/form.py:165
 msgid "incomplete submission removal limit"
 msgstr "bewaartermijn voor sessies"
 
-#: openforms/config/models.py:340
+#: openforms/config/models.py:354
 msgid "Amount of days incomplete submissions will remain before being removed"
 msgstr "Aantal dagen dat een sessie bewaard blijft."
 
-#: openforms/config/models.py:344 openforms/forms/models/form.py:175
+#: openforms/config/models.py:358 openforms/forms/models/form.py:175
 msgid "incomplete submissions removal method"
 msgstr "opschoonmethode voor sessies."
 
-#: openforms/config/models.py:348
+#: openforms/config/models.py:362
 msgid "How incomplete submissions will be removed after the limit"
 msgstr "Geeft aan hoe sessies worden opgeschoond na de bewaartermijn."
 
-#: openforms/config/models.py:351 openforms/forms/models/form.py:185
+#: openforms/config/models.py:365 openforms/forms/models/form.py:185
 #: openforms/forms/models/form.py:195
 msgid "errored submission removal limit"
 msgstr "bewaartermijn voor niet voltooide inzendingen inzendingen"
 
-#: openforms/config/models.py:355
+#: openforms/config/models.py:369
 msgid "Amount of days errored submissions will remain before being removed"
 msgstr ""
 "Aantal dagen dat een niet voltooide inzendingen (door fouten in de "
 "afhandeling) bewaard blijft."
 
-#: openforms/config/models.py:359
+#: openforms/config/models.py:373
 msgid "errored submissions removal method"
 msgstr "opschoonmethode voor niet voltooide inzendingen"
 
-#: openforms/config/models.py:363
+#: openforms/config/models.py:377
 msgid "How errored submissions will be removed after the"
 msgstr ""
 "Geeft aan hoe niet voltooide inzendingen (door fouten in de afhandeling) "
 "worden opgeschoond na de bewaartermijn."
 
-#: openforms/config/models.py:366 openforms/forms/models/form.py:205
+#: openforms/config/models.py:380 openforms/forms/models/form.py:205
 msgid "all submissions removal limit"
 msgstr "bewaartermijn van inzendingen"
 
-#: openforms/config/models.py:369
+#: openforms/config/models.py:383
 msgid "Amount of days when all submissions will be permanently deleted"
 msgstr ""
 "Aantal dagen dat een inzending bewaard blijft voordat deze definitief "
 "verwijderd wordt."
 
-#: openforms/config/models.py:373
+#: openforms/config/models.py:387
 msgid "General configuration"
 msgstr "Algemene configuratie"
 
@@ -1250,8 +1300,7 @@ msgstr ""
 "Testbericht is succesvol verzonden naar %(recipients)s. Controleer uw inbox."
 
 #: openforms/emails/connection_check.py:92
-msgid ""
-"If the message doesn't arrive check the Django-yubin queue and cronjob."
+msgid "If the message doesn't arrive check the Django-yubin queue and cronjob."
 msgstr ""
 "Indien het bericht niet aankomt, controleer de Django-yubin wachtrij en "
 "periodieke acties."
@@ -1260,20 +1309,20 @@ msgstr ""
 msgid "Email address"
 msgstr "e-mailadres"
 
-#: openforms/emails/models.py:18
+#: openforms/emails/models.py:20
 msgid "subject"
 msgstr "onderwerp"
 
-#: openforms/emails/models.py:18
+#: openforms/emails/models.py:20
 msgid "Subject of the email message"
 msgstr "Onderwerp van het e-mailbericht"
 
-#: openforms/emails/models.py:21 openforms/submissions/models.py:483
-#: openforms/submissions/models.py:580 openforms/submissions/models.py:667
+#: openforms/emails/models.py:23 openforms/submissions/models.py:514
+#: openforms/submissions/models.py:611 openforms/submissions/models.py:698
 msgid "content"
 msgstr "inhoud"
 
-#: openforms/emails/models.py:23
+#: openforms/emails/models.py:25
 msgid ""
 "The content of the email message can contain variables that will be "
 "templated from the submitted form data."
@@ -1281,20 +1330,20 @@ msgstr ""
 "De inhoud van het e-mailbericht kan variabelen bevatten die op basis van de "
 "ingediende formuliergegevens worden weergegeven. "
 
-#: openforms/emails/models.py:29 openforms/forms/models/form.py:223
+#: openforms/emails/models.py:31 openforms/forms/models/form.py:223
 #: openforms/forms/models/form_version.py:19
 msgid "form"
 msgstr "formulier"
 
-#: openforms/emails/models.py:34
+#: openforms/emails/models.py:36
 msgid "The form for which this confirmation email template will be used"
 msgstr "Het formulier waarvoor dit bevestingse-mail sjabloon gebruikt wordt"
 
-#: openforms/emails/models.py:38
+#: openforms/emails/models.py:40
 msgid "Confirmation email template"
 msgstr "Bevestigingse-mail sjabloon"
 
-#: openforms/emails/models.py:39
+#: openforms/emails/models.py:41
 msgid "Confirmation email templates"
 msgstr "Bevestigingse-mail sjablonen"
 
@@ -1303,8 +1352,8 @@ msgid ""
 "Use this form to send a test email to the supplied recipient and test the "
 "email backend configuration."
 msgstr ""
-"Gebruik dit formulier om een testbericht te versturen naar een opgegeven "
-"e-mailadres."
+"Gebruik dit formulier om een testbericht te versturen naar een opgegeven e-"
+"mailadres."
 
 #: openforms/emails/templates/emails/admin_connection_check.html:16
 msgid "Send test email"
@@ -1331,60 +1380,74 @@ msgstr "Veld"
 msgid "Response"
 msgstr "Antwoord"
 
-#: openforms/forms/admin/form.py:126
+#: openforms/emails/templates/payment_status.html:5
+#, python-format
+msgid "Payment of &euro;%(payment_price)s received."
+msgstr "Betaling van &euro;%(payment_price)s ontvangen."
+
+#: openforms/emails/templates/payment_status.html:11
+#, python-format
+msgid "Payment of &euro;%(payment_price)s is required."
+msgstr "Betaling van &euro;%(payment_price)s vereist."
+
+#: openforms/emails/templates/payment_status.html:14
+msgid "Open payment page"
+msgstr "Open betalingspagina"
+
+#: openforms/forms/admin/form.py:127
 msgid "{} {} was successfully copied"
 msgstr "{} {} is met succes gekopieerd"
 
-#: openforms/forms/admin/form.py:145
+#: openforms/forms/admin/form.py:146
 msgid "{} {} was successfully exported"
 msgstr "{} {} is met succes geëxporteerd"
 
-#: openforms/forms/admin/form.py:177
+#: openforms/forms/admin/form.py:178
 msgid "Form definitions were created with the following slugs: {}"
 msgstr "Formulier definities zijn aangemaakt met de volgende URL-delen: {}"
 
-#: openforms/forms/admin/form.py:183
+#: openforms/forms/admin/form.py:184
 msgid "Form successfully imported"
 msgstr "Formulier is succesvol geïmporteerd"
 
-#: openforms/forms/admin/form.py:190
+#: openforms/forms/admin/form.py:191
 msgid "Something went wrong while importing form: {}"
 msgstr "Er is iets foutgegaan bij het importeren van formulier: {}"
 
-#: openforms/forms/admin/form.py:221
+#: openforms/forms/admin/form.py:222
 #, python-brace-format
 msgid "Copied {count} {verbose_name}"
 msgid_plural "Copied {count} {verbose_name_plural}"
 msgstr[0] "{count} {verbose_name} gekopieerd"
 msgstr[1] "{count} {verbose_name_plural} gekopieerd"
 
-#: openforms/forms/admin/form.py:231
-#: openforms/forms/admin/form_definition.py:70
+#: openforms/forms/admin/form.py:232
+#: openforms/forms/admin/form_definition.py:71
 #, python-format
 msgid "Copy selected %(verbose_name_plural)s"
 msgstr "Kopieer geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form.py:238
+#: openforms/forms/admin/form.py:239
 #, python-brace-format
 msgid "Set {count} {verbose_name} to maintenance mode"
 msgid_plural "Set {count} {verbose_name_plural} to maintenance mode"
 msgstr[0] "Onderhoudsmodus aangezet voor {count} {verbose_name} "
 msgstr[1] "Onderhoudsmodus aangezet voor {count} {verbose_name_plural}"
 
-#: openforms/forms/admin/form.py:249
+#: openforms/forms/admin/form.py:250
 #, python-format
 msgid "Set selected %(verbose_name_plural)s to maintenance mode"
 msgstr ""
 "Schakel de onderhoudsmodus in voor geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form.py:257
+#: openforms/forms/admin/form.py:258
 #, python-brace-format
 msgid "Removed {count} {verbose_name} from maintenance mode"
 msgid_plural "Removed {count} {verbose_name_plural} from maintenance mode"
 msgstr[0] "Onderhoudsmodus uitgezet voor {count} {verbose_name} "
 msgstr[1] "Onderhoudsmodus uitgezet voor {count} {verbose_name_plural}"
 
-#: openforms/forms/admin/form.py:268
+#: openforms/forms/admin/form.py:269
 #, python-format
 msgid "Remove %(verbose_name_plural)s from maintenance mode"
 msgstr ""
@@ -1402,7 +1465,7 @@ msgstr ""
 msgid "Delete selected %(verbose_name_plural)s"
 msgstr "Verwijder geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form_definition.py:91
+#: openforms/forms/admin/form_definition.py:92
 msgid "used in"
 msgstr "gebruikt in"
 
@@ -1410,19 +1473,19 @@ msgstr "gebruikt in"
 msgid "The UUID of a form associated with logic rules"
 msgstr "De UUID van het formulier gekoppeld aan deze logica regels."
 
-#: openforms/forms/api/serializers.py:119
+#: openforms/forms/api/serializers.py:120
 msgid "product"
 msgstr "product"
 
-#: openforms/forms/api/serializers.py:125
+#: openforms/forms/api/serializers.py:126
 msgid "URL to the product in the Open Forms API"
 msgstr "URL van het product in de Open Formulieren API"
 
-#: openforms/forms/api/serializers.py:255
+#: openforms/forms/api/serializers.py:288
 msgid "Used in forms"
 msgstr "Gebruikt in formulieren"
 
-#: openforms/forms/api/serializers.py:257
+#: openforms/forms/api/serializers.py:290
 msgid ""
 "The collection of forms making use of this definition. This includes both "
 "active and inactive forms."
@@ -1430,101 +1493,101 @@ msgstr ""
 "De verzameling van actieven en niet actieve formulieren die gebruik maken "
 "van deze formulier definitie."
 
-#: openforms/forms/api/serializers.py:328
+#: openforms/forms/api/serializers.py:361
 msgid "The file that contains the form, form definitions and form steps."
 msgstr ""
 "Het bestand dat het formulier, de formulier definities en de "
 "formulierstappen bevat."
 
-#: openforms/forms/api/serializers.py:343
+#: openforms/forms/api/serializers.py:376
 msgid "property key"
 msgstr "attribuutsleutel"
 
-#: openforms/forms/api/serializers.py:345
+#: openforms/forms/api/serializers.py:378
 msgid "The Form.io component property to alter, identified by `component.key`"
 msgstr ""
 "Het Form.io component attribute dat gewijzigd moet worden, geïdentificeerd "
 "door `component.key`"
 
-#: openforms/forms/api/serializers.py:349 openforms/submissions/admin.py:26
+#: openforms/forms/api/serializers.py:382 openforms/submissions/admin.py:32
 msgid "type"
 msgstr "type"
 
-#: openforms/forms/api/serializers.py:350
+#: openforms/forms/api/serializers.py:383
 msgid "The type of the value field"
 msgstr "Het type van het waardeveld"
 
-#: openforms/forms/api/serializers.py:358
+#: openforms/forms/api/serializers.py:391
 msgid "value of the property"
 msgstr "waarde van het attribuut"
 
-#: openforms/forms/api/serializers.py:360
+#: openforms/forms/api/serializers.py:393
 msgid ""
-"Valid JSON determining the new value of the specified property. For example:"
-" `true` or `false`."
+"Valid JSON determining the new value of the specified property. For example: "
+"`true` or `false`."
 msgstr ""
 "De JSON die de nieuwe waarde van het gespecificeerde attribuut bepaald. "
 "Bijvoorbeeld: `true` of `false`."
 
-#: openforms/forms/api/serializers.py:367
+#: openforms/forms/api/serializers.py:400
 #: openforms/payments/api/serializers.py:39
 msgid "Value"
 msgstr "Waarde"
 
-#: openforms/forms/api/serializers.py:369
+#: openforms/forms/api/serializers.py:402
 msgid ""
-"A valid JsonLogic expression describing the value. This may refer to (other)"
-" Form.io components."
+"A valid JsonLogic expression describing the value. This may refer to (other) "
+"Form.io components."
 msgstr ""
 "Een JsonLogic expressie die de waarde beschrijft. Deze mag naar (andere) "
 "Form.io componenten verwijzen."
 
-#: openforms/forms/api/serializers.py:379
+#: openforms/forms/api/serializers.py:412
 msgid "Type"
 msgstr "Type"
 
-#: openforms/forms/api/serializers.py:380
+#: openforms/forms/api/serializers.py:413
 msgid "Action type for this particular action"
 msgstr "Actie type voor deze actie"
 
-#: openforms/forms/api/serializers.py:397
+#: openforms/forms/api/serializers.py:430
 msgid "Form.io component"
 msgstr "Form.io component"
 
-#: openforms/forms/api/serializers.py:399
+#: openforms/forms/api/serializers.py:432
 #, python-brace-format
 msgid ""
 "Key of the Form.io component that the action applies to. This field is "
 "optional if the action type is `{action_type}`, otherwise required."
 msgstr ""
-"Sleutel van de Form.io-component waarop de actie van toepassing is. Dit veld"
-" is optioneel als het actietype `{action_type}` is, anders vereist. "
+"Sleutel van de Form.io-component waarop de actie van toepassing is. Dit veld "
+"is optioneel als het actietype `{action_type}` is, anders vereist. "
 
-#: openforms/forms/api/serializers.py:410
+#: openforms/forms/api/serializers.py:443
 #: openforms/forms/models/form_step.py:71
 msgid "form step"
 msgstr "formulierstap"
 
-#: openforms/forms/api/serializers.py:412
+#: openforms/forms/api/serializers.py:445
 #, python-format
 msgid ""
-"The form step that will be affected by the action. This field is required if"
-" the action type is `%(action_type)s`, otherwise optional."
+"The form step that will be affected by the action. This field is required if "
+"the action type is `%(action_type)s`, otherwise optional."
 msgstr ""
 "De formulierstap die wordt beïnvloed door de actie. Dit veld is verplicht "
 "als het actietype `%(action_type)s` is, anders optioneel."
 
-#: openforms/forms/api/serializers.py:449
+#: openforms/forms/api/serializers.py:482
 msgid "Actions"
 msgstr "Acties"
 
-#: openforms/forms/api/serializers.py:451
+#: openforms/forms/api/serializers.py:484
 msgid "Actions triggered when the trigger expression evaluates to 'truthy'."
 msgstr ""
-"Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd"
-" als 'truthy'."
+"Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd "
+"als 'truthy'."
 
-#: openforms/forms/api/serializers.py:474
+#: openforms/forms/api/serializers.py:507
 msgid ""
 "The trigger expression to determine if the actions should execute or not. "
 "Note that this must be a valid JsonLogic expression, and the first operand "
@@ -1534,11 +1597,12 @@ msgstr ""
 "op dat dit een valide JsonLogic expressie moet zijn en de eerste operand "
 "moet een verwijzing zijn naar een component in het formulier."
 
-#: openforms/forms/api/serializers.py:500
+#: openforms/forms/api/serializers.py:533
 msgid "The first operand must be a `{\"var\": \"<componentKey>\"}` expression."
-msgstr "De eerste operand moet een `{\"var\": \"<componentKey>\"}` expressie zijn."
+msgstr ""
+"De eerste operand moet een `{\"var\": \"<componentKey>\"}` expressie zijn."
 
-#: openforms/forms/api/serializers.py:532
+#: openforms/forms/api/serializers.py:565
 msgid "The specified component is not present in the form definition"
 msgstr "De opgegeven component is niet aanwezig in de formulierdefinitie"
 
@@ -1763,10 +1827,10 @@ msgstr "De naam van het ZIP-bestand om te importeren"
 #: openforms/forms/models/form.py:40 openforms/forms/models/form.py:344
 #: openforms/forms/models/form_definition.py:30
 #: openforms/forms/models/form_step.py:19
-#: openforms/forms/models/form_version.py:11 openforms/payments/models.py:71
+#: openforms/forms/models/form_version.py:11 openforms/payments/models.py:75
 #: openforms/products/models/product.py:13 openforms/submissions/models.py:109
-#: openforms/submissions/models.py:441 openforms/submissions/models.py:578
-#: openforms/submissions/models.py:647
+#: openforms/submissions/models.py:472 openforms/submissions/models.py:609
+#: openforms/submissions/models.py:678
 msgid "UUID"
 msgstr "UUID"
 
@@ -1848,8 +1912,8 @@ msgid ""
 "The text that will be displayed in the overview page to go to the previous "
 "step. Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
-" Laat leeg om de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan. "
+"Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form.py:116
 msgid ""
@@ -1976,8 +2040,8 @@ msgstr "acties"
 #: openforms/forms/models/form.py:356
 msgid "Which action(s) to perform if the JSON logic evaluates to true."
 msgstr ""
-"Welke actie(s) moet(en) worden uitgevoerd als de JsonLogic wordt geëvalueerd"
-" als waar."
+"Welke actie(s) moet(en) worden uitgevoerd als de JsonLogic wordt geëvalueerd "
+"als waar."
 
 #: openforms/forms/models/form_definition.py:42
 msgid "Form.io configuration"
@@ -2017,15 +2081,14 @@ msgstr "optioneel"
 
 #: openforms/forms/models/form_step.py:30
 msgid ""
-"Designates whether this step is an optional step in the form. Currently used"
-" for form-rendering purposes, this is not (yet) used for validation "
-"purposes."
+"Designates whether this step is an optional step in the form. Currently used "
+"for form-rendering purposes, this is not (yet) used for validation purposes."
 msgstr "Geeft aan of deze stap optioneel is binnen het formulier."
 
 #: openforms/forms/models/form_step.py:41
 msgid ""
-"The text that will be displayed in the form step to go to the previous step."
-" Leave blank to get value from global configuration."
+"The text that will be displayed in the form step to go to the previous step. "
+"Leave blank to get value from global configuration."
 msgstr ""
 "Het label van de knop om naar de vorige stap binnen het formulier te gaan. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
@@ -2035,16 +2098,16 @@ msgid ""
 "The text that will be displayed in the form step to save the current "
 "information. Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop om het formulier tussentijds op te slaan. Laat leeg om"
-" de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop om het formulier tussentijds op te slaan. Laat leeg om "
+"de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form_step.py:59
 msgid ""
 "The text that will be displayed in the form step to go to the next step. "
 "Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop om naar de volgende stap binnen het formulier te gaan."
-" Laat leeg om de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop om naar de volgende stap binnen het formulier te gaan. "
+"Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form_step.py:72
 msgid "form steps"
@@ -2098,8 +2161,8 @@ msgstr "SDK Javascript"
 #: openforms/forms/templates/admin/forms/form/change_form.html:47
 msgid ""
 "Include this snippet close to where other styles (CSS) are loaded. This "
-"snippet provides the default form styling. If you have own styles overriding"
-" the default styles, ensure this snippet is included BEFORE your custom "
+"snippet provides the default form styling. If you have own styles overriding "
+"the default styles, ensure this snippet is included BEFORE your custom "
 "styles."
 msgstr ""
 "Voeg dit snippet toe op de HTML pagina waar de andere CSS-bestanden "
@@ -2217,39 +2280,51 @@ msgid "House number of the address"
 msgstr "Huisnummer van het adres"
 
 #: openforms/logging/apps.py:7
-#| msgid "Logged in as"
 msgid "Logging"
 msgstr "Logboek"
 
-#: openforms/logging/models.py:23
+#: openforms/logging/constants.py:7
+msgid "AVG"
+msgstr "AVG"
+
+#: openforms/logging/models.py:27
+#: openforms/logging/templates/logging/admin_list.html:29
 msgid "timeline log entry"
 msgstr "tijdlijn logboekvermelding"
 
-#: openforms/logging/models.py:24
+#: openforms/logging/models.py:28
+#: openforms/logging/templates/logging/admin_list.html:29
 msgid "timeline log entries"
 msgstr "tijdlijn logboekvermeldingen "
 
-#: openforms/logging/models.py:51
+#: openforms/logging/models.py:55
 msgid "User"
 msgstr "Gebruiker"
 
-#: openforms/logging/models.py:52
+#: openforms/logging/models.py:56
 msgid "Anonymous user"
 msgstr "Anonieme gebruiker"
 
-#: openforms/logging/models.py:67
+#: openforms/logging/models.py:77 openforms/logging/models.py:101
+#: openforms/logging/models.py:110
 msgid "(unknown)"
 msgstr "(onbekend)"
 
-#: openforms/logging/models.py:90
-#| msgid "content type"
+#: openforms/logging/models.py:129
 msgid "content object"
 msgstr "object"
 
-#: openforms/logging/models.py:95
-#| msgid "error message"
+#: openforms/logging/models.py:134
 msgid "message"
 msgstr "bericht"
+
+#: openforms/logging/models.py:149
+msgid "avg timeline log entry"
+msgstr "AVG logboekvermelding"
+
+#: openforms/logging/models.py:150
+msgid "avg timeline log entries"
+msgstr "AVG logboekvermeldingen "
 
 #: openforms/logging/templates/logging/events/appointment_cancel_failure.txt:2
 #, python-format
@@ -2305,25 +2380,21 @@ msgstr "%(lead)s: Afspraakplugin %(plugin)s meldt: Aanpassing geslaagd."
 
 #: openforms/logging/templates/logging/events/confirmation_email_failure.txt:2
 #, python-format
-#| msgid "Confirmation email template"
 msgid "%(lead)s: Confirmation email task failed."
 msgstr "%(lead)s: Bevestigingse-mail taak mislukt."
 
 #: openforms/logging/templates/logging/events/confirmation_email_skip.txt:2
 #, python-format
-#| msgid "Confirmation email template"
 msgid "%(lead)s: Confirmation email task skipped."
 msgstr "%(lead)s: Bevestigingse-mail taak overgeslagen."
 
 #: openforms/logging/templates/logging/events/confirmation_email_start.txt:2
 #, python-format
-#| msgid "Confirmation email template"
 msgid "%(lead)s: Confirmation email task started."
 msgstr "%(lead)s: Bevestigingse-mail taak gestart."
 
 #: openforms/logging/templates/logging/events/confirmation_email_success.txt:2
 #, python-format
-#| msgid "Confirmation email template"
 msgid "%(lead)s: Confirmation email sent."
 msgstr "%(lead)s: Bevestigingse-mail verstuurd."
 
@@ -2397,21 +2468,18 @@ msgstr "%(lead)s: PDF generatietaak overgeslagen: Document bestaat al."
 
 #: openforms/logging/templates/logging/events/pdf_generation_start.txt:2
 #, python-format
-#| msgid "Get PDF report generation status"
 msgid "%(lead)s: PDF generation started."
 msgstr "%(lead)s: PDF generatie gestart."
 
 #: openforms/logging/templates/logging/events/pdf_generation_success.txt:2
 #, python-format
-#| msgid "The task executed successfully."
 msgid "%(lead)s: PDF generated succesfully."
 msgstr "%(lead)s: PDF succesvol gegenereerd."
 
 #: openforms/logging/templates/logging/events/prefill_retrieve_failure.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Prefill plugin %(plugin)s reported: Failed to retrieve "
-"information."
+"%(lead)s: Prefill plugin %(plugin)s reported: Failed to retrieve information."
 msgstr ""
 "%(lead)s: Prefill plugin %(plugin)s meldt: Informatie kon niet worden "
 "opgehaald."
@@ -2420,14 +2488,14 @@ msgstr ""
 #, python-format
 msgid ""
 "%(lead)s: Prefill plugin %(plugin)s reported: Successfully retrieved "
-"information."
+"information to prefill fields: %(fields)s"
 msgstr ""
-"%(lead)s: Prefill plugin %(plugin)s meldt: Informatie met succes opgehaald."
+"%(lead)s: Prefill plugin %(plugin)s meldt: Informatie met succes opgehaald "
+"om velden te prefillen: %(fields)s."
 
 #: openforms/logging/templates/logging/events/registration_failure.txt:2
 #, python-format
-msgid ""
-"%(lead)s: Registration plugin %(plugin)s reported: Registration failed."
+msgid "%(lead)s: Registration plugin %(plugin)s reported: Registration failed."
 msgstr "%(lead)s: Registratieplugin %(plugin)s meldt: Registratie mislukt."
 
 #: openforms/logging/templates/logging/events/registration_skip.txt:2
@@ -2437,7 +2505,6 @@ msgstr "%(lead)s: Registratietaak overgeslagen: Geen backend geconfigureerd."
 
 #: openforms/logging/templates/logging/events/registration_start.txt:2
 #, python-format
-#| msgid "Registration backend"
 msgid "%(lead)s: Registration task started."
 msgstr "%(lead)s: Registratietaak gestart."
 
@@ -2446,6 +2513,55 @@ msgstr "%(lead)s: Registratietaak gestart."
 msgid ""
 "%(lead)s: Registration plugin %(plugin)s reported: Registration succeeded."
 msgstr "%(lead)s: Registratieplugin %(plugin)s meldt: Registratie geslaagd."
+
+#: openforms/logging/templates/logging/events/stuf_bg_request.txt:2
+#, python-format
+msgid "%(lead)s: Making StUF BG request to url %(url)s"
+msgstr "%(lead)s: Uitvoeren StUF-BG verzoek naar url %(url)s"
+
+#: openforms/logging/templates/logging/events/stuf_bg_response.txt:2
+#, python-format
+msgid "%(lead)s: StUF BG response from url %(url)s"
+msgstr "%(lead)s: StUF-BG antwoord ontvangen van url %(url)s"
+
+#: openforms/logging/templates/logging/events/stuf_zds_failure_response.txt:2
+#, python-format
+msgid "%(lead)s: Failed StUF ZDS response from url %(url)s"
+msgstr "%(lead)s: Gefaald StUF-ZDS antwoord van url %(url)s"
+
+#: openforms/logging/templates/logging/events/stuf_zds_request.txt:2
+#, python-format
+msgid "%(lead)s: Making StUF ZDS request to url %(url)s"
+msgstr "%(lead)s: Uitvoeren StUF-ZDS verzoek naar url %(url)s"
+
+#: openforms/logging/templates/logging/events/stuf_zds_success_response.txt:2
+#, python-format
+msgid "%(lead)s: Successful StUF ZDS response from url %(url)s"
+msgstr "%(lead)s: Geslaagd StUF-ZDS antwoord van url %(url)s"
+
+#: openforms/logging/templates/logging/events/submission_details_view_admin.txt:2
+#, python-format
+msgid ""
+"%(lead)s: User %(user)s viewed submission %(submission)s for form %(form)s "
+"in the admin"
+msgstr ""
+"%(lead)s: Gebruiker %(user)s bekeek inzending %(submission)s voor formulier "
+"%(form)s in de admin"
+
+#: openforms/logging/templates/logging/events/submission_details_view_api.txt:2
+#, python-format
+msgid ""
+"%(lead)s: User %(user)s viewed submission %(submission)s for form %(form)s "
+"through the api"
+msgstr ""
+"%(lead)s: Gebruiker %(user)s bekeek inzending %(submission)s voor formulier "
+"%(form)s via de API"
+
+#: openforms/logging/templates/logging/events/submission_export_list.txt:2
+#, python-format
+msgid "%(lead)s: User %(user)s exported submissions for form %(form)s"
+msgstr ""
+"%(lead)s: Gebruiker %(user)s exporteerde inzendingen voor formulier %(form)s"
 
 #: openforms/logging/templates/logging/events/submission_start.txt:2
 #, python-format
@@ -2472,14 +2588,12 @@ msgstr "URL"
 #: openforms/multidomain/models.py:16
 msgid ""
 "The absolute URL to redirect to. Typically this starts the login process on "
-"the other domain. For example: https://open-"
-"forms.example.com/oidc/authenticate/ or https://open-"
-"forms.example.com/admin/login/"
+"the other domain. For example: https://open-forms.example.com/oidc/"
+"authenticate/ or https://open-forms.example.com/admin/login/"
 msgstr ""
 "De volledige URL om naar om te leiden. Deze URL start typisch het login "
-"proces op het doeldomein. Bijvoorbeeld: https://open-"
-"forms.example.com/oidc/authenticate/ of https://open-"
-"forms.example.com/admin/login/"
+"proces op het doeldomein. Bijvoorbeeld: https://open-forms.example.com/oidc/"
+"authenticate/ of https://open-forms.example.com/admin/login/"
 
 #: openforms/multidomain/models.py:22
 msgid "current"
@@ -2487,11 +2601,11 @@ msgstr "huidige"
 
 #: openforms/multidomain/models.py:24
 msgid ""
-"Select this to show this domain as the current domain. The current domain is"
-" selected by default and will not trigger a redirect."
+"Select this to show this domain as the current domain. The current domain is "
+"selected by default and will not trigger a redirect."
 msgstr ""
-"Selecteer deze optie om dit domein weer te geven als het huidige domein. Het"
-" huidige domein is standaard geselecteerd in de domeinwisselaar."
+"Selecteer deze optie om dit domein weer te geven als het huidige domein. Het "
+"huidige domein is standaard geselecteerd in de domeinwisselaar."
 
 #: openforms/multidomain/models.py:30
 msgid "domain"
@@ -2504,10 +2618,6 @@ msgstr "domeinen"
 #: openforms/multidomain/templates/multidomain/includes/switcher.html:5
 msgid "Domain switcher"
 msgstr "Domeinwisselaar"
-
-#: openforms/payments/admin.py:59 openforms/payments/models.py:86
-msgid "Order ID"
-msgstr "Bestelling ID"
 
 #: openforms/payments/api/serializers.py:18
 #: openforms/registrations/api/serializers.py:13
@@ -2524,7 +2634,7 @@ msgid "Request type"
 msgstr "Verzoektype"
 
 #: openforms/payments/api/serializers.py:36
-#: openforms/submissions/api/serializers.py:304 stuf/models.py:62
+#: openforms/submissions/api/serializers.py:304 stuf/models.py:16
 msgid "URL"
 msgstr "URL"
 
@@ -2637,56 +2747,65 @@ msgstr "Optioneel de vooraf ingestelde URL overschrijven"
 msgid "Specify either '{preset}' or '{custom}'"
 msgstr "Specificeer '{preset}' of '{custom}'"
 
-#: openforms/payments/contrib/ogone/plugin.py:30
+#: openforms/payments/contrib/ogone/plugin.py:31
 msgid "Merchant to use"
 msgstr "Handelaar (Merchant) om te gebruiken"
 
-#: openforms/payments/contrib/ogone/plugin.py:39
+#: openforms/payments/contrib/ogone/plugin.py:40
 msgid "Ogone legacy"
 msgstr "Ogone legacy"
 
-#: openforms/payments/models.py:77
+#: openforms/payments/models.py:81
 msgid "Payment backend"
 msgstr "Betaalprovider backend"
 
-#: openforms/payments/models.py:79
+#: openforms/payments/models.py:83
 msgid "Payment options"
 msgstr "Betaalopties"
 
-#: openforms/payments/models.py:82
+#: openforms/payments/models.py:86
 msgid "Copy of payment options at time of initializing payment."
 msgstr ""
 "Kopie van betalingsopties op het moment van initialisatie van de betaling."
 
-#: openforms/payments/models.py:84
+#: openforms/payments/models.py:88
 msgid "Form URL"
 msgstr "Formulier URL"
 
-#: openforms/payments/models.py:89
+#: openforms/payments/models.py:90
+msgid "Order ID"
+msgstr "Bestelling ID"
+
+#: openforms/payments/models.py:93
 msgid "Unique tracking across backend"
 msgstr "Unieke ID die wordt meegegeven aan andere systemen."
 
-#: openforms/payments/models.py:92 openforms/submissions/api/serializers.py:86
-msgid "payment amount"
-msgstr "bedrag"
-
-#: openforms/payments/models.py:96
-msgid "Total payment amount."
-msgstr "Totaal bedrag."
-
-#: openforms/payments/models.py:99
+#: openforms/payments/models.py:96 openforms/payments/models.py:109
 msgid "payment status"
 msgstr "betaalstatus"
 
-#: openforms/payments/models.py:103
+#: openforms/payments/models.py:99 openforms/payments/models.py:113
 msgid "Status of the payment process in the configured backend."
 msgstr "Status van het betalingsproces in de geconfigureerde back-end."
+
+#: openforms/payments/models.py:102 openforms/submissions/api/serializers.py:86
+msgid "payment amount"
+msgstr "bedrag"
+
+#: openforms/payments/models.py:106
+msgid "Total payment amount."
+msgstr "Totaal bedrag."
+
+#: openforms/payments/models.py:118 openforms/payments/models.py:119
+msgid "submission payment details"
+msgstr "betalingsdetails"
 
 #: openforms/payments/templates/payments/payment_link.html:7
 msgid "Payment required!"
 msgstr "Betaling benodigd!"
 
 #: openforms/payments/templates/payments/payment_link.html:9
+#: openforms/payments/templates/payments/payment_link.html:21
 msgid "Total:"
 msgstr "Totaal:"
 
@@ -2694,19 +2813,29 @@ msgstr "Totaal:"
 msgid "Start payment"
 msgstr "Start het betaalproces"
 
-#: openforms/payments/templates/payments/payment_link.html:15
+#: openforms/payments/templates/payments/payment_link.html:22
 msgid "Thanks!"
 msgstr "Bedankt!"
 
-#: openforms/payments/views.py:40
+#: openforms/payments/validators.py:10
+#, python-brace-format
+msgid ""
+"Prefix must be alpha numeric, no spaces or special characters except {year}"
+msgstr ""
+"Het voorvoegsel moet alfanumeriek zijn - spaties of speciale karakter "
+"behalve \"{year}\" zijn niet toegelaten."
+
+#: openforms/payments/views.py:41
 msgid "Start payment flow"
 msgstr "Start het betaalproces"
 
-#: openforms/payments/views.py:42
+#: openforms/payments/views.py:43
 msgid ""
-"This endpoint provides information to start the payment flow for a submission.\n"
+"This endpoint provides information to start the payment flow for a "
+"submission.\n"
 "\n"
-"Due to support for legacy platforms this view doesn't redirect but provides information for the frontend to be used client side.\n"
+"Due to support for legacy platforms this view doesn't redirect but provides "
+"information for the frontend to be used client side.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form and submission must require payment\n"
@@ -2715,11 +2844,16 @@ msgid ""
 "* the `next` parameter must be present\n"
 "* the `next` parameter must match the CORS policy\n"
 "\n"
-"The HTTP 200 response contains the information to start the flow with the payment provider. Depending on the 'type', send a `GET` or `POST` request with the `data` as 'Form Data' to the given 'url'."
+"The HTTP 200 response contains the information to start the flow with the "
+"payment provider. Depending on the 'type', send a `GET` or `POST` request "
+"with the `data` as 'Form Data' to the given 'url'."
 msgstr ""
-"Dit endpoint geeft informatie om het betaalproces te starten voor een inzending.\n"
+"Dit endpoint geeft informatie om het betaalproces te starten voor een "
+"inzending.\n"
 "\n"
-"Om legacy platformen te ondersteunen kan dit endpoint niet doorverwijzen maar geeft doorverwijs informatie terug aan de frontend die het verder moet afhandelen.\n"
+"Om legacy platformen te ondersteunen kan dit endpoint niet doorverwijzen "
+"maar geeft doorverwijs informatie terug aan de frontend die het verder moet "
+"afhandelen.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* het formulier vereist betaling\n"
@@ -2727,13 +2861,15 @@ msgstr ""
 "* de `next` parameter moet aanwezig zijn\n"
 "* de `next` parameter moet overeenkomen met het CORS-beleid\n"
 "\n"
-"Het HTTP 200 antwoord bevat informatie om het betaalproces te starten bij de betaalprovider. Afhankelijk van het `type`, een `POST` of `GET` is wordt verstuurd met de `data` als 'Form Data' naar de opgegeven 'url'."
+"Het HTTP 200 antwoord bevat informatie om het betaalproces te starten bij de "
+"betaalprovider. Afhankelijk van het `type`, een `POST` of `GET` is wordt "
+"verstuurd met de `data` als 'Form Data' naar de opgegeven 'url'."
 
-#: openforms/payments/views.py:60
+#: openforms/payments/views.py:61
 msgid "UUID identifying the submission."
 msgstr "UUID van de inzending."
 
-#: openforms/payments/views.py:67 openforms/payments/views.py:278
+#: openforms/payments/views.py:68 openforms/payments/views.py:285
 msgid ""
 "Identifier of the payment plugin. Note that this is validated against the "
 "configured available plugins for this particular form."
@@ -2741,7 +2877,7 @@ msgstr ""
 "Unieke identificatie van de betaalprovider plugin. Merk op dat deze waarde "
 "gevalideerd wordt met de beschikbare plugins voor dit formulier."
 
-#: openforms/payments/views.py:92
+#: openforms/payments/views.py:93
 msgid ""
 "Not found. The slug did not point to a live submission or the `plugin_id` "
 "does not exist."
@@ -2749,15 +2885,17 @@ msgstr ""
 "Niet gevonden. Het URL-deel verwees niet naar een actieve inzending of het "
 "`plugin_id` bestaat niet."
 
-#: openforms/payments/views.py:142
+#: openforms/payments/views.py:143
 msgid "Return from external payment flow"
 msgstr "Aanroeppunt van het externe betaalprovider proces"
 
-#: openforms/payments/views.py:144
+#: openforms/payments/views.py:145
 msgid ""
-"Payment plugins call this endpoint in the return step of the payment flow. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
+"Payment plugins call this endpoint in the return step of the payment flow. "
+"Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
 "\n"
-"Typically payment plugins will redirect again to the URL where the SDK is embedded.\n"
+"Typically payment plugins will redirect again to the URL where the SDK is "
+"embedded.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form and submission must require payment\n"
@@ -2765,7 +2903,9 @@ msgid ""
 "* payment is required and configured on the form\n"
 "* the redirect target must match the CORS policy"
 msgstr ""
-"Betaalprovider plugins roepen dit endpoint aan zodra het externe betaalproces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
+"Betaalprovider plugins roepen dit endpoint aan zodra het externe "
+"betaalproces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is "
+"toegestaan als HTTP-methode.\n"
 "\n"
 "Betaalprovider plugins zullen typisch een redirect uitvoeren naar de SDK.\n"
 "\n"
@@ -2774,19 +2914,19 @@ msgstr ""
 "* de `plugin_id` moet geconfigureerd zijn op het formulier\n"
 "* de URL waarnaar geredirect wordt moet overeenkomen met het CORS-beleid"
 
-#: openforms/payments/views.py:159
+#: openforms/payments/views.py:160
 msgid "UUID identifying the payment."
 msgstr "UUID dat de betaling identificeert."
 
-#: openforms/payments/views.py:165
+#: openforms/payments/views.py:166
 msgid "URL where the SDK initiated the payment flow."
 msgstr "URL waar de SDK begonnen is met het betaalproces."
 
-#: openforms/payments/views.py:179
+#: openforms/payments/views.py:180
 msgid "Tempomrary redirect"
 msgstr "Tijdelijke omleiding"
 
-#: openforms/payments/views.py:187
+#: openforms/payments/views.py:188
 msgid ""
 "Not found. The slug did not point to a live submission payment or the "
 "`plugin_id` does not exist."
@@ -2794,28 +2934,33 @@ msgstr ""
 "Niet gevonden. Het URL-deel verwees niet naar een actieve betaling of de "
 "`plugin_id` bestaat niet."
 
-#: openforms/payments/views.py:264
+#: openforms/payments/views.py:271
 msgid "Webhook handler for external payment flow"
 msgstr "Webhook-handler voor externe betalingsproces"
 
-#: openforms/payments/views.py:266
+#: openforms/payments/views.py:273
 msgid ""
-"This endpoint is used for server-to-server calls. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
+"This endpoint is used for server-to-server calls. Depending on the plugin, "
+"either `GET` or `POST` is allowed as HTTP method.\n"
 "\n"
 "Various validations are performed:\n"
 "* the `plugin_id` is configured on the form\n"
 "* payment is required and configured on the form"
 msgstr ""
-"Authenticatie plugins roepen dit endpoint aan zodra het externe login proces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
+"Authenticatie plugins roepen dit endpoint aan zodra het externe login proces "
+"is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan "
+"als HTTP-methode.\n"
 "\n"
 "\n"
-"Dit endpoint wordt gebruikt voor server-naar-server communicatie. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
+"Dit endpoint wordt gebruikt voor server-naar-server communicatie. "
+"Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-"
+"methode.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* de `plugin_id` moet geconfigureerd zijn op het formulier\n"
 "* het formulier vereist betaling"
 
-#: openforms/payments/views.py:299
+#: openforms/payments/views.py:306
 msgid "Not found. The slug did not point to a live plugin."
 msgstr "Niet gevonden. Het URL-deel verwees niet naar een actieve plugin."
 
@@ -2913,7 +3058,7 @@ msgstr "KvK Bedrijf via KvK-nummer"
 msgid "StUF-BG prefill plugin"
 msgstr "StUF-BG prefill plugin"
 
-#: openforms/prefill/contrib/stufbg/plugin.py:36
+#: openforms/prefill/contrib/stufbg/plugin.py:38
 msgid "StUF-BG"
 msgstr "StUF-BG"
 
@@ -2953,7 +3098,7 @@ msgstr "Extra print statement"
 msgid "Demo - print to console"
 msgstr "Console (test)"
 
-#: openforms/registrations/contrib/demo/plugin.py:32
+#: openforms/registrations/contrib/demo/plugin.py:33
 msgid "Demo - fail registration"
 msgstr "Uitval simulatie (test)"
 
@@ -2961,21 +3106,52 @@ msgstr "Uitval simulatie (test)"
 msgid "Email plugin"
 msgstr "E-mailplugin"
 
-#: openforms/registrations/contrib/email/config.py:11
+#: openforms/registrations/contrib/email/config.py:13
 msgid "The email addresses to which the submission details will be sent"
 msgstr "Het e-mailadres waar de inzendingen naar toe gemaild worden"
 
-#: openforms/registrations/contrib/email/plugin.py:21
+#: openforms/registrations/contrib/email/config.py:18
+msgid "The format(s) of the attachment(s) containing the submission details"
+msgstr ""
+"De formaten (of het formaat) van de bijlage(n) die de inzendingsgegevens "
+"bevatten."
+
+#: openforms/registrations/contrib/email/constants.py:7
+msgid "PDF"
+msgstr "PDF"
+
+#: openforms/registrations/contrib/email/constants.py:8
+msgid "CSV"
+msgstr "CSV"
+
+#: openforms/registrations/contrib/email/constants.py:9
+msgid "Excel"
+msgstr "Excel"
+
+#: openforms/registrations/contrib/email/plugin.py:25
 msgid "Email registration"
 msgstr "E-mail registratie"
 
-#: openforms/registrations/contrib/email/plugin.py:27
-msgid "Submission details for {} (submitted on {})"
-msgstr "Inzending details van {} (verzonden op {})"
+#: openforms/registrations/contrib/email/plugin.py:34
+#, python-brace-format
+msgid "[Open Forms] {form_name} - submission {public_reference}"
+msgstr "[Open Formulieren] {form_name} - inzending {public_reference}"
 
-#: openforms/registrations/contrib/email/plugin.py:50
-msgid "[Open Forms] {} - submission {}"
-msgstr "[Open Formulieren] {} - inzending {}"
+#: openforms/registrations/contrib/email/plugin.py:39
+#, python-brace-format
+msgid "Submission details for {form_name} (submitted on {datetime})"
+msgstr "Inzendingdetails van {form_name} (verzonden op {datetime})"
+
+#: openforms/registrations/contrib/email/plugin.py:100
+#, python-brace-format
+msgid ""
+"[Open Forms] {form_name} - submission payment received {public_reference}"
+msgstr "[Open Formulieren] {form_name} - betaling ontvangen {public_reference}"
+
+#: openforms/registrations/contrib/email/plugin.py:106
+#, python-brace-format
+msgid "Submission payment received for {form_name} (submitted on {datetime})"
+msgstr "Inzendingbetaling ontvangen voor {form_name} (verzonden op {datetime})"
 
 #: openforms/registrations/contrib/objects_api/apps.py:8
 msgid "Objects API plugin"
@@ -2989,11 +3165,11 @@ msgstr "objecttype"
 #: openforms/registrations/contrib/objects_api/config.py:13
 msgid ""
 "URL that points to the ProductAanvraag objecttype in the Objecttypes API. "
-"The objecttype should have the following three attributes: 1) submission_id;"
-" 2) type (the type of productaanvraag); 3) data (the submitted form data)"
+"The objecttype should have the following three attributes: 1) submission_id; "
+"2) type (the type of productaanvraag); 3) data (the submitted form data)"
 msgstr ""
-"URL naar het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het"
-" objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
+"URL naar het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het "
+"objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formulier gegevens)"
 
 #: openforms/registrations/contrib/objects_api/config.py:22
@@ -3014,38 +3190,62 @@ msgid "The type of ProductAanvraag"
 msgstr "Het type ProductAanvraag"
 
 #: openforms/registrations/contrib/objects_api/config.py:32
-#: openforms/registrations/contrib/objects_api/models.py:60
-msgid "submission report informatieobjecttype"
+msgid "submission report PDF informatieobjecttype"
 msgstr "inzendings PDF document informatieobjecttype"
 
 #: openforms/registrations/contrib/objects_api/config.py:34
 msgid ""
-"URL that points to the Informatieobjecttype in the Documenten API to be used"
-" for the submission report"
+"URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
+"for the submission report PDF"
 msgstr ""
-"URL naar het INFORMATIEOBJECTTYPE in een Documenten API dat wordt gebruikt "
+"URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
 "voor het PDF document."
 
 #: openforms/registrations/contrib/objects_api/config.py:40
-#: openforms/registrations/contrib/objects_api/models.py:69
-msgid "attachment informatieobjecttype"
-msgstr "bijlage informatieobjecttype"
+msgid "Upload submission CSV"
+msgstr "CSV bestand inzending uploaden"
 
 #: openforms/registrations/contrib/objects_api/config.py:42
 msgid ""
-"URL that points to the Informatieobjecttype in the Documenten API to be used"
-" for the submission attachments"
+"Indicates whether or not the submission CSV should be uploaded as a Document "
+"in Documenten API and attached to the ProductAanvraag"
 msgstr ""
-"URL naar het INFORMATIEOBJECTTYPE in een Documenten API dat wordt gebruikt "
-"voor het bijlagen."
+"Geeft aan of de inzendingsgegevens als CSV in de Documenten API moet "
+"geüpload worden en toegevoegd aan de ProductAanvraag."
 
 #: openforms/registrations/contrib/objects_api/config.py:48
+#: openforms/registrations/contrib/objects_api/models.py:69
+msgid "submission report CSV informatieobjecttype"
+msgstr "inzendings CSV document informatieobjecttype"
+
+#: openforms/registrations/contrib/objects_api/config.py:50
+msgid ""
+"URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
+"for the submission report CSV"
+msgstr ""
+"URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
+"voor het CSV document."
+
+#: openforms/registrations/contrib/objects_api/config.py:56
 #: openforms/registrations/contrib/objects_api/models.py:78
+msgid "attachment informatieobjecttype"
+msgstr "bijlage informatieobjecttype"
+
+#: openforms/registrations/contrib/objects_api/config.py:58
+msgid ""
+"URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
+"for the submission attachments"
+msgstr ""
+"URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
+"voor de bijlagen."
+
+#: openforms/registrations/contrib/objects_api/config.py:64
+#: openforms/registrations/contrib/objects_api/models.py:87
 #: openforms/registrations/contrib/zgw_apis/models.py:54
 msgid "organisation RSIN"
 msgstr "organisatie RSIN"
 
-#: openforms/registrations/contrib/objects_api/config.py:51
+#: openforms/registrations/contrib/objects_api/config.py:67
 msgid "RSIN of organization, which creates the INFORMATIEOBJECT"
 msgstr "RSIN van de organisatie, die het INFORMATIEOBJECT aanmaakt"
 
@@ -3064,9 +3264,9 @@ msgid ""
 "objecttype should have the following three attributes: 1) submission_id; 2) "
 "type (the type of productaanvraag); 3) data (the submitted form data)"
 msgstr ""
-"Standaard URL van het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen"
-" API. Het objecttype moet de volgende attributen bevatten: 1) submission_id;"
-" 2) type (het type van de 'ProductAanvraag'); 3) data (ingezonden formulier "
+"Standaard URL van het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen "
+"API. Het objecttype moet de volgende attributen bevatten: 1) submission_id; "
+"2) type (het type van de 'ProductAanvraag'); 3) data (ingezonden formulier "
 "gegevens)"
 
 #: openforms/registrations/contrib/objects_api/models.py:49
@@ -3079,101 +3279,61 @@ msgstr "Productaanvraag type"
 
 #: openforms/registrations/contrib/objects_api/models.py:54
 msgid ""
-"Description of the 'ProductAanvraag' type. This value is saved in the 'type'"
-" attribute of the 'ProductAanvraag'."
+"Description of the 'ProductAanvraag' type. This value is saved in the 'type' "
+"attribute of the 'ProductAanvraag'."
 msgstr ""
 "Omschrijving van het type van de 'Productaanvraag'. Deze waarde wordt "
 "bewaard in het 'type' attribuut van de 'ProductAanvraag'."
 
+#: openforms/registrations/contrib/objects_api/models.py:60
+msgid "submission report informatieobjecttype"
+msgstr "inzendings PDF document informatieobjecttype"
+
 #: openforms/registrations/contrib/objects_api/models.py:64
 msgid ""
-"Default URL of the INFORMATIEOBJECTTYPE for the submission report in the "
-"Catalogi API"
+"Default URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to "
+"be used for the submission report PDF"
 msgstr ""
-"Standaard URL van het INFORMATIEOBJECTTYPE van het inzendings PDF document "
-"in de Catalogi API"
+"URL naar het standaard INFORMATIEOBJECTTYPE in een Catalogi API dat wordt "
+"gebruikt voor het PDF document."
 
 #: openforms/registrations/contrib/objects_api/models.py:73
 msgid ""
-"Default URL of the INFORMATIEOBJECTTYPE for the submission attachments in "
-"the Catalogi API"
+"Default URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to "
+"be used for the submission report CSV"
 msgstr ""
-"Standaard URL van het INFORMATIEOBJECTTYPE voor bijlagen in de Catalogi API"
+"URL naar het standaard INFORMATIEOBJECTTYPE in een Catalogi API dat wordt "
+"gebruikt voor het CSV document."
 
 #: openforms/registrations/contrib/objects_api/models.py:82
+msgid ""
+"Default URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to "
+"be used for the submission attachments"
+msgstr ""
+"URL naar het standaard INFORMATIEOBJECTTYPE in een Catalogi API dat wordt "
+"gebruikt voor de bijlagen."
+
+#: openforms/registrations/contrib/objects_api/models.py:91
 msgid "Default RSIN of organization, which creates the INFORMATIEOBJECT"
 msgstr "Standaard RSIN van de organisatie, die het INFORMATIEOBJECT aanmaakt"
 
-#: openforms/registrations/contrib/objects_api/models.py:86
+#: openforms/registrations/contrib/objects_api/models.py:95
 msgid "Objects API configuration"
 msgstr "Objecten API configuratie"
 
-#: openforms/registrations/contrib/objects_api/plugin.py:30
+#: openforms/registrations/contrib/objects_api/plugin.py:32
 msgid "Objects API registration"
 msgstr "Objecten API registratie"
 
-#: openforms/registrations/contrib/stuf_zds/models.py:28
-msgid "Municipality code"
-msgstr "Gemeentecode"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:30
-msgid "Municipality code to register zaken"
-msgstr "Gemeentecode om zaken aan te maken"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:34
-msgid "Zaaktype code"
-msgstr "zaaktype code"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:36
-msgid "Zaaktype code for newly created zaken in StUF-ZDS"
-msgstr "Zaaktype code voor nieuw aangemaakte zaken via StUF-ZDS"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:39
-msgid "Zaaktype description"
-msgstr "Zaaktype omschrijving"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:41
-msgid "Zaaktype description for newly created zaken in StUF-ZDS"
-msgstr "Zaaktype omschrijving voor nieuw aangemaakt zaken via StUF-ZDS"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:44
-msgid "Zaaktype status code"
-msgstr "Zaaktype status code"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:46
-msgid "Zaaktype status code for newly created zaken in StUF-ZDS"
-msgstr "Zaaktype status code voor nieuw aangemaakte zaken via StUF-ZDS"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:49
-msgid "Zaaktype status omschrijving"
-msgstr "Zaaktype status omschrijving"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:51
-msgid "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
-msgstr ""
-"Zaaktype status omschrijving voor nieuw aangemaakte zaken via StUF-ZDS"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:54
-msgid "Documenttype description"
-msgstr "Documenttype omschrijving"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:56
-msgid "Documenttype description for newly created zaken in StUF-ZDS"
-msgstr "Documenttype omschrijving voor nieuw aangemaakt zaken via StUF-ZDS"
-
-#: openforms/registrations/contrib/stuf_zds/models.py:79
-msgid "StUF-ZDS configuration"
-msgstr "StUF-ZDS configuratie"
-
-#: openforms/registrations/contrib/stuf_zds/plugin.py:29
+#: openforms/registrations/contrib/stuf_zds/plugin.py:28
 msgid "Zaaktype code for newly created Zaken in StUF-ZDS"
 msgstr "Zaaktype code voor nieuw aangemaakte zaken via StUF-ZDS"
 
-#: openforms/registrations/contrib/stuf_zds/plugin.py:33
+#: openforms/registrations/contrib/stuf_zds/plugin.py:32
 msgid "Zaaktype description for newly created Zaken in StUF-ZDS"
 msgstr "Zaaktype omschrijving voor nieuw aangemaakt zaken via StUF-ZDS"
 
-#: openforms/registrations/contrib/stuf_zds/plugin.py:101
+#: openforms/registrations/contrib/stuf_zds/plugin.py:100
 msgid "StUF-ZDS"
 msgstr "StUF-ZDS"
 
@@ -3245,59 +3405,59 @@ msgstr ""
 msgid "ZGW API's"
 msgstr "ZGW API's"
 
-#: openforms/submissions/admin.py:54
+#: openforms/submissions/admin.py:60
 msgid "All"
 msgstr "Alle"
 
-#: openforms/submissions/admin.py:152
+#: openforms/submissions/admin.py:174
+msgid "Succesfully processed"
+msgstr "Successvolle verwerking"
+
+#: openforms/submissions/admin.py:179
 msgid "Registration backend"
 msgstr "registratie backend"
 
-#: openforms/submissions/admin.py:160
+#: openforms/submissions/admin.py:187
 msgid "Appointment status"
 msgstr "Afspraakstatus"
 
-#: openforms/submissions/admin.py:168
+#: openforms/submissions/admin.py:195
 msgid "Appointment Id"
 msgstr "Afspraak ID"
 
-#: openforms/submissions/admin.py:177
+#: openforms/submissions/admin.py:204
 msgid "Appointment error information"
 msgstr "Afspraak foutmelding"
 
-#: openforms/submissions/admin.py:198
+#: openforms/submissions/admin.py:226
 msgid "You can only export the submissions of the same form type."
 msgstr ""
-"Je kan alleen de inzendingen van één enkel formuliertype tegelijk "
-"exporteren."
+"Je kan alleen de inzendingen van één enkel formuliertype tegelijk exporteren."
 
-#: openforms/submissions/admin.py:208
+#: openforms/submissions/admin.py:237
 #, python-format
 msgid "Export selected %(verbose_name_plural)s as CSV-file."
 msgstr "Exporteer geselecteerde %(verbose_name_plural)s als CSV-bestand."
 
-#: openforms/submissions/admin.py:215
+#: openforms/submissions/admin.py:244
 #, python-format
 msgid "Export selected %(verbose_name_plural)s as Excel-file."
 msgstr "Exporteer geselecteerde %(verbose_name_plural)s als Excel-bestand."
 
-#: openforms/submissions/admin.py:223
+#: openforms/submissions/admin.py:252
 #, python-brace-format
-msgid "Resending {count} {verbose_name} to registration backend"
-msgid_plural "Resending {count} {verbose_name_plural} to registration backend"
-msgstr[0] ""
-"Bezig met {count} {verbose_name} nogmaals te versturen naar registratie "
-"backend"
+msgid "Retrying processing flow for {count} {verbose_name}"
+msgid_plural "Retrying processing flow for {count} {verbose_name_plural}"
+msgstr[0] "Nieuwe verwerkingspoging voor {count} {verbose_name} wordt gestart."
 msgstr[1] ""
-"Bezig met {count} {verbose_name_plural} nogmaals te versturen naar "
-"registratie backend"
+"Nieuwe verwerkingspoging voor {count} {verbose_name_plural} wordt gestart."
 
-#: openforms/submissions/admin.py:236
+#: openforms/submissions/admin.py:265
 #, python-format
-msgid "Resend %(verbose_name_plural)s to the registration backend."
-msgstr "Verstuur %(verbose_name_plural)s nogmaals naar registratie backend"
+msgid "Retry processing %(verbose_name_plural)s."
+msgstr "Probeer %(verbose_name_plural)s opnieuw te verwerken"
 
-#: openforms/submissions/admin.py:295 openforms/submissions/admin.py:344
+#: openforms/submissions/admin.py:324 openforms/submissions/admin.py:373
 #: openforms/submissions/api/serializers.py:310
 msgid "File size"
 msgstr "Bestandsgrootte"
@@ -3323,7 +3483,7 @@ msgid "Amount (to be) paid"
 msgstr "Het te betalen bedrag"
 
 #: openforms/submissions/api/serializers.py:106
-#: openforms/submissions/models.py:454
+#: openforms/submissions/models.py:485
 msgid "Submission steps"
 msgstr "Inzendingsstappen"
 
@@ -3350,8 +3510,8 @@ msgstr "Formuliergegevens"
 #: openforms/submissions/api/serializers.py:244
 msgid ""
 "The Form.io submission data object. This will be merged with the full form "
-"submission data, including data from other steps, to evaluate the configured"
-" form logic."
+"submission data, including data from other steps, to evaluate the configured "
+"form logic."
 msgstr ""
 "De Form.io inzendingsgegevens. Dit wordt samengevoegd met de "
 "inzendingsgegevens, inclusief de gegevens van de andere stappen, om de "
@@ -3364,8 +3524,7 @@ msgstr "Contact e-mailadres"
 #: openforms/submissions/api/serializers.py:257
 msgid "The email address where the 'magic' resume link should be sent to"
 msgstr ""
-"Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet "
-"worden"
+"Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet worden"
 
 #: openforms/submissions/api/serializers.py:283
 msgid "Your form submission"
@@ -3413,8 +3572,8 @@ msgid ""
 "The result from the background processing. This field only has a value if "
 "the processing has completed (both successfully or with errors)."
 msgstr ""
-"Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde"
-" als de verwerking is voltooid (zowel met succes als met fouten)."
+"Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde "
+"als de verwerking is voltooid (zowel met succes als met fouten)."
 
 #: openforms/submissions/api/serializers.py:377
 msgid "Error information"
@@ -3444,8 +3603,7 @@ msgstr "Bevestigingspagina tekst"
 #: openforms/submissions/api/serializers.py:401
 msgid "Body text of the confirmation page. May contain HTML!"
 msgstr ""
-"Inhoud van de bevestigingspagina. Hierin mogen HTML-karakers woren "
-"opgenomen."
+"Inhoud van de bevestigingspagina. Hierin mogen HTML-karakers woren opgenomen."
 
 #: openforms/submissions/api/serializers.py:404
 msgid "Report download URL"
@@ -3497,15 +3655,19 @@ msgstr "Maak tijdelijk bestand aan"
 msgid ""
 "File upload handler for the Form.io file upload \"url\" storage type.\n"
 "\n"
-"The uploads are stored temporarily and have to be claimed by the form submission using the returned JSON data. \n"
+"The uploads are stored temporarily and have to be claimed by the form "
+"submission using the returned JSON data. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary "
+"files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Bestandsupload handler voor jet Form.io bestandsupload opslagtype 'url'.\n"
 "\n"
-"Bestandsuploads worden tijdelijke opgeslagen en moeten gekoppeld worden aan een inzending.\n"
+"Bestandsuploads worden tijdelijke opgeslagen en moeten gekoppeld worden aan "
+"een inzending.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
+"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
 #: openforms/submissions/api/views.py:101
 msgid "View/delete temporary upload."
@@ -3522,13 +3684,15 @@ msgid ""
 "\n"
 "This is called by the default Form.io file upload widget. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary "
+"files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Haal tijdelijk bestand op.\n"
 "\n"
 "Deze aanroep wordt gedaan door het standaard Form.io bestandsupload widget.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
+"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
 #: openforms/submissions/api/views.py:115
 msgid "Delete temporary file upload"
@@ -3541,43 +3705,44 @@ msgid ""
 "\n"
 "This is called by the default Form.io file upload widget. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary "
+"files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Verwijder tijdelijk bestand.\n"
 "\n"
 "Deze aanroep wordt gedaan door het standaard Form.io bestandsupload widget.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
+"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
-#: openforms/submissions/api/viewsets.py:51
+#: openforms/submissions/api/viewsets.py:53
 msgid "List active submissions"
 msgstr "Actieve inzendingen weergeven"
 
-#: openforms/submissions/api/viewsets.py:53
+#: openforms/submissions/api/viewsets.py:55
 msgid ""
 "Active submissions are submissions whose ID is in the user session. This "
-"endpoint returns user-bound submissions. Note that you get different results"
-" on different results because of the differing sessions."
+"endpoint returns user-bound submissions. Note that you get different results "
+"on different results because of the differing sessions."
 msgstr ""
 "Actieve inzendingen zijn inzendingen waarvan het ID zich in de "
 "gebruikerssessie bevindt. Dit endpoint geeft alle inzendingen terug die "
 "gekoppeld zijn aan de gebruiker. Het antwoord hangt dus af van de actieve "
 "sessie."
 
-#: openforms/submissions/api/viewsets.py:59
+#: openforms/submissions/api/viewsets.py:61
 msgid "Retrieve submission details"
 msgstr "Inzending detail weergeven"
 
-#: openforms/submissions/api/viewsets.py:60
+#: openforms/submissions/api/viewsets.py:62
 msgid "Get the state of a single submission in the user session."
-msgstr ""
-"Haal de status op van een enkele inzending op van de gebruikerssessie."
+msgstr "Haal de status op van een enkele inzending op van de gebruikerssessie."
 
-#: openforms/submissions/api/viewsets.py:63
+#: openforms/submissions/api/viewsets.py:65
 msgid "Start a submission"
 msgstr "Inzending starten"
 
-#: openforms/submissions/api/viewsets.py:65
+#: openforms/submissions/api/viewsets.py:67
 msgid ""
 "Start a submission for a particular form. The submission is added to the "
 "user session."
@@ -3585,27 +3750,27 @@ msgstr ""
 "Start een inzending voor een specifiek formulier. De inzending wordt "
 "onderdeel van de gebruikerssessie."
 
-#: openforms/submissions/api/viewsets.py:98
+#: openforms/submissions/api/viewsets.py:100
 msgid "Complete a submission"
 msgstr "Inzending voltooien"
 
-#: openforms/submissions/api/viewsets.py:157
+#: openforms/submissions/api/viewsets.py:165
 msgid "Get the submission processing status"
 msgstr "De verwerkingsstatus van de inzending ophalen"
 
-#: openforms/submissions/api/viewsets.py:169
+#: openforms/submissions/api/viewsets.py:177
 msgid "Time-based authentication token"
 msgstr "Op tijd gebaseerde authenticatietoken"
 
-#: openforms/submissions/api/viewsets.py:194
+#: openforms/submissions/api/viewsets.py:203
 msgid "Suspend a submission"
 msgstr "Inzending onderbreken"
 
-#: openforms/submissions/api/viewsets.py:231
+#: openforms/submissions/api/viewsets.py:244
 msgid "Retrieve step details"
 msgstr "Stap details weergeven"
 
-#: openforms/submissions/api/viewsets.py:233
+#: openforms/submissions/api/viewsets.py:246
 msgid ""
 "The details of a particular submission step always return the related form "
 "step configuration. If there is no data yet for the step, the ID will be "
@@ -3615,15 +3780,15 @@ msgstr ""
 "formulierstap configuratie terug. Indien er nog geen gegevens zijn voor de "
 "stap dan zal het ID `null` zijn."
 
-#: openforms/submissions/api/viewsets.py:287
+#: openforms/submissions/api/viewsets.py:300
 msgid "Store submission step data"
 msgstr "Inzendingsstap gegevens bewaren"
 
-#: openforms/submissions/api/viewsets.py:319
+#: openforms/submissions/api/viewsets.py:332
 msgid "Apply/check form logic"
 msgstr "Pas formulier logica toe"
 
-#: openforms/submissions/api/viewsets.py:320
+#: openforms/submissions/api/viewsets.py:333
 msgid "Apply/check the logic rules specified on the form step."
 msgstr ""
 "Pas de logische regels toe die zijn gespecificeerd in de formulierstap."
@@ -3656,8 +3821,8 @@ msgstr "Mislukt, gebruiker moet terugkeren naar het begin van het formulier. "
 msgid "Success, proceed to confirmation page."
 msgstr "Succes, ga verder naar de bevestigingspagina."
 
-#: openforms/submissions/models.py:111 openforms/submissions/models.py:445
-#: openforms/submissions/models.py:586 openforms/submissions/models.py:678
+#: openforms/submissions/models.py:111 openforms/submissions/models.py:476
+#: openforms/submissions/models.py:617 openforms/submissions/models.py:709
 msgid "created on"
 msgstr "aangemaakt op"
 
@@ -3700,10 +3865,8 @@ msgstr "registratie backend status"
 
 #: openforms/submissions/models.py:153
 msgid ""
-"Indication whether the registration in the configured backend was "
-"successful."
-msgstr ""
-"Indicatie of de doorzetting naar de registratie backend succesvol was."
+"Indication whether the registration in the configured backend was successful."
+msgstr "Indicatie of de doorzetting naar de registratie backend succesvol was."
 
 #: openforms/submissions/models.py:157
 msgid "public registration reference"
@@ -3711,9 +3874,9 @@ msgstr "publieke referentie"
 
 #: openforms/submissions/models.py:161
 msgid ""
-"The registration reference communicated to the end-user completing the form."
-" This reference is intended to be unique and the reference the end-user uses"
-" to communicate with the service desk. It should be extracted from the "
+"The registration reference communicated to the end-user completing the form. "
+"This reference is intended to be unique and the reference the end-user uses "
+"to communicate with the service desk. It should be extracted from the "
 "registration result where possible, and otherwise generated to be unique. "
 "Note that this reference is displayed to the end-user and used as payment "
 "reference!"
@@ -3727,106 +3890,126 @@ msgstr ""
 "betalingskenmerk!"
 
 #: openforms/submissions/models.py:171
+msgid "confirmation email sent"
+msgstr "Bevestigingse-mail verstuurd"
+
+#: openforms/submissions/models.py:173
+msgid "Indicates whether the confirmation email has been sent."
+msgstr "Geeft aan of de bevestigingse-mail al verstuurd is."
+
+#: openforms/submissions/models.py:177
 msgid "is cleaned"
 msgstr "is opgeschoond"
 
-#: openforms/submissions/models.py:174
+#: openforms/submissions/models.py:180
 msgid ""
 "Indicates whether sensitive data (if there was any) has been removed from "
 "this submission."
 msgstr "Geeft aan of gevoelige gegevens verwijders zijn van deze inzending."
 
-#: openforms/submissions/models.py:181
+#: openforms/submissions/models.py:187
 msgid "on completion task ID"
 msgstr "bij voltooiing taak-ID"
 
-#: openforms/submissions/models.py:186
+#: openforms/submissions/models.py:192
 msgid "on completion task IDs"
 msgstr "bij voltooiing taak-ID's"
 
-#: openforms/submissions/models.py:189
+#: openforms/submissions/models.py:195
 msgid ""
-"Celery task IDs of the on_completion workflow. Use this to inspect the state"
-" of the async jobs."
+"Celery task IDs of the on_completion workflow. Use this to inspect the state "
+"of the async jobs."
 msgstr ""
-"Celery-taak-ID's van de on_completion-workflow. Gebruik dit om de status van"
-" de asynchrone taken te inspecteren. "
+"Celery-taak-ID's van de on_completion-workflow. Gebruik dit om de status van "
+"de asynchrone taken te inspecteren. "
 
-#: openforms/submissions/models.py:197
+#: openforms/submissions/models.py:200
+msgid "needs on_completion retry"
+msgstr "verwerking opnieuw proberen"
+
+#: openforms/submissions/models.py:203
+msgid ""
+"Flag to track if the on_completion_retry chain should be invoked. This is "
+"scheduled via celery-beat."
+msgstr ""
+"Vlag die aangeeft of een nieuwe verwerkingspoging nodig is. Dit wordt "
+"automatisch uitgevoerd op de achtergrond."
+
+#: openforms/submissions/models.py:211
 msgid "Submission"
 msgstr "Inzending"
 
-#: openforms/submissions/models.py:208
+#: openforms/submissions/models.py:222
 #, python-brace-format
 msgid "{pk} - started on {started}"
 msgstr "{pk} - gestart op {started}"
 
-#: openforms/submissions/models.py:209
+#: openforms/submissions/models.py:223
 msgid "(unsaved)"
 msgstr "(niet bewaard)"
 
-#: openforms/submissions/models.py:210
+#: openforms/submissions/models.py:224
 msgid "(no timestamp yet)"
 msgstr "(nog geen datum)"
 
-#: openforms/submissions/models.py:377
+#: openforms/submissions/models.py:408
 #, python-format
 msgid "attachment: %s"
 msgstr "bijlage: %s"
 
-#: openforms/submissions/models.py:381
-msgid "attachment"
-msgstr "bijlage"
+#: openforms/submissions/models.py:412
+msgid "empty"
+msgstr "leeg"
 
-#: openforms/submissions/models.py:444
+#: openforms/submissions/models.py:475
 msgid "data"
 msgstr "gegevens"
 
-#: openforms/submissions/models.py:446
+#: openforms/submissions/models.py:477
 msgid "modified on"
 msgstr "gewijzigd op"
 
-#: openforms/submissions/models.py:453
+#: openforms/submissions/models.py:484
 msgid "Submission step"
 msgstr "Inzendingsstap"
 
-#: openforms/submissions/models.py:478
+#: openforms/submissions/models.py:509
 msgid "title"
 msgstr "titel"
 
-#: openforms/submissions/models.py:480
+#: openforms/submissions/models.py:511
 msgid "Title of the submission report"
 msgstr "Titel van het document"
 
-#: openforms/submissions/models.py:485
+#: openforms/submissions/models.py:516
 msgid "Content of the submission report"
 msgstr "Inhoud van het document"
 
-#: openforms/submissions/models.py:492 openforms/submissions/models.py:651
+#: openforms/submissions/models.py:523 openforms/submissions/models.py:682
 msgid "submission"
 msgstr "inzending"
 
-#: openforms/submissions/models.py:493
+#: openforms/submissions/models.py:524
 msgid "Submission the report is about."
 msgstr "De inzending die hoort bij dit document."
 
-#: openforms/submissions/models.py:497
+#: openforms/submissions/models.py:528
 msgid "last accessed"
 msgstr "laatst gedownload"
 
-#: openforms/submissions/models.py:501
+#: openforms/submissions/models.py:532
 msgid ""
-"When the submission report was last accessed. This value is updated when the"
-" report is downloaded."
+"When the submission report was last accessed. This value is updated when the "
+"report is downloaded."
 msgstr ""
 "Datum waarom het document voor het laatst is opgevraagd. Deze waarde wordt "
 "bijgewerkt zodra het document wordt gedownload."
 
-#: openforms/submissions/models.py:506
+#: openforms/submissions/models.py:537
 msgid "task id"
 msgstr "Taak ID"
 
-#: openforms/submissions/models.py:509
+#: openforms/submissions/models.py:540
 msgid ""
 "ID of the celery task creating the content of the report. This is used to "
 "check the generation status."
@@ -3834,67 +4017,67 @@ msgstr ""
 "ID van de taak die het document genereerd. Dit ID kan worden gebruikt om de "
 "document generatie status te controleren."
 
-#: openforms/submissions/models.py:516
+#: openforms/submissions/models.py:547
 msgid "submission report"
 msgstr "document"
 
-#: openforms/submissions/models.py:517
+#: openforms/submissions/models.py:548
 msgid "submission reports"
 msgstr "documenten"
 
-#: openforms/submissions/models.py:582
+#: openforms/submissions/models.py:613
 msgid "content of the file attachment."
 msgstr "inhoud van de bijlage."
 
-#: openforms/submissions/models.py:584 openforms/submissions/models.py:675
+#: openforms/submissions/models.py:615 openforms/submissions/models.py:706
 msgid "original name"
 msgstr "originele naam"
 
-#: openforms/submissions/models.py:585 openforms/submissions/models.py:677
+#: openforms/submissions/models.py:616 openforms/submissions/models.py:708
 msgid "content type"
 msgstr "content type"
 
-#: openforms/submissions/models.py:591 openforms/submissions/models.py:592
+#: openforms/submissions/models.py:622 openforms/submissions/models.py:623
 msgid "temporary file upload"
 msgstr "tijdelijk bestand"
 
-#: openforms/submissions/models.py:652
+#: openforms/submissions/models.py:683
 msgid "Submission step the file is attached to."
 msgstr "Inzendingsstap waar het bestand bij hoort."
 
-#: openforms/submissions/models.py:660
+#: openforms/submissions/models.py:691
 msgid "temporary file"
 msgstr "tijdelijk bestand"
 
-#: openforms/submissions/models.py:661
+#: openforms/submissions/models.py:692
 msgid "Temporary upload this file is sourced to."
 msgstr "Tijdelijk bestand waar deze bijlage bij hoort."
 
-#: openforms/submissions/models.py:664
+#: openforms/submissions/models.py:695
 msgid "form component key"
 msgstr "formulier veld sleutel"
 
-#: openforms/submissions/models.py:669
+#: openforms/submissions/models.py:700
 msgid "Content of the submission file attachment."
 msgstr "Inhoud van de inzendingsbijlage"
 
-#: openforms/submissions/models.py:672
+#: openforms/submissions/models.py:703
 msgid "file name"
 msgstr "bestandsnaam"
 
-#: openforms/submissions/models.py:672
+#: openforms/submissions/models.py:703
 msgid "reformatted file name"
 msgstr "veilige bestandsnaam"
 
-#: openforms/submissions/models.py:675
+#: openforms/submissions/models.py:706
 msgid "original uploaded file name"
 msgstr "originele bestandsnaam"
 
-#: openforms/submissions/models.py:685
+#: openforms/submissions/models.py:716
 msgid "submission file attachment"
 msgstr "inzendingsbijlage"
 
-#: openforms/submissions/models.py:686
+#: openforms/submissions/models.py:717
 msgid "submission file attachments"
 msgstr "inzendingsbijlagen"
 
@@ -4018,6 +4201,14 @@ msgstr "Alles toestaan"
 msgid "Decline all"
 msgstr "Alles weigeren"
 
+#: openforms/translations/views.py:20
+msgid "Get FormIO translations"
+msgstr "Ophalen FormIO vertalingen"
+
+#: openforms/translations/views.py:21
+msgid "Retrieve the translations for the strings used by FormIO"
+msgstr "Haal de vertalingen op voor de teksten gebruikt door FormIO"
+
 #: openforms/ui/templates/ui/components/a11y_toolbar/a11y_toolbar.html:6
 msgid "API docs"
 msgstr "API documentatie"
@@ -4111,11 +4302,11 @@ msgstr "Valideer waarde met validatie plugin"
 
 #: openforms/validations/api/views.py:53
 msgid ""
-"ID of the validation plugin, see the "
-"[`validation_plugin_list`](./#operation/validation_plugin_list) operation"
+"ID of the validation plugin, see the [`validation_plugin_list`](./#operation/"
+"validation_plugin_list) operation"
 msgstr ""
-"ID van de validatie plugin. Zie de "
-"[`validation_plugin_list`](./#operation/validation_plugin_list) operatie"
+"ID van de validatie plugin. Zie de [`validation_plugin_list`](./#operation/"
+"validation_plugin_list) operatie"
 
 #: stuf/admin.py:34
 msgid "StUF parameters"
@@ -4125,7 +4316,7 @@ msgstr "StUF parameters"
 msgid "Connection"
 msgstr "Verbinding"
 
-#: stuf/admin.py:61
+#: stuf/admin.py:60
 msgid "Authentication"
 msgstr "Authenticatie"
 
@@ -4153,134 +4344,146 @@ msgstr "label"
 msgid "Human readable label to identify services"
 msgstr "Eenvoudige naam om services te identificeren"
 
-#: stuf/models.py:16
+#: stuf/models.py:18
+msgid "URL of the service to connect to."
+msgstr "URL naar de service om mee te verbinden."
+
+#: stuf/models.py:22
+msgid "SOAP service"
+msgstr "SOAP service"
+
+#: stuf/models.py:23
+msgid "SOAP services"
+msgstr "SOAP service"
+
+#: stuf/models.py:35
+msgid "The soap service this stuf service uses"
+msgstr "De SOAP-service die deze StUF-service gebruikt."
+
+#: stuf/models.py:39
 msgid "receiving organisation"
 msgstr "ontvangende organisatie"
 
-#: stuf/models.py:17
+#: stuf/models.py:40
 msgid "Field 'ontvanger organisatie' in StUF"
 msgstr "Veld 'ontvanger organisatie' in StUF-berichten"
 
-#: stuf/models.py:21
+#: stuf/models.py:45
 msgid "receiving application"
 msgstr "ontvangende applicatie"
 
-#: stuf/models.py:22
+#: stuf/models.py:46
 msgid "Field 'ontvanger applicatie' in StUF"
 msgstr "Veld 'ontvanger applicatie' in StUF-berichten"
 
-#: stuf/models.py:26
+#: stuf/models.py:50
 msgid "receiving administration"
 msgstr "ontvangende administratie"
 
-#: stuf/models.py:27
+#: stuf/models.py:51
 msgid "Field 'ontvanger administratie' in StUF"
 msgstr "Veld 'ontvanger administratie' in StUF-berichten"
 
-#: stuf/models.py:32
+#: stuf/models.py:56
 msgid "receiving user"
 msgstr "ontvangende gebruiker"
 
-#: stuf/models.py:33
+#: stuf/models.py:57
 msgid "Field 'ontvanger gebruiker' in StUF"
 msgstr "Veld 'ontvanger gebruiker' in StUF-berichten"
 
-#: stuf/models.py:39
+#: stuf/models.py:63
 msgid "sending organisation"
 msgstr "versturende organisatie"
 
-#: stuf/models.py:40
+#: stuf/models.py:64
 msgid "Field 'zender organisatie' in StUF"
 msgstr "Veld 'zender organisatie' in StUF-berichten"
 
-#: stuf/models.py:44
+#: stuf/models.py:69
 msgid "sending application"
 msgstr "versturende applicatie"
 
-#: stuf/models.py:45
+#: stuf/models.py:70
 msgid "Field 'zender applicatie' in StUF"
 msgstr "Veld 'zender applicatie' in StUF-berichten"
 
-#: stuf/models.py:49
+#: stuf/models.py:74
 msgid "sending administration"
 msgstr "versturende administratie"
 
-#: stuf/models.py:50
+#: stuf/models.py:75
 msgid "Field 'zender administratie' in StUF"
 msgstr "Veld 'zender administratie' in StUF-berichten"
 
-#: stuf/models.py:55
+#: stuf/models.py:80
 msgid "sending user"
 msgstr "versturende gebruiker"
 
-#: stuf/models.py:56
+#: stuf/models.py:81
 msgid "Field 'zender gebruiker' in StUF"
 msgstr "Veld 'zender gebruiker' in StUF-berichten"
 
-#: stuf/models.py:64
-msgid "URL of the StUF service to connect to."
-msgstr "URL naar de StUF service om mee te verbinden."
-
-#: stuf/models.py:68
+#: stuf/models.py:87
 msgid "endpoint BeantwoordVraag"
 msgstr "endpoint BeantwoordVraag"
 
-#: stuf/models.py:71
+#: stuf/models.py:90
 msgid ""
 "Endpoint for synchronous request messages, usually '[...]/BeantwoordVraag'"
 msgstr ""
 "Endpoint voor synchrone vraagberichten, typisch '[...]/BeantwoordVraag'."
 
-#: stuf/models.py:75
+#: stuf/models.py:94
 msgid "endpoint VrijeBerichten"
 msgstr "endpoint VrijeBerichten"
 
-#: stuf/models.py:78
+#: stuf/models.py:97
 msgid ""
-"Endpoint for synchronous free messages, usually "
-"'[...]/VerwerkSynchroonVrijBericht' or '[...]/VrijeBerichten'."
+"Endpoint for synchronous free messages, usually '[...]/"
+"VerwerkSynchroonVrijBericht' or '[...]/VrijeBerichten'."
 msgstr ""
-"Endpoint voor synchrone vrije berichten, typisch "
-"'[...]/VerwerkSynchroonVrijBericht' of '[...]/VrijeBerichten'."
+"Endpoint voor synchrone vrije berichten, typisch '[...]/"
+"VerwerkSynchroonVrijBericht' of '[...]/VrijeBerichten'."
 
-#: stuf/models.py:82
+#: stuf/models.py:101
 msgid "endpoint OntvangAsynchroon"
 msgstr "endpoint OntvangAsynchroon"
 
-#: stuf/models.py:85
+#: stuf/models.py:104
 msgid "Endpoint for asynchronous messages, usually '[...]/OntvangAsynchroon'."
 msgstr ""
 "Endpoint voor a-synchrone berichten, typisch '[...]/OntvangAsynchroon'."
 
-#: stuf/models.py:90
+#: stuf/models.py:109
 msgid "SOAP version"
 msgstr "SOAP versie"
 
-#: stuf/models.py:94
+#: stuf/models.py:113
 msgid "The SOAP version to use for the message envelope."
 msgstr "De SOAP versie gebruikt in de berichten envelop."
 
-#: stuf/models.py:98
+#: stuf/models.py:117
 msgid "Security"
 msgstr "Beveiliging"
 
-#: stuf/models.py:102
+#: stuf/models.py:121
 msgid "The security to use for messages sent to the endpoints."
 msgstr "De beveiliging om berichten te versturen naar de endpoints."
 
-#: stuf/models.py:109
+#: stuf/models.py:128
 msgid "Username to use in the XML security context."
 msgstr "Gebruikersnaam voor de XML security context."
 
-#: stuf/models.py:112
+#: stuf/models.py:131
 msgid "password"
 msgstr "wachtwoord"
 
-#: stuf/models.py:115
+#: stuf/models.py:134
 msgid "Password to use in the XML security context."
 msgstr "Wachtwoord voor de XML security context."
 
-#: stuf/models.py:123
+#: stuf/models.py:142
 msgid ""
 "The SSL certificate file used for client identification. If left empty, "
 "mutual TLS is disabled."
@@ -4288,7 +4491,7 @@ msgstr ""
 "Het SSL-certificaat bestand dat gebruikt wordt voor client-side "
 "identificatie. Indien leeg wordt mutual TLS uitschakeld."
 
-#: stuf/models.py:129
+#: stuf/models.py:148
 msgid ""
 "The SSL certificate key file used for client identification. If left empty, "
 "mutual TLS is disabled."
@@ -4296,13 +4499,13 @@ msgstr ""
 "Het SSL-certificaat sleutelbestand dat gebruikt wordt voor client-side "
 "identificatie. Indien leeg wordt mutual TLS uitschakeld."
 
-#: stuf/models.py:136
-msgid "SOAP service"
-msgstr "SOAP service"
+#: stuf/models.py:155
+msgid "StUF service"
+msgstr "StUF-service"
 
-#: stuf/models.py:137
-msgid "SOAP services"
-msgstr "SOAP service"
+#: stuf/models.py:156
+msgid "StUF services"
+msgstr "StUF-services"
 
 #: stuf/stuf_bg/constants.py:22
 msgid "First name"
@@ -4312,202 +4515,90 @@ msgstr "Voornaam"
 msgid "Last name"
 msgstr "Achternaam"
 
-#: stuf/stuf_bg/constants.py:24
+#: stuf/stuf_bg/constants.py:25
+msgid "Last name prefix"
+msgstr "Voorvoegsel"
+
+#: stuf/stuf_bg/constants.py:27
 msgid "Street Name"
 msgstr "Straatnaam"
 
-#: stuf/stuf_bg/constants.py:25
+#: stuf/stuf_bg/constants.py:28
 msgid "House number"
 msgstr "Huisnummer"
 
-#: stuf/stuf_bg/constants.py:26
+#: stuf/stuf_bg/constants.py:29
 msgid "House letter"
 msgstr "Huisletter"
 
-#: stuf/stuf_bg/constants.py:28
+#: stuf/stuf_bg/constants.py:31
 msgid "House number addition"
 msgstr "Huisnummertoevoeging"
 
-#: stuf/stuf_bg/constants.py:30
+#: stuf/stuf_bg/constants.py:33
 msgid "Postal code"
 msgstr "Postcode"
 
-#: stuf/stuf_bg/constants.py:31
+#: stuf/stuf_bg/constants.py:34
 msgid "Residence name"
 msgstr "Woonplaatsnaam"
+
+#: stuf/stuf_bg/constants.py:36
+msgid "Municipality where registered"
+msgstr "Gemeente van inschrijving"
 
 #: stuf/stuf_bg/models.py:32
 msgid "StUF-BG configuration"
 msgstr "StUF-BG configuratie"
 
-#~ msgid "availability"
-#~ msgstr "beschikbaarheid"
+#: stuf/stuf_zds/models.py:28
+msgid "Municipality code"
+msgstr "Gemeentecode"
 
-#~ msgid ""
-#~ "Availability strategy to use. A step must be available before it can be "
-#~ "filled out. Note that this is not validated (yet) during step submission."
-#~ msgstr ""
-#~ "Te gebruiken beschikbaarheidsstrategie. Een stap moet beschikbaar zijn "
-#~ "voordat deze ingevuld kan worden. Merk op dat deze (nog) niet gevalideerd is"
-#~ " tijdens het verzenden van de stap."
+#: stuf/stuf_zds/models.py:30
+msgid "Municipality code to register zaken"
+msgstr "Gemeentecode om zaken aan te maken"
 
-#~ msgid ""
-#~ "The URL where the PDF report with submission data can be downloaded from."
-#~ msgstr ""
-#~ "De URL waar het PDF document met alle inzendingsgegevens kan worden "
-#~ "gedownload."
+#: stuf/stuf_zds/models.py:34
+msgid "Zaaktype code"
+msgstr "zaaktype code"
 
-#~ msgid "Report status url"
-#~ msgstr "Document status URL"
+#: stuf/stuf_zds/models.py:36
+msgid "Zaaktype code for newly created zaken in StUF-ZDS"
+msgstr "Zaaktype code voor nieuw aangemaakte zaken via StUF-ZDS"
 
-#~ msgid "The endpoint where the PDF report generation status can be checked."
-#~ msgstr ""
-#~ "De URL waar de status van de documentgeneratie gecontroleerd kan worden."
+#: stuf/stuf_zds/models.py:39
+msgid "Zaaktype description"
+msgstr "Zaaktype omschrijving"
 
-#~ msgid "Status"
-#~ msgstr "Status"
+#: stuf/stuf_zds/models.py:41
+msgid "Zaaktype description for newly created zaken in StUF-ZDS"
+msgstr "Zaaktype omschrijving voor nieuw aangemaakt zaken via StUF-ZDS"
 
-#~ msgid "The task is waiting for execution."
-#~ msgstr "De taak wacht tot deze wordt uitgevoerd."
+#: stuf/stuf_zds/models.py:44
+msgid "Zaaktype status code"
+msgstr "Zaaktype status code"
 
-#~ msgid "The task has been started."
-#~ msgstr "De taak is gestart."
+#: stuf/stuf_zds/models.py:46
+msgid "Zaaktype status code for newly created zaken in StUF-ZDS"
+msgstr "Zaaktype status code voor nieuw aangemaakte zaken via StUF-ZDS"
 
-#~ msgid "The task is to be retried, possibly because of failure."
-#~ msgstr ""
-#~ "De taak moet opnieuw worden gestart, mogelijk door een eerdere foutsituatie."
+#: stuf/stuf_zds/models.py:49
+msgid "Zaaktype status omschrijving"
+msgstr "Zaaktype status omschrijving"
 
-#~ msgid "The task has failed."
-#~ msgstr "De taak is mislukt."
+#: stuf/stuf_zds/models.py:51
+msgid "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+msgstr "Zaaktype status omschrijving voor nieuw aangemaakte zaken via StUF-ZDS"
 
-#~ msgid ""
-#~ "Status of the background task responsible for generating the submission data"
-#~ " PDF."
-#~ msgstr ""
-#~ "Status van de achtergrondtaak die verantwoordelijk is voor het genereren van"
-#~ " het document."
+#: stuf/stuf_zds/models.py:54
+msgid "Documenttype description"
+msgstr "Documenttype omschrijving"
 
-#~ msgid ""
-#~ "On submission completion, a PDF report is generated with the submitted form "
-#~ "data. This is done in a background job. You can use this endpoint to check "
-#~ "the status of this PDF generation. The endpoint requires a token which is "
-#~ "tied to the submission from the session. Once the PDF is downloaded, this "
-#~ "token is invalidated. The token also automatically expires after "
-#~ "{expire_days} day(s)."
-#~ msgstr ""
-#~ "Na het inzenden van een formulier wordt een document gegenereerd met de "
-#~ "ingezonden gegevens, in PDF vorm. Dit proces vind op de achtergrond plaats. "
-#~ "Middels dit endpoint kan de status van dit proces worden opgevraagd. Dit "
-#~ "endpoint kan alleen worden benaderd met een token die hoort bij de formulier"
-#~ " sessie. Nadat het document is gedownload, of na {expire_days} dagen, is het"
-#~ " token niet meer te gebruiken."
+#: stuf/stuf_zds/models.py:56
+msgid "Documenttype description for newly created zaken in StUF-ZDS"
+msgstr "Documenttype omschrijving voor nieuw aangemaakt zaken via StUF-ZDS"
 
-#~ msgid "current step"
-#~ msgstr "huidige stap"
-
-#~ msgid "Product ID"
-#~ msgstr "Product ID"
-
-#~ msgid "Location ID"
-#~ msgstr "Locatie ID"
-
-#~ msgid "Product ID to get dates for"
-#~ msgstr "Unieke sleutel van het product om datums voor op te halen"
-
-#~ msgid "Location ID to get dates for"
-#~ msgstr "Unieke sleutel van de locatie om beschikbare datums op te halen"
-
-#~ msgid "Product ID to get times for"
-#~ msgstr "Unieke sleutel van het product om beschikbare tijden op te halen"
-
-#~ msgid "Location ID to get times for"
-#~ msgstr "Unieke sleutel van de locatie om beschikbare tijden op te halen"
-
-#~ msgid "Objecttype"
-#~ msgstr "Objecttype"
-
-#~ msgid "Objecttype version"
-#~ msgstr "Objecttype versie"
-
-#~ msgid "Attachment informatieobjecttype"
-#~ msgstr "Bijlage informatieobjecttype"
-
-#~ msgid "Organisation RSIN"
-#~ msgstr "Organiatie RSIN"
-
-#~ msgid "organisatie RSIN"
-#~ msgstr "organisatie RSIN"
-
-#~ msgid "Registration Backend"
-#~ msgstr "Registratie backend"
-
-#~ msgid "Invalid data."
-#~ msgstr "Ongeldig gegevens"
-
-#, fuzzy
-#~ msgid "Too many requests"
-#~ msgstr "endpoint voor synchrone berichten"
-
-#~ msgid "Production"
-#~ msgstr "Productie"
-
-#~ msgid "Development"
-#~ msgstr "Ontwikkeling"
-
-#~ msgid "KVK Environment"
-#~ msgstr "KvK omgeving"
-
-#~ msgid "The development API uses different paths/operations"
-#~ msgstr ""
-#~ "De ontwikkel API gebruikt andere paden en operaties dan de productie API."
-
-#~ msgid "Form deleted via the API."
-#~ msgstr "Formulier verwijderd via de API."
-
-#~ msgid "You must save the form before the snippet can be generated."
-#~ msgstr "Je moet het formulier bewaren voor een snippet beschikbaar is."
-
-#~ msgid "This field is required."
-#~ msgstr "Dit veld is verplicht."
-
-#~ msgid "Open"
-#~ msgstr "Openen"
-
-#~ msgid "citizen service number"
-#~ msgstr "BSN"
-
-#~ msgid "chamber of commerce number"
-#~ msgstr "KvK-nummer"
-
-#~ msgid "First Name"
-#~ msgstr "Voornamen"
-
-#~ msgid "Last Name"
-#~ msgstr "Geslachtsnaam"
-
-#~ msgid "House Number"
-#~ msgstr "Huisnummer"
-
-#~ msgid "Post Code"
-#~ msgstr "Postcode"
-
-#~ msgid "KvK number should have %(size)i characters."
-#~ msgstr "KvK-nummer moet %(size)i tekens lang zijn."
-
-#~ msgid "KvK Company by RSIN"
-#~ msgstr "KvK Bedrijf via RSIN"
-
-#~ msgid "Feature flags"
-#~ msgstr "Feature flags"
-
-#~ msgid ""
-#~ "The name of the attribute in the submission data that contains the email "
-#~ "address to which the confirmation email will be sent. If not specified, "
-#~ "`email` will be used."
-#~ msgstr ""
-#~ "De naam van het attribuut in de inzendingsgegevens dat het e-mailadres bevat"
-#~ " waarnaar de bevestigingse-mail verstuurd zal worden. Indien niet opgegeven,"
-#~ " dan wordt het veld `email` gebruikt."
-
-#~ msgid "Submitted data"
-#~ msgstr "Verzonden gegevens"
+#: stuf/stuf_zds/models.py:79
+msgid "StUF-ZDS configuration"
+msgstr "StUF-ZDS configuratie"

--- a/src/openforms/emails/tests/test_confirmation_email.py
+++ b/src/openforms/emails/tests/test_confirmation_email.py
@@ -276,7 +276,16 @@ class PaymentConfirmationEmailTests(TestCase):
 
         rendered_content = email.render(submission)
 
-        self.assertNotIn(_("Payment of"), rendered_content)
+        literals = [
+            _("Payment of &euro;%(payment_price)s received."),
+            _("Payment of &euro;%(payment_price)s is required."),
+        ]
+        for literal in literals:
+            with self.subTest(literal=literal):
+                self.assertNotIn(
+                    literal % {"payment_price": submission.form.product.price},
+                    rendered_content,
+                )
 
     def test_email_payment_incomplete(self):
         email = ConfirmationEmailTemplate(content="test {% payment_status %}")
@@ -290,8 +299,10 @@ class PaymentConfirmationEmailTests(TestCase):
         rendered_content = email.render(submission)
 
         # show amount
-        self.assertIn(_("Payment of"), rendered_content)
-        self.assertIn("12.34", rendered_content)
+        literal = _("Payment of &euro;%(payment_price)s is required.") % {
+            "payment_price": submission.form.product.price
+        }
+        self.assertIn(literal, rendered_content)
 
         # show link
         url = build_absolute_uri(
@@ -315,8 +326,10 @@ class PaymentConfirmationEmailTests(TestCase):
         rendered_content = email.render(submission)
 
         # still show amount
-        self.assertIn(_("Payment of"), rendered_content)
-        self.assertIn("12.34", rendered_content)
+        literal = _("Payment of &euro;%(payment_price)s received.") % {
+            "payment_price": submission.form.product.price
+        }
+        self.assertIn(literal, rendered_content)
 
         # no payment link
         url = reverse("payments:link", kwargs={"uuid": submission.uuid})

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -72,9 +72,9 @@ class EmailBackendTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            _("[Open Forms] {form} - submission {ref}").format(
-                form=submission.form.admin_name,
-                ref=submission.public_registration_reference,
+            _("[Open Forms] {form_name} - submission {public_reference}").format(
+                form_name=submission.form.admin_name,
+                public_reference=submission.public_registration_reference,
             ),
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
@@ -83,8 +83,8 @@ class EmailBackendTests(TestCase):
         # Check that the template is used
         self.assertIn('<table border="0">', message.body)
         self.assertIn(
-            _("Submission details for {form} (submitted on {date})").format(
-                form=self.form.admin_name, date="12:00:00 01-01-2021"
+            _("Submission details for {form_name} (submitted on {datetime})").format(
+                form_name=self.form.admin_name, datetime="12:00:00 01-01-2021"
             ),
             message.body,
         )
@@ -126,9 +126,9 @@ class EmailBackendTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            _("[Open Forms] {form} - submission {ref}").format(
-                form=submission.form.admin_name,
-                ref=submission.public_registration_reference,
+            _("[Open Forms] {form_name} - submission {public_reference}").format(
+                form_name=submission.form.admin_name,
+                public_reference=submission.public_registration_reference,
             ),
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
@@ -137,8 +137,8 @@ class EmailBackendTests(TestCase):
         # Check that the template is used
         self.assertIn('<table border="0">', message.body)
         self.assertIn(
-            _("Submission details for {form} (submitted on {date})").format(
-                form=self.form.admin_name, date="12:00:00 01-01-2021"
+            _("Submission details for {form_name} (submitted on {datetime})").format(
+                form_name=self.form.admin_name, datetime="12:00:00 01-01-2021"
             ),
             message.body,
         )
@@ -176,9 +176,9 @@ class EmailBackendTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            _("[Open Forms] {form} - submission {ref}").format(
-                form=submission.form.admin_name,
-                ref=submission.public_registration_reference,
+            _("[Open Forms] {form_name} - submission {public_reference}").format(
+                form_name=submission.form.admin_name,
+                public_reference=submission.public_registration_reference,
             ),
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
@@ -187,8 +187,8 @@ class EmailBackendTests(TestCase):
         # Check that the template is used
         self.assertIn('<table border="0">', message.body)
         self.assertIn(
-            _("Submission details for {form} (submitted on {date})").format(
-                form=self.form.admin_name, date="12:00:00 01-01-2021"
+            _("Submission details for {form_name} (submitted on {datetime})").format(
+                form_name=self.form.admin_name, datetime="12:00:00 01-01-2021"
             ),
             message.body,
         )
@@ -217,9 +217,11 @@ class EmailBackendTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            _("[Open Forms] {form} - submission payment received {ref}").format(
-                form=submission.form.admin_name,
-                ref=submission.public_registration_reference,
+            _(
+                "[Open Forms] {form_name} - submission payment received {public_reference}"
+            ).format(
+                form_name=submission.form.admin_name,
+                public_reference=submission.public_registration_reference,
             ),
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
@@ -272,9 +274,9 @@ class EmailBackendTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            _("[Open Forms] {form} - submission {ref}").format(
-                form=submission.form.admin_name,
-                ref=submission.public_registration_reference,
+            _("[Open Forms] {form_name} - submission {public_reference}").format(
+                form_name=submission.form.admin_name,
+                public_reference=submission.public_registration_reference,
             ),
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
@@ -283,8 +285,8 @@ class EmailBackendTests(TestCase):
         # Check that the template is used
         self.assertIn('<table border="0">', message.body)
         self.assertIn(
-            _("Submission details for {form} (submitted on {date})").format(
-                form=self.form.admin_name, date="12:00:00 01-01-2021"
+            _("Submission details for {form_name} (submitted on {datetime})").format(
+                form_name=self.form.admin_name, datetime="12:00:00 01-01-2021"
             ),
             message.body,
         )
@@ -357,9 +359,9 @@ class EmailBackendTests(TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            _("[Open Forms] {form} - submission {ref}").format(
-                form=submission.form.admin_name,
-                ref=submission.public_registration_reference,
+            _("[Open Forms] {form_name} - submission {public_reference}").format(
+                form_name=submission.form.admin_name,
+                public_reference=submission.public_registration_reference,
             ),
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
@@ -368,8 +370,8 @@ class EmailBackendTests(TestCase):
         # Check that the template is used
         self.assertIn('<table border="0">', message.body)
         self.assertIn(
-            _("Submission details for {form} (submitted on {date})").format(
-                form=self.form.admin_name, date="12:00:00 01-01-2021"
+            _("Submission details for {form_name} (submitted on {datetime})").format(
+                form_name=self.form.admin_name, datetime="12:00:00 01-01-2021"
             ),
             message.body,
         )


### PR DESCRIPTION
* Added translations
* Fixed message strings in tests
* Fixed assertions with partial strings, this will **never** work with translatable strings, you must include the full string.