### PR TITLE
Add password component to form builder

### DIFF
--- a/src/openforms/js/components/form/password.js
+++ b/src/openforms/js/components/form/password.js
@@ -1,0 +1,14 @@
+import {Formio} from 'react-formio';
+
+import { DEFAULT_SENSITIVE_TABS } from './edit/tabs';
+
+
+class PasswordField extends Formio.Components.components.password {
+
+    static editForm() {
+        return {components: [DEFAULT_SENSITIVE_TABS]};
+    }
+
+}
+
+export default PasswordField;

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -39,6 +39,7 @@ const BUILDER_OPTIONS = {
                 postcode: true,
                 file: true,
                 map: true,
+                password: true,
             }
         },
         custom_layout: {

--- a/src/openforms/js/formio_module.js
+++ b/src/openforms/js/formio_module.js
@@ -14,6 +14,7 @@ import SelectBoxesField from './components/form/selectBoxes';
 import EmailField from './components/form/email';
 import FieldSet from './components/form/fieldset';
 import Map from './components/form/map';
+import PasswordField from './components/form/password';
 
 const FormIOModule = {
   components: {
@@ -32,6 +33,7 @@ const FormIOModule = {
     selectboxes: SelectBoxesField,
     email: EmailField,
     map: Map,
+    password: PasswordField,
     fieldset: FieldSet,
   },
 };


### PR DESCRIPTION
Resolves #197 

Related SDK PR: https://github.com/open-formulieren/open-forms-sdk/pull/106

As discussed in Slack this will store the password in plain text as FormIO does not do any password encryption and we aren't adding our own.  This will mean in the admin screen, PDF download, etc. you can see the password that the user entered.

**Screenshots**

![Screenshot 2021-11-12 at 14 46 25](https://user-images.githubusercontent.com/60747362/141477101-7a400f66-d658-4543-9f2e-a50bd94c79cb.png)

![Screenshot 2021-11-12 at 14 46 40](https://user-images.githubusercontent.com/60747362/141477123-70990ed2-0c5e-4284-9d16-0a52fac9eea3.png)
