### PR TITLE
:sparkles: [#1043] Add warning in formbuilder for duplicate keys in formdefs

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -16,7 +16,7 @@ from ...payments.admin import PaymentBackendChoiceFieldMixin
 from ...utils.expressions import FirstNotBlank
 from ..forms.form import FormImportForm
 from ..models import Form, FormStep
-from ..utils import export_form, import_form
+from ..utils import export_form, get_duplicates_keys_for_form, import_form
 
 
 class FormStepInline(OrderedTabularInline):
@@ -101,6 +101,27 @@ class FormAdmin(
         return super().get_inline_instances(request, *args, **kwargs)
 
     def get_form(self, request, *args, **kwargs):
+        if kwargs.get("change"):
+            # Display a warning if duplicate keys are used in form definitions
+            duplicate_keys = get_duplicates_keys_for_form(args[0])
+
+            if duplicate_keys:
+                error_message = _("{} occurs in both {}")
+                error_messages = "; ".join(
+                    [
+                        error_message.format(key, ", ".join(form_definitions))
+                        for key, form_definitions in duplicate_keys.items()
+                    ]
+                )
+                self.message_user(
+                    request,
+                    _(
+                        "The following form definitions contain fields with duplicate keys: %s"
+                    )
+                    % (error_messages),
+                    level=messages.WARNING,
+                )
+
         if self.use_react(request):
             # no actual changes to the fields are triggered, we're only ending up here
             # because of the copy/export actions.

--- a/src/openforms/forms/models/form_definition.py
+++ b/src/openforms/forms/models/form_definition.py
@@ -139,6 +139,10 @@ class FormDefinition(models.Model):
                         configuration=component, recursive=recursive
                     )
 
+    def get_all_keys(self) -> List[str]:
+        keys = [field["key"] for field in self.iter_components(recursive=True)]
+        return keys
+
     def get_keys_for_email_summary(self) -> List[Tuple[str, str]]:
         """Return the key and the label of fields to include in the email summary"""
         keys_for_email_summary = []

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -1,6 +1,7 @@
 import json
 import zipfile
-from typing import List
+from collections import defaultdict
+from typing import Dict, List
 from uuid import uuid4
 
 from django.conf import settings
@@ -202,3 +203,15 @@ def remove_key_from_dict(dictionary, key):
             for value in dictionary[dict_key]:
                 if isinstance(value, dict):
                     remove_key_from_dict(value, key)
+
+
+def get_duplicates_keys_for_form(form: Form) -> Dict[str, List]:
+    seen = defaultdict(list)
+    for formstep in form.formstep_set.select_related("form_definition").order_by("pk"):
+        for key in formstep.form_definition.get_all_keys():
+            seen[key].append(formstep.form_definition.name)
+
+    duplicate_keys = {
+        key: formdefs for key, formdefs in seen.items() if len(formdefs) > 1
+    }
+    return duplicate_keys


### PR DESCRIPTION
fixes: #1043

Adds a warning message to the FormAdmin in case there are any duplicate keys used in multiple form definitions