### PR TITLE
Fixes #863 -- fix date-picker z-index

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -40,7 +40,8 @@ li.nav-item {
 }
 
 .formio-dialog,
-.ck-body .ck.ck-balloon-panel
+.ck-body .ck.ck-balloon-panel,
+div.flatpickr-calendar.open
 {
   z-index: 10000000;
 }


### PR DESCRIPTION
This was hidden because of higher z-indices from django apps.