### PR TITLE
Fix and refactor setting auth information from session

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,4 +83,5 @@ linkcheck_ignore = [
     r"https://.*sentry.*",
     r"https://example.com*",
     r"https://portal.azure.com*",
+    r"https://.*kvk\.nl*",
 ]

--- a/src/openforms/authentication/__init__.py
+++ b/src/openforms/authentication/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "openforms.authentication.apps.AuthenticationConfig"

--- a/src/openforms/authentication/apps.py
+++ b/src/openforms/authentication/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class AuthenticationConfig(AppConfig):
+    name = "openforms.authentication"
+    label = "of_authentication"
+    verbose_name = _("Authentication module")
+
+    def ready(self):
+        # ensure signal receivers are registered
+        from . import signals  # noqa

--- a/src/openforms/authentication/constants.py
+++ b/src/openforms/authentication/constants.py
@@ -2,6 +2,8 @@ from django.utils.translation import gettext_lazy as _
 
 from djchoices import ChoiceItem, DjangoChoices
 
+FORM_AUTH_SESSION_KEY = "form_auth"  # pending #957 rework
+
 
 class AuthAttribute(DjangoChoices):
     """

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_integration.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_integration.py
@@ -1,0 +1,60 @@
+from django.test import override_settings
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.authentication.constants import AuthAttribute
+from openforms.forms.tests.factories import FormFactory
+from openforms.submissions.models import Submission
+
+FORM_AUTH_SESSION_KEY = "form_auth"  # TODO: #957 - use centrally defined constant
+
+
+class SubmissionIntegrationTests(APITestCase):
+    """
+    Assert that eHerkenning login has the expected side effects for submissions.
+    """
+
+    def _set_kvk_in_session(self, kvknr: str):
+        session = self.client.session
+
+        # TODO: remove old format, see #957 for the rework
+        # old format
+        session[AuthAttribute.kvk] = kvknr
+
+        # new format
+        session[FORM_AUTH_SESSION_KEY] = {
+            "plugin": "eherkenning",
+            "attribute": AuthAttribute.kvk,
+            "value": kvknr,
+        }
+        session.save()
+
+    @override_settings(CORS_ALLOW_ALL_ORIGINS=True)
+    def test_kvk_stored_on_submission_after_authentication(self):
+        """
+        Assert that after succesful authentication the KVK number is recorded on the
+        started submission.
+        """
+        # see .test_auth.AuthenticationStep5Tests.test_receive_samlart_from_eHerkenning
+        # for the source of this session attribute
+        self._set_kvk_in_session("12345")
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__login_required=True,
+            authentication_backends=["eherkenning"],
+        )
+        form_path = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+        start_endpoint = reverse("api:submission-list")
+        body = {
+            "form": f"http://testserver.com{form_path}",
+            "formUrl": "http://testserver.com/my-form",
+        }
+
+        # start a submission
+        response = self.client.post(start_endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        submission = Submission.objects.get()
+        self.assertEqual(submission.kvk, "12345")

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_integration.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_integration.py
@@ -4,11 +4,10 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.authentication.constants import AuthAttribute
 from openforms.forms.tests.factories import FormFactory
 from openforms.submissions.models import Submission
 
-FORM_AUTH_SESSION_KEY = "form_auth"  # TODO: #957 - use centrally defined constant
+from ....constants import FORM_AUTH_SESSION_KEY, AuthAttribute
 
 
 class SubmissionIntegrationTests(APITestCase):

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -1,8 +1,11 @@
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from django.http import HttpRequest
 
 from openforms.plugins.registry import BaseRegistry
+
+if TYPE_CHECKING:
+    from .base import LoginInfo
 
 
 class Registry(BaseRegistry):

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -8,7 +8,7 @@ from openforms.submissions.models import Submission
 from openforms.submissions.signals import submission_start
 
 
-@receiver(submission_start, dispatch_uid="auth.eherkenning.set_submission_kvk")
+@receiver(submission_start, dispatch_uid="auth.set_submission_kvk")
 def set_kvk_from_session(sender, instance: Submission, request: Request, **kwargs):
     kvk = request.session.get("kvk")
     if not kvk:
@@ -22,3 +22,19 @@ def set_kvk_from_session(sender, instance: Submission, request: Request, **kwarg
 
     instance.kvk = kvk
     instance.save(update_fields=["kvk"])
+
+
+@receiver(submission_start, dispatch_uid="auth.set_submission_bsn")
+def set_bsn_from_session(sender, instance: Submission, request: Request, **kwargs):
+    bsn = request.session.get("bsn")
+    if not bsn:
+        return
+
+    warnings.warn(
+        "The bare 'bsn' session key is deprecated in favour of the generic 'form_auth' "
+        "session key.",
+        DeprecationWarning,
+    )
+
+    instance.bsn = bsn
+    instance.save(update_fields=["bsn"])

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -1,0 +1,24 @@
+import warnings
+
+from django.dispatch import receiver
+
+from rest_framework.request import Request
+
+from openforms.submissions.models import Submission
+from openforms.submissions.signals import submission_start
+
+
+@receiver(submission_start, dispatch_uid="auth.eherkenning.set_submission_kvk")
+def set_kvk_from_session(sender, instance: Submission, request: Request, **kwargs):
+    kvk = request.session.get("kvk")
+    if not kvk:
+        return
+
+    warnings.warn(
+        "The bare 'kvk' session key is deprecated in favour of the generic 'form_auth' "
+        "session key.",
+        DeprecationWarning,
+    )
+
+    instance.kvk = kvk
+    instance.save(update_fields=["kvk"])

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 
 from django.dispatch import receiver
@@ -6,6 +7,10 @@ from rest_framework.request import Request
 
 from openforms.submissions.models import Submission
 from openforms.submissions.signals import submission_start
+
+from .constants import FORM_AUTH_SESSION_KEY, AuthAttribute
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(submission_start, dispatch_uid="auth.set_submission_kvk")
@@ -38,3 +43,30 @@ def set_bsn_from_session(sender, instance: Submission, request: Request, **kwarg
 
     instance.bsn = bsn
     instance.save(update_fields=["bsn"])
+
+
+@receiver(submission_start, dispatch_uid="auth.set_submission_form_auth")
+def set_auth_attribute_on_session(
+    sender, instance: Submission, request: Request, **kwargs
+):
+    form_auth = request.session.get(FORM_AUTH_SESSION_KEY)
+    if not form_auth:
+        return
+
+    plugin = form_auth["plugin"]
+    attribute = form_auth["attribute"]
+    assert (
+        attribute in AuthAttribute.values
+    ), f"Unexpected auth attribute {attribute} specified"
+    # DO NOT log this in plain text, it is considered sensitive information (BSN for example)
+    identifier = form_auth["value"]
+
+    logger.debug(
+        "Persisting form auth to submission %s. Plugin: '%s' (setting attribute '%s')",
+        instance.uuid,
+        plugin,
+        attribute,
+    )
+    instance.auth_plugin = plugin
+    setattr(instance, attribute, identifier)
+    instance.save(update_fields=["auth_plugin", attribute])

--- a/src/openforms/prefill/contrib/kvk/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/kvk/tests/test_plugin.py
@@ -5,9 +5,10 @@ from glom import PathAccessError, glom
 from zgw_consumers.test import mock_service_oas_get
 
 from openforms.contrib.kvk.tests.base import KVKTestMixin
-from openforms.prefill.contrib.kvk.constants import Attributes
-from openforms.prefill.contrib.kvk.plugin import KVK_KVKNumberPrefill
 from openforms.submissions.tests.factories import SubmissionFactory
+
+from ..constants import Attributes
+from ..plugin import KVK_KVKNumberPrefill
 
 
 class KVKPrefillTest(KVKTestMixin, TestCase):

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -2,7 +2,6 @@ import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Optional
-from urllib.parse import urljoin
 
 from django.conf import settings
 from django.db import transaction
@@ -192,9 +191,6 @@ class ContextAwareFormStepSerializer(serializers.ModelSerializer):
         }
 
     def get_configuration(self, instance) -> dict:
-        # can't simply declare this because the JSON is stored as string in
-        # the DB instead of actual JSON
-        # FIXME: sort out the storing of configuration
         submission = self.root.instance.submission
         serializer = FormDefinitionSerializer(
             instance=instance.form_definition,

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -89,12 +89,6 @@ class SubmissionViewSet(
             sender=self.__class__, instance=serializer.instance, request=self.request
         )
 
-        bsn = self.request.session.get("bsn")
-        if bsn:
-            instance = serializer.instance
-            instance.bsn = bsn
-            instance.save(update_fields=["bsn"])
-
         # store the submission ID in the session, so that only the session owner can
         # mutate/view the submission
         # note: possible race condition with concurrent requests

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -24,6 +24,7 @@ from ..attachments import attach_uploads_to_submission_step
 from ..form_logic import evaluate_form_logic
 from ..models import Submission, SubmissionStep
 from ..parsers import IgnoreDataFieldCamelCaseJSONParser
+from ..signals import submission_start
 from ..status import SubmissionProcessingStatus
 from ..tasks import on_completion
 from ..tokens import submission_status_token_generator
@@ -82,6 +83,11 @@ class SubmissionViewSet(
     @transaction.atomic
     def perform_create(self, serializer):
         super().perform_create(serializer)
+
+        # dispatch signal for modules to tap into
+        submission_start.send(
+            sender=self.__class__, instance=serializer.instance, request=self.request
+        )
 
         bsn = self.request.session.get("bsn")
         if bsn:

--- a/src/openforms/submissions/signals.py
+++ b/src/openforms/submissions/signals.py
@@ -2,11 +2,17 @@ import logging
 
 from django.db.models.base import ModelBase
 from django.db.models.signals import post_delete
-from django.dispatch import receiver
+from django.dispatch import Signal, receiver
 
 from openforms.submissions.models import SubmissionReport
 
 logger = logging.getLogger(__name__)
+
+
+# custom signal to decouple actions done by feature modules - this avoids having to
+# import specific module functionality and also allows third party apps/extensions to
+# tap into certain events.
+submission_start = Signal(providing_args=["instance", "request"])
 
 
 @receiver(post_delete, sender=SubmissionReport)


### PR DESCRIPTION
Relates to #977

1. Authentication flow sets _some_ key in the session (`bsn` or `kvk`, soon (through #957) `form_auth`)
2. On submission start, these keys are checked and persisted on the `Submission` record
3. Refactored into signals so that it's more pluggable and decoupled & we can install a generic handler.