### PR TITLE
:arrow_up: Bump mozilla-django-oidc-db to 0.6.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -232,7 +232,7 @@ maykin-django-two-factor-auth[phonenumbers]==2.0.4
     # via -r requirements/base.in
 git+https://github.com/maykinmedia/json-logic-py.git@1ceb93ad165d69a5639edc623d5613d0229c05e2#egg=maykin-json-logic-py
     # via -r requirements/base.in
-mozilla-django-oidc-db==0.4.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/base.in
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -447,7 +447,7 @@ git+https://github.com/maykinmedia/json-logic-py.git@1ceb93ad165d69a5639edc623d5
     #   -r requirements/base.txt
 mccabe==0.6.1
     # via flake8
-mozilla-django-oidc-db==0.4.0
+mozilla-django-oidc-db==0.6.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -525,7 +525,7 @@ mccabe==0.6.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   flake8
-mozilla-django-oidc-db==0.4.0
+mozilla-django-oidc-db==0.6.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Some extra functionality and bugfixes for the OpenID Connect integration, mentioned in the changelog: https://github.com/maykinmedia/mozilla-django-oidc-db/blob/master/CHANGELOG.rst