### PR TITLE
[#847] Changed admin registration backend label

### DIFF
--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -236,7 +236,7 @@ class Form(models.Model):
         choices = dict(registration_register.get_choices())
         return choices.get(
             self.registration_backend,
-            _("{backend} (invalid)").format(backend=self.registration_backend),
+            "-",
         )
 
     get_registration_backend_display.short_description = _("registration backend")


### PR DESCRIPTION
Fixes #847 

I went for showing "-" instead of "(geen)" so that it is consistent with the payment backend and the authentication backend