### PR TITLE
Fixes #937 -- include flatpickr styles in bundle

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -4,6 +4,8 @@
 @import '~@fortawesome/fontawesome-free/scss/regular';
 @import '~@fortawesome/fontawesome-free/scss/solid';
 @import '~formiojs/dist/formio.full.css';
+// since we include flatpickr in the global scope, we need to embed the CSS ourselves
+@import '~flatpickr/dist/flatpickr.css';
 
 
 .field-configuration {


### PR DESCRIPTION
Traced this down to a difference in Formio 4.12 (sdk) and 4.13 (backend),
which explains why the same flatpickr init code works on the SDK but
doesn't in the backend.

The cause of our bug is that the `flatpickr.min.css` stylesheet is not loaded
in the backend, which causes the DOM element to be visible and SVGs to not
have any dimension information. This stylesheet is loaded in the SDK however,
via the `FormIO.requireLibrary` function.

This function loads the library from Formio's CDN _if it's not present in the
global scope yet_. This works different for flatpickr in 4.12 and 4.13:

* 4.12 loads it with `flatpickr-css` as property name (see
  https://github.com/formio/formio.js/blob/4.12.x/src/widgets/CalendarWidget.js#L144)
* 4.13 loads it with `flatpickr` as property name (see
  https://github.com/formio/formio.js/blob/4.13.x/src/widgets/CalendarWidget.js#L152)

Now, because we load `flatpickr` in the bundle to set the localization options,
this adds `flatpickr` to the global scope. Not a problem in 4.12, as `flatpickr-css`
is not set, but on 4.13 this breaks since now the library `flatpickr` is set
already, hence the CSS is no longer loaded.