### PR TITLE
Camunda process selection + registration backend core

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1516,6 +1516,24 @@ paths:
                 items:
                   $ref: '#/components/schemas/RegistrationPlugin'
           description: ''
+  /api/v1/registration/plugins/camunda/process-definitions:
+    get:
+      operationId: registration_plugins_camunda_process_definitions_list
+      description: List the available process definitions & their versions.
+      summary: List available Camunda process definitions
+      tags:
+      - registration
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProcessDefinition'
+          description: ''
   /api/v1/submissions:
     get:
       operationId: submissions_list
@@ -3834,6 +3852,26 @@ components:
             getoond wanneer de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid.
       required:
       - requiresPrivacyConsent
+    ProcessDefinition:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+          description: The process definition identifier, used to group different
+            versions.
+        name:
+          type: string
+          description: The human-readable name of the process definition.
+        version:
+          type: integer
+          description: The version identifier relative to the 'key'.
+      required:
+      - id
+      - key
+      - name
+      - version
     Product:
       type: object
       properties:

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -433,6 +433,12 @@
       "value": "Slug of the form, used in URLs"
     }
   ],
+  "Hfdfv2": [
+    {
+      "type": 0,
+      "value": "Which version of the process definition to start. The latest version is used if not specified."
+    }
+  ],
   "HqVHBq": [
     {
       "type": 0,
@@ -557,6 +563,12 @@
     {
       "type": 0,
       "value": "Save and add another"
+    }
+  ],
+  "PaEo2j": [
+    {
+      "type": 0,
+      "value": "Process"
     }
   ],
   "PdaMqg": [
@@ -1005,6 +1017,12 @@
     {
       "type": 0,
       "value": "months"
+    }
+  ],
+  "n4Y2ex": [
+    {
+      "type": 0,
+      "value": "Version"
     }
   ],
   "naInSZ": [

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -67,6 +67,12 @@
       "value": "Registration backend options"
     }
   ],
+  "2uIYst": [
+    {
+      "type": 0,
+      "value": "The process definition for which to start a process instance."
+    }
+  ],
   "2utbek": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -437,6 +437,12 @@
       "value": "URL-deel van het formulier."
     }
   ],
+  "Hfdfv2": [
+    {
+      "type": 0,
+      "value": "Which version of the process definition to start. The latest version is used if not specified."
+    }
+  ],
   "HqVHBq": [
     {
       "type": 0,
@@ -561,6 +567,12 @@
     {
       "type": 0,
       "value": "Opslaan en nieuwe toevoegen"
+    }
+  ],
+  "PaEo2j": [
+    {
+      "type": 0,
+      "value": "Process"
     }
   ],
   "PdaMqg": [
@@ -1009,6 +1021,12 @@
     {
       "type": 0,
       "value": "maanden"
+    }
+  ],
+  "n4Y2ex": [
+    {
+      "type": 0,
+      "value": "Version"
     }
   ],
   "naInSZ": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -70,7 +70,7 @@
   "2uIYst": [
     {
       "type": 0,
-      "value": "The process definition for which to start a process instance."
+      "value": "De procesdefinitie waarvoor een proces instantie gestart moet worden."
     }
   ],
   "2utbek": [
@@ -446,7 +446,7 @@
   "Hfdfv2": [
     {
       "type": 0,
-      "value": "Which version of the process definition to start. The latest version is used if not specified."
+      "value": "Welke versie van de procesdefinitie moet gebruikt worden. Indien niet opgegeven dan wordt altijd de laatste versie gebruikt."
     }
   ],
   "HqVHBq": [
@@ -578,7 +578,7 @@
   "PaEo2j": [
     {
       "type": 0,
-      "value": "Process"
+      "value": "Proces"
     }
   ],
   "PdaMqg": [
@@ -1032,7 +1032,7 @@
   "n4Y2ex": [
     {
       "type": 0,
-      "value": "Version"
+      "value": "Versie"
     }
   ],
   "naInSZ": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -67,6 +67,12 @@
       "value": "Opties"
     }
   ],
+  "2uIYst": [
+    {
+      "type": 0,
+      "value": "The process definition for which to start a process instance."
+    }
+  ],
   "2utbek": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/RJSFWrapper.js
+++ b/src/openforms/js/components/admin/RJSFWrapper.js
@@ -168,4 +168,5 @@ FormRjsfWrapper.propTypes = {
 };
 
 
+export {CustomFieldTemplate};
 export default FormRjsfWrapper;

--- a/src/openforms/js/components/admin/form_design/constants.js
+++ b/src/openforms/js/components/admin/form_design/constants.js
@@ -7,3 +7,4 @@ export const PAYMENT_PLUGINS_ENDPOINT = '/api/v1/payment/plugins';
 export const PRODUCTS_ENDPOINT = '/api/v1/products';
 export const LOGICS_ENDPOINT = '/api/v1/logic-rules';
 export const PRICE_RULES_ENDPOINT = '/api/v1/price-rules';
+export const PROCESS_DEFINITIONS_ENDPOINT = '/api/v1/registration/plugins/camunda/process-definitions';

--- a/src/openforms/js/components/admin/form_design/registrations/camunda.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Field from '../../forms/Field';
+import {CustomFieldTemplate} from '../../RJSFWrapper';
+
+
+const CamundaOptionsForm = ({ name, label, formData, onChange }) => {
+    // TODO: handle validation errors properly
+
+    return (
+        <Field name={name} label={label} errors={[]}>
+            <div>yep</div>
+        </Field>
+    );
+};
+
+CamundaOptionsForm.propTypes = {
+    name: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
+    formData: PropTypes.shape({ // matches the backend serializer!
+        processDefinition: PropTypes.string,
+        processDefinitionVersion: PropTypes.string,
+    }),
+    onChange: PropTypes.func.isRequired,
+};
+
+
+export default CamundaOptionsForm;

--- a/src/openforms/js/components/admin/form_design/registrations/camunda.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda.js
@@ -5,13 +5,11 @@ import {useIntl} from 'react-intl';
 import useAsync from 'react-use/esm/useAsync';
 
 import {get} from '../../../../utils/fetch';
+import {PROCESS_DEFINITIONS_ENDPOINT} from '../constants';
 import Field from '../../forms/Field';
 import Select from '../../forms/Select';
 import {CustomFieldTemplate} from '../../RJSFWrapper';
 import Loader from '../../Loader';
-
-
-const PROCESS_DEFINITIONS_ENDPOINT = '/api/v1/registration/plugins/camunda/process-definitions';
 
 
 const useLoadProcessDefinitions = () => {
@@ -21,7 +19,7 @@ const useLoadProcessDefinitions = () => {
             const response = await get(PROCESS_DEFINITIONS_ENDPOINT);
             if (!response.ok) throw new Error(`Response status: ${response.status}`);
             return response.data;
-        }, [PROCESS_DEFINITIONS_ENDPOINT]
+        }, []
     );
 
     if (!loading && !error) {
@@ -97,6 +95,10 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
                     description: 'Camunda \'process definition\' label'
                 })}
                 rawErrors={null} errors={null} // TODO
+                rawDescription={intl.formatMessage({
+                    description: 'Camunda \'process definition\' help text',
+                    defaultMessage: 'The process definition for which to start a process instance.'
+                })}
                 required
                 displayLabel
             >

--- a/src/openforms/js/components/admin/form_design/registrations/camunda.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda.js
@@ -1,17 +1,57 @@
+import groupBy from 'lodash/groupBy';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
+import useAsync from 'react-use/esm/useAsync';
 
+import {get} from '../../../../utils/fetch';
 import Field from '../../forms/Field';
 import {CustomFieldTemplate} from '../../RJSFWrapper';
+import Loader from '../../Loader';
+
+
+const PROCESS_DEFINITIONS_ENDPOINT = '/api/v1/registration/plugins/camunda/process-definitions';
+
+
+const useLoadProcessDefinitions = () => {
+    let formDefinitions;
+    const { loading, value, error } = useAsync(
+        async () => {
+            const response = await get(PROCESS_DEFINITIONS_ENDPOINT);
+            if (!response.ok) throw new Error(`Response status: ${response.status}`);
+            return response.data;
+        }, [PROCESS_DEFINITIONS_ENDPOINT]
+    );
+
+    if (!loading && !error) {
+        // transform the process definitions in a grouped structure
+        formDefinitions = groupBy(value, 'key');
+    }
+
+    return {loading, formDefinitions, error};
+};
+
 
 
 const CamundaOptionsForm = ({ name, label, formData, onChange }) => {
     // TODO: handle validation errors properly
 
+    const {loading, formDefinitions, error} = useLoadProcessDefinitions();
+    if (error) {
+        console.error(error);
+        return 'Unexpected error, see console';
+    }
+
+    console.log(formDefinitions);
+
     return (
         <Field name={name} label={label} errors={[]}>
-            <div>yep</div>
+            {loading
+                ? <Loader />
+                : (
+                    <div>yep</div>
+                )
+            }
         </Field>
     );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -1,7 +1,9 @@
-import './camunda';
+import CamundaOptionsForm from './camunda';
 
 /**
  * A map of backend ID to components for the (advanced) option forms.
  * @type {Object}
  */
-export const BACKEND_OPTIONS_FORMS = {};
+export const BACKEND_OPTIONS_FORMS = {
+    camunda: CamundaOptionsForm,
+};

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -1,0 +1,7 @@
+import './camunda';
+
+/**
+ * A map of backend ID to components for the (advanced) option forms.
+ * @type {Object}
+ */
+export const BACKEND_OPTIONS_FORMS = {};

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -324,6 +324,11 @@
     "description": "Form slug field help text",
     "originalDefault": "Slug of the form, used in URLs"
   },
+  "Hfdfv2": {
+    "defaultMessage": "Which version of the process definition to start. The latest version is used if not specified.",
+    "description": "Camunda 'process definition version' help text",
+    "originalDefault": "Which version of the process definition to start. The latest version is used if not specified."
+  },
   "HqVHBq": {
     "defaultMessage": "Will send the email specified.",
     "description": "Form confirmation email help text",
@@ -428,6 +433,11 @@
     "defaultMessage": "Save and add another",
     "description": "Admin save and add another submit button",
     "originalDefault": "Save and add another"
+  },
+  "PaEo2j": {
+    "defaultMessage": "Process",
+    "description": "Camunda 'process definition' label",
+    "originalDefault": "Process"
   },
   "PdaMqg": {
     "defaultMessage": "Add rule",
@@ -778,6 +788,11 @@
     "defaultMessage": "months",
     "description": "Logic trigger number of months",
     "originalDefault": "months"
+  },
+  "n4Y2ex": {
+    "defaultMessage": "Version",
+    "description": "Camunda 'process definition version' label",
+    "originalDefault": "Version"
   },
   "naInSZ": {
     "defaultMessage": "Toggle DSL preview",

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -49,6 +49,11 @@
     "description": "Registration backend options label",
     "originalDefault": "Registration backend options"
   },
+  "2uIYst": {
+    "defaultMessage": "The process definition for which to start a process instance.",
+    "description": "Camunda 'process definition' help text",
+    "originalDefault": "The process definition for which to start a process instance."
+  },
   "2utbek": {
     "defaultMessage": "Email option",
     "description": "Form confirmation email label",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -49,6 +49,11 @@
     "description": "Registration backend options label",
     "originalDefault": "Registration backend options"
   },
+  "2uIYst": {
+    "defaultMessage": "The process definition for which to start a process instance.",
+    "description": "Camunda 'process definition' help text",
+    "originalDefault": "The process definition for which to start a process instance."
+  },
   "2utbek": {
     "defaultMessage": "E-mailsjabloon",
     "description": "Form confirmation email label",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -324,6 +324,11 @@
     "description": "Form slug field help text",
     "originalDefault": "Slug of the form, used in URLs"
   },
+  "Hfdfv2": {
+    "defaultMessage": "Which version of the process definition to start. The latest version is used if not specified.",
+    "description": "Camunda 'process definition version' help text",
+    "originalDefault": "Which version of the process definition to start. The latest version is used if not specified."
+  },
   "HqVHBq": {
     "defaultMessage": "Gebruikt het bevestigingsmailsjabloon zoals hier is opgegeven.",
     "description": "Form confirmation email help text",
@@ -428,6 +433,11 @@
     "defaultMessage": "Opslaan en nieuwe toevoegen",
     "description": "Admin save and add another submit button",
     "originalDefault": "Save and add another"
+  },
+  "PaEo2j": {
+    "defaultMessage": "Process",
+    "description": "Camunda 'process definition' label",
+    "originalDefault": "Process"
   },
   "PdaMqg": {
     "defaultMessage": "Regel toevoegen",
@@ -778,6 +788,11 @@
     "defaultMessage": "maanden",
     "description": "Logic trigger number of months",
     "originalDefault": "months"
+  },
+  "n4Y2ex": {
+    "defaultMessage": "Version",
+    "description": "Camunda 'process definition version' label",
+    "originalDefault": "Version"
   },
   "naInSZ": {
     "defaultMessage": "Toon/verberg DSL weergave",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -50,7 +50,7 @@
     "originalDefault": "Registration backend options"
   },
   "2uIYst": {
-    "defaultMessage": "The process definition for which to start a process instance.",
+    "defaultMessage": "De procesdefinitie waarvoor een proces instantie gestart moet worden.",
     "description": "Camunda 'process definition' help text",
     "originalDefault": "The process definition for which to start a process instance."
   },
@@ -330,7 +330,7 @@
     "originalDefault": "Slug of the form, used in URLs"
   },
   "Hfdfv2": {
-    "defaultMessage": "Which version of the process definition to start. The latest version is used if not specified.",
+    "defaultMessage": "Welke versie van de procesdefinitie moet gebruikt worden. Indien niet opgegeven dan wordt altijd de laatste versie gebruikt.",
     "description": "Camunda 'process definition version' help text",
     "originalDefault": "Which version of the process definition to start. The latest version is used if not specified."
   },
@@ -440,7 +440,7 @@
     "originalDefault": "Save and add another"
   },
   "PaEo2j": {
-    "defaultMessage": "Process",
+    "defaultMessage": "Proces",
     "description": "Camunda 'process definition' label",
     "originalDefault": "Process"
   },
@@ -795,7 +795,7 @@
     "originalDefault": "months"
   },
   "n4Y2ex": {
-    "defaultMessage": "Version",
+    "defaultMessage": "Versie",
     "description": "Camunda 'process definition version' label",
     "originalDefault": "Version"
   },

--- a/src/openforms/registrations/api/urls.py
+++ b/src/openforms/registrations/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import include, path
 
 from .views import AllAttributesListView, PluginListView
 
@@ -9,4 +9,11 @@ urlpatterns = [
         AllAttributesListView.as_view(),
         name="registrations-attribute-list",
     ),
+]
+
+
+# add plugin URL patterns
+# TODO: make this dynamic and include it through the registry?
+urlpatterns += [
+    path("plugins/camunda/", include("openforms.registrations.contrib.camunda.api")),
 ]

--- a/src/openforms/registrations/api/views.py
+++ b/src/openforms/registrations/api/views.py
@@ -4,7 +4,8 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import authentication, permissions
 from rest_framework.views import APIView
 
-from ...utils.api.views import ListMixin
+from openforms.utils.api.views import ListMixin
+
 from ..constants import RegistrationAttribute
 from ..registry import register
 from .serializers import (

--- a/src/openforms/registrations/contrib/camunda/api.py
+++ b/src/openforms/registrations/contrib/camunda/api.py
@@ -1,0 +1,62 @@
+from typing import List
+
+from django.urls import path
+from django.utils.translation import gettext_lazy as _
+
+from django_camunda.api import get_process_definitions
+from django_camunda.camunda_models import ProcessDefinition
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import authentication, permissions, views
+from zgw_consumers.drf.serializers import APIModelSerializer
+
+from openforms.utils.api.views import ListMixin
+
+
+class ProcessDefinitionSerializer(APIModelSerializer):
+    class Meta:
+        model = ProcessDefinition
+        fields = ("id", "key", "name", "version")
+        extra_kwargs = {
+            "key": {
+                "help_text": _(
+                    "The process definition identifier, used to group different versions."
+                ),
+            },
+            "name": {
+                "help_text": _("The human-readable name of the process definition."),
+            },
+            "version": {
+                "help_text": _("The version identifier relative to the 'key'."),
+            },
+        }
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary=_("List available Camunda process definitions"),
+        tags=["registration"],
+    ),
+)
+class ProcessDefinitionListView(ListMixin, views.APIView):
+    """
+    List the available process definitions & their versions.
+    """
+
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = ProcessDefinitionSerializer
+
+    @staticmethod
+    def get_objects() -> List[ProcessDefinition]:
+        return get_process_definitions()
+
+
+app_name = "camunda"
+
+urlpatterns = [
+    path(
+        "process-definitions",
+        ProcessDefinitionListView.as_view(),
+        name="process-definitions",
+    ),
+]

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -29,6 +29,7 @@ class CamundaOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer
             "Which version of the process definition to start. The latest version is "
             "used if not specified."
         ),
+        allow_null=True,
     )
     # TODO: derived_variables, variables_to_include (from component keys) - might have
     # to be done in react alltogether
@@ -37,6 +38,7 @@ class CamundaOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer
 @register("camunda")
 class CamundaRegistration(BasePlugin):
     verbose_name = _("Camunda")
+    configuration_options = CamundaOptionsSerializer
 
     def register_submission(
         self, submission: Submission, options: dict

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -23,7 +23,7 @@ class CamundaOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer
         help_text=_("The process definition for which to start a process instance."),
     )
     # TODO: get choices from django-camunda
-    process_definition_version = serializers.CharField(
+    process_definition_version = serializers.IntegerField(
         required=False,
         help_text=_(
             "Which version of the process definition to start. The latest version is "

--- a/src/openforms/registrations/contrib/camunda/tests/test_api_endpoints.py
+++ b/src/openforms/registrations/contrib/camunda/tests/test_api_endpoints.py
@@ -1,0 +1,45 @@
+"""
+Test the Camunda-plugin specific extra API endpoints.
+
+These endpoints are only used in the form designer.
+"""
+from unittest.mock import patch
+
+import requests_mock
+from django_camunda.camunda_models import ProcessDefinition
+from rest_framework import status
+from rest_framework.reverse import reverse, reverse_lazy
+from rest_framework.test import APITestCase
+
+from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
+
+
+class ProcessDefinitionsListEndpointTests(APITestCase):
+    endpoint = reverse_lazy("api:camunda:process-definitions")
+
+    def test_auth_required(self):
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch(
+        "openforms.registrations.contrib.camunda.api.get_process_definitions",
+        return_value=[],
+    )
+    def test_staff_user_required(self, mock_get_process_definitions):
+        user = UserFactory.create()
+        staff_user = StaffUserFactory.create()
+
+        with self.subTest(staff=False):
+            self.client.force_authenticate(user=user)
+
+            response = self.client.get(self.endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest(staff=True):
+            self.client.force_authenticate(user=staff_user)
+
+            response = self.client.get(self.endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/src/openforms/registrations/contrib/camunda/tests/test_api_endpoints.py
+++ b/src/openforms/registrations/contrib/camunda/tests/test_api_endpoints.py
@@ -3,12 +3,12 @@ Test the Camunda-plugin specific extra API endpoints.
 
 These endpoints are only used in the form designer.
 """
+import uuid
 from unittest.mock import patch
 
-import requests_mock
 from django_camunda.camunda_models import ProcessDefinition
 from rest_framework import status
-from rest_framework.reverse import reverse, reverse_lazy
+from rest_framework.reverse import reverse_lazy
 from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
@@ -43,3 +43,71 @@ class ProcessDefinitionsListEndpointTests(APITestCase):
             response = self.client.get(self.endpoint)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_subset_process_definition_information_returned(self):
+        staff_user = StaffUserFactory.create()
+        self.client.force_authenticate(user=staff_user)
+        mock_data = [
+            ProcessDefinition(
+                id="p1:1:7a249a3d-86f8-4c33-9ce4-fd87d7f2ee91",
+                key="p1",
+                name="Process 1",
+                category="",
+                version=1,
+                deployment_id=uuid.uuid4(),
+                resource="sample.bpmn",
+                startable_in_tasklist=True,
+                suspended=False,
+            ),
+            ProcessDefinition(
+                id="p1:2:7a249a3d-86f8-4c33-9ce4-fd87d7f2ee91",
+                key="p1",
+                name="Process 1",
+                category="",
+                version=2,
+                deployment_id=uuid.uuid4(),
+                resource="sample.bpmn",
+                startable_in_tasklist=True,
+                suspended=False,
+            ),
+            ProcessDefinition(
+                id="p2:1:11714efa-b5a2-45a3-904b-31281db1539e",
+                key="p2",
+                name="Process 2",
+                category="",
+                version=1,
+                deployment_id=uuid.uuid4(),
+                resource="sample.bpmn",
+                startable_in_tasklist=True,
+                suspended=False,
+            ),
+        ]
+
+        with patch(
+            "openforms.registrations.contrib.camunda.api.get_process_definitions",
+            return_value=mock_data,
+        ):
+            response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected = [
+            {
+                "id": "p1:1:7a249a3d-86f8-4c33-9ce4-fd87d7f2ee91",
+                "key": "p1",
+                "version": 1,
+                "name": "Process 1",
+            },
+            {
+                "id": "p1:2:7a249a3d-86f8-4c33-9ce4-fd87d7f2ee91",
+                "key": "p1",
+                "version": 2,
+                "name": "Process 1",
+            },
+            {
+                "id": "p2:1:11714efa-b5a2-45a3-904b-31281db1539e",
+                "key": "p2",
+                "version": 1,
+                "name": "Process 2",
+            },
+        ]
+        self.assertEqual(response.json(), expected)

--- a/src/openforms/registrations/contrib/camunda/tests/test_checks.py
+++ b/src/openforms/registrations/contrib/camunda/tests/test_checks.py
@@ -1,0 +1,65 @@
+"""
+Test the Camunda-plugin specific extra API endpoints.
+
+These endpoints are only used in the form designer.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils.translation import gettext as _
+
+import requests_mock
+from django_camunda.models import CamundaConfig
+
+from openforms.plugins.exceptions import InvalidPluginConfiguration
+
+from ..checks import check_config
+
+
+@patch("openforms.registrations.contrib.camunda.checks.CamundaConfig.get_solo")
+class PluginChecksTests(TestCase):
+    def test_not_enabled(self, mock_get_solo):
+        mock_get_solo.return_value = CamundaConfig(enabled=False)
+
+        err = _("Camunda integration is not enabled in the configuration.")
+        with self.assertRaisesMessage(InvalidPluginConfiguration, err):
+            check_config()
+
+    @requests_mock.Mocker()
+    def test_invalid_host(self, mock_get_solo, m):
+        m.get(
+            "https://camunda.example.com/camunda/engine-rest/version", status_code=404
+        )
+        mock_get_solo.return_value = CamundaConfig(
+            enabled=True,
+            root_url="https://camunda.example.com",
+            rest_api_path="camunda/engine-rest/",
+        )
+
+        with self.assertRaises(InvalidPluginConfiguration) as ctx:
+            check_config()
+
+        self.assertIn("404", ctx.exception.args[0])
+
+    @requests_mock.Mocker()
+    def test_no_process_definitions(self, mock_get_solo, m):
+        m.get(
+            "https://camunda.example.com/camunda/engine-rest/version",
+            json={"version": "dummy"},
+        )
+        m.get(
+            "https://camunda.example.com/camunda/engine-rest/process-definition?sortBy=name&sortOrder=asc",
+            json=[],
+        )
+
+        mock_get_solo.return_value = CamundaConfig(
+            enabled=True,
+            root_url="https://camunda.example.com",
+            rest_api_path="camunda/engine-rest/",
+        )
+
+        err = _(
+            "No process definitions found. The Camunda user may not have sufficient permissions."
+        )
+        with self.assertRaisesMessage(InvalidPluginConfiguration, err):
+            check_config()


### PR DESCRIPTION
Related to #326 

**Changes**

* Added API endpoint for staff members to read the available process instances
* Added custom, dynamic registration backend options form in UI to select a process definition
    * Optionally, a specific version (i.e. - not the "latest") can be selected