### PR TITLE
Fix self-certifi flow with runserver

### DIFF
--- a/src/openforms/setup.py
+++ b/src/openforms/setup.py
@@ -24,8 +24,6 @@ from dotenv import load_dotenv
 from requests import Session
 from self_certifi import load_self_signed_certs as _load_self_signed_certs
 
-_certs_initialized = False
-
 logger = logging.getLogger(__name__)
 
 
@@ -45,7 +43,7 @@ def setup_env():
 
 
 def load_self_signed_certs() -> None:
-    global _certs_initialized
+    _certs_initialized = bool(os.environ.get("REQUESTS_CA_BUNDLE"))
     if _certs_initialized:
         return
 


### PR DESCRIPTION
Detection of REQUESTS_CA_BUNDLE is broken on runserver since the module
global mutation is not picked up in the runserver thread. This is now fixed
by looking at os.environ which is a mutable dict.