### PR TITLE
[#941] Added plugin config tests

### DIFF
--- a/src/openforms/config/__init__.py
+++ b/src/openforms/config/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "openforms.config.apps.OpenFormsConfigConfig"

--- a/src/openforms/config/templates/admin/config/overview.html
+++ b/src/openforms/config/templates/admin/config/overview.html
@@ -1,0 +1,53 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">{% endblock %}
+
+{% block title %} {% trans "Configuration" %} {{ block.super }} {% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; {% trans 'Configuration' %}
+&rsaquo; {% trans 'Overview' %}
+</div>
+{% endblock %}
+
+{% block content %}
+    <h1>{% trans 'Configuration' %}</h1>
+    <div id="content-main">
+        
+        {% for section in sections %}
+            <section class="module">
+                <table class="table" width="100%">
+                    <caption>{{ section.name }}</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col" width="300">{% trans "Name" %}</th>
+                            <th scope="col">{% trans "Status" %}</th>
+                            <th scope="col" width="300">{% trans "Actions" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in section.entries %}
+                            <tr>
+                                <td><strong>{{ entry.name }}</strong></td>
+                                <td>{{ entry.status }}{% if entry.status_message %} {{ entry.status_message }}{% endif %}</td>
+                                <td>
+                                    {% for label, url in entry.actions %}
+                                        <a href="{{ url }}">{{ label }}</a>
+                                    {% endfor %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </section>
+        {% endfor %}
+
+        <div class="submit-row">
+            <input type="button" class="default" value="{% trans 'Cancel' %}" onclick="javascript:history.back();">
+        </div>
+    </div>
+
+{% endblock %}

--- a/src/openforms/config/tests/test_config_check.py
+++ b/src/openforms/config/tests/test_config_check.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
+
+
+class ConfigCheckTests(TestCase):
+    def test_access_permission(self):
+        url = reverse("config:overview")
+        with self.subTest("anon"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+
+        with self.subTest("user"):
+            self.client.force_login(UserFactory())
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+
+        with self.subTest("user"):
+            self.client.force_login(StaffUserFactory())
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)

--- a/src/openforms/config/urls.py
+++ b/src/openforms/config/urls.py
@@ -5,5 +5,5 @@ from .views import ConfigurationView
 app_name = "config"
 
 urlpatterns = [
-    path("overview/", ConfigurationView.as_view(), name="config-overview"),
+    path("overview/", ConfigurationView.as_view(), name="overview"),
 ]

--- a/src/openforms/config/urls.py
+++ b/src/openforms/config/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import ConfigurationView
+
+app_name = "config"
+
+urlpatterns = [
+    path("overview/", ConfigurationView.as_view(), name="config-overview"),
+]

--- a/src/openforms/config/views.py
+++ b/src/openforms/config/views.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict
+
+from django.contrib.admin.templatetags.admin_list import _boolean_icon
+from django.utils.translation import ugettext_lazy as _
+from django.views.generic import TemplateView
+
+# from openforms.appointments.registry import register as appointments_register
+from openforms.payments.registry import register as payments_register
+from openforms.plugins.exceptions import InvalidPluginConfiguration
+from openforms.prefill.registry import register as prefill_register
+from openforms.registrations.registry import register as registrations_register
+
+
+class ConfigurationView(TemplateView):
+    template_name = "admin/config/overview.html"
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        sections = []
+
+        def get_plugin_entry(plugin: Any) -> Dict[str, Any]:
+            try:
+                plugin.check_config()
+            except InvalidPluginConfiguration as e:
+                status_message = e
+                status = False
+            except Exception as e:
+                status_message = _("Internal error: {exception}").format(exception=e)
+                status = None
+            else:
+                status_message = None
+                status = True
+
+            try:
+                actions = plugin.get_config_actions()
+            except Exception:
+                actions = [
+                    (
+                        "Not implemented",
+                        "TODO: REMOVE THIS WHEN ALL PLUGINS HAVE THIS FUNCTION.",
+                    )
+                ]
+
+            return {
+                "name": plugin.verbose_name,
+                "status": _boolean_icon(status),
+                "status_message": status_message,
+                "actions": actions,
+            }
+
+        # Iterate over all plugin registries.
+        plugin_registries = [
+            # (_("Appointment plugins"), appointments_register),
+            (_("Registration plugins"), registrations_register),
+            (_("Prefill plugins"), prefill_register),
+            (_("Payment plugins"), payments_register),
+        ]
+
+        for name, register in plugin_registries:
+            sections.append(
+                {
+                    "name": name,
+                    "entries": [
+                        get_plugin_entry(plugin)
+                        for plugin in register.iter_enabled_plugins()
+                    ],
+                }
+            )
+
+        context.update({"sections": sections})
+
+        return context

--- a/src/openforms/config/views.py
+++ b/src/openforms/config/views.py
@@ -18,36 +18,6 @@ class ConfigurationView(TemplateView):
         context = super().get_context_data(**kwargs)
         sections = []
 
-        def get_plugin_entry(plugin: Any) -> Dict[str, Any]:
-            try:
-                plugin.check_config()
-            except InvalidPluginConfiguration as e:
-                status_message = e
-                status = False
-            except Exception as e:
-                status_message = _("Internal error: {exception}").format(exception=e)
-                status = None
-            else:
-                status_message = None
-                status = True
-
-            try:
-                actions = plugin.get_config_actions()
-            except Exception:
-                actions = [
-                    (
-                        "Not implemented",
-                        "TODO: REMOVE THIS WHEN ALL PLUGINS HAVE THIS FUNCTION.",
-                    )
-                ]
-
-            return {
-                "name": plugin.verbose_name,
-                "status": _boolean_icon(status),
-                "status_message": status_message,
-                "actions": actions,
-            }
-
         # Iterate over all plugin registries.
         plugin_registries = [
             # (_("Appointment plugins"), appointments_register),
@@ -61,7 +31,7 @@ class ConfigurationView(TemplateView):
                 {
                     "name": name,
                     "entries": [
-                        get_plugin_entry(plugin)
+                        self.get_plugin_entry(plugin)
                         for plugin in register.iter_enabled_plugins()
                     ],
                 }
@@ -70,3 +40,33 @@ class ConfigurationView(TemplateView):
         context.update({"sections": sections})
 
         return context
+
+    def get_plugin_entry(self, plugin: Any) -> Dict[str, Any]:
+        try:
+            plugin.check_config()
+        except InvalidPluginConfiguration as e:
+            status_message = e
+            status = False
+        except Exception as e:
+            status_message = _("Internal error: {exception}").format(exception=e)
+            status = None
+        else:
+            status_message = None
+            status = True
+
+        try:
+            actions = plugin.get_config_actions()
+        except Exception:
+            actions = [
+                (
+                    "Not implemented",
+                    "TODO: REMOVE THIS WHEN ALL PLUGINS HAVE THIS FUNCTION.",
+                )
+            ]
+
+        return {
+            "name": plugin.verbose_name,
+            "status": _boolean_icon(status),
+            "status_message": status_message,
+            "actions": actions,
+        }

--- a/src/openforms/emails/tests/test_check_email.py
+++ b/src/openforms/emails/tests/test_check_email.py
@@ -42,6 +42,8 @@ smtp_settings = dict(
 
 
 class CheckEmailSettingsFunctionTests(TestCase):
+    maxDiff = None
+
     def test_ok(self):
         res = check_email_backend("receiver@bar.bazz")
 

--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -334,5 +334,16 @@
         "name": "Audit log",
         "link": "/admin/logging/timelinelogproxy/auditlog/"
     }
+},
+{
+    "model": "admin_index.applink",
+    "fields": {
+        "order": 5,
+        "app_group": [
+            "handige-links"
+        ],
+        "name": "Configuratie Overview",
+        "link": "/admin/config/overview/"
+    }
 }
 ]

--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -340,9 +340,9 @@
     "fields": {
         "order": 5,
         "app_group": [
-            "handige-links"
+            "configuratie"
         ],
-        "name": "Configuratie Overview",
+        "name": "Configuratie overview",
         "link": "/admin/config/overview/"
     }
 }

--- a/src/openforms/plugins/exceptions.py
+++ b/src/openforms/plugins/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidPluginConfiguration(Exception):
+    pass

--- a/src/openforms/registrations/base.py
+++ b/src/openforms/registrations/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
 
 from django.utils.translation import gettext_lazy as _
 
@@ -60,3 +60,29 @@ class BasePlugin(ABC):
 
     def get_label(self):
         return self.verbose_name
+
+    def check_config(self):
+        """
+        Validates if this plugin was properly configured. Typically you should
+        avoid using any data altering actions.
+
+        Implementations should essentially check 3 things (if applicable and
+        possible):
+
+        1. Check the settings (can be deployment variables or database values)
+        2. Check connection to external system
+        3. Check credentials to external system
+
+        :raises InvalidPluginConfiguration: if plugin was not properly
+            configured, this exception is raised.
+        """
+        raise NotImplementedError()
+
+    def get_config_actions(self) -> List[Tuple[str, str]]:
+        """
+        Returns a list of tuples containing the label and URL of each action
+        that is related to the configuration of this plugin. This can be to
+        perform a data altering action that is similar to the plugin's
+        behaviour, a configuration page, etc.
+        """
+        return []

--- a/src/openforms/registrations/contrib/demo/plugin.py
+++ b/src/openforms/registrations/contrib/demo/plugin.py
@@ -27,6 +27,12 @@ class DemoRegistration(BasePlugin):
     def update_payment_status(self, submission: "Submission", options: dict):
         print(submission)
 
+    def check_config(self):
+        """
+        Demo config is always valid.
+        """
+        pass
+
 
 @register("failing-demo")
 class DemoFailRegistration(BasePlugin):
@@ -41,4 +47,10 @@ class DemoFailRegistration(BasePlugin):
         raise NoSubmissionReference("Demo plugin does not emit a reference")
 
     def update_payment_status(self, submission: "Submission", options: dict):
+        pass
+
+    def check_config(self):
+        """
+        Demo config is always valid.
+        """
         pass

--- a/src/openforms/registrations/contrib/email/checks.py
+++ b/src/openforms/registrations/contrib/email/checks.py
@@ -2,14 +2,12 @@ from django.conf import settings
 from django.core.mail import get_connection
 from django.utils.translation import gettext_lazy as _
 
+from django_yubin import settings as yubin_settings
+
 from openforms.plugins.exceptions import InvalidPluginConfiguration
 
 
 def check_config():
-    # NOTE: Moving this import to module level causes this test to fail:
-    # openforms.emails.tests.test_check_email.CheckEmailSettingsFunctionTests.test_init_yubin
-    from django_yubin import settings as yubin_settings
-
     if settings.EMAIL_BACKEND == "django_yubin.smtp_queue.EmailBackend":
         backend = yubin_settings.USE_BACKEND
     else:

--- a/src/openforms/registrations/contrib/email/checks.py
+++ b/src/openforms/registrations/contrib/email/checks.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.core.mail import get_connection
+from django.utils.translation import gettext_lazy as _
+
+from django_yubin import settings as yubin_settings
+
+from openforms.plugins.exceptions import InvalidPluginConfiguration
+
+
+def check_config():
+    if settings.EMAIL_BACKEND == "django_yubin.smtp_queue.EmailBackend":
+        backend = yubin_settings.USE_BACKEND
+    else:
+        backend = settings.EMAIL_BACKEND
+
+    try:
+        connection = get_connection(backend, fail_silently=False)
+        result = connection.open()
+        if result:
+            connection.close()
+    except Exception as e:
+        raise InvalidPluginConfiguration(
+            _("Could not connect to mail service: {exception}").format(exception=e)
+        )

--- a/src/openforms/registrations/contrib/email/checks.py
+++ b/src/openforms/registrations/contrib/email/checks.py
@@ -2,12 +2,14 @@ from django.conf import settings
 from django.core.mail import get_connection
 from django.utils.translation import gettext_lazy as _
 
-from django_yubin import settings as yubin_settings
-
 from openforms.plugins.exceptions import InvalidPluginConfiguration
 
 
 def check_config():
+    # NOTE: Moving this import to module level causes this test to fail:
+    # openforms.emails.tests.test_check_email.CheckEmailSettingsFunctionTests.test_init_yubin
+    from django_yubin import settings as yubin_settings
+
     if settings.EMAIL_BACKEND == "django_yubin.smtp_queue.EmailBackend":
         backend = yubin_settings.USE_BACKEND
     else:

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -10,7 +10,6 @@ from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from openforms.emails.utils import send_mail_html, strip_tags_plus
-from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.submissions.exports import create_submission_export
 from openforms.submissions.models import Submission
 from openforms.submissions.tasks.registration import set_submission_reference

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -1,14 +1,16 @@
 import html
 from mimetypes import types_map
-from typing import NoReturn
+from typing import List, NoReturn, Tuple
 
 from django.conf import settings
 from django.template.loader import get_template
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from openforms.emails.utils import send_mail_html, strip_tags_plus
+from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.submissions.exports import create_submission_export
 from openforms.submissions.models import Submission
 from openforms.submissions.tasks.registration import set_submission_reference
@@ -16,6 +18,7 @@ from openforms.submissions.tasks.registration import set_submission_reference
 from ...base import BasePlugin
 from ...exceptions import NoSubmissionReference
 from ...registry import register
+from .checks import check_config
 from .config import EmailOptionsSerializer
 from .constants import AttachmentFormat
 
@@ -117,3 +120,11 @@ class EmailRegistration(BasePlugin):
             options["to_emails"],
             fail_silently=False,
         )
+
+    def check_config(self):
+        check_config()
+
+    def get_config_actions(self) -> List[Tuple[str, str]]:
+        return [
+            (_("Test"), reverse("admin_email_test")),
+        ]

--- a/src/openforms/registrations/contrib/microsoft_graph/plugin.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/plugin.py
@@ -3,6 +3,7 @@ from typing import NoReturn
 from django.utils.translation import ugettext_lazy as _
 
 from openforms.contrib.microsoft.client import MSGraphClient, MSGraphUploadHelper
+from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.submissions.models import Submission, SubmissionReport
 from openforms.submissions.tasks.registration import set_submission_reference
 
@@ -65,3 +66,6 @@ class MSGraphRegistration(BasePlugin):
             else:
                 content = f"{_('payment required')}: € {submission.form.product.price}"
             uploader.upload_string(content, f"{folder_name}/payment_status.txt")
+
+    def check_config(self):
+        raise InvalidPluginConfiguration("TODO")

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -6,6 +6,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from zgw_consumers.models import Service
 
+from openforms.plugins.exceptions import InvalidPluginConfiguration
+
 # "Borrow" the functions from another plugin.
 from openforms.registrations.contrib.zgw_apis.service import (
     create_attachment_document,
@@ -131,3 +133,6 @@ class ObjectsAPIRegistration(BasePlugin):
 
     def get_reference_from_result(self, result: None) -> NoReturn:
         raise NoSubmissionReference("Object API plugin does not emit a reference")
+
+    def check_config(self):
+        raise InvalidPluginConfiguration("TODO")

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 
+from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.registrations.base import BasePlugin
 from openforms.registrations.constants import (
     REGISTRATION_ATTRIBUTE,
@@ -191,3 +192,6 @@ class StufZDSRegistration(BasePlugin):
         client = config.get_client(submission.form.registration_backend_options)
 
         client.set_zaak_payment(submission.registration_result["zaak"])
+
+    def check_config(self):
+        raise InvalidPluginConfiguration("TODO")

--- a/src/openforms/registrations/contrib/zgw_apis/checks.py
+++ b/src/openforms/registrations/contrib/zgw_apis/checks.py
@@ -1,0 +1,56 @@
+from django.utils.translation import gettext_lazy as _
+
+from requests.models import HTTPError
+from zds_client.client import ClientError
+
+from openforms.plugins.exceptions import InvalidPluginConfiguration
+from openforms.registrations.contrib.zgw_apis.models import ZgwConfig
+
+
+def check_config():
+    config = ZgwConfig.get_solo()
+
+    # We need to check 3 API's for this configuration.
+    services = (
+        (
+            "zrc_service",
+            "Zaken API",
+            "zaak",
+        ),
+        (
+            "drc_service",
+            "Documenten API",
+            "enkelvoudiginformatieobject",
+        ),
+        (
+            "ztc_service",
+            "Catalogi API",
+            "zaaktype",
+        ),
+    )
+
+    for service_field, api_name, api_operation in services:
+
+        # Check settings
+        service = getattr(config, service_field)
+        if not service:
+            raise InvalidPluginConfiguration(
+                _("{api_name} endpoint is not configured.").format(api_name=api_name)
+            )
+
+        # Check connection and API-response
+        try:
+            client = service.build_client()
+            client.list(api_operation)
+        except (HTTPError, ClientError) as e:
+            raise InvalidPluginConfiguration(
+                _("Invalid response from {api_name}: {exception}").format(
+                    api_name=api_name, exception=e
+                )
+            )
+        except Exception as e:
+            raise InvalidPluginConfiguration(
+                _("Could not connect to {api_name}: {exception}").format(
+                    api_name=api_name, exception=e
+                )
+            )

--- a/src/openforms/registrations/contrib/zgw_apis/checks.py
+++ b/src/openforms/registrations/contrib/zgw_apis/checks.py
@@ -29,7 +29,7 @@ def check_config():
         ),
     )
 
-    for service_field, api_name, api_operation in services:
+    for service_field, api_name, api_resource in services:
 
         # Check settings
         service = getattr(config, service_field)
@@ -41,7 +41,7 @@ def check_config():
         # Check connection and API-response
         try:
             client = service.build_client()
-            client.list(api_operation)
+            client.list(api_resource)
         except (HTTPError, ClientError) as e:
             raise InvalidPluginConfiguration(
                 _("Invalid response from {api_name}: {exception}").format(

--- a/src/openforms/urls.py
+++ b/src/openforms/urls.py
@@ -36,6 +36,10 @@ urlpatterns = [
         name="admin_email_test",
     ),
     path("admin/hijack/", include("hijack.urls")),
+    path(
+        "admin/config/",
+        decorator_include(login_required, "openforms.config.urls", namespace="config"),
+    ),
     path("admin/", admin.site.urls),
     path(
         "reset/<uidb64>/<token>/",

--- a/src/openforms/urls.py
+++ b/src/openforms/urls.py
@@ -2,6 +2,7 @@ from django.apps import apps
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -38,7 +39,9 @@ urlpatterns = [
     path("admin/hijack/", include("hijack.urls")),
     path(
         "admin/config/",
-        decorator_include(login_required, "openforms.config.urls", namespace="config"),
+        decorator_include(
+            staff_member_required, "openforms.config.urls", namespace="config"
+        ),
     ),
     path("admin/", admin.site.urls),
     path(


### PR DESCRIPTION
Fixes #941

* Adds ZGW and e-mail config tests
* All other plugins still need a `check_config` and `get_config_actions` implementation.
* [x] Need a link somewhere in the menu

Initial work:

![image](https://user-images.githubusercontent.com/96970/142384581-5e1f3351-5804-41f5-aea2-065ee81724f7.png)
