### PR TITLE
:bug: Fix FormDefinition admin for readonly access

### DIFF
--- a/src/openforms/forms/admin/form_definition.py
+++ b/src/openforms/forms/admin/form_definition.py
@@ -60,8 +60,9 @@ class FormDefinitionAdmin(admin.ModelAdmin):
 
     def get_actions(self, request):
         actions = super().get_actions(request)
-        (old_func, name, short_description) = actions["delete_selected"]
-        actions["delete_selected"] = (delete_selected, name, short_description)
+        if "delete_selected" in actions:
+            (old_func, name, short_description) = actions["delete_selected"]
+            actions["delete_selected"] = (delete_selected, name, short_description)
         return actions
 
     def make_copies(self, request, queryset):

--- a/src/openforms/forms/tests/test_formdefinition_admin.py
+++ b/src/openforms/forms/tests/test_formdefinition_admin.py
@@ -1,0 +1,31 @@
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+from django_webtest import WebTest
+
+from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
+from openforms.tests.utils import disable_2fa
+
+
+@disable_2fa
+class FormDefinitionAdminTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.staff_user = UserFactory.create(is_staff=True)
+        cls.superuser = SuperUserFactory.create()
+
+    def test_formdefinition_list_for_user_with_readonly_perms(self):
+        perm = Permission.objects.get(codename="view_formdefinition")
+        self.staff_user.user_permissions.add(perm)
+
+        url = reverse("admin:forms_formdefinition_changelist")
+        response = self.app.get(url, user=self.staff_user)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_formdefinition_list_for_user_with_all_perms(self):
+        url = reverse("admin:forms_formdefinition_changelist")
+        response = self.app.get(url, user=self.superuser)
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
fixes: https://github.com/open-formulieren/open-forms/issues/998

Relatively minor issues, only occurred for staff users with readonly access