### PR TITLE
Fix pinned lxml/xmlsec build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/setuptools.txt
+          . ./bin/fix-xmlsec.sh
           pip install -r requirements/ci.txt codecov
 
       - name: Build frontend
@@ -103,6 +104,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/setuptools.txt
+          . ./bin/fix-xmlsec.sh
           pip install -r requirements/ci.txt
 
       - name: Build and test docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,10 @@ RUN mkdir /app/src
 # Ensure we use the latest version of pip
 RUN pip install pip -U
 COPY ./requirements /app/requirements
+COPY ./bin/fix-xmlsec.sh /app/
 RUN pip install -r requirements/setuptools.txt
-RUN pip install -r requirements/production.txt
+RUN . ./fix-xmlsec.sh \
+    && pip install -r requirements/production.txt
 
 # Stage 2 - Install frontend deps and build assets
 FROM node:15-buster AS frontend-build

--- a/bin/fix-xmlsec.sh
+++ b/bin/fix-xmlsec.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Workaround for installing xmlsec with pinned lmxl version.
+# See https://github.com/mehcode/python-xmlsec/issues/198 for more information
+
+# extract the pinned lxml version
+LXML=$(grep lxml -r requirements/base.txt)
+
+# ensure this version is installed before xmlsec is attempted to install
+pip install "$LXML"
+
+# export the include path for the xmlsec build
+SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
+
+export C_INCLUDE_PATH="$SITE_PACKAGES/lxml/includes"


### PR DESCRIPTION
lxml released a new version breaking the build of xmlsec (which used lxml as build tool and therefore
pulls in a newer version of lxml than the pinned version.

This patch fixes CI and Docker image build by explicitly pointing to a pinned lxml install for the
xmlsec build.

See https://github.com/mehcode/python-xmlsec/issues/198 for more information.