### PR TITLE
[#974] Fix email layout

### DIFF
--- a/src/openforms/emails/context.py
+++ b/src/openforms/emails/context.py
@@ -32,7 +32,7 @@ def _get_design_token_values(tokens):
             ),
         },
         "logo": {
-            # Setting height to a default of 50 obtaines the same result on the 
+            # Setting height to a default of 50 obtaines the same result on the
             # website that uses flexbox shrink, to size the logo to it's minimum
             # size.
             "height": glom(tokens, "logo-header.height.value", default="50"),

--- a/src/openforms/emails/context.py
+++ b/src/openforms/emails/context.py
@@ -26,13 +26,16 @@ def _get_design_token_values(tokens):
     """
     return {
         "header": {
-            "color": glom(tokens, "page-header.color.value", default="#ffffff"),
+            "color": glom(tokens, "page-header.color.value", default="#000000"),
             "background": glom(
-                tokens, "page-header.background.value", default="#2980b9"
+                tokens, "page-header.background.value", default="#ffffff"
             ),
         },
         "logo": {
-            "height": glom(tokens, "logo-header.height.value", default="auto"),
+            # Setting height to a default of 50 obtaines the same result on the 
+            # website that uses flexbox shrink, to size the logo to it's minimum
+            # size.
+            "height": glom(tokens, "logo-header.height.value", default="50"),
             "width": glom(tokens, "logo-header.width.value", default="auto"),
         },
         "footer": {

--- a/src/openforms/emails/templates/emails/wrapper.html
+++ b/src/openforms/emails/templates/emails/wrapper.html
@@ -5,7 +5,7 @@
 <table style="font-family: Verdana, Arial, sans-serif; font-size: 12px; width: 100%; border: none; margin: 0; padding: 0; background-color: {{ style.layout.background }}; border-collapse: collapse;" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td align="left" style="padding: 20px;">
-            <table style="width: 768px; background-color: #ffffff; text-align: left; border: none; border-collapse: collapse;" cellpadding="0" cellspacing="0" width="768">
+            <table style="max-width: 768px; background-color: #ffffff; text-align: left; border: none; border-collapse: collapse;" cellpadding="0" cellspacing="0">
                 <tr>
                     <td align="left" style="padding: 20px; color: {{ style.header.color }}; background-color: {{ style.header.background }};">
                         {% if logo_url %}

--- a/src/openforms/emails/templates/emails/wrapper.html
+++ b/src/openforms/emails/templates/emails/wrapper.html
@@ -4,10 +4,10 @@
 
 <table style="font-family: Verdana, Arial, sans-serif; font-size: 12px; width: 100%; border: none; margin: 0; padding: 0; background-color: {{ style.layout.background }}; border-collapse: collapse;" cellpadding="0" cellspacing="0" width="100%">
     <tr>
-        <td align="center">
+        <td align="left" style="padding: 20px;">
             <table style="width: 768px; background-color: #ffffff; text-align: left; border: none; border-collapse: collapse;" cellpadding="0" cellspacing="0" width="768">
                 <tr>
-                    <td align="left" style="padding: 10px; color: {{ style.header.color }}; background-color: {{ style.header.background }};">
+                    <td align="left" style="padding: 20px; color: {{ style.header.color }}; background-color: {{ style.header.background }};">
                         {% if logo_url %}
                             <a style="text-decoration: none;" href="{{ main_website_url }}">
                                 <img


### PR DESCRIPTION
Partially fixes #974 

* Limit logo size to 50px height by default
* Default header background is now white
* Align the content to the left
* Add grey border all around to not blend too much with the mail app
* Allow mobile devices to shrink the width of the inner table to scale the content