### PR TITLE
[DRAFT] Objects API registration IOtype configurable per upload field

### DIFF
--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -6,6 +6,13 @@ from openforms.utils.mixins import JsonSchemaSerializerMixin
 from openforms.utils.validators import validate_rsin
 
 
+class AttachmentInformatieObjecttype(serializers.Serializer):
+    attachment_field_name = serializers.CharField(label=_("attachment fieldname"))
+    informatieobjecttype_url = serializers.URLField(
+        label=_("attachment informatieobjecttype"),
+    )
+
+
 class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     objecttype = serializers.URLField(
         label=_("objecttype"),
@@ -52,10 +59,11 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         ),
         required=False,
     )
-    informatieobjecttype_attachment = serializers.URLField(
-        label=_("attachment informatieobjecttype"),
+    informatieobjecttypes_attachments = serializers.ListField(
+        child=AttachmentInformatieObjecttype(),
+        label=_("attachment informatieobjecttypes"),
         help_text=_(
-            "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API "
+            "List of URLs that point to the INFORMATIEOBJECTTYPE in the Catalogi API "
             "to be used for the submission attachments"
         ),
         required=False,

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -68,12 +68,20 @@ class ObjectsAPIRegistration(BasePlugin):
             get_drc=get_drc,
         )
 
-        attachment_options = deepcopy(options)
-        attachment_options["informatieobjecttype"] = options[
-            "informatieobjecttype_attachment"
-        ]
         attachments = []
         for attachment in submission.attachments:
+            attachment_options = deepcopy(options)
+
+            informatieobjecttype = options["informatieobjecttype_attachment"]
+
+            # Use specific IOType if defined
+            for attachment_iotype in options.get(
+                "informatieobjecttypes_attachments", []
+            ):
+                if attachment_iotype["attachment_field_name"] == attachment.form_key:
+                    informatieobjecttype = attachment_iotype["informatieobjecttype_url"]
+
+            attachment_options["informatieobjecttype"] = informatieobjecttype
             attachment_document = create_attachment_document(
                 submission.form.admin_name,
                 attachment,

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
@@ -1157,6 +1157,233 @@ class ObjectsAPIBackendTests(TestCase):
         self.assertEqual(object_create.url, "https://objecten.nl/api/v1/objects")
         self.assertDictEqual(object_create_body, expected_object_body)
 
+    def test_submission_with_objects_api_backend_attachments_specific_iotypen(self, m):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "voornaam",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_voornamen,
+                    },
+                },
+            ],
+            submitted_data={
+                "voornaam": "Foo",
+            },
+        )
+
+        objects_form_options = dict(
+            informatieobjecttypes_attachments=[
+                {
+                    "attachment_field_name": "field1",
+                    "informatieobjecttype_url": "https://catalogi.nl/api/v1/informatieobjecttypen/10",
+                },
+            ],
+        )
+
+        attachment1 = SubmissionFileAttachmentFactory.create(
+            submission_step__submission=submission,
+            file_name="attachment1.jpg",
+            form_key="field1",
+        )
+        attachment2 = SubmissionFileAttachmentFactory.create(
+            submission_step__submission=submission,
+            file_name="attachment2.jpg",
+            form_key="field2",
+        )
+
+        mock_service_oas_get(m, "https://objecten.nl/api/v1/", "objecten")
+        mock_service_oas_get(m, "https://documenten.nl/api/v1/", "documenten")
+
+        expected_result = {
+            "url": "https://objecten.nl/api/v1/objects/1",
+            "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            "type": "https://objecttypen.nl/api/v1/objecttypes/1",
+            "record": {
+                "index": 0,
+                "typeVersion": 1,
+                "data": {
+                    "data": submission.get_merged_data(),
+                    "type": "terugbelnotitie",
+                    "submission_id": str(submission.uuid),
+                    "attachments": [
+                        "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/2",
+                        "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/3",
+                    ],
+                    "pdf_url": "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/1",
+                },
+                "geometry": {"type": "Point", "coordinates": [0, 0]},
+                "startAt": date.today().isoformat(),
+                "endAt": date.today().isoformat(),
+                "registrationAt": date.today().isoformat(),
+                "correctionFor": 0,
+                "correctedBy": "",
+            },
+        }
+        expected_document_result = generate_oas_component(
+            "documenten",
+            "schemas/EnkelvoudigInformatieObject",
+            url="https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/1",
+        )
+
+        def match_pdf_document(request):
+            if request.json()["bestandsnaam"].endswith(".pdf"):
+                return True
+            return False
+
+        expected_attachment_result1 = generate_oas_component(
+            "documenten",
+            "schemas/EnkelvoudigInformatieObject",
+            url="https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/2",
+        )
+
+        def match_attachment1(request):
+            if request.json()["bestandsnaam"] == "attachment1.jpg":
+                return True
+            return False
+
+        expected_attachment_result2 = generate_oas_component(
+            "documenten",
+            "schemas/EnkelvoudigInformatieObject",
+            url="https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/3",
+        )
+
+        def match_attachment2(request):
+            if request.json()["bestandsnaam"] == "attachment2.jpg":
+                return True
+            return False
+
+        m.post(
+            "https://objecten.nl/api/v1/objects",
+            status_code=201,
+            json=expected_result,
+        )
+
+        m.post(
+            "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten",
+            status_code=201,
+            json=expected_document_result,
+            additional_matcher=match_pdf_document,
+        )
+        m.post(
+            "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten",
+            status_code=201,
+            json=expected_attachment_result1,
+            additional_matcher=match_attachment1,
+        )
+        m.post(
+            "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten",
+            status_code=201,
+            json=expected_attachment_result2,
+            additional_matcher=match_attachment2,
+        )
+
+        plugin = ObjectsAPIRegistration("objects_api")
+        result = plugin.register_submission(submission, objects_form_options)
+
+        # Result is simply the created object
+        self.assertEqual(result, expected_result)
+
+        self.assertEqual(len(m.request_history), 6)
+
+        (
+            documenten_oas_get,
+            document_create_pdf,
+            document_create_attachment1,
+            document_create_attachment2,
+            objecten_oas_get,
+            object_create,
+        ) = m.request_history
+
+        self.assertEqual(documenten_oas_get.method, "GET")
+        self.assertEqual(
+            documenten_oas_get.url,
+            "https://documenten.nl/api/v1/schema/openapi.yaml?v=3",
+        )
+
+        document_create_pdf_body = document_create_pdf.json()
+        self.assertEqual(document_create_pdf.method, "POST")
+        self.assertEqual(
+            document_create_pdf.url,
+            "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten",
+        )
+        self.assertEqual(document_create_pdf_body["bronorganisatie"], "000000000")
+        self.assertEqual(
+            document_create_pdf_body["informatieobjecttype"],
+            "https://catalogi.nl/api/v1/informatieobjecttypen/1",
+        )
+        self.assertNotIn("vertrouwelijkheidaanduiding", document_create_pdf_body)
+
+        self.assertEqual(objecten_oas_get.method, "GET")
+        self.assertEqual(
+            objecten_oas_get.url, "https://objecten.nl/api/v1/schema/openapi.yaml?v=3"
+        )
+
+        # Verify attachments
+        document_create_attachment1_body = document_create_attachment1.json()
+        self.assertEqual(document_create_attachment1.method, "POST")
+        self.assertEqual(
+            document_create_attachment1.url,
+            "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten",
+        )
+        self.assertEqual(
+            document_create_attachment1_body["bronorganisatie"], "000000000"
+        )
+        # Use override IOType
+        self.assertEqual(
+            document_create_attachment1_body["informatieobjecttype"],
+            "https://catalogi.nl/api/v1/informatieobjecttypen/10",
+        )
+        self.assertNotIn(
+            "vertrouwelijkheidaanduiding", document_create_attachment1_body
+        )
+
+        document_create_attachment2_body = document_create_attachment2.json()
+        self.assertEqual(document_create_attachment2.method, "POST")
+        self.assertEqual(
+            document_create_attachment2.url,
+            "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten",
+        )
+        self.assertEqual(
+            document_create_attachment2_body["bronorganisatie"], "000000000"
+        )
+        # Fallback to default IOType
+        self.assertEqual(
+            document_create_attachment2_body["informatieobjecttype"],
+            "https://catalogi.nl/api/v1/informatieobjecttypen/3",
+        )
+        self.assertNotIn(
+            "vertrouwelijkheidaanduiding", document_create_attachment2_body
+        )
+
+        self.assertEqual(objecten_oas_get.method, "GET")
+        self.assertEqual(
+            objecten_oas_get.url, "https://objecten.nl/api/v1/schema/openapi.yaml?v=3"
+        )
+
+        expected_object_body = {
+            "type": "https://objecttypen.nl/api/v1/objecttypes/1",
+            "record": {
+                "typeVersion": 1,
+                "data": {
+                    "data": submission.get_merged_data(),
+                    "type": "terugbelnotitie",
+                    "submission_id": str(submission.uuid),
+                    "attachments": [
+                        "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/2",
+                        "https://documenten.nl/api/v1/enkelvoudiginformatieobjecten/3",
+                    ],
+                    "pdf_url": expected_document_result["url"],
+                },
+                "startAt": date.today().isoformat(),
+            },
+        }
+
+        object_create_body = object_create.json()
+        self.assertEqual(object_create.method, "POST")
+        self.assertEqual(object_create.url, "https://objecten.nl/api/v1/objects")
+        self.assertDictEqual(object_create_body, expected_object_body)
+
     def test_no_reference_can_be_extracted(self, m):
         submission = SubmissionFactory.create(
             form__registration_backend="objects_api",


### PR DESCRIPTION
Fixes: #1007

* Allows using different InformatieObjecttypes for different upload fields, configurable via the admin interface