### PR TITLE
Bump versions of some libraries

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -133,7 +133,7 @@ django-solo==1.1.3
     #   zgw-consumers
 django-timeline-logger==1.1.2
     # via -r requirements/base.in
-django-tinymce==3.3.0
+django-tinymce==3.4.0
     # via -r requirements/base.in
 django-yubin==1.6.0
     # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,7 @@ celery==4.4.7
     #   -r requirements/base.in
     #   celery-once
     #   flower
-certifi==2020.6.20
+certifi==2021.10.8
     # via
     #   elastic-apm
     #   requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -66,7 +66,7 @@ celery==4.4.7
     #   -r requirements/base.txt
     #   celery-once
     #   flower
-certifi==2020.6.20
+certifi==2021.10.8
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -248,7 +248,7 @@ django-timeline-logger==1.1.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-tinymce==3.3.0
+django-tinymce==3.4.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -78,7 +78,7 @@ celery==4.4.7
     #   -r requirements/ci.txt
     #   celery-once
     #   flower
-certifi==2020.6.20
+certifi==2021.10.8
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -286,7 +286,7 @@ django-timeline-logger==1.1.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-tinymce==3.3.0
+django-tinymce==3.4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Dependabot had a django-tinymce alert open for a while now, there's finally a fix.