### PR TITLE
Camunda complex derived process vars

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -174,7 +174,7 @@ django==2.2.25
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   zgw-consumers
-djangorestframework-camel-case==1.2.0
+djangorestframework-camel-case==1.3.0
     # via -r requirements/base.in
 djangorestframework==3.12.4
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -299,7 +299,7 @@ django==2.2.25
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   zgw-consumers
-djangorestframework-camel-case==1.2.0
+djangorestframework-camel-case==1.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -343,7 +343,7 @@ django==2.2.25
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   zgw-consumers
-djangorestframework-camel-case==1.2.0
+djangorestframework-camel-case==1.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -445,12 +445,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Form'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Form'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Form'
         required: true
       security:
       - tokenAuth: []
@@ -827,12 +821,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Form'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Form'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Form'
         required: true
       security:
       - tokenAuth: []
@@ -866,12 +854,6 @@ paths:
       requestBody:
         content:
           application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedForm'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedForm'
-          multipart/form-data:
             schema:
               $ref: '#/components/schemas/PatchedForm'
       security:
@@ -929,12 +911,6 @@ paths:
       requestBody:
         content:
           application/json:
-            schema:
-              $ref: '#/components/schemas/FormAdminMessage'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/FormAdminMessage'
-          multipart/form-data:
             schema:
               $ref: '#/components/schemas/FormAdminMessage'
         required: true

--- a/src/openforms/forms/api/drf_camel_case.py
+++ b/src/openforms/forms/api/drf_camel_case.py
@@ -1,0 +1,29 @@
+from djangorestframework_camel_case.settings import api_settings
+
+from openforms.registrations.registry import register
+
+
+class FormCamelCaseMixin:
+    @property
+    def json_underscoreize(self):
+        """
+        Get the keys to ignore from all registration plugins.
+
+        .. todo:: this would greatly benefit from a more advanced drf-camel-case, where
+           keys are now global without any context. it would benefit greatly from being
+           able to namespace this, but that's currently not possible in the library.
+
+        .. warning:: this also puts _all_ the plugin-specific keys into the same parser,
+           while we'd rather be able to just validate this depending on the applicable
+           registration backend. Future improvement!
+        """
+        ignore_fields = []
+        for plugin in register:
+            if not plugin.camel_case_ignore_fields:
+                continue
+            ignore_fields += list(plugin.camel_case_ignore_fields)
+
+        return {
+            **api_settings.JSON_UNDERSCOREIZE,
+            "ignore_fields": ignore_fields,
+        }

--- a/src/openforms/forms/api/parsers.py
+++ b/src/openforms/forms/api/parsers.py
@@ -1,5 +1,7 @@
 from djangorestframework_camel_case.parser import CamelCaseJSONParser
 
+from .drf_camel_case import FormCamelCaseMixin
+
 
 class IgnoreConfigurationFieldCamelCaseJSONParser(CamelCaseJSONParser):
     # This is SUPER important - when using the API to manage forms, form steps and form
@@ -11,3 +13,17 @@ class IgnoreConfigurationFieldCamelCaseJSONParser(CamelCaseJSONParser):
     # functionality. This can happen because JSON objects DO NOT HAVE inherent ordering
     # and the spec is non-deterministic.
     json_underscoreize = {"ignore_fields": ("configuration",)}
+
+
+class FormCamelCaseJSONParser(FormCamelCaseMixin, CamelCaseJSONParser):
+    """
+    Parser for Form resource.
+
+    A camelcase JSON parser subclass to deal with registration-backend specific keys
+    that should not be converted from camelCase to snake_case. Rather than using the
+    "global" ``ignore_fields`` option, we defer to the registration backend plugin
+    to re-instate the keys that should not have been converted, which allows for
+    more context.
+    """
+
+    pass

--- a/src/openforms/forms/api/renderers.py
+++ b/src/openforms/forms/api/renderers.py
@@ -1,0 +1,17 @@
+from djangorestframework_camel_case.render import CamelCaseJSONRenderer
+
+from .drf_camel_case import FormCamelCaseMixin
+
+
+class FormCamelCaseJSONRenderer(FormCamelCaseMixin, CamelCaseJSONRenderer):
+    """
+    Renderer for Form resource.
+
+    A camelcase JSON renderer subclass to deal with registration-backend specific keys
+    that should not be converted from camelCase to snake_case. Rather than using the
+    "global" ``ignore_fields`` option, we defer to the registration backend plugin
+    to re-instate the keys that should not have been converted, which allows for
+    more context.
+    """
+
+    pass

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -30,8 +30,12 @@ from ..models import (
 )
 from ..utils import export_form, form_to_json, import_form
 from .filters import FormLogicFilter, FormPriceLogicFilter
-from .parsers import IgnoreConfigurationFieldCamelCaseJSONParser
+from .parsers import (
+    FormCamelCaseJSONParser,
+    IgnoreConfigurationFieldCamelCaseJSONParser,
+)
 from .permissions import FormAPIPermissions
+from .renderers import FormCamelCaseJSONRenderer
 from .serializers import (
     FormAdminMessageSerializer,
     FormDefinitionDetailSerializer,
@@ -229,6 +233,8 @@ class FormViewSet(viewsets.ModelViewSet):
     re-used among different forms.
     """
 
+    parser_classes = (FormCamelCaseJSONParser,)
+    renderer_classes = (FormCamelCaseJSONRenderer,)
     queryset = Form.objects.filter(_is_deleted=False).prefetch_related(
         Prefetch(
             "formstep_set",

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -1143,6 +1143,12 @@
       "value": "Are you sure you want to delete this rule?"
     }
   ],
+  "evbysh": [
+    {
+      "type": 0,
+      "value": "Variable definition"
+    }
+  ],
   "f590Rb": [
     {
       "type": 0,
@@ -1403,6 +1409,12 @@
     {
       "type": 0,
       "value": "Step name"
+    }
+  ],
+  "pyX2Tl": [
+    {
+      "type": 0,
+      "value": "Confirm"
     }
   ],
   "qUYLVg": [

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -49,6 +49,12 @@
       "value": "?"
     }
   ],
+  "1ArmQ5": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
   "1fD+K4": [
     {
       "type": 0,
@@ -59,6 +65,18 @@
     {
       "type": 0,
       "value": "Is deleted"
+    }
+  ],
+  "2MK7iF": [
+    {
+      "type": 0,
+      "value": "Number"
+    }
+  ],
+  "2Z/hNo": [
+    {
+      "type": 0,
+      "value": "Type"
     }
   ],
   "2d5RfI": [
@@ -83,6 +101,12 @@
     {
       "type": 0,
       "value": "Add another"
+    }
+  ],
+  "4FQxD/": [
+    {
+      "type": 0,
+      "value": "Configure"
     }
   ],
   "4iGsG1": [
@@ -229,10 +253,64 @@
       "value": "The text that will be displayed in the form step to save the current information. Leave blank to get value from global configuration."
     }
   ],
+  "8VqmbG": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "8pemD3": [
+    {
+      "type": 0,
+      "value": "Edit variable "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
   "9N67XB": [
     {
       "type": 0,
       "value": "Invalid JSON syntax"
+    }
+  ],
+  "9RDDDn": [
+    {
+      "offset": 0,
+      "options": {
+        "=0": {
+          "value": [
+          ]
+        },
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "(1 variable defined)"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "("
+            },
+            {
+              "type": 1,
+              "value": "varCount"
+            },
+            {
+              "type": 0,
+              "value": " variables defined)"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "varCount"
     }
   ],
   "9bGp7h": [
@@ -245,6 +323,12 @@
     {
       "type": 0,
       "value": "and"
+    }
+  ],
+  "9y3/ek": [
+    {
+      "type": 0,
+      "value": "Confirm"
     }
   ],
   "9zJefY": [
@@ -375,6 +459,12 @@
       "value": "Submission allowed"
     }
   ],
+  "DEAqyQ": [
+    {
+      "type": 0,
+      "value": "Boolean"
+    }
+  ],
   "DGpAyT": [
     {
       "type": 0,
@@ -469,6 +559,12 @@
     {
       "type": 0,
       "value": "Use linked product price"
+    }
+  ],
+  "GjcAY2": [
+    {
+      "type": 0,
+      "value": "Null"
     }
   ],
   "H3dRU6": [
@@ -579,10 +675,22 @@
       "value": "Content"
     }
   ],
+  "KjDolH": [
+    {
+      "type": 0,
+      "value": "Manually defined"
+    }
+  ],
   "L0g8AL": [
     {
       "type": 0,
       "value": "Payment provider"
+    }
+  ],
+  "LHBcNe": [
+    {
+      "type": 0,
+      "value": "Variable definition"
     }
   ],
   "LN58C1": [
@@ -615,10 +723,28 @@
       "value": "Change text"
     }
   ],
+  "MEkGHD": [
+    {
+      "type": 0,
+      "value": "Component"
+    }
+  ],
   "NwTdLM": [
     {
       "type": 0,
       "value": "Component where locations for an appointment will be shown"
+    }
+  ],
+  "O/wKJh": [
+    {
+      "type": 0,
+      "value": "Value"
+    }
+  ],
+  "O3l+pQ": [
+    {
+      "type": 0,
+      "value": "Type"
     }
   ],
   "OFAJVW": [
@@ -737,6 +863,12 @@
       "value": "change a property of a component."
     }
   ],
+  "T0OLUV": [
+    {
+      "type": 0,
+      "value": "Add key-value pair"
+    }
+  ],
   "TCQic2": [
     {
       "type": 0,
@@ -807,6 +939,12 @@
       "value": "\" attribute. Please select an authentication plugin that provides this attribute."
     }
   ],
+  "VUOOSy": [
+    {
+      "type": 0,
+      "value": "Name"
+    }
+  ],
   "VV2TCH": [
     {
       "type": 0,
@@ -855,6 +993,12 @@
       "value": "Save"
     }
   ],
+  "YdIu8k": [
+    {
+      "type": 0,
+      "value": "Add item"
+    }
+  ],
   "YzLSHY": [
     {
       "type": 0,
@@ -865,12 +1009,6 @@
     {
       "type": 0,
       "value": "Previous text"
-    }
-  ],
-  "a3dhuP": [
-    {
-      "type": 0,
-      "value": "Manage process variables"
     }
   ],
   "a4gS07": [
@@ -921,6 +1059,12 @@
       "value": "Incomplete Submissions Removal Limit"
     }
   ],
+  "cID9dz": [
+    {
+      "type": 0,
+      "value": "(complex value)"
+    }
+  ],
   "cUVVbl": [
     {
       "type": 0,
@@ -945,10 +1089,22 @@
       "value": "No email"
     }
   ],
+  "d1W41c": [
+    {
+      "type": 0,
+      "value": "From form field"
+    }
+  ],
   "d45v2X": [
     {
       "type": 0,
       "value": "Export this form"
+    }
+  ],
+  "ddDA6+": [
+    {
+      "type": 0,
+      "value": "Array"
     }
   ],
   "ddR92A": [
@@ -1075,6 +1231,12 @@
       "value": "change the value of a component"
     }
   ],
+  "jU/t8O": [
+    {
+      "type": 0,
+      "value": "Edit complex variable"
+    }
+  ],
   "jZIu+e": [
     {
       "type": 0,
@@ -1093,10 +1255,22 @@
       "value": "Name"
     }
   ],
+  "kHn5Yw": [
+    {
+      "type": 0,
+      "value": "Edit definition"
+    }
+  ],
   "kNOyt+": [
     {
       "type": 0,
       "value": "disabled"
+    }
+  ],
+  "l1fi1t": [
+    {
+      "type": 0,
+      "value": "(missing information)"
     }
   ],
   "l2Wag+": [
@@ -1129,6 +1303,18 @@
       "value": "months"
     }
   ],
+  "mZ5Rrx": [
+    {
+      "type": 0,
+      "value": "Form field"
+    }
+  ],
+  "myvtu0": [
+    {
+      "type": 0,
+      "value": "Manage process variables"
+    }
+  ],
   "n4Y2ex": [
     {
       "type": 0,
@@ -1147,6 +1333,12 @@
       "value": "Amount of days when all submissions of this form will be permanently deleted. Leave blank to use value in General Configuration."
     }
   ],
+  "o8CfuS": [
+    {
+      "type": 0,
+      "value": "String"
+    }
+  ],
   "ow5AAO": [
     {
       "type": 0,
@@ -1159,10 +1351,22 @@
       "value": "How successful submissions of this form will be removed after the limit. Leave blank to use value in General Configuration."
     }
   ],
+  "p18yml": [
+    {
+      "type": 0,
+      "value": "Complex process variables"
+    }
+  ],
   "p8LSwF": [
     {
       "type": 0,
       "value": "Add action"
+    }
+  ],
+  "pWHOT1": [
+    {
+      "type": 0,
+      "value": "Value"
     }
   ],
   "piUWzT": [
@@ -1199,6 +1403,12 @@
     {
       "type": 0,
       "value": "Step slug"
+    }
+  ],
+  "r5Olb9": [
+    {
+      "type": 0,
+      "value": "Manage complex process variables"
     }
   ],
   "r6Wa2m": [
@@ -1255,10 +1465,22 @@
       "value": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
     }
   ],
+  "vng/5K": [
+    {
+      "type": 0,
+      "value": "Set a key name before you can configure this variable"
+    }
+  ],
   "wIaGgb": [
     {
       "type": 0,
       "value": "Errored Submissions Removal Method"
+    }
+  ],
+  "wOMoEs": [
+    {
+      "type": 0,
+      "value": "Source"
     }
   ],
   "wjwFwT": [
@@ -1271,6 +1493,12 @@
     {
       "type": 0,
       "value": "Component where products for an appointment will be shown"
+    }
+  ],
+  "x4gaYf": [
+    {
+      "type": 0,
+      "value": "Cancel"
     }
   ],
   "xJBMaf": [
@@ -1297,6 +1525,12 @@
       "value": "Select definition"
     }
   ],
+  "yTpHh0": [
+    {
+      "type": 0,
+      "value": "(unset)"
+    }
+  ],
   "yYw2Rb": [
     {
       "type": 0,
@@ -1313,6 +1547,12 @@
     {
       "type": 0,
       "value": "There are validation errors"
+    }
+  ],
+  "zV3nNZ": [
+    {
+      "type": 0,
+      "value": "Object"
     }
   ],
   "zeXZzX": [

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -5,6 +5,12 @@
       "value": "Are you sure you want to delete this action?"
     }
   ],
+  "+BicbW": [
+    {
+      "type": 0,
+      "value": "Configure"
+    }
+  ],
   "+hAGg7": [
     {
       "type": 0,
@@ -397,6 +403,12 @@
       "pluralType": "cardinal",
       "type": 6,
       "value": "varCount"
+    }
+  ],
+  "BR6rKB": [
+    {
+      "type": 0,
+      "value": "Check to include the field as process variable"
     }
   ],
   "BStu9Z": [
@@ -1191,6 +1203,18 @@
       "value": "Form design"
     }
   ],
+  "hZl34s": [
+    {
+      "type": 0,
+      "value": "Enabled"
+    }
+  ],
+  "huHjRm": [
+    {
+      "type": 0,
+      "value": "Configure"
+    }
+  ],
   "hzx+WF": [
     {
       "type": 0,
@@ -1435,6 +1459,12 @@
       "value": "Submission confirmation email template"
     }
   ],
+  "twWsC2": [
+    {
+      "type": 0,
+      "value": "Name"
+    }
+  ],
   "uBO/Al": [
     {
       "type": 0,
@@ -1469,6 +1499,12 @@
     {
       "type": 0,
       "value": "Set a key name before you can configure this variable"
+    }
+  ],
+  "vp12ou": [
+    {
+      "type": 0,
+      "value": "The variable name to be used for the process instance."
     }
   ],
   "wIaGgb": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -49,6 +49,12 @@
       "value": " wil verwijderen?"
     }
   ],
+  "1ArmQ5": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
   "1fD+K4": [
     {
       "type": 0,
@@ -59,6 +65,18 @@
     {
       "type": 0,
       "value": "Verwijderd"
+    }
+  ],
+  "2MK7iF": [
+    {
+      "type": 0,
+      "value": "Number"
+    }
+  ],
+  "2Z/hNo": [
+    {
+      "type": 0,
+      "value": "Type"
     }
   ],
   "2d5RfI": [
@@ -83,6 +101,12 @@
     {
       "type": 0,
       "value": "Voeg nog één toe"
+    }
+  ],
+  "4FQxD/": [
+    {
+      "type": 0,
+      "value": "Configure"
     }
   ],
   "4iGsG1": [
@@ -233,10 +257,64 @@
       "value": "De tekst op de knop om de gegevens van de huidige stap op te slaan en het formulier te onderbreken. Laat dit veld leeg om de standaardinstelling te gebruiken."
     }
   ],
+  "8VqmbG": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "8pemD3": [
+    {
+      "type": 0,
+      "value": "Edit variable "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
   "9N67XB": [
     {
       "type": 0,
       "value": "Invalid JSON syntax"
+    }
+  ],
+  "9RDDDn": [
+    {
+      "offset": 0,
+      "options": {
+        "=0": {
+          "value": [
+          ]
+        },
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "(1 variable defined)"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "("
+            },
+            {
+              "type": 1,
+              "value": "varCount"
+            },
+            {
+              "type": 0,
+              "value": " variables defined)"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "varCount"
     }
   ],
   "9bGp7h": [
@@ -249,6 +327,12 @@
     {
       "type": 0,
       "value": "en"
+    }
+  ],
+  "9y3/ek": [
+    {
+      "type": 0,
+      "value": "Confirm"
     }
   ],
   "9zJefY": [
@@ -379,6 +463,12 @@
       "value": "Submission allowed"
     }
   ],
+  "DEAqyQ": [
+    {
+      "type": 0,
+      "value": "Boolean"
+    }
+  ],
   "DGpAyT": [
     {
       "type": 0,
@@ -473,6 +563,12 @@
     {
       "type": 0,
       "value": "Gebruik gekoppelde productprijs"
+    }
+  ],
+  "GjcAY2": [
+    {
+      "type": 0,
+      "value": "Null"
     }
   ],
   "H3dRU6": [
@@ -583,10 +679,22 @@
       "value": "Inhoud"
     }
   ],
+  "KjDolH": [
+    {
+      "type": 0,
+      "value": "Manually defined"
+    }
+  ],
   "L0g8AL": [
     {
       "type": 0,
       "value": "Betaalprovider"
+    }
+  ],
+  "LHBcNe": [
+    {
+      "type": 0,
+      "value": "Variable definition"
     }
   ],
   "LN58C1": [
@@ -619,10 +727,28 @@
       "value": "'Wijzigen' tekst"
     }
   ],
+  "MEkGHD": [
+    {
+      "type": 0,
+      "value": "Component"
+    }
+  ],
   "NwTdLM": [
     {
       "type": 0,
       "value": "Veld waar beschikbare lokaties voor een afspraak komen te staan"
+    }
+  ],
+  "O/wKJh": [
+    {
+      "type": 0,
+      "value": "Value"
+    }
+  ],
+  "O3l+pQ": [
+    {
+      "type": 0,
+      "value": "Type"
     }
   ],
   "OFAJVW": [
@@ -741,6 +867,12 @@
       "value": "wijzig een attribuut van een veld/component."
     }
   ],
+  "T0OLUV": [
+    {
+      "type": 0,
+      "value": "Add key-value pair"
+    }
+  ],
   "TCQic2": [
     {
       "type": 0,
@@ -811,6 +943,12 @@
       "value": "\"-attribuut nodig heeft. Gebruik een inlogoptie die dit attribuut aanbiedt."
     }
   ],
+  "VUOOSy": [
+    {
+      "type": 0,
+      "value": "Name"
+    }
+  ],
   "VV2TCH": [
     {
       "type": 0,
@@ -859,6 +997,12 @@
       "value": "Opslaan"
     }
   ],
+  "YdIu8k": [
+    {
+      "type": 0,
+      "value": "Add item"
+    }
+  ],
   "YzLSHY": [
     {
       "type": 0,
@@ -869,12 +1013,6 @@
     {
       "type": 0,
       "value": "'Vorige' tekst"
-    }
-  ],
-  "a3dhuP": [
-    {
-      "type": 0,
-      "value": "Manage process variables"
     }
   ],
   "a4gS07": [
@@ -925,6 +1063,12 @@
       "value": "bewaartermijn voor sessies"
     }
   ],
+  "cID9dz": [
+    {
+      "type": 0,
+      "value": "(complex value)"
+    }
+  ],
   "cUVVbl": [
     {
       "type": 0,
@@ -949,10 +1093,22 @@
       "value": "Geen e-mail"
     }
   ],
+  "d1W41c": [
+    {
+      "type": 0,
+      "value": "From form field"
+    }
+  ],
   "d45v2X": [
     {
       "type": 0,
       "value": "Exporteer dit formulier"
+    }
+  ],
+  "ddDA6+": [
+    {
+      "type": 0,
+      "value": "Array"
     }
   ],
   "ddR92A": [
@@ -1079,6 +1235,12 @@
       "value": "wijzig de waarde van een veld"
     }
   ],
+  "jU/t8O": [
+    {
+      "type": 0,
+      "value": "Edit complex variable"
+    }
+  ],
   "jZIu+e": [
     {
       "type": 0,
@@ -1097,10 +1259,22 @@
       "value": "Naam"
     }
   ],
+  "kHn5Yw": [
+    {
+      "type": 0,
+      "value": "Edit definition"
+    }
+  ],
   "kNOyt+": [
     {
       "type": 0,
       "value": "uitgeschakeld"
+    }
+  ],
+  "l1fi1t": [
+    {
+      "type": 0,
+      "value": "(missing information)"
     }
   ],
   "l2Wag+": [
@@ -1133,6 +1307,18 @@
       "value": "maanden"
     }
   ],
+  "mZ5Rrx": [
+    {
+      "type": 0,
+      "value": "Form field"
+    }
+  ],
+  "myvtu0": [
+    {
+      "type": 0,
+      "value": "Manage process variables"
+    }
+  ],
   "n4Y2ex": [
     {
       "type": 0,
@@ -1151,6 +1337,12 @@
       "value": "Aantal dagen dat een inzending bewaard blijft voordat deze definitief verwijderd wordt. Laat leeg om de waarde van de algemene configuratie te gebruiken."
     }
   ],
+  "o8CfuS": [
+    {
+      "type": 0,
+      "value": "String"
+    }
+  ],
   "ow5AAO": [
     {
       "type": 0,
@@ -1163,10 +1355,22 @@
       "value": "Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn. Laat leeg om de waarde van de algemene configuratie te gebruiken."
     }
   ],
+  "p18yml": [
+    {
+      "type": 0,
+      "value": "Complex process variables"
+    }
+  ],
   "p8LSwF": [
     {
       "type": 0,
       "value": "Voeg actie toe"
+    }
+  ],
+  "pWHOT1": [
+    {
+      "type": 0,
+      "value": "Value"
     }
   ],
   "piUWzT": [
@@ -1203,6 +1407,12 @@
     {
       "type": 0,
       "value": "URL-deel"
+    }
+  ],
+  "r5Olb9": [
+    {
+      "type": 0,
+      "value": "Manage complex process variables"
     }
   ],
   "r6Wa2m": [
@@ -1259,10 +1469,22 @@
       "value": "De inhoud van bevestigingspagina na het versturen van de inzending. Dit sjabloon mag variabelen bevatten met inzendings-gegevens. Laat dit veld leeg om de standaardinstelling te gebruiken."
     }
   ],
+  "vng/5K": [
+    {
+      "type": 0,
+      "value": "Set a key name before you can configure this variable"
+    }
+  ],
   "wIaGgb": [
     {
       "type": 0,
       "value": "Opschoonmethode voor niet voltooide inzendingen"
+    }
+  ],
+  "wOMoEs": [
+    {
+      "type": 0,
+      "value": "Source"
     }
   ],
   "wjwFwT": [
@@ -1275,6 +1497,12 @@
     {
       "type": 0,
       "value": "Veld waar beschikbare producten voor een afspraak komen te staan"
+    }
+  ],
+  "x4gaYf": [
+    {
+      "type": 0,
+      "value": "Cancel"
     }
   ],
   "xJBMaf": [
@@ -1301,6 +1529,12 @@
       "value": "Formulierdefinitie selecteren"
     }
   ],
+  "yTpHh0": [
+    {
+      "type": 0,
+      "value": "(unset)"
+    }
+  ],
   "yYw2Rb": [
     {
       "type": 0,
@@ -1317,6 +1551,12 @@
     {
       "type": 0,
       "value": "Er zijn validatiefouten"
+    }
+  ],
+  "zV3nNZ": [
+    {
+      "type": 0,
+      "value": "Object"
     }
   ],
   "zeXZzX": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -1147,6 +1147,12 @@
       "value": "Weet u zeker dat u deze regel wil verwijderen?"
     }
   ],
+  "evbysh": [
+    {
+      "type": 0,
+      "value": "Variable definition"
+    }
+  ],
   "f590Rb": [
     {
       "type": 0,
@@ -1407,6 +1413,12 @@
     {
       "type": 0,
       "value": "Naam"
+    }
+  ],
+  "pyX2Tl": [
+    {
+      "type": 0,
+      "value": "Confirm"
     }
   ],
   "qUYLVg": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -5,6 +5,12 @@
       "value": "Ben je zeker dat je deze actie wil verwijderen?"
     }
   ],
+  "+BicbW": [
+    {
+      "type": 0,
+      "value": "Configure"
+    }
+  ],
   "+hAGg7": [
     {
       "type": 0,
@@ -401,6 +407,12 @@
       "pluralType": "cardinal",
       "type": 6,
       "value": "varCount"
+    }
+  ],
+  "BR6rKB": [
+    {
+      "type": 0,
+      "value": "Check to include the field as process variable"
     }
   ],
   "BStu9Z": [
@@ -1195,6 +1207,18 @@
       "value": "Formulierontwerp"
     }
   ],
+  "hZl34s": [
+    {
+      "type": 0,
+      "value": "Enabled"
+    }
+  ],
+  "huHjRm": [
+    {
+      "type": 0,
+      "value": "Configure"
+    }
+  ],
   "hzx+WF": [
     {
       "type": 0,
@@ -1439,6 +1463,12 @@
       "value": "Bevestingsmailsjabloon"
     }
   ],
+  "twWsC2": [
+    {
+      "type": 0,
+      "value": "Name"
+    }
+  ],
   "uBO/Al": [
     {
       "type": 0,
@@ -1473,6 +1503,12 @@
     {
       "type": 0,
       "value": "Set a key name before you can configure this variable"
+    }
+  ],
+  "vp12ou": [
+    {
+      "type": 0,
+      "value": "The variable name to be used for the process instance."
     }
   ],
   "wIaGgb": [

--- a/src/openforms/js/components/admin/FormioComponentRepresentation.js
+++ b/src/openforms/js/components/admin/FormioComponentRepresentation.js
@@ -1,0 +1,27 @@
+import React, {useContext} from 'react';
+import PropTypes from 'prop-types';
+
+import {ComponentsContext} from './forms/Context';
+
+
+/**
+ * Render a string representation of a component identified by its key.
+ * @param  {String} options.key The (unique) key of the component. Note that this key
+ *                              should be unique across the entire form and all steps.
+ * @return {String              The textual representation - label including step
+ *                              information if available, otherwise the component label
+ *                              and as a last resort the key itself is rendered.
+ */
+const FormioComponentRepresentation = ({ componentKey }) => {
+    const allComponents = useContext(ComponentsContext);
+    const component = allComponents[componentKey];
+    const {stepLabel, label} = component;
+    return ( stepLabel || label || componentKey );
+};
+
+FormioComponentRepresentation.propTypes = {
+    componentKey: PropTypes.string.isRequired,
+};
+
+
+export default FormioComponentRepresentation;

--- a/src/openforms/js/components/admin/debug/definition.json
+++ b/src/openforms/js/components/admin/debug/definition.json
@@ -1,0 +1,61 @@
+{
+    "name": "foo",
+    "source": "manual",
+    "type": "object",
+    "definition": {
+        "fixed1": {
+            "source": "manual",
+            "type": "string",
+            "definition": "test1"
+        },
+        "fixed2": {
+            "source": "manual",
+            "type": "number",
+            "definition": 123
+        },
+        "fixed3": {
+            "source": "manual",
+            "type": "boolean",
+            "definition": false
+        },
+        "component1": {
+            "source": "component",
+            "definition": {
+                "var": "component1"
+            },
+        },
+        "nested1": {
+            "source": "manual",
+            "type": "object",
+            "definition": {
+                "fixed4": {
+                    "source": "manual",
+                    "type": "string",
+                    "definition": "nested"
+                }
+            }
+        },
+        "nested2": {
+            "source": "manual",
+            "type": "list",
+            "definition": [
+                {
+                    "source": "manual",
+                    "type": "number",
+                    "definition": 456
+                },
+                {
+                    "source": "manual",
+                    "type": "object",
+                    "definition": {
+                        "fixed5": {
+                            "source": "manual",
+                            "type": "string",
+                            "definition": "final node"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/openforms/js/components/admin/debug/index.js
+++ b/src/openforms/js/components/admin/debug/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactModal from 'react-modal';
+import {IntlProvider} from 'react-intl';
+
+import {ComponentsContext} from '../forms/Context';
+import ComplexProcessVariable from '../form_design/registrations/camunda/ComplexProcessVariable';
+
+
+const allComponents = {
+    comp1: {
+        type: 'textfield',
+        stepLabel: 'Stap 1: Component 1',
+    },
+    comp2: {
+        type: 'textfield',
+        stepLabel: 'Stap 1: Component 2',
+    },
+    comp3: {
+        type: 'textfield',
+        stepLabel: 'Stap 2: Component 1',
+    },
+};
+
+
+
+const Debug = () => {
+    return (
+        <IntlProvider messages={{}} locale="en" defaultLocale="en">
+            <ComponentsContext.Provider value={allComponents}>
+                <ComplexProcessVariable />
+            </ComponentsContext.Provider>
+        </IntlProvider>
+    );
+};
+
+Debug.propTypes = {
+};
+
+
+ReactModal.setAppElement(document.getElementById('react'));
+
+export default Debug;

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariable.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariable.js
@@ -1,0 +1,227 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {produce} from 'immer';
+import {useImmerReducer} from 'use-immer';
+import {FormattedMessage} from 'react-intl';
+
+import FormModal from '../../../FormModal';
+import {TextInput} from '../../../forms/Inputs';
+import Field from '../../../forms/Field';
+import Fieldset from '../../../forms/Fieldset';
+import FormRow from '../../../forms/FormRow';
+import Select from '../../../forms/Select';
+import {ComplexVariable, EditPanel, TypeSelector} from '../../../json_editor';
+
+
+const initialState = {
+    // modal state
+    modalOpen: true,
+    // variable definition/state
+    name: '',
+    type: 'object',
+    definition: {},
+    // edit panel state
+    editPanelOpen: false,
+    editVariable: {
+        name: '',
+        definition: null,
+        parent: null,
+    },
+};
+
+
+const reducer = (draft, action) => {
+    switch (action.type) {
+        case 'CLOSE_MODAL': {
+            draft.modalOpen = false;
+            break;
+        }
+        case 'FIELD_CHANGED': {
+            const {name, value} = action.payload;
+            draft[name] = value;
+            if (name === 'type') {
+                draft.definition = null;
+            }
+            break;
+        }
+        case 'START_EDIT_VARIABLE_DEFINITION': {
+            const {name, definition, parent} = action.payload;
+            draft.editPanelOpen = true;
+            draft.editVariable = {
+                name,
+                definition,
+                parent,
+            };
+            break;
+        }
+        case 'SAVE_VARIABLE_DEFINITION': {
+            const {name, definition: newDefinition, parent} = action.payload;
+
+            // two possible paths:
+            // * parent is set, so we updated the definition of the parent and change
+            //   the state of the edit panel
+            // * parent is null, which means we're editing the root object, so we
+            //   update the draft state and close the edit panel
+
+            if (parent != null) {
+                // update edit panel state
+                // parent is originally from a prop, so it's immutable, which is why we
+                // use the produce from immer inside of the immer reducer
+                const parentDefinition = produce(parent.definition, definitionDraft => {
+                    definitionDraft.definition[name] = newDefinition;
+                });
+
+                // let the editVariable state 'crawl' up a level
+                draft.editVariable = {
+                    name: parent.name,
+                    definition: parentDefinition,
+                    parent: parent.parent,
+                }
+                // do not fall down into edit panel reset, so that the panel stays open
+                // and maintains its state
+                break;
+            } else {
+                // update draft definition
+                // name is either an object key or a list index, both work with the
+                // same syntax and explicit casting is not needed.
+                draft.definition[name] = newDefinition;
+            }
+
+            // fall through to reset edit panel so it gets closed and state is reset
+        }
+        case 'CANCEL_EDIT_VARIABLE_DEFINITION':
+        case 'RESET_EDIT_PANEL': {
+            // reset edit state
+            draft.editVariable = initialState.editVariable;
+            // close the panel
+            draft.editPanelOpen = false;
+            break;
+        }
+        default: {
+            throw new Error(`Unknown action type '${action.type}'`);
+        }
+    }
+};
+
+
+const editPanelStyle = {
+    borderLeft: 'solid 1px #ddd',
+    boxShadow: '-2px 0 3px rgba(0, 0, 0, 0.1)',
+    padding: '20px',
+    position: 'absolute',
+    zIndex: '2',
+    top: '0',
+    bottom: '0',
+    right: '0',
+    left: '10%',
+    background: 'white',
+    flexDirection: 'column',
+};
+
+
+const ComplexProcessVariable = () => {
+    // state
+    const [
+        {modalOpen, name, type, definition, editPanelOpen, editVariable},
+        dispatch
+    ] = useImmerReducer(reducer, initialState);
+
+    // event handlers
+    const onChange = (event) => dispatch({type: 'FIELD_CHANGED', payload: event.target});
+
+    const onEditDefinition = ({ name, definition, parent=null }) => {
+        dispatch({
+            type: 'START_EDIT_VARIABLE_DEFINITION',
+            payload: {
+                name,
+                definition,
+                parent,
+            },
+        });
+    };
+
+    return (
+        <FormModal
+            isOpen={modalOpen}
+            closeModal={() => dispatch({type: 'CLOSE_MODAL'}) }
+            title={<FormattedMessage
+                description="Camunda complex process var configuration modal title"
+                defaultMessage="Edit complex variable"
+            />}
+        >
+
+            {/* container */}
+            <section>
+
+                {/* main body */}
+                <div>
+                    <Fieldset>
+                        <FormRow>
+                            <Field name="name" label={<FormattedMessage
+                                description="Camunda complex process var 'name' label"
+                                defaultMessage="Name"
+                            />}>
+                                <TextInput value={name} onChange={onChange} placeholder="Camunda variable name" />
+                            </Field>
+                        </FormRow>
+
+                        <FormRow>
+                            <Field name="type" label={<FormattedMessage
+                                description="Camunda complex process var 'type' label"
+                                defaultMessage="Type"
+                            />}>
+                                <TypeSelector value={type} onChange={onChange} complexOnly />
+                            </Field>
+                        </FormRow>
+                    </Fieldset>
+
+                    <Fieldset title={<FormattedMessage
+                        description="JSON editor: complex variable definition title"
+                        defaultMessage="Variable definition"
+                    />}>
+                        {/* Root node of an arbitrarily deep tree. */}
+                        <ComplexVariable
+                            type={type}
+                            definition={definition}
+                            onChange={(newDefinition) => dispatch({
+                                type: 'FIELD_CHANGED',
+                                payload: {name: 'definition', value: newDefinition}
+                            })}
+                            onEditDefinition={onEditDefinition}
+                        />
+                    </Fieldset>
+                </div>
+
+                {/* variable edit panel */}
+                <aside style={{
+                    ...editPanelStyle,
+                    display: editPanelOpen ? 'flex' : 'none',
+                }}>
+                    {editPanelOpen
+                        ? (<EditPanel
+                            name={editVariable.name}
+                            definition={editVariable.definition}
+                            parent={editVariable.parent}
+                            onEditDefinition={onEditDefinition}
+                            onCancel={() => dispatch({type: 'CANCEL_EDIT_VARIABLE_DEFINITION'})}
+                            onChange={(definition, parent) => dispatch({
+                                type: 'SAVE_VARIABLE_DEFINITION',
+                                payload: {
+                                    name: editVariable.name,
+                                    definition,
+                                    parent,
+                                },
+                            })}
+                        />)
+                        : null
+                    }
+                </aside>
+
+            </section>
+
+        </FormModal>
+    );
+};
+
+
+export default ComplexProcessVariable;

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariable.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariable.js
@@ -84,7 +84,17 @@ const reducer = (draft, action) => {
 
             // fall through to reset edit panel so it gets closed and state is reset
         }
-        case 'CANCEL_EDIT_VARIABLE_DEFINITION':
+        case 'CANCEL_EDIT_VARIABLE_DEFINITION': {
+            const {parent} = draft.editVariable;
+            if (parent) {
+                draft.editVariable = {
+                    name: parent.name,
+                    definition: parent.definition,
+                    parent: parent.parent,
+                };
+                break;
+            }
+        }
         case 'RESET_EDIT_PANEL': {
             // reset edit state
             draft.editVariable = initialState.editVariable;

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariable.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariable.js
@@ -2,21 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {produce} from 'immer';
 import {useImmerReducer} from 'use-immer';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import FormModal from '../../../FormModal';
+import {SubmitAction} from '../../../forms/ActionButton';
 import {TextInput} from '../../../forms/Inputs';
 import Field from '../../../forms/Field';
 import Fieldset from '../../../forms/Fieldset';
 import FormRow from '../../../forms/FormRow';
 import Select from '../../../forms/Select';
+import SubmitRow from '../../../forms/SubmitRow';
 import {ComplexVariable, EditPanel, TypeSelector} from '../../../json_editor';
 import {jsonComplex as COMPLEX_JSON_TYPES} from '../../../json_editor/types';
 
 
 const initialState = {
     // variable definition/state
-    name: '',
     type: 'object',
     definition: {},
     // edit panel state
@@ -124,17 +125,21 @@ const editPanelStyle = {
 };
 
 
-const ComplexProcessVariable = ({ name: initialName, type: initialType, definition: initialDefinition }) => {
+const ComplexProcessVariable = ({
+    name, type: initialType, definition: initialDefinition,
+    onConfirm,
+}) => {
+    const intl = useIntl();
+
     // state
     const [
         {
-            name, type, definition,
+            type, definition,
             editPanelOpen, editVariable,
         },
         dispatch
     ] = useImmerReducer(reducer, {
         ...initialState,
-        name: initialName,
         type: initialType,
         definition: initialDefinition,
     });
@@ -153,19 +158,24 @@ const ComplexProcessVariable = ({ name: initialName, type: initialType, definiti
         });
     };
 
+    const onConfirmDefinition = (event) => {
+        event.preventDefault();
+        onConfirm({name, type, definition});
+    };
+
     return (
         /* container */
-        <section>
+        <section style={{display: 'flex', flexDirection: 'column', flexGrow: '1'}}>
 
             {/* main body */}
-            <div>
+            <div className="react-modal__form">
                 <Fieldset>
                     <FormRow>
                         <Field name="name" label={<FormattedMessage
                             description="Camunda complex process var 'name' label"
                             defaultMessage="Name"
                         />}>
-                            <TextInput value={name} onChange={onChange} placeholder="Camunda variable name" />
+                            <div className="readonly">{name}</div>
                         </Field>
                     </FormRow>
 
@@ -180,7 +190,7 @@ const ComplexProcessVariable = ({ name: initialName, type: initialType, definiti
                 </Fieldset>
 
                 <Fieldset title={<FormattedMessage
-                    description="JSON editor: complex variable definition title"
+                    description="Camunda complex variable definition title"
                     defaultMessage="Variable definition"
                 />}>
                     {/* Root node of an arbitrarily deep tree. */}
@@ -194,6 +204,13 @@ const ComplexProcessVariable = ({ name: initialName, type: initialType, definiti
                         onEditDefinition={onEditDefinition}
                     />
                 </Fieldset>
+
+                <SubmitRow>
+                    <SubmitAction text={intl.formatMessage({
+                        description: 'Confirm complex Camunda variable definition',
+                        defaultMessage: 'Confirm',
+                    })} onClick={onConfirmDefinition} />
+                </SubmitRow>
             </div>
 
             {/* variable edit panel */}
@@ -232,6 +249,7 @@ ComplexProcessVariable.propTypes = {
         PropTypes.object,
         PropTypes.array,
     ]).isRequired,
+    onConfirm: PropTypes.func.isRequired,
 };
 
 

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariables.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariables.js
@@ -5,9 +5,10 @@ import {useImmerReducer} from 'use-immer';
 
 import FormModal from '../../../FormModal';
 import ButtonContainer from '../../../forms/ButtonContainer';
-import {Checkbox} from '../../../forms/Inputs';
+import {Checkbox, TextInput} from '../../../forms/Inputs';
 import {ChangelistTableWrapper, HeadColumn, TableRow} from '../../../tables';
 import DeleteIcon from '../../../DeleteIcon';
+import {jsonComplex as COMPLEX_JSON_TYPES} from '../../../json_editor/types';
 import ComplexProcessVariable from './ComplexProcessVariable';
 
 
@@ -72,7 +73,7 @@ const ProcessVariable = ({ index, enabled=true, alias='', onChange, onDelete, on
                 />
             </div>
 
-            <span>{alias}</span>
+            <TextInput name="alias" value={alias} onChange={onChange} />
 
             <a href="#" onClick={onConfigure}>
                 <FormattedMessage
@@ -125,6 +126,14 @@ const ComplexProcessVariables = ({ variables=[], onChange, onAdd, onDelete }) =>
 
     const editVariable = variables[editVariableIndex];
 
+    const onVariableConfirm = ({ name, type, definition }) => {
+        const variable = variables.find(variable => variable.alias);
+        const index = variables.indexOf(variable);
+        onChange(index, {target: {name: 'type', value: type}});
+        onChange(index, {target: {name: 'definition', value: definition}});
+        dispatch({type: 'RESET'});
+    };
+
     return (
         <>
             <ChangelistTableWrapper headColumns={<HeadColumns />} extraModifiers={['camunda-vars']}>
@@ -163,11 +172,11 @@ const ComplexProcessVariables = ({ variables=[], onChange, onAdd, onDelete }) =>
                     // pass an onChange handler
                     modalOpen && editVariable
                     ? (
-                        /* TODO: onChange etc. */
                         <ComplexProcessVariable
                             name={editVariable.alias}
                             type={editVariable.type}
                             definition={editVariable.definition}
+                            onConfirm={onVariableConfirm}
                         />
                     )
                     : null
@@ -178,7 +187,12 @@ const ComplexProcessVariables = ({ variables=[], onChange, onAdd, onDelete }) =>
 };
 
 ComplexProcessVariables.propTypes = {
-    variables: PropTypes.array,
+    variables: PropTypes.arrayOf(PropTypes.shape({
+        enabled: PropTypes.bool,
+        alias: PropTypes.string,
+        type: PropTypes.oneOf(COMPLEX_JSON_TYPES).isRequired,
+        definition: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    })),
     onChange: PropTypes.func.isRequired,
     onAdd: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariables.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariables.js
@@ -8,7 +8,7 @@ import ButtonContainer from '../../../forms/ButtonContainer';
 import {Checkbox} from '../../../forms/Inputs';
 import {ChangelistTableWrapper, HeadColumn, TableRow} from '../../../tables';
 import DeleteIcon from '../../../DeleteIcon';
-import {jsonComplex as COMPLEX_JSON_TYPES} from '../../../json_editor/types';
+import ComplexProcessVariable from './ComplexProcessVariable';
 
 
 const HeadColumns = () => {
@@ -158,11 +158,17 @@ const ComplexProcessVariables = ({ variables=[], onChange, onAdd, onDelete }) =>
                 />}
             >
                 {
-                    editVariable
+                    // TODO: currently we rely on the mount/unmount to turn props into local state
+                    // instead, ComplexProcessVariable should have an useEffect to synchronize this, or we
+                    // pass an onChange handler
+                    modalOpen && editVariable
                     ? (
-                        <code>
-                            <pre>{JSON.stringify(editVariable, null, 4)}</pre>
-                        </code>
+                        /* TODO: onChange etc. */
+                        <ComplexProcessVariable
+                            name={editVariable.alias}
+                            type={editVariable.type}
+                            definition={editVariable.definition}
+                        />
                     )
                     : null
                 }

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariables.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/ComplexProcessVariables.js
@@ -2,54 +2,50 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage, useIntl} from 'react-intl';
 
-import {Checkbox, TextInput} from '../../../forms/Inputs';
 import ButtonContainer from '../../../forms/ButtonContainer';
-import ComponentSelection from '../../../forms/ComponentSelection';
+import {Checkbox} from '../../../forms/Inputs';
 import {ChangelistTableWrapper, HeadColumn, TableRow} from '../../../tables';
 import DeleteIcon from '../../../DeleteIcon';
+import {jsonComplex as COMPLEX_JSON_TYPES} from '../../../json_editor/types';
 
 
 const HeadColumns = () => {
     const intl = useIntl();
 
     const enabledText = (<FormattedMessage
-        description="Manage process vars enabled checkbox column title"
+        description="Manage complex process vars enabled checkbox column title"
         defaultMessage="Enabled"
     />);
     const enabledHelp = intl.formatMessage({
-        description: 'Manage process vars enabled checkbox help text',
+        description: 'Manage complex process vars enabled checkbox help text',
         defaultMessage: 'Check to include the field as process variable',
     });
 
-    const componentText = (<FormattedMessage
-        description="Manage process vars component column title"
-        defaultMessage="Field"
-    />);
-    const componentHelp = intl.formatMessage({
-        description: 'Manage process vars component help text',
-        defaultMessage: 'The value of the selected field will be the process variable value.',
-    });
-
     const aliasText = (<FormattedMessage
-        description="Manage process vars alias column title"
-        defaultMessage="Alias"
+        description="Manage complex process vars alias column title"
+        defaultMessage="Name"
     />);
     const aliasHelp = intl.formatMessage({
         description: 'Manage process vars alias help text',
-        defaultMessage: 'If desired, you can specify a different process variable name.',
+        defaultMessage: 'The variable name to be used for the process instance.',
     });
+
+    const editText = (<FormattedMessage
+        description="Manage complex process vars configure column title"
+        defaultMessage="Configure"
+    />);
 
     return (
         <>
             <HeadColumn content={enabledText} title={enabledHelp} />
-            <HeadColumn content={componentText} title={componentHelp} />
             <HeadColumn content={aliasText} title={aliasHelp} />
+            <HeadColumn content={editText} />
         </>
     );
 };
 
 
-const ProcessVariable = ({ index, enabled=true, componentKey='', alias='', componentFilterFunc, onChange, onDelete }) => {
+const ProcessVariable = ({ index, enabled=true, alias='', type, definition, onChange, onDelete }) => {
     const intl = useIntl();
 
     const onCheckboxChange = (event, current) => {
@@ -74,8 +70,14 @@ const ProcessVariable = ({ index, enabled=true, componentKey='', alias='', compo
                 />
             </div>
 
-            <ComponentSelection name="componentKey" value={componentKey} onChange={onChange} filter={componentFilterFunc.bind(null, componentKey)} />
-            <TextInput name="alias" value={alias} onChange={onChange} placeholder={componentKey} />
+            <span>{alias}</span>
+
+            <a href="#" onClick={(e) => {e.preventDefault(); console.log('edit')}}>
+                <FormattedMessage
+                    description="Manage complex process vars configure link text"
+                    defaultMessage="Configure"
+                />
+            </a>
         </TableRow>
     );
 };
@@ -83,30 +85,26 @@ const ProcessVariable = ({ index, enabled=true, componentKey='', alias='', compo
 ProcessVariable.propTypes = {
     index: PropTypes.number.isRequired,
     enabled: PropTypes.bool,
-    componentKey: PropTypes.string,
     alias: PropTypes.string,
-    componentFilterFunc: PropTypes.func.isRequired,
+    type: PropTypes.oneOf(COMPLEX_JSON_TYPES).isRequired,
+    definition: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]).isRequired,
     onChange: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
 };
 
 
-const SelectProcessVariables = ({ processVariables=[], onChange, onAdd, onDelete }) => {
-    const usedComponents = processVariables
-        .filter(variable => variable.componentKey !== '')
-        .map(variable => variable.componentKey);
-
-    const filterFunc = (componentKey, { key }) => componentKey === key || !usedComponents.includes(key);
-
+const ComplexProcessVariables = ({ variables=[], onChange, onAdd, onDelete }) => {
     return (
         <>
-            <ChangelistTableWrapper headColumns={<HeadColumns />}>
+            <ChangelistTableWrapper headColumns={<HeadColumns />} extraModifiers={['camunda-vars']}>
                 {
-                    processVariables.map((processVar, index) => (
+                    variables.map((processVar, index) => (
                         <ProcessVariable
                             key={index}
                             index={index}
-                            componentFilterFunc={filterFunc}
                             onChange={onChange.bind(null, index)}
                             onDelete={onDelete.bind(null, index)}
                             {...processVar}
@@ -122,16 +120,12 @@ const SelectProcessVariables = ({ processVariables=[], onChange, onAdd, onDelete
     );
 };
 
-SelectProcessVariables.propTypes = {
-    processVariables: PropTypes.arrayOf(PropTypes.shape({
-        enabled: PropTypes.bool,
-        componentKey: PropTypes.string,
-        alias: PropTypes.string,
-    })),
+ComplexProcessVariables.propTypes = {
+    variables: PropTypes.array,
     onChange: PropTypes.func.isRequired,
     onAdd: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
 };
 
 
-export default SelectProcessVariables;
+export default ComplexProcessVariables;

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/FormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/FormFields.js
@@ -9,6 +9,7 @@ import SubmitRow from '../../../forms/SubmitRow';
 import FormModal from '../../../FormModal';
 import {CustomFieldTemplate} from '../../../RJSFWrapper';
 import SelectProcessVariables from './SelectProcessVariables';
+import ComplexProcessVariables from './ComplexProcessVariables';
 
 
 // use rjsf wrapper to keep consistent markup/styling
@@ -25,6 +26,13 @@ const Wrapper = ({children}) => (
 const EMPTY_PROCESS_VARIABLE = {
     enabled: true,
     componentKey: '',
+    alias: '',
+};
+
+const EMPTY_COMPLEX_PROCESS_VARIABLE = {
+    enabled: true,
+    type: 'object',
+    definition: {},
     alias: '',
 };
 
@@ -106,6 +114,27 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
     const onDeleteProcessVariable = (index) => {
         const nextFormData = produce(formData, draft => {
             draft.processVariables.splice(index, 1);
+        });
+        onChange(nextFormData);
+    };
+
+    const onAddComplexProcessVariable = () => {
+        const nextFormData = produce(formData, draft => {
+            if (!draft.complexProcessVariables) draft.complexProcessVariables = [];
+            draft.complexProcessVariables.push(EMPTY_COMPLEX_PROCESS_VARIABLE);
+        });
+        onChange(nextFormData);
+    };
+    const onChangeComplexProcessVariable = (index, event) => {
+        const {name, value} = event.target;
+        const nextFormData = produce(formData, draft => {
+            draft.complexProcessVariables[index][name] = value;
+        });
+        onChange(nextFormData);
+    };
+    const onDeleteComplexProcessVariable = (index, event) => {
+        const nextFormData = produce(formData, draft => {
+            draft.complexProcessVariables.splice(index, 1);
         });
         onChange(nextFormData);
     };
@@ -229,8 +258,12 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
                 title={<FormattedMessage description="Camunda complex process vars modal title" defaultMessage="Manage complex process variables" />}
                 closeModal={() => setComplexVarsModalOpen(false)}
             >
-                Complicated
-
+                <ComplexProcessVariables
+                    variables={complexProcessVariables}
+                    onChange={onChangeComplexProcessVariable}
+                    onAdd={onAddComplexProcessVariable}
+                    onDelete={onDeleteComplexProcessVariable}
+                />
                 <SubmitRow>
                     <SubmitAction
                         text={intl.formatMessage({description: 'Camunda complex process variables confirm button', defaultMessage: 'Confirm'})}

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/FormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/FormFields.js
@@ -7,6 +7,7 @@ import ActionButton, {SubmitAction} from '../../../forms/ActionButton';
 import Select from '../../../forms/Select';
 import SubmitRow from '../../../forms/SubmitRow';
 import FormModal from '../../../FormModal';
+import {jsonComplex as COMPLEX_JSON_TYPES} from '../../../json_editor/types';
 import {CustomFieldTemplate} from '../../../RJSFWrapper';
 import SelectProcessVariables from './SelectProcessVariables';
 import ComplexProcessVariables from './ComplexProcessVariables';
@@ -293,6 +294,12 @@ FormFields.propTypes = {
             componentKey: PropTypes.string.isRequired,
             alias: PropTypes.string.isRequired,
         })),
+        complexProcessVariables: PropTypes.arrayOf(PropTypes.shape({
+            enabled: PropTypes.bool,
+            alias: PropTypes.string,
+            type: PropTypes.oneOf(COMPLEX_JSON_TYPES).isRequired,
+            definition: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+        }))
     }),
     onChange: PropTypes.func.isRequired,
 };

--- a/src/openforms/js/components/admin/form_design/registrations/camunda/FormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/camunda/FormFields.js
@@ -51,10 +51,12 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
         processDefinition='',
         processDefinitionVersion=null,
         processVariables=[],
+        complexProcessVariables=[],
     } = formData;
 
     const intl = useIntl();
-    const [modalOpen, setModalOpen] = useState(false);
+    const [simpleVarsModalOpen, setSimpleVarsModalOpen] = useState(false);
+    const [complexVarsModalOpen, setComplexVarsModalOpen] = useState(false);
     const [processDefinitionChoices, versionChoices] = getProcessSelectionChoices(processDefinitions, processDefinition);
 
     const onFieldChange = (event) => {
@@ -159,11 +161,11 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
                 <CustomFieldTemplate id="camundaOptions.manageProcessVars" displayLabel={false} rawErrors={null}>
                     <ActionButton
                         text={ intl.formatMessage({
-                            description: 'Open manage camnda process vars modal button',
+                            description: 'Open manage camunda process vars modal button',
                             defaultMessage: 'Manage process variables'
                         })}
                         type="button"
-                        onClick={() => setModalOpen(!modalOpen)}
+                        onClick={() => setSimpleVarsModalOpen(!simpleVarsModalOpen)}
                     />
                     &nbsp;
                     <FormattedMessage
@@ -177,12 +179,33 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
                     />
                 </CustomFieldTemplate>
 
+                <CustomFieldTemplate id="camundaOptions.manageComplexProcessVars" displayLabel={false} rawErrors={null}>
+                    <ActionButton
+                        text={ intl.formatMessage({
+                            description: 'Open manage complex camunda process vars modal button',
+                            defaultMessage: 'Complex process variables'
+                        })}
+                        type="button"
+                        onClick={() => setComplexVarsModalOpen(!complexVarsModalOpen)}
+                    />
+                    &nbsp;
+                    <FormattedMessage
+                        description="Managed complex Camunda process vars state feedback"
+                        defaultMessage="{varCount, plural,
+                            =0 {}
+                            one {(1 variable defined)}
+                            other {({varCount} variables defined)}
+                        }"
+                        values={{varCount: complexProcessVariables.length}}
+                    />
+                </CustomFieldTemplate>
+
             </Wrapper>
 
             <FormModal
-                isOpen={modalOpen}
+                isOpen={simpleVarsModalOpen}
                 title={<FormattedMessage description="Camunda process var selection modal title" defaultMessage="Manage process variables" />}
-                closeModal={() => setModalOpen(false)}
+                closeModal={() => setSimpleVarsModalOpen(false)}
             >
                 <SelectProcessVariables
                     processVariables={processVariables}
@@ -195,7 +218,25 @@ const FormFields = ({processDefinitions, formData, onChange}) => {
                         text={intl.formatMessage({description: 'Camunda process variables confirm button', defaultMessage: 'Confirm'})}
                         onClick={(event) => {
                             event.preventDefault();
-                            setModalOpen(false);
+                            setSimpleVarsModalOpen(false);
+                        }}
+                    />
+                </SubmitRow>
+            </FormModal>
+
+            <FormModal
+                isOpen={complexVarsModalOpen}
+                title={<FormattedMessage description="Camunda complex process vars modal title" defaultMessage="Manage complex process variables" />}
+                closeModal={() => setComplexVarsModalOpen(false)}
+            >
+                Complicated
+
+                <SubmitRow>
+                    <SubmitAction
+                        text={intl.formatMessage({description: 'Camunda complex process variables confirm button', defaultMessage: 'Confirm'})}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            setComplexVarsModalOpen(false);
                         }}
                     />
                 </SubmitRow>

--- a/src/openforms/js/components/admin/forms/Select.js
+++ b/src/openforms/js/components/admin/forms/Select.js
@@ -1,16 +1,29 @@
 import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
+import {useIntl} from 'react-intl';
 
 import { PrefixContext } from './Context';
+import {getTranslatedChoices} from '../../../utils/i18n';
 
 
 const BLANK_OPTION = ['', '------'];
 
 
-const Select = ({ name='select', choices, allowBlank=false, ...extraProps }) => {
+const Select = ({ name='select', choices, allowBlank=false, translateChoices=false, ...extraProps }) => {
+    // normalize to array of choices
+    if (!Array.isArray(choices)) {
+        choices = Object.entries(choices);
+    }
+
+    const intl = useIntl();
+    if (translateChoices) {
+        choices = choices.map(([value, msg]) => [value, intl.formatMessage(msg)]);
+    }
+
     const prefix = useContext(PrefixContext);
     name = prefix ? `${prefix}-${name}` : name;
     const options = allowBlank ? [BLANK_OPTION].concat(choices) : choices;
+
     return (
         <select name={name} {...extraProps}>
         {
@@ -23,12 +36,31 @@ const Select = ({ name='select', choices, allowBlank=false, ...extraProps }) => 
 };
 
 
+const Message = PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+        PropTypes.array,
+    ]),
+});
+
+
+const Label = PropTypes.oneOfType([
+    PropTypes.string,
+    Message,
+]);
+
+
 Select.propTypes = {
     name: PropTypes.string, // typically injected by the wrapping <Field> component
     allowBlank: PropTypes.bool,
-    choices: PropTypes.arrayOf(
-        PropTypes.arrayOf(PropTypes.string),
-    ).isRequired,
+    choices: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+        PropTypes.arrayOf(PropTypes.arrayOf(Label)),
+        PropTypes.objectOf(Label),
+    ]).isRequired,
+    translateChoices: PropTypes.bool,
 };
 
 

--- a/src/openforms/js/components/admin/index.js
+++ b/src/openforms/js/components/admin/index.js
@@ -8,6 +8,8 @@ import {TinyMceContext} from './form_design/Context';
 import FormVersionsTable from './form_versions/FormVersionsTable';
 import './sdk-snippet';
 
+import Debug from './debug';
+
 const loadLocaleData = (locale) => {
     switch (locale) {
         case 'nl':
@@ -58,6 +60,13 @@ const mountFormVersions = (locale, messages) => {
 };
 
 
+const mountDebugComponent = () => {
+    const node = document.getElementById('react');
+    if (!node) return;
+    ReactDOM.render(<Debug />, node);
+};
+
+
 const bootstrapApplication = async () => {
     const lang = document.querySelector('html').getAttribute("lang");
     const messages = await loadLocaleData(lang);
@@ -67,3 +76,4 @@ const bootstrapApplication = async () => {
 };
 
 bootstrapApplication();
+mountDebugComponent();

--- a/src/openforms/js/components/admin/json_editor/TypeRepresentation.js
+++ b/src/openforms/js/components/admin/json_editor/TypeRepresentation.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {defineMessage, useIntl} from 'react-intl';
+
+import Types from './types';
+
+
+const TYPE_MESSAGES = {
+    unset: defineMessage({
+        description: 'JSON variable type unset representation',
+        defaultMessage: '(unset)',
+    }),
+    component: defineMessage({
+        description: 'JSON variable type "Form field" representation',
+        defaultMessage: 'Form field',
+    }),
+    // manual subset
+    string: defineMessage({
+        description: 'JSON variable type "string" representation',
+        defaultMessage: 'String',
+    }),
+    number: defineMessage({
+        description: 'JSON variable type "number" representation',
+        defaultMessage: 'Number',
+    }),
+    boolean: defineMessage({
+        description: 'JSON variable type "boolean" representation',
+        defaultMessage: 'Boolean',
+    }),
+    null: defineMessage({
+        description: 'JSON variable type "null" representation',
+        defaultMessage: 'Null',
+    }),
+    object: defineMessage({
+        description: 'JSON variable type "object" representation',
+        defaultMessage: 'Object',
+    }),
+    array: defineMessage({
+        description: 'JSON variable type "array" representation',
+        defaultMessage: 'Array',
+    }),
+};
+
+
+const TypeRepresentation = ({ definition=null }) => {
+    const intl = useIntl();
+
+    // set default 'unset' in case there's no match
+    let typeRepresentationMessage = TYPE_MESSAGES.unset;
+
+    switch(definition?.source) {
+        case 'component': {
+            typeRepresentationMessage = TYPE_MESSAGES.component;
+            break;
+        }
+        case 'manual': {
+            if (!definition.type) break;
+            typeRepresentationMessage = TYPE_MESSAGES[definition.type] || TYPE_MESSAGES.unset;
+            break;
+        }
+    }
+
+    return intl.formatMessage(typeRepresentationMessage);
+};
+
+TypeRepresentation.propTypes = {
+    definition: Types.VariableDefinition,
+};
+
+
+export default TypeRepresentation;

--- a/src/openforms/js/components/admin/json_editor/TypeRepresentation.js
+++ b/src/openforms/js/components/admin/json_editor/TypeRepresentation.js
@@ -5,7 +5,7 @@ import {defineMessage, useIntl} from 'react-intl';
 import Types from './types';
 
 
-const TYPE_MESSAGES = {
+export const TYPE_MESSAGES = {
     unset: defineMessage({
         description: 'JSON variable type unset representation',
         defaultMessage: '(unset)',

--- a/src/openforms/js/components/admin/json_editor/TypeSelector.js
+++ b/src/openforms/js/components/admin/json_editor/TypeSelector.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {useIntl} from 'react-intl';
+
+import {getTranslatedChoices} from '../../../utils/i18n';
+import Select from '../forms/Select';
+import {TYPE_MESSAGES} from './TypeRepresentation';
+
+
+export const TYPE_CHOICES = [
+    {
+        complex: true,
+        value: 'array',
+        label: TYPE_MESSAGES.array,
+    },
+    {
+        complex: true,
+        value: 'object',
+        label: TYPE_MESSAGES.object,
+    },
+    {
+        complex: false,
+        value: 'string',
+        label: TYPE_MESSAGES.string,
+    },
+    {
+        complex: false,
+        value: 'number',
+        label: TYPE_MESSAGES.number,
+    },
+    {
+        complex: false,
+        value: 'boolean',
+        label: TYPE_MESSAGES.boolean,
+    },
+    {
+        complex: false,
+        value: 'null',
+        label: TYPE_MESSAGES.null,
+    },
+];
+
+
+/**
+ * Select a JSON datatype.
+ *
+ * Thin wrapper around a Select dropdown providing the available type choices.
+ *
+ * @param  {Boolean}   props.complexOnly   Whether to only display/allow complex
+ *                                         datatypes. If true, primitives are not available.
+ * @param  {...object} props.extra         Any extra props are forwarded to the underlying
+ *                                         Select component.
+ * @return {JSX}                           A Select dropdown with pre-defined choices.
+ */
+const TypeSelector = ({ complexOnly=false, ...extra }) => {
+    const intl = useIntl();
+    const choices = TYPE_CHOICES
+        .filter(opt => !complexOnly || (complexOnly && opt.complex))
+        .map(opt => [opt.value, opt.label])
+    ;
+    return (
+        <Select choices={getTranslatedChoices(intl, choices)} allowBlank={false} {...extra} />
+    );
+};
+
+TypeSelector.propTypes = {
+    complexOnly: PropTypes.bool,
+};
+
+
+export default TypeSelector;

--- a/src/openforms/js/components/admin/json_editor/TypeSelector.js
+++ b/src/openforms/js/components/admin/json_editor/TypeSelector.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {useIntl} from 'react-intl';
 
-import {getTranslatedChoices} from '../../../utils/i18n';
 import Select from '../forms/Select';
 import {TYPE_MESSAGES} from './TypeRepresentation';
 
@@ -53,13 +51,12 @@ export const TYPE_CHOICES = [
  * @return {JSX}                           A Select dropdown with pre-defined choices.
  */
 const TypeSelector = ({ complexOnly=false, ...extra }) => {
-    const intl = useIntl();
     const choices = TYPE_CHOICES
         .filter(opt => !complexOnly || (complexOnly && opt.complex))
         .map(opt => [opt.value, opt.label])
     ;
     return (
-        <Select choices={getTranslatedChoices(intl, choices)} allowBlank={false} {...extra} />
+        <Select choices={choices} translateChoices allowBlank={false} {...extra} />
     );
 };
 

--- a/src/openforms/js/components/admin/json_editor/ValueRepresentation.js
+++ b/src/openforms/js/components/admin/json_editor/ValueRepresentation.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import FormioComponentRepresentation from '../FormioComponentRepresentation'
+
+import Types from './types';
+
+
+const ValueRepresentation = ({ definition=null }) => {
+    let valueRepresentation = null;
+
+    switch(definition?.source) {
+        case 'component': {
+            // initially, we support very simple {"var": "foo"} jsonLogic expressions
+            const componentKey = definition?.definition?.var;
+            if (!componentKey) {
+                return (
+                    <FormattedMessage
+                        description="JSON editor: unknown FormIO component key"
+                        defaultMessage="(missing information)"
+                    />
+                );
+            }
+            valueRepresentation = (<FormioComponentRepresentation componentKey={componentKey} />);
+            break;
+        }
+        case 'manual': {
+            switch (definition?.type) {
+                case 'number':
+                case 'boolean':
+                case 'string': {
+                    const value = definition?.definition;
+                    if (value != null) {
+                        valueRepresentation = value.toString();
+                    }
+                    break;
+                }
+                case 'null': {
+                    valueRepresentation = 'null';
+                    break;
+                }
+                case 'array':
+                case 'object': {
+                    valueRepresentation = (
+                        <FormattedMessage
+                            description="JSON editor: complex value representation"
+                            defaultMessage="(complex value)"
+                        />
+                    );
+                    break;
+                }
+            }
+            break;
+        }
+    }
+    return valueRepresentation;
+};
+
+ValueRepresentation.propTypes = {
+    definition: Types.VariableDefinition,
+};
+
+
+export default ValueRepresentation;

--- a/src/openforms/js/components/admin/json_editor/complex_variables/ArrayVariable.js
+++ b/src/openforms/js/components/admin/json_editor/complex_variables/ArrayVariable.js
@@ -1,0 +1,103 @@
+import React, {useState, useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {produce} from 'immer';
+import {FormattedMessage} from 'react-intl';
+
+import ButtonContainer from '../../forms/ButtonContainer';
+import {ChangelistTableWrapper, HeadColumn, TableRow} from '../../tables';
+import TypeRepresentation from '../TypeRepresentation';
+import Types from '../types';
+import ValueRepresentation from '../ValueRepresentation';
+
+
+
+const ArrayItem = ({index, definition=null, onEditDefinition}) => (
+    <TableRow index={index}>
+        <span>{index}.</span>
+        <TypeRepresentation definition={definition} />
+        <ValueRepresentation definition={definition} />
+        <a href="#" onClick={onEditDefinition}>
+            <FormattedMessage
+                description="JSON editor: edit value definition"
+                defaultMessage="Edit definition"
+            />
+        </a>
+    </TableRow>
+);
+
+ArrayItem.propTypes = {
+    index: PropTypes.number.isRequired,
+    definition: Types.VariableDefinition,
+    onEditDefinition: PropTypes.func.isRequired,
+};
+
+
+const ArrayVariable = ({ definition=[], onChange, onEditDefinition }) => {
+
+    const items = definition ?? [];
+
+    const onEditClick = (index, event) => {
+        event.preventDefault();
+        onEditDefinition({
+            name: index,
+            definition: definition[index],
+        });
+    }
+
+    const onAddItem = (event) => {
+        event.preventDefault();
+        const newDefinition = produce(items, draft => {
+            draft.push(null); // add new, empty definition to the end
+        });
+        onChange(newDefinition);
+    };
+
+    const headColumns = (
+        <>
+            <HeadColumn content="#" />
+            <HeadColumn content={<FormattedMessage
+                description="JSON editor: 'type' header label"
+                defaultMessage="Type"
+            />} />
+            <HeadColumn content={<FormattedMessage
+                description="JSON editor: 'value' header label"
+                defaultMessage="Value"
+            />} />
+            <HeadColumn content={<FormattedMessage
+                description="JSON editor: 'configure' header label"
+                defaultMessage="Configure"
+            />} />
+        </>
+    );
+    return (
+        <div style={{paddingTop: '10px'}}>
+            <ChangelistTableWrapper headColumns={headColumns}>
+                {
+                    items.map((item, index) => (
+                        <ArrayItem
+                            key={index}
+                            index={index}
+                            definition={item}
+                            onEditDefinition={onEditClick.bind(null, index)}
+                        />
+                    ))
+                }
+            </ChangelistTableWrapper>
+
+            <ButtonContainer onClick={onAddItem}>
+                <FormattedMessage
+                    description="JSON editor: add array value button"
+                    defaultMessage="Add item"
+                />
+            </ButtonContainer>
+        </div>
+    );
+};
+
+ArrayVariable.propTypes = {
+    definition: PropTypes.arrayOf(Types.VariableDefinition),
+    onChange: PropTypes.func.isRequired,
+    onEditDefinition: PropTypes.func.isRequired,
+};
+
+export default ArrayVariable;

--- a/src/openforms/js/components/admin/json_editor/complex_variables/ObjectVariable.js
+++ b/src/openforms/js/components/admin/json_editor/complex_variables/ObjectVariable.js
@@ -1,0 +1,168 @@
+import isEqual from 'lodash/isEqual';
+import React, {useState, useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {produce} from 'immer';
+import {FormattedMessage} from 'react-intl';
+
+import ButtonContainer from '../../forms/ButtonContainer';
+import {TextInput} from '../../forms/Inputs';
+import TypeRepresentation from '../TypeRepresentation';
+import Types from '../types';
+import ValueRepresentation from '../ValueRepresentation';
+
+
+const ObjectKeyValuePair = ({ name='', definition={}, onNameChange, onEditDefinition }) => {
+
+    const onEditClick = (event) => {
+        event.preventDefault();
+        onEditDefinition({name, definition});
+    }
+
+    return (
+        <div style={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+            alignItems: 'center',
+            padding: '5px',
+        }}>
+            <div style={{width: '100%', paddingRight: '5px'}}>
+                <TextInput name="name" value={name} onChange={onNameChange} style={{width: '100%'}} />
+            </div>
+
+            <div style={{width: '100%', paddingRight: '5px'}}>
+                <TypeRepresentation definition={definition} />
+            </div>
+
+            <div style={{
+                width: '100%',
+                paddingLeft: '5px',
+                display: 'flex',
+                justifyContent: 'space-between',
+                flexWrap: 'wrap',
+            }}>
+
+                <div>
+                    <ValueRepresentation definition={definition} />
+                </div>
+
+                <div>
+                {
+                    !name
+                    ? (<FormattedMessage
+                        description="JSON editor: object entry has empty key name"
+                        defaultMessage="Set a key name before you can configure this variable" />)
+                    : (
+                        <a href="#" onClick={onEditClick}>
+                            <FormattedMessage
+                                description="JSON editor: edit value definition"
+                                defaultMessage="Edit definition"
+                            />
+                        </a>
+                    )
+                }
+                </div>
+            </div>
+        </div>
+    );
+};
+
+
+ObjectKeyValuePair.propTypes = {
+    name: PropTypes.string.isRequired,
+    definition: Types.VariableDefinition,
+    onNameChange: PropTypes.func.isRequired,
+    onEditDefinition: PropTypes.func.isRequired,
+};
+
+
+const ObjectVariable = ({ definition=null, onChange, onEditDefinition }) => {
+    // normalize to object
+    definition = definition || {};
+
+    // keep the ordering consistent when replacing keys so that the UI doesn't jump
+    // around. For that, we convert the object into an array of objects with
+    // deterministic ordering.
+    const [pairs, setPairs] = useState([]);
+
+    // synchronization step to track order in local state while keeping data-structure
+    // clean in parent component
+    useEffect(() => {
+        const entries = Object.entries(definition);
+        // compare the entries and the pairs. If they are not equal, we update the
+        // pairs, as the definition prop is authorative.
+        if (!isEqual(pairs, entries)) {
+            const pairsStillPresent = pairs.filter(([key]) => key in definition);
+            const keysStillPresent = pairsStillPresent.map(([key]) => key);
+            const newPairs = entries.filter(([key]) => !keysStillPresent.includes(key))
+
+            const allPairs = pairsStillPresent.concat(newPairs)
+                .map(([key]) => [key, definition[key]]);
+            setPairs(allPairs);
+        }
+    }, [definition]);
+
+    const onAdd = (event) => {
+        event.preventDefault();
+        const randomName = Math.random().toString(16).substr(2, 8);
+        const newPairs = produce(pairs, draft => {
+            // add empty definition for randomly generated name
+            draft.push([randomName, null]);
+        });
+        onChange(Object.fromEntries(newPairs));
+    };
+
+    const onKeyChange = (index, event) => {
+        const {value: newName} = event.target;
+        const newPairs = produce(pairs, draft => {
+            draft[index][0] = newName;
+        });
+        setPairs(newPairs);
+        onChange(Object.fromEntries(newPairs));
+    };
+
+    return (
+        <div style={{padding: '10px'}}>
+            <div style={{
+                display: 'flex',
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                padding: '5px',
+            }}>
+                <div style={{width: '100%', paddingRight: '5px'}}>
+                    <strong>Key</strong>
+                </div>
+                <div style={{width: '100%', paddingRight: '5px'}}>
+                    <strong>Type</strong>
+                </div>
+                <div style={{width: '100%', paddingLeft: '5px'}}>
+                    <strong>Value</strong>
+                </div>
+            </div>
+            {
+                pairs.map(([name, valueDefinition], index) => (
+                    <ObjectKeyValuePair
+                        key={index}
+                        name={name}
+                        definition={valueDefinition}
+                        onNameChange={onKeyChange.bind(null, index)}
+                        onEditDefinition={onEditDefinition}
+                    />
+                ))
+            }
+            <ButtonContainer onClick={onAdd}>
+                <FormattedMessage
+                    description="JSON editor: add object key-value pair button"
+                    defaultMessage="Add key-value pair"
+                />
+            </ButtonContainer>
+        </div>
+    );
+};
+
+ObjectVariable.propTypes = {
+    definition: PropTypes.objectOf(Types.VariableDefinition),
+    onChange: PropTypes.func.isRequired,
+    onEditDefinition: PropTypes.func.isRequired,
+};
+
+export default ObjectVariable;

--- a/src/openforms/js/components/admin/json_editor/complex_variables/index.js
+++ b/src/openforms/js/components/admin/json_editor/complex_variables/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Types, {jsonComplex as COMPLEX_TYPES} from '../types';
+import ArrayVariable from './ArrayVariable';
+import ObjectVariable from './ObjectVariable';
+
+
+const TYPE_MAP = {
+    array: ArrayVariable,
+    object: ObjectVariable,
+};
+
+
+const ComplexVariable = ({ type, definition=null, onChange, onEditDefinition }) => {
+    const Component = TYPE_MAP[type];
+    if (!Component) {
+        throw new Error(`Component type '${type}' is not supported`);
+    }
+    return (
+        <Component definition={definition} onChange={onChange} onEditDefinition={onEditDefinition} />
+    );
+};
+
+ComplexVariable.propTypes = {
+    type: PropTypes.oneOf(COMPLEX_TYPES).isRequired,
+    definition: Types.VariableDefinition,
+    onChange: PropTypes.func.isRequired,
+    onEditDefinition: PropTypes.func.isRequired,
+};
+
+export default ComplexVariable;

--- a/src/openforms/js/components/admin/json_editor/complex_variables/index.js
+++ b/src/openforms/js/components/admin/json_editor/complex_variables/index.js
@@ -24,7 +24,10 @@ const ComplexVariable = ({ type, definition=null, onChange, onEditDefinition }) 
 
 ComplexVariable.propTypes = {
     type: PropTypes.oneOf(COMPLEX_TYPES).isRequired,
-    definition: Types.VariableDefinition,
+    definition: PropTypes.oneOfType([
+        PropTypes.arrayOf(Types.VariableDefinition),
+        PropTypes.objectOf(Types.VariableDefinition),
+    ]),
     onChange: PropTypes.func.isRequired,
     onEditDefinition: PropTypes.func.isRequired,
 };

--- a/src/openforms/js/components/admin/json_editor/edit_panel/ComplexManualVariable.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/ComplexManualVariable.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Fieldset from '../../forms/Fieldset';
+import ComplexVariable from '../complex_variables';
+import Types, {jsonComplex as COMPLEX_TYPES} from '../types';
+
+
+const ComplexManualVariable = ({ name, type, definition=null, parent=null, onEditDefinition, onChange }) => {
+    if (!COMPLEX_TYPES.includes(type)) return null;
+
+    const onComplexVariableChange = (newDefinition) => {
+        const fakeEvent = {
+            target: {
+                name: 'definition',  // TODO: lift up in parent component?
+                value: newDefinition,
+            },
+        };
+        onChange(fakeEvent);
+    };
+
+    // keep track of the parent(s)
+    const self = {
+        name: name,
+        definition: {
+            source: 'manual',
+            type,
+            definition
+        },
+        parent,
+    };
+
+    const onComplexVariableEditDefinition = ({ name, definition }) => {
+        onEditDefinition({name, definition, parent: self});
+    };
+
+    return (
+        <Fieldset title={<FormattedMessage
+            description="JSON editor: complex variable definition title"
+            defaultMessage="Variable definition"
+        />}>
+            <ComplexVariable
+                type={type}
+                definition={definition}
+                onChange={onComplexVariableChange}
+                onEditDefinition={onComplexVariableEditDefinition}
+            />
+        </Fieldset>
+    );
+};
+
+ComplexManualVariable.propTypes = {
+    name: Types.VariableIdentifier.isRequired,
+    type: Types.VariableType.isRequired,
+    definition: PropTypes.oneOfType([
+        Types.VariableDefinition,
+        Types.LeafVariableDefinition,
+    ]),
+    parent: Types.VariableParent,
+    onEditDefinition: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
+
+
+export default ComplexManualVariable;

--- a/src/openforms/js/components/admin/json_editor/edit_panel/EditPanel.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/EditPanel.js
@@ -1,0 +1,219 @@
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {useImmerReducer} from 'use-immer';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {SubmitAction} from '../../forms/ActionButton';
+import SubmitRow from '../../forms/SubmitRow';
+import Types from '../types';
+import EditVariable from './EditVariable';
+
+
+const initialState = {
+    source: 'component',
+    component: '',
+    manual: {
+        type: '',
+        definition: null,
+    },
+};
+
+
+const reducer = (draft, action) => {
+    switch (action.type) {
+        case 'LOAD_EXISTING_DEFINITION': {
+            const {source, type, definition} = action.payload;
+
+            switch (source) {
+                case 'component': {
+                    // initially, simple jsonLogic support {"var": "componentKey"}
+                    draft.component = definition?.var || '';
+                    break;
+                }
+                case 'manual': {
+                    draft.manual.type = type;
+                    draft.manual.definition = definition;
+                    break;
+                }
+                default: {
+                    throw new Error(`Unknown var source ${source}`);
+                }
+            }
+
+            draft.source = source;
+            break;
+        }
+        case 'FIELD_CHANGED': {
+            const {name, value} = action.payload;
+            draft[name] = value;
+            break;
+        }
+        case 'MANUAL_VARIABLE_FIELD_CHANGED': {
+            const {name, value} = action.payload;
+            draft.manual[name] = value;
+
+            // type change -> reset value
+            if (name === 'type') {
+                draft.manual.definition = null;
+            }
+
+            // handle type-conversion for boolean select
+            if (name === 'value' && draft.manual.type === 'boolean') {
+                let castValue = null;
+                if (value === 'true') castValue = true;
+                if (value === 'false') castValue = false;
+                draft.manual.definition = castValue;
+            }
+
+            break;
+        }
+        case 'RESET': {
+            return initialState;
+        }
+    }
+};
+
+
+const EditPanel = ({ name, definition=null, parent=null, onEditDefinition, onChange, onCancel }) => {
+    const originalParent = parent;
+
+    // hooks
+    const intl = useIntl();
+    const [
+        {source, component, manual},
+        dispatch,
+    ] = useImmerReducer(reducer, initialState)
+
+    // consolidate local state and prop definition - we only save changes from
+    // state to parent component after explicit button click, but we need to load
+    // existing configuration into the state too
+    useEffect(() => {
+        // no pre-existing definition
+        if (!definition) {
+            dispatch({type: 'RESET'});
+        } else {
+            dispatch({
+                type: 'LOAD_EXISTING_DEFINITION',
+                payload: definition
+            });
+        }
+        return () => dispatch({type: 'RESET'});
+    }, [definition, originalParent]);
+
+    // event handlers
+    const onFieldChange = (event) => dispatch({
+        type: 'FIELD_CHANGED',
+        payload: event.target,
+    });
+
+    const onManualChange = (event) => dispatch({
+        type: 'MANUAL_VARIABLE_FIELD_CHANGED',
+        payload: event.target,
+    });
+
+    const onConfirm = (event) => {
+        event.preventDefault();
+
+        let variableDefinition = null;
+        switch (source) {
+            case 'component': {
+                // most simple json logic expression initially, later this can become
+                // more complex
+                variableDefinition = {
+                    definition: {var: component}
+                };
+                break;
+            }
+            case 'manual': {
+                variableDefinition = {
+                    type: manual.type,
+                    definition: manual.definition,
+                };
+                break;
+            }
+            // TODO: if none match, throw error/render validation errors
+        }
+        variableDefinition.source = source;
+        dispatch({type: 'RESET'});
+        onChange(variableDefinition, originalParent);
+    };
+
+    // manage the different sources of variables
+    let dependentFieldsOnChange;
+
+    switch(source) {
+        case 'component': {
+            dependentFieldsOnChange = onFieldChange;
+            break;
+        }
+        case 'manual': {
+            dependentFieldsOnChange = onManualChange;
+            break;
+        }
+    }
+
+    const nameBits = [name];
+    while (parent != null) {
+        nameBits.push(parent.name);
+        parent = parent.parent;
+    }
+    const jsonPathName = nameBits.reverse().join('.');
+
+    // render the full component tree
+    return (
+        <>
+            <header className="react-modal__header">
+                <h2 className="react-modal__title">
+                    <FormattedMessage
+                        description="JSON editor: variable edit panel title"
+                        defaultMessage="Edit variable {name}"
+                        values={{name: jsonPathName}}
+                    />
+                </h2>
+            </header>
+
+            <div className="react-modal__form">
+
+                <EditVariable
+                    name={name}
+                    source={source}
+                    component={component}
+                    manual={manual}
+                    parent={originalParent}
+                    onFieldChange={onFieldChange}
+                    onManualChange={onManualChange}
+                    dependentFieldsOnChange={dependentFieldsOnChange}
+                    onEditDefinition={onEditDefinition}
+                />
+
+                <SubmitRow>
+                    <a href="#" onClick={(event) => {
+                        event.preventDefault();
+                        dispatch({type: 'RESET'});
+                        onCancel();
+                    }}>
+                        <FormattedMessage
+                            description="JSON editor: cancel variable edit"
+                            defaultMessage="Cancel"
+                        />
+                    </a>
+                    <SubmitAction text={intl.formatMessage({
+                        description: 'JSON editor: confirm edited variable definition',
+                        defaultMessage: 'Confirm',
+                    })} onClick={onConfirm} />
+                </SubmitRow>
+            </div>
+        </>
+    );
+};
+
+EditPanel.propTypes = {
+    name: Types.VariableIdentifier.isRequired,
+    definition: Types.VariableDefinition,
+    parent: Types.VariableParent,
+    onEditDefinition: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
+
+export default EditPanel;

--- a/src/openforms/js/components/admin/json_editor/edit_panel/EditVariable.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/EditVariable.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import ComponentSelection from '../../forms/ComponentSelection';
+import Field from '../../forms/Field';
+import Fieldset from '../../forms/Fieldset';
+import FormRow from '../../forms/FormRow';
+import Types from '../types';
+
+import ComplexManualVariable from './ComplexManualVariable';
+import PrimitiveManualVariable from './PrimitiveManualVariable';
+import VariableSourceSelector from './VariableSourceSelector';
+
+
+const ComponentSelectionRow = ({ component='', onChange }) => {
+    return (
+        <FormRow>
+            <Field name="component" label={<FormattedMessage
+                description="Formio component selection label"
+                defaultMessage="Component"
+            />}>
+                <ComponentSelection name="component" value={component} onChange={onChange} />
+            </Field>
+        </FormRow>
+    );
+};
+
+ComponentSelectionRow.propTypes = {
+    component: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+};
+
+
+const DependentFields = ({ source, component, manual, onChange }) => {
+    let fields = null;
+
+    switch (source) {
+        case 'component': {
+            fields = (<ComponentSelectionRow component={component} onChange={onChange} />);
+            break;
+        }
+        case 'manual': {
+            fields = (
+                <PrimitiveManualVariable {...manual} onChange={onChange} />
+            );
+            break;
+        }
+    }
+    return fields;
+};
+
+DependentFields.propTypes = {
+    source: Types.VariableSource.isRequired,
+    component: PropTypes.string,
+    manual: PropTypes.shape({
+        type: Types.VariableType,
+        definition: Types.LeafVariableDefinition,
+    }),
+    onChange: PropTypes.func.isRequired,
+};
+
+
+const EditVariable = ({
+    name, source, component='', manual, parent=null,
+    onFieldChange, onManualChange, dependentFieldsOnChange, onEditDefinition,
+}) => {
+    return (
+        <>
+            <Fieldset>
+                <FormRow>
+                    <Field name="source" label={<FormattedMessage
+                        description="JSON editor: value source selector label"
+                        defaultMessage="Source"
+                    />}
+                    >
+                        <VariableSourceSelector value={source} onChange={onFieldChange} />
+                    </Field>
+                </FormRow>
+
+                <DependentFields
+                    source={source}
+                    component={component}
+                    manual={manual}
+                    onChange={dependentFieldsOnChange}
+                />
+
+            </Fieldset>
+
+            { source === 'manual'
+                ? (
+                    <ComplexManualVariable
+                        name={name}
+                        {...manual}
+                        parent={parent}
+                        onChange={onManualChange}
+                        onEditDefinition={onEditDefinition}
+                    />
+                )
+                : null
+            }
+        </>
+    );
+};
+
+EditVariable.propTypes = {
+    name: Types.VariableIdentifier.isRequired,
+    source: Types.VariableSource.isRequired,
+    component: PropTypes.string,
+    manual: PropTypes.shape({
+        type: Types.VariableType,
+        definition: Types.LeafVariableDefinition,
+    }),
+    parent: Types.VariableParent,
+    onFieldChange: PropTypes.func.isRequired,
+    onManualChange: PropTypes.func.isRequired,
+    dependentFieldsOnChange: PropTypes.func.isRequired,
+    onEditDefinition: PropTypes.func.isRequired,
+};
+
+
+export default EditVariable;

--- a/src/openforms/js/components/admin/json_editor/edit_panel/PrimitiveManualVariable.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/PrimitiveManualVariable.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Field from '../../forms/Field';
+import FormRow from '../../forms/FormRow';
+import {TextInput, NumberInput} from '../../forms/Inputs';
+import Select from '../../forms/Select';
+import Types from '../types';
+import TypeSelector from '../TypeSelector';
+
+
+const PrimitiveManualVariable = ({ type='', definition=null, onChange }) => {
+
+    let variableInput = null;
+
+    switch (type) {
+        case 'string': {
+            variableInput = (
+                <TextInput name="value" value={definition || ''} onChange={onChange} />
+            );
+            break;
+        }
+        case 'number': {
+            variableInput = (
+                <NumberInput name="value" value={definition || ''} onChange={onChange} />
+            );
+            break;
+        }
+        case 'boolean': {
+            variableInput = (
+                <Select
+                    choices={[['true', 'true'], ['false', 'false']]}
+                    allowBlank
+                    value={(definition == null || definition === '') ? '' : definition ? 'true' : 'false'}
+                    onChange={onChange}
+                />
+            );
+            break;
+        }
+    }
+
+    return (
+        <>
+            <FormRow>
+                <Field name="type" label={<FormattedMessage
+                    description="JSON datatype selector label"
+                    defaultMessage="Type"
+                />}>
+                    <TypeSelector value={type} onChange={onChange} allowBlank />
+                </Field>
+            </FormRow>
+            {
+                variableInput
+                ? (
+                    <FormRow>
+                        <Field name="definition" label={<FormattedMessage
+                            description="JSON (primitive) value label"
+                            defaultMessage="Value"
+                        />}>
+                            {variableInput}
+                        </Field>
+                    </FormRow>
+                )
+                : null
+            }
+        </>
+    );
+};
+
+PrimitiveManualVariable.propTypes = {
+    type: Types.VariableType.isRequired,
+    definition: Types.LeafVariableDefinition,
+    onChange: PropTypes.func.isRequired,
+};
+
+
+export default PrimitiveManualVariable;

--- a/src/openforms/js/components/admin/json_editor/edit_panel/VariableSourceSelector.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/VariableSourceSelector.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {defineMessage, useIntl} from 'react-intl';
+import {defineMessage} from 'react-intl';
 
-import {getTranslatedChoices} from '../../../../utils/i18n';
 import Select from '../../forms/Select';
 import Types from '../types';
 
@@ -20,12 +19,9 @@ const VARIABLE_SOURCES = {
 
 
 
-const VariableSourceSelector = ({ varSource='', ...props }) => {
-    const intl = useIntl();
-    return (
-        <Select choices={getTranslatedChoices(intl, VARIABLE_SOURCES)} value={varSource} {...props} />
-    );
-};
+const VariableSourceSelector = ({ varSource='', ...props }) => (
+    <Select choices={VARIABLE_SOURCES} translateChoices value={varSource} {...props} />
+);
 
 VariableSourceSelector.propTypes = {
     varSource: Types.VariableSource,

--- a/src/openforms/js/components/admin/json_editor/edit_panel/VariableSourceSelector.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/VariableSourceSelector.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {defineMessage, useIntl} from 'react-intl';
+
+import {getTranslatedChoices} from '../../../../utils/i18n';
+import Select from '../../forms/Select';
+import Types from '../types';
+
+
+const VARIABLE_SOURCES = {
+    component: defineMessage({
+        description: 'JSON editor: "component" variable source label',
+        defaultMessage: 'From form field',
+    }),
+    manual: defineMessage({
+        description: 'JSON editor: "manual" variable source label',
+        defaultMessage: 'Manually defined',
+    }),
+};
+
+
+
+const VariableSourceSelector = ({ varSource='', ...props }) => {
+    const intl = useIntl();
+    return (
+        <Select choices={getTranslatedChoices(intl, VARIABLE_SOURCES)} value={varSource} {...props} />
+    );
+};
+
+VariableSourceSelector.propTypes = {
+    varSource: Types.VariableSource,
+};
+
+
+export default VariableSourceSelector;

--- a/src/openforms/js/components/admin/json_editor/edit_panel/index.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/index.js
@@ -1,0 +1,3 @@
+import EditPanel from './EditPanel';
+
+export default EditPanel;

--- a/src/openforms/js/components/admin/json_editor/index.js
+++ b/src/openforms/js/components/admin/json_editor/index.js
@@ -6,3 +6,8 @@
  * you have a pre-defined schema for which you want to render a form, look into
  * react-json-schema-form.
  */
+import ComplexVariable from './complex_variables';
+import EditPanel from './edit_panel';
+import TypeSelector from './TypeSelector';
+
+export {EditPanel, ComplexVariable, TypeSelector};

--- a/src/openforms/js/components/admin/json_editor/index.js
+++ b/src/openforms/js/components/admin/json_editor/index.js
@@ -1,0 +1,8 @@
+/**
+ * A user-friendly JSON-editor.
+ *
+ * This editor allows definining an arbitrary JSON schema (object or array) AND set
+ * values. If you only want to describe schema's, look into json-schema instead, and if
+ * you have a pre-defined schema for which you want to render a form, look into
+ * react-json-schema-form.
+ */

--- a/src/openforms/js/components/admin/json_editor/types.js
+++ b/src/openforms/js/components/admin/json_editor/types.js
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types';
+
+// JSON types
+
+const jsonPrimitives = [
+    'string',
+    'number',
+    'boolean',
+    'null',
+];
+
+const jsonComplex = [
+    'object',
+    'array',
+];
+
+// (React) proptypes
+
+/*
+Meta-information about the JSON type of a variable.
+ */
+export const VariableType = PropTypes.oneOf(
+    [''] // empty/unset
+    + jsonPrimitives
+    + jsonComplex
+);
+
+/*
+The definition of a variable. Type depends on the specified variable type and is
+therefore polymorphic. Note that `null` is included by not using `.isRequired`.
+
+These are essentially the JSON types mapped to proptypes.
+ */
+export const LeafVariableDefinition = PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+]);
+
+
+export const VariableDefinition = PropTypes.shape({
+    source: PropTypes.oneOf([
+        '',
+        'manual',
+        'component'
+    ]).isRequired,
+    definition: PropTypes.oneOfType([
+        LeafVariableDefinition,
+        PropTypes.object, // TODO: recursive `VariableDefinition` prop type
+    ]), // can initially be null, so no `.isRequired`
+    // optional, set if source is 'manual'
+    // TODO: custom prop type to enforce this?
+    type: VariableType,
+});
+
+
+/*
+A variable may have a parent, which itself is described in Javascript objects.
+ */
+export const VariableParent = PropTypes.shape({
+    name: PropTypes.oneOfType([
+        PropTypes.string, // key in an object
+        PropTypes.number, // index in an array
+    ]).isRequired,
+    definition: VariableDefinition,
+    parent: PropTypes.object, // TODO: recursive `VariableParent` prop type
+});
+
+
+const Types = {
+    LeafVariableDefinition,
+    VariableDefinition,
+    VariableType,
+    VariableParent,
+};
+
+
+export default Types;

--- a/src/openforms/js/components/admin/json_editor/types.js
+++ b/src/openforms/js/components/admin/json_editor/types.js
@@ -9,12 +9,17 @@ const jsonPrimitives = [
     'null',
 ];
 
-const jsonComplex = [
+export const jsonComplex = [
     'object',
     'array',
 ];
 
 // (React) proptypes
+
+export const VariableIdentifier = PropTypes.oneOfType([
+    PropTypes.string,  // key in an object
+    PropTypes.number,  // index in an array
+]);
 
 /*
 Meta-information about the JSON type of a variable.
@@ -73,6 +78,7 @@ export const VariableParent = PropTypes.shape({
 
 
 const Types = {
+    VariableIdentifier,
     LeafVariableDefinition,
     VariableSource,
     VariableDefinition,

--- a/src/openforms/js/components/admin/json_editor/types.js
+++ b/src/openforms/js/components/admin/json_editor/types.js
@@ -21,8 +21,8 @@ Meta-information about the JSON type of a variable.
  */
 export const VariableType = PropTypes.oneOf(
     [''] // empty/unset
-    + jsonPrimitives
-    + jsonComplex
+    .concat(jsonPrimitives)
+    .concat(jsonComplex)
 );
 
 /*
@@ -40,12 +40,15 @@ export const LeafVariableDefinition = PropTypes.oneOfType([
 ]);
 
 
+export const VariableSource = PropTypes.oneOf([
+    '',
+    'manual',
+    'component'
+]);
+
+
 export const VariableDefinition = PropTypes.shape({
-    source: PropTypes.oneOf([
-        '',
-        'manual',
-        'component'
-    ]).isRequired,
+    source: VariableSource,
     definition: PropTypes.oneOfType([
         LeafVariableDefinition,
         PropTypes.object, // TODO: recursive `VariableDefinition` prop type
@@ -71,6 +74,7 @@ export const VariableParent = PropTypes.shape({
 
 const Types = {
     LeafVariableDefinition,
+    VariableSource,
     VariableDefinition,
     VariableType,
     VariableParent,

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -4,6 +4,11 @@
     "description": "Logic rule action deletion confirm message",
     "originalDefault": "Are you sure you want to delete this action?"
   },
+  "+BicbW": {
+    "defaultMessage": "Configure",
+    "description": "Manage complex process vars configure link text",
+    "originalDefault": "Configure"
+  },
   "+hAGg7": {
     "defaultMessage": "Users will not be able to start the form if it is in maintenance mode.",
     "description": "Form maintenance mode field help text",
@@ -238,6 +243,11 @@
     "defaultMessage": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }",
     "description": "Managed Camunda process vars state feedback",
     "originalDefault": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }"
+  },
+  "BR6rKB": {
+    "defaultMessage": "Check to include the field as process variable",
+    "description": "Manage complex process vars enabled checkbox help text",
+    "originalDefault": "Check to include the field as process variable"
   },
   "BStu9Z": {
     "defaultMessage": "Form",
@@ -879,6 +889,16 @@
     "description": "Form design/editor fieldset title",
     "originalDefault": "Form design"
   },
+  "hZl34s": {
+    "defaultMessage": "Enabled",
+    "description": "Manage complex process vars enabled checkbox column title",
+    "originalDefault": "Enabled"
+  },
+  "huHjRm": {
+    "defaultMessage": "Configure",
+    "description": "Manage complex process vars configure column title",
+    "originalDefault": "Configure"
+  },
   "hzx+WF": {
     "defaultMessage": "Internal name",
     "description": "Form name field label",
@@ -1079,6 +1099,11 @@
     "description": "Submission confirmation email fieldset title",
     "originalDefault": "Submission confirmation email template"
   },
+  "twWsC2": {
+    "defaultMessage": "Name",
+    "description": "Manage complex process vars alias column title",
+    "originalDefault": "Name"
+  },
   "uBO/Al": {
     "defaultMessage": "Select a step to view or modify.",
     "description": "No-active-step-selected notice",
@@ -1108,6 +1133,11 @@
     "defaultMessage": "Set a key name before you can configure this variable",
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
+  },
+  "vp12ou": {
+    "defaultMessage": "The variable name to be used for the process instance.",
+    "description": "Manage process vars alias help text",
+    "originalDefault": "The variable name to be used for the process instance."
   },
   "wIaGgb": {
     "defaultMessage": "Errored Submissions Removal Method",

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -34,6 +34,11 @@
     "description": "Step delete confirmation",
     "originalDefault": "Are you sure you want to delete the step {step}?"
   },
+  "1ArmQ5": {
+    "defaultMessage": "Confirm",
+    "description": "Camunda complex process variables confirm button",
+    "originalDefault": "Confirm"
+  },
   "1fD+K4": {
     "defaultMessage": "Incomplete Submissions Removal Method",
     "description": "Incomplete Submissions Removal Method field label",
@@ -43,6 +48,16 @@
     "defaultMessage": "Is deleted",
     "description": "Form deleted field label",
     "originalDefault": "Is deleted"
+  },
+  "2MK7iF": {
+    "defaultMessage": "Number",
+    "description": "JSON variable type \"number\" representation",
+    "originalDefault": "Number"
+  },
+  "2Z/hNo": {
+    "defaultMessage": "Type",
+    "description": "Camunda complex process var 'type' label",
+    "originalDefault": "Type"
   },
   "2d5RfI": {
     "defaultMessage": "Registration backend options",
@@ -63,6 +78,11 @@
     "defaultMessage": "Add another",
     "description": "Button text to add extra item",
     "originalDefault": "Add another"
+  },
+  "4FQxD/": {
+    "defaultMessage": "Configure",
+    "description": "JSON editor: 'configure' header label",
+    "originalDefault": "Configure"
   },
   "4iGsG1": {
     "defaultMessage": "Birth Date Component",
@@ -154,10 +174,25 @@
     "description": "Form step save text field help text",
     "originalDefault": "The text that will be displayed in the form step to save the current information. Leave blank to get value from global configuration."
   },
+  "8VqmbG": {
+    "defaultMessage": "Type",
+    "description": "JSON editor: 'type' header label",
+    "originalDefault": "Type"
+  },
+  "8pemD3": {
+    "defaultMessage": "Edit variable {name}",
+    "description": "JSON editor: variable edit panel title",
+    "originalDefault": "Edit variable {name}"
+  },
   "9N67XB": {
     "defaultMessage": "Invalid JSON syntax",
     "description": "Advanced logic rule invalid json message",
     "originalDefault": "Invalid JSON syntax"
+  },
+  "9RDDDn": {
+    "defaultMessage": "{varCount, plural, =0 {} one {(1 variable defined)} other {({varCount} variables defined)} }",
+    "description": "Managed complex Camunda process vars state feedback",
+    "originalDefault": "{varCount, plural, =0 {} one {(1 variable defined)} other {({varCount} variables defined)} }"
   },
   "9bGp7h": {
     "defaultMessage": "Active",
@@ -168,6 +203,11 @@
     "defaultMessage": "and",
     "description": "Extra logic action prefix",
     "originalDefault": "and"
+  },
+  "9y3/ek": {
+    "defaultMessage": "Confirm",
+    "description": "JSON editor: confirm edited variable definition",
+    "originalDefault": "Confirm"
   },
   "9zJefY": {
     "defaultMessage": "Errored Submissions Removal Limit",
@@ -249,6 +289,11 @@
     "description": "Form submissionAllowed field label",
     "originalDefault": "Submission allowed"
   },
+  "DEAqyQ": {
+    "defaultMessage": "Boolean",
+    "description": "JSON variable type \"boolean\" representation",
+    "originalDefault": "Boolean"
+  },
   "DGpAyT": {
     "defaultMessage": "Move down",
     "description": "Move down icon title",
@@ -328,6 +373,11 @@
     "defaultMessage": "Use linked product price",
     "description": "static pricing mode label",
     "originalDefault": "Use linked product price"
+  },
+  "GjcAY2": {
+    "defaultMessage": "Null",
+    "description": "JSON variable type \"null\" representation",
+    "originalDefault": "Null"
   },
   "H3dRU6": {
     "defaultMessage": "Check to include the field as process variable",
@@ -419,10 +469,20 @@
     "description": "Confirmation Email Content label",
     "originalDefault": "Content"
   },
+  "KjDolH": {
+    "defaultMessage": "Manually defined",
+    "description": "JSON editor: \"manual\" variable source label",
+    "originalDefault": "Manually defined"
+  },
   "L0g8AL": {
     "defaultMessage": "Payment provider",
     "description": "Payment provider fieldset title",
     "originalDefault": "Payment provider"
+  },
+  "LHBcNe": {
+    "defaultMessage": "Variable definition",
+    "description": "JSON editor: complex variable definition title",
+    "originalDefault": "Variable definition"
   },
   "LN58C1": {
     "defaultMessage": "Sensitive data within the submissions will be deleted",
@@ -449,10 +509,25 @@
     "description": "literals.changeText form label",
     "originalDefault": "Change text"
   },
+  "MEkGHD": {
+    "defaultMessage": "Component",
+    "description": "Formio component selection label",
+    "originalDefault": "Component"
+  },
   "NwTdLM": {
     "defaultMessage": "Component where locations for an appointment will be shown",
     "description": "Locations Component field help text",
     "originalDefault": "Component where locations for an appointment will be shown"
+  },
+  "O/wKJh": {
+    "defaultMessage": "Value",
+    "description": "JSON (primitive) value label",
+    "originalDefault": "Value"
+  },
+  "O3l+pQ": {
+    "defaultMessage": "Type",
+    "description": "JSON datatype selector label",
+    "originalDefault": "Type"
   },
   "OFAJVW": {
     "defaultMessage": "Registration",
@@ -544,6 +619,11 @@
     "description": "action type \"property\" label",
     "originalDefault": "change a property of a component."
   },
+  "T0OLUV": {
+    "defaultMessage": "Add key-value pair",
+    "description": "JSON editor: add object key-value pair button",
+    "originalDefault": "Add key-value pair"
+  },
   "TCQic2": {
     "defaultMessage": "Confirm text",
     "description": "literals.confirmText form label",
@@ -589,6 +669,11 @@
     "description": "Prefill plugin requires unavailable auth attribute warning",
     "originalDefault": "Component \"{label}\" uses a prefill that requires the \"{requiredAuthAttribute}\" attribute. Please select an authentication plugin that provides this attribute."
   },
+  "VUOOSy": {
+    "defaultMessage": "Name",
+    "description": "Camunda complex process var 'name' label",
+    "originalDefault": "Name"
+  },
   "VV2TCH": {
     "defaultMessage": "disable continuing to the next form step.",
     "description": "action type \"disable-next\" label",
@@ -629,6 +714,11 @@
     "description": "Admin save submit button",
     "originalDefault": "Save"
   },
+  "YdIu8k": {
+    "defaultMessage": "Add item",
+    "description": "JSON editor: add array value button",
+    "originalDefault": "Add item"
+  },
   "YzLSHY": {
     "defaultMessage": "Are you sure you want to delete this?",
     "description": "Default delete confirmation message",
@@ -638,11 +728,6 @@
     "defaultMessage": "Previous text",
     "description": "Form step previous text label",
     "originalDefault": "Previous text"
-  },
-  "a3dhuP": {
-    "defaultMessage": "Manage process variables",
-    "description": "Open manage camnda process vars modal button",
-    "originalDefault": "Manage process variables"
   },
   "a4gS07": {
     "defaultMessage": "No (without overview page)",
@@ -684,6 +769,11 @@
     "description": "Incomplete Submissions Removal Limit field label",
     "originalDefault": "Incomplete Submissions Removal Limit"
   },
+  "cID9dz": {
+    "defaultMessage": "(complex value)",
+    "description": "JSON editor: complex value representation",
+    "originalDefault": "(complex value)"
+  },
   "cUVVbl": {
     "defaultMessage": "is greater than or equal to",
     "description": "\">=\" operator description",
@@ -704,10 +794,20 @@
     "description": "no_email option label",
     "originalDefault": "No email"
   },
+  "d1W41c": {
+    "defaultMessage": "From form field",
+    "description": "JSON editor: \"component\" variable source label",
+    "originalDefault": "From form field"
+  },
   "d45v2X": {
     "defaultMessage": "Export this form",
     "description": "Export form button title",
     "originalDefault": "Export this form"
+  },
+  "ddDA6+": {
+    "defaultMessage": "Array",
+    "description": "JSON variable type \"array\" representation",
+    "originalDefault": "Array"
   },
   "ddR92A": {
     "defaultMessage": "Explanation template",
@@ -809,6 +909,11 @@
     "description": "action type \"value\" label",
     "originalDefault": "change the value of a component"
   },
+  "jU/t8O": {
+    "defaultMessage": "Edit complex variable",
+    "description": "Camunda complex process var configuration modal title",
+    "originalDefault": "Edit complex variable"
+  },
   "jZIu+e": {
     "defaultMessage": "No",
     "description": "Component property boolean value \"false\"",
@@ -824,10 +929,20 @@
     "description": "Form list 'name' column header",
     "originalDefault": "Name"
   },
+  "kHn5Yw": {
+    "defaultMessage": "Edit definition",
+    "description": "JSON editor: edit value definition",
+    "originalDefault": "Edit definition"
+  },
   "kNOyt+": {
     "defaultMessage": "disabled",
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
+  },
+  "l1fi1t": {
+    "defaultMessage": "(missing information)",
+    "description": "JSON editor: unknown FormIO component key",
+    "originalDefault": "(missing information)"
   },
   "l2Wag+": {
     "defaultMessage": "Mark the form step as not-applicable",
@@ -854,6 +969,16 @@
     "description": "Logic trigger number of months",
     "originalDefault": "months"
   },
+  "mZ5Rrx": {
+    "defaultMessage": "Form field",
+    "description": "JSON variable type \"Form field\" representation",
+    "originalDefault": "Form field"
+  },
+  "myvtu0": {
+    "defaultMessage": "Manage process variables",
+    "description": "Open manage camunda process vars modal button",
+    "originalDefault": "Manage process variables"
+  },
   "n4Y2ex": {
     "defaultMessage": "Version",
     "description": "Camunda 'process definition version' label",
@@ -869,6 +994,11 @@
     "description": "All Submissions Removal Limit help text",
     "originalDefault": "Amount of days when all submissions of this form will be permanently deleted. Leave blank to use value in General Configuration."
   },
+  "o8CfuS": {
+    "defaultMessage": "String",
+    "description": "JSON variable type \"string\" representation",
+    "originalDefault": "String"
+  },
   "ow5AAO": {
     "defaultMessage": "The form is invalid. Please correct the errors below.",
     "description": "Generic error message",
@@ -879,10 +1009,20 @@
     "description": "Successful Submissions Removal Method help text",
     "originalDefault": "How successful submissions of this form will be removed after the limit. Leave blank to use value in General Configuration."
   },
+  "p18yml": {
+    "defaultMessage": "Complex process variables",
+    "description": "Open manage complex camunda process vars modal button",
+    "originalDefault": "Complex process variables"
+  },
   "p8LSwF": {
     "defaultMessage": "Add action",
     "description": "Add form logic rule action button",
     "originalDefault": "Add action"
+  },
+  "pWHOT1": {
+    "defaultMessage": "Value",
+    "description": "JSON editor: 'value' header label",
+    "originalDefault": "Value"
   },
   "piUWzT": {
     "defaultMessage": "Select registration backend",
@@ -913,6 +1053,11 @@
     "defaultMessage": "Step slug",
     "description": "Form step slug label",
     "originalDefault": "Step slug"
+  },
+  "r5Olb9": {
+    "defaultMessage": "Manage complex process variables",
+    "description": "Camunda complex process vars modal title",
+    "originalDefault": "Manage complex process variables"
   },
   "r6Wa2m": {
     "defaultMessage": "the field",
@@ -959,10 +1104,20 @@
     "description": "Confirmation template help text",
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
   },
+  "vng/5K": {
+    "defaultMessage": "Set a key name before you can configure this variable",
+    "description": "JSON editor: object entry has empty key name",
+    "originalDefault": "Set a key name before you can configure this variable"
+  },
   "wIaGgb": {
     "defaultMessage": "Errored Submissions Removal Method",
     "description": "Errored Submissions Removal Method field label",
     "originalDefault": "Errored Submissions Removal Method"
+  },
+  "wOMoEs": {
+    "defaultMessage": "Source",
+    "description": "JSON editor: value source selector label",
+    "originalDefault": "Source"
   },
   "wjwFwT": {
     "defaultMessage": "Component where times for an appointment will be shown",
@@ -973,6 +1128,11 @@
     "defaultMessage": "Component where products for an appointment will be shown",
     "description": "Products Component field help text",
     "originalDefault": "Component where products for an appointment will be shown"
+  },
+  "x4gaYf": {
+    "defaultMessage": "Cancel",
+    "description": "JSON editor: cancel variable edit",
+    "originalDefault": "Cancel"
   },
   "xJBMaf": {
     "defaultMessage": "Submission confirmation template",
@@ -994,6 +1154,11 @@
     "description": "select definition icon title",
     "originalDefault": "Select definition"
   },
+  "yTpHh0": {
+    "defaultMessage": "(unset)",
+    "description": "JSON variable type unset representation",
+    "originalDefault": "(unset)"
+  },
   "yYw2Rb": {
     "defaultMessage": "Phone Number Component",
     "description": "Phone Number Component field label",
@@ -1008,6 +1173,11 @@
     "defaultMessage": "There are validation errors",
     "description": "Step validation errors icon title",
     "originalDefault": "There are validation errors"
+  },
+  "zV3nNZ": {
+    "defaultMessage": "Object",
+    "description": "JSON variable type \"object\" representation",
+    "originalDefault": "Object"
   },
   "zeXZzX": {
     "defaultMessage": "Use logic rules to determine the price",

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -839,6 +839,11 @@
     "description": "Price rule deletion confirm message",
     "originalDefault": "Are you sure you want to delete this rule?"
   },
+  "evbysh": {
+    "defaultMessage": "Variable definition",
+    "description": "Camunda complex variable definition title",
+    "originalDefault": "Variable definition"
+  },
   "f590Rb": {
     "defaultMessage": "Begin text",
     "description": "literals.beginText form label",
@@ -1053,6 +1058,11 @@
     "defaultMessage": "Step name",
     "description": "Form step name label",
     "originalDefault": "Step name"
+  },
+  "pyX2Tl": {
+    "defaultMessage": "Confirm",
+    "description": "Confirm complex Camunda variable definition",
+    "originalDefault": "Confirm"
   },
   "qUYLVg": {
     "defaultMessage": "Product & payment",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -4,6 +4,11 @@
     "description": "Logic rule action deletion confirm message",
     "originalDefault": "Are you sure you want to delete this action?"
   },
+  "+BicbW": {
+    "defaultMessage": "Configure",
+    "description": "Manage complex process vars configure link text",
+    "originalDefault": "Configure"
+  },
   "+hAGg7": {
     "defaultMessage": "Gebruikers kunnen dit formulier niet starten als het in onderhoud is",
     "description": "Form maintenance mode field help text",
@@ -238,6 +243,11 @@
     "defaultMessage": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }",
     "description": "Managed Camunda process vars state feedback",
     "originalDefault": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }"
+  },
+  "BR6rKB": {
+    "defaultMessage": "Check to include the field as process variable",
+    "description": "Manage complex process vars enabled checkbox help text",
+    "originalDefault": "Check to include the field as process variable"
   },
   "BStu9Z": {
     "defaultMessage": "Formulier",
@@ -879,6 +889,16 @@
     "description": "Form design/editor fieldset title",
     "originalDefault": "Form design"
   },
+  "hZl34s": {
+    "defaultMessage": "Enabled",
+    "description": "Manage complex process vars enabled checkbox column title",
+    "originalDefault": "Enabled"
+  },
+  "huHjRm": {
+    "defaultMessage": "Configure",
+    "description": "Manage complex process vars configure column title",
+    "originalDefault": "Configure"
+  },
   "hzx+WF": {
     "defaultMessage": "Interne naam",
     "description": "Form name field label",
@@ -1079,6 +1099,11 @@
     "description": "Submission confirmation email fieldset title",
     "originalDefault": "Submission confirmation email template"
   },
+  "twWsC2": {
+    "defaultMessage": "Name",
+    "description": "Manage complex process vars alias column title",
+    "originalDefault": "Name"
+  },
   "uBO/Al": {
     "defaultMessage": "Kies een stap om te bekijken of aan te passen.",
     "description": "No-active-step-selected notice",
@@ -1108,6 +1133,11 @@
     "defaultMessage": "Set a key name before you can configure this variable",
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
+  },
+  "vp12ou": {
+    "defaultMessage": "The variable name to be used for the process instance.",
+    "description": "Manage process vars alias help text",
+    "originalDefault": "The variable name to be used for the process instance."
   },
   "wIaGgb": {
     "defaultMessage": "Opschoonmethode voor niet voltooide inzendingen",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -839,6 +839,11 @@
     "description": "Price rule deletion confirm message",
     "originalDefault": "Are you sure you want to delete this rule?"
   },
+  "evbysh": {
+    "defaultMessage": "Variable definition",
+    "description": "Camunda complex variable definition title",
+    "originalDefault": "Variable definition"
+  },
   "f590Rb": {
     "defaultMessage": "'Start' tekst",
     "description": "literals.beginText form label",
@@ -1053,6 +1058,11 @@
     "defaultMessage": "Naam",
     "description": "Form step name label",
     "originalDefault": "Step name"
+  },
+  "pyX2Tl": {
+    "defaultMessage": "Confirm",
+    "description": "Confirm complex Camunda variable definition",
+    "originalDefault": "Confirm"
   },
   "qUYLVg": {
     "defaultMessage": "Product en betaling",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -34,6 +34,11 @@
     "description": "Step delete confirmation",
     "originalDefault": "Are you sure you want to delete the step {step}?"
   },
+  "1ArmQ5": {
+    "defaultMessage": "Confirm",
+    "description": "Camunda complex process variables confirm button",
+    "originalDefault": "Confirm"
+  },
   "1fD+K4": {
     "defaultMessage": "Opschoonmethode voor niet voltooide inzendingen",
     "description": "Incomplete Submissions Removal Method field label",
@@ -43,6 +48,16 @@
     "defaultMessage": "Verwijderd",
     "description": "Form deleted field label",
     "originalDefault": "Is deleted"
+  },
+  "2MK7iF": {
+    "defaultMessage": "Number",
+    "description": "JSON variable type \"number\" representation",
+    "originalDefault": "Number"
+  },
+  "2Z/hNo": {
+    "defaultMessage": "Type",
+    "description": "Camunda complex process var 'type' label",
+    "originalDefault": "Type"
   },
   "2d5RfI": {
     "defaultMessage": "Opties",
@@ -63,6 +78,11 @@
     "defaultMessage": "Voeg nog één toe",
     "description": "Button text to add extra item",
     "originalDefault": "Add another"
+  },
+  "4FQxD/": {
+    "defaultMessage": "Configure",
+    "description": "JSON editor: 'configure' header label",
+    "originalDefault": "Configure"
   },
   "4iGsG1": {
     "defaultMessage": "Geboortedatum veld",
@@ -154,10 +174,25 @@
     "description": "Form step save text field help text",
     "originalDefault": "The text that will be displayed in the form step to save the current information. Leave blank to get value from global configuration."
   },
+  "8VqmbG": {
+    "defaultMessage": "Type",
+    "description": "JSON editor: 'type' header label",
+    "originalDefault": "Type"
+  },
+  "8pemD3": {
+    "defaultMessage": "Edit variable {name}",
+    "description": "JSON editor: variable edit panel title",
+    "originalDefault": "Edit variable {name}"
+  },
   "9N67XB": {
     "defaultMessage": "Invalid JSON syntax",
     "description": "Advanced logic rule invalid json message",
     "originalDefault": "Invalid JSON syntax"
+  },
+  "9RDDDn": {
+    "defaultMessage": "{varCount, plural, =0 {} one {(1 variable defined)} other {({varCount} variables defined)} }",
+    "description": "Managed complex Camunda process vars state feedback",
+    "originalDefault": "{varCount, plural, =0 {} one {(1 variable defined)} other {({varCount} variables defined)} }"
   },
   "9bGp7h": {
     "defaultMessage": "Actief",
@@ -168,6 +203,11 @@
     "defaultMessage": "en",
     "description": "Extra logic action prefix",
     "originalDefault": "and"
+  },
+  "9y3/ek": {
+    "defaultMessage": "Confirm",
+    "description": "JSON editor: confirm edited variable definition",
+    "originalDefault": "Confirm"
   },
   "9zJefY": {
     "defaultMessage": "Bewaartermijn voor niet voltooide inzendingen inzendingen",
@@ -249,6 +289,11 @@
     "description": "Form submissionAllowed field label",
     "originalDefault": "Submission allowed"
   },
+  "DEAqyQ": {
+    "defaultMessage": "Boolean",
+    "description": "JSON variable type \"boolean\" representation",
+    "originalDefault": "Boolean"
+  },
   "DGpAyT": {
     "defaultMessage": "Verplaats omlaag",
     "description": "Move down icon title",
@@ -328,6 +373,11 @@
     "defaultMessage": "Gebruik gekoppelde productprijs",
     "description": "static pricing mode label",
     "originalDefault": "Use linked product price"
+  },
+  "GjcAY2": {
+    "defaultMessage": "Null",
+    "description": "JSON variable type \"null\" representation",
+    "originalDefault": "Null"
   },
   "H3dRU6": {
     "defaultMessage": "Check to include the field as process variable",
@@ -419,10 +469,20 @@
     "description": "Confirmation Email Content label",
     "originalDefault": "Content"
   },
+  "KjDolH": {
+    "defaultMessage": "Manually defined",
+    "description": "JSON editor: \"manual\" variable source label",
+    "originalDefault": "Manually defined"
+  },
   "L0g8AL": {
     "defaultMessage": "Betaalprovider",
     "description": "Payment provider fieldset title",
     "originalDefault": "Payment provider"
+  },
+  "LHBcNe": {
+    "defaultMessage": "Variable definition",
+    "description": "JSON editor: complex variable definition title",
+    "originalDefault": "Variable definition"
   },
   "LN58C1": {
     "defaultMessage": "Gevoelige gegevens in de inzendingen worden verwijderd",
@@ -449,10 +509,25 @@
     "description": "literals.changeText form label",
     "originalDefault": "Change text"
   },
+  "MEkGHD": {
+    "defaultMessage": "Component",
+    "description": "Formio component selection label",
+    "originalDefault": "Component"
+  },
   "NwTdLM": {
     "defaultMessage": "Veld waar beschikbare lokaties voor een afspraak komen te staan",
     "description": "Locations Component field help text",
     "originalDefault": "Component where locations for an appointment will be shown"
+  },
+  "O/wKJh": {
+    "defaultMessage": "Value",
+    "description": "JSON (primitive) value label",
+    "originalDefault": "Value"
+  },
+  "O3l+pQ": {
+    "defaultMessage": "Type",
+    "description": "JSON datatype selector label",
+    "originalDefault": "Type"
   },
   "OFAJVW": {
     "defaultMessage": "Registratie",
@@ -544,6 +619,11 @@
     "description": "action type \"property\" label",
     "originalDefault": "change a property of a component."
   },
+  "T0OLUV": {
+    "defaultMessage": "Add key-value pair",
+    "description": "JSON editor: add object key-value pair button",
+    "originalDefault": "Add key-value pair"
+  },
   "TCQic2": {
     "defaultMessage": "'Bevestigen' tekst",
     "description": "literals.confirmText form label",
@@ -589,6 +669,11 @@
     "description": "Prefill plugin requires unavailable auth attribute warning",
     "originalDefault": "Component \"{label}\" uses a prefill that requires the \"{requiredAuthAttribute}\" attribute. Please select an authentication plugin that provides this attribute."
   },
+  "VUOOSy": {
+    "defaultMessage": "Name",
+    "description": "Camunda complex process var 'name' label",
+    "originalDefault": "Name"
+  },
   "VV2TCH": {
     "defaultMessage": "blokkeer doorgaan naar de volgende stap.",
     "description": "action type \"disable-next\" label",
@@ -629,6 +714,11 @@
     "description": "Admin save submit button",
     "originalDefault": "Save"
   },
+  "YdIu8k": {
+    "defaultMessage": "Add item",
+    "description": "JSON editor: add array value button",
+    "originalDefault": "Add item"
+  },
   "YzLSHY": {
     "defaultMessage": "Weet u zeker dat u dit wilt verwijderen?",
     "description": "Default delete confirmation message",
@@ -638,11 +728,6 @@
     "defaultMessage": "'Vorige' tekst",
     "description": "Form step previous text label",
     "originalDefault": "Previous text"
-  },
-  "a3dhuP": {
-    "defaultMessage": "Manage process variables",
-    "description": "Open manage camnda process vars modal button",
-    "originalDefault": "Manage process variables"
   },
   "a4gS07": {
     "defaultMessage": "No (without overview page)",
@@ -684,6 +769,11 @@
     "description": "Incomplete Submissions Removal Limit field label",
     "originalDefault": "Incomplete Submissions Removal Limit"
   },
+  "cID9dz": {
+    "defaultMessage": "(complex value)",
+    "description": "JSON editor: complex value representation",
+    "originalDefault": "(complex value)"
+  },
   "cUVVbl": {
     "defaultMessage": "is groter dan of gelijk aan",
     "description": "\">=\" operator description",
@@ -704,10 +794,20 @@
     "description": "no_email option label",
     "originalDefault": "No email"
   },
+  "d1W41c": {
+    "defaultMessage": "From form field",
+    "description": "JSON editor: \"component\" variable source label",
+    "originalDefault": "From form field"
+  },
   "d45v2X": {
     "defaultMessage": "Exporteer dit formulier",
     "description": "Export form button title",
     "originalDefault": "Export this form"
+  },
+  "ddDA6+": {
+    "defaultMessage": "Array",
+    "description": "JSON variable type \"array\" representation",
+    "originalDefault": "Array"
   },
   "ddR92A": {
     "defaultMessage": "Toelichtingssjabloon",
@@ -809,6 +909,11 @@
     "description": "action type \"value\" label",
     "originalDefault": "change the value of a component"
   },
+  "jU/t8O": {
+    "defaultMessage": "Edit complex variable",
+    "description": "Camunda complex process var configuration modal title",
+    "originalDefault": "Edit complex variable"
+  },
   "jZIu+e": {
     "defaultMessage": "Nee",
     "description": "Component property boolean value \"false\"",
@@ -824,10 +929,20 @@
     "description": "Form list 'name' column header",
     "originalDefault": "Name"
   },
+  "kHn5Yw": {
+    "defaultMessage": "Edit definition",
+    "description": "JSON editor: edit value definition",
+    "originalDefault": "Edit definition"
+  },
   "kNOyt+": {
     "defaultMessage": "uitgeschakeld",
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
+  },
+  "l1fi1t": {
+    "defaultMessage": "(missing information)",
+    "description": "JSON editor: unknown FormIO component key",
+    "originalDefault": "(missing information)"
   },
   "l2Wag+": {
     "defaultMessage": "Markeer de formulierstap als niet van toepassing",
@@ -854,6 +969,16 @@
     "description": "Logic trigger number of months",
     "originalDefault": "months"
   },
+  "mZ5Rrx": {
+    "defaultMessage": "Form field",
+    "description": "JSON variable type \"Form field\" representation",
+    "originalDefault": "Form field"
+  },
+  "myvtu0": {
+    "defaultMessage": "Manage process variables",
+    "description": "Open manage camunda process vars modal button",
+    "originalDefault": "Manage process variables"
+  },
   "n4Y2ex": {
     "defaultMessage": "Versie",
     "description": "Camunda 'process definition version' label",
@@ -869,6 +994,11 @@
     "description": "All Submissions Removal Limit help text",
     "originalDefault": "Amount of days when all submissions of this form will be permanently deleted. Leave blank to use value in General Configuration."
   },
+  "o8CfuS": {
+    "defaultMessage": "String",
+    "description": "JSON variable type \"string\" representation",
+    "originalDefault": "String"
+  },
   "ow5AAO": {
     "defaultMessage": "De gegevens zijn ongeldig. Los de problemen hieronder op.",
     "description": "Generic error message",
@@ -879,10 +1009,20 @@
     "description": "Successful Submissions Removal Method help text",
     "originalDefault": "How successful submissions of this form will be removed after the limit. Leave blank to use value in General Configuration."
   },
+  "p18yml": {
+    "defaultMessage": "Complex process variables",
+    "description": "Open manage complex camunda process vars modal button",
+    "originalDefault": "Complex process variables"
+  },
   "p8LSwF": {
     "defaultMessage": "Voeg actie toe",
     "description": "Add form logic rule action button",
     "originalDefault": "Add action"
+  },
+  "pWHOT1": {
+    "defaultMessage": "Value",
+    "description": "JSON editor: 'value' header label",
+    "originalDefault": "Value"
   },
   "piUWzT": {
     "defaultMessage": "Registratiemethode",
@@ -913,6 +1053,11 @@
     "defaultMessage": "URL-deel",
     "description": "Form step slug label",
     "originalDefault": "Step slug"
+  },
+  "r5Olb9": {
+    "defaultMessage": "Manage complex process variables",
+    "description": "Camunda complex process vars modal title",
+    "originalDefault": "Manage complex process variables"
   },
   "r6Wa2m": {
     "defaultMessage": "het veld",
@@ -959,10 +1104,20 @@
     "description": "Confirmation template help text",
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
   },
+  "vng/5K": {
+    "defaultMessage": "Set a key name before you can configure this variable",
+    "description": "JSON editor: object entry has empty key name",
+    "originalDefault": "Set a key name before you can configure this variable"
+  },
   "wIaGgb": {
     "defaultMessage": "Opschoonmethode voor niet voltooide inzendingen",
     "description": "Errored Submissions Removal Method field label",
     "originalDefault": "Errored Submissions Removal Method"
+  },
+  "wOMoEs": {
+    "defaultMessage": "Source",
+    "description": "JSON editor: value source selector label",
+    "originalDefault": "Source"
   },
   "wjwFwT": {
     "defaultMessage": "Veld waar beschikbare tijden voor een afspraak komen te staan",
@@ -973,6 +1128,11 @@
     "defaultMessage": "Veld waar beschikbare producten voor een afspraak komen te staan",
     "description": "Products Component field help text",
     "originalDefault": "Component where products for an appointment will be shown"
+  },
+  "x4gaYf": {
+    "defaultMessage": "Cancel",
+    "description": "JSON editor: cancel variable edit",
+    "originalDefault": "Cancel"
   },
   "xJBMaf": {
     "defaultMessage": "Sjabloon bevestigingspagina",
@@ -994,6 +1154,11 @@
     "description": "select definition icon title",
     "originalDefault": "Select definition"
   },
+  "yTpHh0": {
+    "defaultMessage": "(unset)",
+    "description": "JSON variable type unset representation",
+    "originalDefault": "(unset)"
+  },
   "yYw2Rb": {
     "defaultMessage": "Telefoonnummer veld",
     "description": "Phone Number Component field label",
@@ -1008,6 +1173,11 @@
     "defaultMessage": "Er zijn validatiefouten",
     "description": "Step validation errors icon title",
     "originalDefault": "There are validation errors"
+  },
+  "zV3nNZ": {
+    "defaultMessage": "Object",
+    "description": "JSON variable type \"object\" representation",
+    "originalDefault": "Object"
   },
   "zeXZzX": {
     "defaultMessage": "Gebruik prijsregels om de prijs te bepalen",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -5,7 +5,7 @@
     "originalDefault": "Are you sure you want to delete this action?"
   },
   "+BicbW": {
-    "defaultMessage": "Configure",
+    "defaultMessage": "Configureren",
     "description": "Manage complex process vars configure link text",
     "originalDefault": "Configure"
   },
@@ -40,7 +40,7 @@
     "originalDefault": "Are you sure you want to delete the step {step}?"
   },
   "1ArmQ5": {
-    "defaultMessage": "Confirm",
+    "defaultMessage": "Bevestigen",
     "description": "Camunda complex process variables confirm button",
     "originalDefault": "Confirm"
   },
@@ -55,7 +55,7 @@
     "originalDefault": "Is deleted"
   },
   "2MK7iF": {
-    "defaultMessage": "Number",
+    "defaultMessage": "Getal (number)",
     "description": "JSON variable type \"number\" representation",
     "originalDefault": "Number"
   },
@@ -85,7 +85,7 @@
     "originalDefault": "Add another"
   },
   "4FQxD/": {
-    "defaultMessage": "Configure",
+    "defaultMessage": "Configureren",
     "description": "JSON editor: 'configure' header label",
     "originalDefault": "Configure"
   },
@@ -185,7 +185,7 @@
     "originalDefault": "Type"
   },
   "8pemD3": {
-    "defaultMessage": "Edit variable {name}",
+    "defaultMessage": "Wijzig variabele {name}",
     "description": "JSON editor: variable edit panel title",
     "originalDefault": "Edit variable {name}"
   },
@@ -195,7 +195,7 @@
     "originalDefault": "Invalid JSON syntax"
   },
   "9RDDDn": {
-    "defaultMessage": "{varCount, plural, =0 {} one {(1 variable defined)} other {({varCount} variables defined)} }",
+    "defaultMessage": "{varCount, plural, =0 {} one {(1 variabele ingesteld)} other {({varCount} variabelen ingesteld)} }",
     "description": "Managed complex Camunda process vars state feedback",
     "originalDefault": "{varCount, plural, =0 {} one {(1 variable defined)} other {({varCount} variables defined)} }"
   },
@@ -210,7 +210,7 @@
     "originalDefault": "and"
   },
   "9y3/ek": {
-    "defaultMessage": "Confirm",
+    "defaultMessage": "Bevestigen",
     "description": "JSON editor: confirm edited variable definition",
     "originalDefault": "Confirm"
   },
@@ -245,7 +245,7 @@
     "originalDefault": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }"
   },
   "BR6rKB": {
-    "defaultMessage": "Check to include the field as process variable",
+    "defaultMessage": "Vink aan om het veld op te nemen als procesvariabele",
     "description": "Manage complex process vars enabled checkbox help text",
     "originalDefault": "Check to include the field as process variable"
   },
@@ -300,7 +300,7 @@
     "originalDefault": "Submission allowed"
   },
   "DEAqyQ": {
-    "defaultMessage": "Boolean",
+    "defaultMessage": "Waar/Niet waar (boolean)",
     "description": "JSON variable type \"boolean\" representation",
     "originalDefault": "Boolean"
   },
@@ -385,7 +385,7 @@
     "originalDefault": "Use linked product price"
   },
   "GjcAY2": {
-    "defaultMessage": "Null",
+    "defaultMessage": "Leeg (null)",
     "description": "JSON variable type \"null\" representation",
     "originalDefault": "Null"
   },
@@ -480,7 +480,7 @@
     "originalDefault": "Content"
   },
   "KjDolH": {
-    "defaultMessage": "Manually defined",
+    "defaultMessage": "Handmatig ingesteld",
     "description": "JSON editor: \"manual\" variable source label",
     "originalDefault": "Manually defined"
   },
@@ -490,7 +490,7 @@
     "originalDefault": "Payment provider"
   },
   "LHBcNe": {
-    "defaultMessage": "Variable definition",
+    "defaultMessage": "Variabeledefinitie",
     "description": "JSON editor: complex variable definition title",
     "originalDefault": "Variable definition"
   },
@@ -530,7 +530,7 @@
     "originalDefault": "Component where locations for an appointment will be shown"
   },
   "O/wKJh": {
-    "defaultMessage": "Value",
+    "defaultMessage": "Waarde",
     "description": "JSON (primitive) value label",
     "originalDefault": "Value"
   },
@@ -630,7 +630,7 @@
     "originalDefault": "change a property of a component."
   },
   "T0OLUV": {
-    "defaultMessage": "Add key-value pair",
+    "defaultMessage": "Voeg sleutel-waarde paar toe",
     "description": "JSON editor: add object key-value pair button",
     "originalDefault": "Add key-value pair"
   },
@@ -680,7 +680,7 @@
     "originalDefault": "Component \"{label}\" uses a prefill that requires the \"{requiredAuthAttribute}\" attribute. Please select an authentication plugin that provides this attribute."
   },
   "VUOOSy": {
-    "defaultMessage": "Name",
+    "defaultMessage": "Naam",
     "description": "Camunda complex process var 'name' label",
     "originalDefault": "Name"
   },
@@ -725,7 +725,7 @@
     "originalDefault": "Save"
   },
   "YdIu8k": {
-    "defaultMessage": "Add item",
+    "defaultMessage": "Voeg item toe",
     "description": "JSON editor: add array value button",
     "originalDefault": "Add item"
   },
@@ -780,7 +780,7 @@
     "originalDefault": "Incomplete Submissions Removal Limit"
   },
   "cID9dz": {
-    "defaultMessage": "(complex value)",
+    "defaultMessage": "(complexe waarde)",
     "description": "JSON editor: complex value representation",
     "originalDefault": "(complex value)"
   },
@@ -805,7 +805,7 @@
     "originalDefault": "No email"
   },
   "d1W41c": {
-    "defaultMessage": "From form field",
+    "defaultMessage": "Van formulierveld",
     "description": "JSON editor: \"component\" variable source label",
     "originalDefault": "From form field"
   },
@@ -815,7 +815,7 @@
     "originalDefault": "Export this form"
   },
   "ddDA6+": {
-    "defaultMessage": "Array",
+    "defaultMessage": "Lijst (array)",
     "description": "JSON variable type \"array\" representation",
     "originalDefault": "Array"
   },
@@ -840,7 +840,7 @@
     "originalDefault": "Are you sure you want to delete this rule?"
   },
   "evbysh": {
-    "defaultMessage": "Variable definition",
+    "defaultMessage": "Variabeledefinitie",
     "description": "Camunda complex variable definition title",
     "originalDefault": "Variable definition"
   },
@@ -895,12 +895,12 @@
     "originalDefault": "Form design"
   },
   "hZl34s": {
-    "defaultMessage": "Enabled",
+    "defaultMessage": "Ingeschakeld",
     "description": "Manage complex process vars enabled checkbox column title",
     "originalDefault": "Enabled"
   },
   "huHjRm": {
-    "defaultMessage": "Configure",
+    "defaultMessage": "Configureren",
     "description": "Manage complex process vars configure column title",
     "originalDefault": "Configure"
   },
@@ -935,7 +935,7 @@
     "originalDefault": "change the value of a component"
   },
   "jU/t8O": {
-    "defaultMessage": "Edit complex variable",
+    "defaultMessage": "Wijzig complexe waarde",
     "description": "Camunda complex process var configuration modal title",
     "originalDefault": "Edit complex variable"
   },
@@ -955,7 +955,7 @@
     "originalDefault": "Name"
   },
   "kHn5Yw": {
-    "defaultMessage": "Edit definition",
+    "defaultMessage": "Wijzig definitie",
     "description": "JSON editor: edit value definition",
     "originalDefault": "Edit definition"
   },
@@ -965,7 +965,7 @@
     "originalDefault": "disabled"
   },
   "l1fi1t": {
-    "defaultMessage": "(missing information)",
+    "defaultMessage": "(ontbrekende informatie)",
     "description": "JSON editor: unknown FormIO component key",
     "originalDefault": "(missing information)"
   },
@@ -995,12 +995,12 @@
     "originalDefault": "months"
   },
   "mZ5Rrx": {
-    "defaultMessage": "Form field",
+    "defaultMessage": "Formulierveld",
     "description": "JSON variable type \"Form field\" representation",
     "originalDefault": "Form field"
   },
   "myvtu0": {
-    "defaultMessage": "Manage process variables",
+    "defaultMessage": "Beheer procesvariabelen",
     "description": "Open manage camunda process vars modal button",
     "originalDefault": "Manage process variables"
   },
@@ -1020,7 +1020,7 @@
     "originalDefault": "Amount of days when all submissions of this form will be permanently deleted. Leave blank to use value in General Configuration."
   },
   "o8CfuS": {
-    "defaultMessage": "String",
+    "defaultMessage": "Tekst (string)",
     "description": "JSON variable type \"string\" representation",
     "originalDefault": "String"
   },
@@ -1035,7 +1035,7 @@
     "originalDefault": "How successful submissions of this form will be removed after the limit. Leave blank to use value in General Configuration."
   },
   "p18yml": {
-    "defaultMessage": "Complex process variables",
+    "defaultMessage": "Complexe procesvariabelen",
     "description": "Open manage complex camunda process vars modal button",
     "originalDefault": "Complex process variables"
   },
@@ -1045,7 +1045,7 @@
     "originalDefault": "Add action"
   },
   "pWHOT1": {
-    "defaultMessage": "Value",
+    "defaultMessage": "Waarde",
     "description": "JSON editor: 'value' header label",
     "originalDefault": "Value"
   },
@@ -1060,7 +1060,7 @@
     "originalDefault": "Step name"
   },
   "pyX2Tl": {
-    "defaultMessage": "Confirm",
+    "defaultMessage": "Bevestigen",
     "description": "Confirm complex Camunda variable definition",
     "originalDefault": "Confirm"
   },
@@ -1085,7 +1085,7 @@
     "originalDefault": "Step slug"
   },
   "r5Olb9": {
-    "defaultMessage": "Manage complex process variables",
+    "defaultMessage": "Beheer complexe procesvariabelen",
     "description": "Camunda complex process vars modal title",
     "originalDefault": "Manage complex process variables"
   },
@@ -1110,7 +1110,7 @@
     "originalDefault": "Submission confirmation email template"
   },
   "twWsC2": {
-    "defaultMessage": "Name",
+    "defaultMessage": "Naam",
     "description": "Manage complex process vars alias column title",
     "originalDefault": "Name"
   },
@@ -1140,12 +1140,12 @@
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
   },
   "vng/5K": {
-    "defaultMessage": "Set a key name before you can configure this variable",
+    "defaultMessage": "Er moet een sleutelnaam ingesteld worden voordat deze variabele geconfigureerd kan worden",
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
   },
   "vp12ou": {
-    "defaultMessage": "The variable name to be used for the process instance.",
+    "defaultMessage": "De variabelenaam om te gebruiken in de procesinstantie.",
     "description": "Manage process vars alias help text",
     "originalDefault": "The variable name to be used for the process instance."
   },
@@ -1155,7 +1155,7 @@
     "originalDefault": "Errored Submissions Removal Method"
   },
   "wOMoEs": {
-    "defaultMessage": "Source",
+    "defaultMessage": "Bron",
     "description": "JSON editor: value source selector label",
     "originalDefault": "Source"
   },
@@ -1170,7 +1170,7 @@
     "originalDefault": "Component where products for an appointment will be shown"
   },
   "x4gaYf": {
-    "defaultMessage": "Cancel",
+    "defaultMessage": "Annuleren",
     "description": "JSON editor: cancel variable edit",
     "originalDefault": "Cancel"
   },
@@ -1195,7 +1195,7 @@
     "originalDefault": "Select definition"
   },
   "yTpHh0": {
-    "defaultMessage": "(unset)",
+    "defaultMessage": "(niet ingesteld)",
     "description": "JSON variable type unset representation",
     "originalDefault": "(unset)"
   },
@@ -1215,7 +1215,7 @@
     "originalDefault": "There are validation errors"
   },
   "zV3nNZ": {
-    "defaultMessage": "Object",
+    "defaultMessage": "Sleutel-waarde paar (object)",
     "description": "JSON variable type \"object\" representation",
     "originalDefault": "Object"
   },

--- a/src/openforms/registrations/base.py
+++ b/src/openforms/registrations/base.py
@@ -27,6 +27,10 @@ class BasePlugin(ABC, AbstractBasePlugin):
     in the database, and de-serialize them into native Python/Django objects when the
     plugin is called.
     """
+    camel_case_ignore_fields = None
+    """
+    Iterable of JSON keys to ignore when converting between snake_case/camelCase.
+    """
 
     @abstractmethod
     def register_submission(

--- a/src/openforms/registrations/contrib/camunda/complex_variables.py
+++ b/src/openforms/registrations/contrib/camunda/complex_variables.py
@@ -1,0 +1,187 @@
+"""
+Process the complex variable schema and evaluate it against the submission data.
+
+The variable schema is both a schema and an instance of the schema. Submission data
+is injected and evaluated using json-logic expressions, while the remainder of the
+data may be static/hardcoded.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict, List, Union
+
+from django_camunda.types import JSONObject, JSONValue
+from json_logic import jsonLogic
+
+AnyVariable = Union[
+    "ComponentVariable",
+    "StringVariable",
+    "NumberVariable",
+    "BooleanVariable",
+    "NullVariable",
+    "ObjectVariable",
+    "ArrayVariable",
+]
+
+
+@dataclass
+class Variable:
+    source: str
+
+    @staticmethod
+    def build(**kwargs) -> Union["ComponentVariable", "ManualVariable"]:
+        _source_map = {
+            "manual": ManualVariable,
+            "component": ComponentVariable,
+        }
+        cls = _source_map[kwargs["source"]]
+        return cls.build(**kwargs)
+
+    def evaluate(self, data: Dict[str, Any]) -> JSONValue:
+        raise NotImplementedError(
+            "Subclass %r must implement 'def evaluate'.", type(self)
+        )
+
+
+@dataclass
+class ComponentVariable(Variable):
+    definition: Dict[str, Any]  # JSON-logic
+
+    @classmethod
+    def build(cls, **kwargs):
+        return cls(**kwargs)
+
+    def evaluate(self, data: dict) -> JSONValue:
+        return jsonLogic(self.definition, data)
+
+
+@dataclass
+class ManualVariable(Variable):
+    type: str
+
+    @staticmethod
+    def build(**kwargs) -> "ManualVariable":
+        this_type = kwargs["type"]
+        _type_map = {
+            "string": StringVariable,
+            "number": NumberVariable,
+            "boolean": BooleanVariable,
+            "null": NullVariable,
+            "object": ObjectVariable,
+            "array": ArrayVariable,
+        }
+        cls = _type_map[this_type]
+
+        if this_type == "object":
+            kwargs["definition"] = {
+                key: Variable.build(**value)
+                for key, value in kwargs["definition"].items()
+            }
+
+        if this_type == "array":
+            kwargs["definition"] = [
+                Variable.build(**value) for value in kwargs["definition"]
+            ]
+
+        return cls(**kwargs)
+
+    def evaluate(self, data: dict) -> JSONValue:
+        # recurse into the leaf nodes
+        if self.type == "array":
+            return [sub_definition.evaluate(data) for sub_definition in self.definition]
+
+        elif self.type == "object":
+            return {
+                key: sub_definition.evaluate(data)
+                for key, sub_definition in self.definition.items()
+            }
+
+        raise ValueError(f"Unknown type {self.type}")  # pragma: no cover
+
+
+@dataclass
+class StringVariable(ManualVariable):
+    definition: str
+
+    def evaluate(self, data: dict) -> str:
+        return self.definition
+
+
+@dataclass
+class NumberVariable(ManualVariable):
+    definition: Union[float, int]
+
+    def evaluate(self, data: dict) -> Union[float, int]:
+        return self.definition
+
+
+@dataclass
+class BooleanVariable(ManualVariable):
+    definition: bool
+
+    def evaluate(self, data: dict) -> bool:
+        return self.definition
+
+
+@dataclass
+class NullVariable(ManualVariable):
+    definition: None
+
+    def evaluate(self, data: dict) -> None:
+        return None
+
+
+@dataclass
+class ObjectVariable(ManualVariable):
+    definition: Dict[str, AnyVariable]
+
+
+@dataclass
+class ArrayVariable(ManualVariable):
+    definition: List[AnyVariable]
+
+
+@dataclass
+class ComplexVariable:
+    enabled: bool
+    alias: str
+    type: str
+    definition: Union[ObjectVariable, ArrayVariable]
+
+    @classmethod
+    def build(cls, **kwargs):
+        # we assume that the data passed in has a valid schema - this is enforced by
+        # the camunda options serializer(s)
+        _type_map = {
+            "object": ObjectVariable,
+            "array": ArrayVariable,
+        }
+        Nested = _type_map[kwargs["type"]]
+        kwargs["definition"] = Nested.build(
+            type=kwargs["type"],
+            definition=kwargs["definition"],
+            source="manual",
+        )
+        return cls(**kwargs)
+
+    def evaluate(self, data: dict) -> JSONValue:
+        # defer evaluation to the underlying value definition
+        return self.definition.evaluate(data)
+
+
+def get_complex_process_variables(
+    variables: List[dict], merged_data: dict
+) -> Dict[str, JSONObject]:
+    if not variables:
+        return {}
+
+    # normalize object into dataclasses
+    variables = [
+        ComplexVariable.build(**variable)
+        for variable in variables
+        if variable["enabled"]
+    ]
+
+    evaluated = {
+        variable.alias: variable.evaluate(merged_data) for variable in variables
+    }
+
+    return evaluated

--- a/src/openforms/registrations/contrib/camunda/constants.py
+++ b/src/openforms/registrations/contrib/camunda/constants.py
@@ -1,0 +1,24 @@
+from django.utils.translation import gettext_lazy as _
+
+from djchoices import ChoiceItem, DjangoChoices
+
+
+class JSONPrimitiveVariableTypes(DjangoChoices):
+    string = ChoiceItem("string", _("String"))
+    number = ChoiceItem("number", _("Number"))
+    boolean = ChoiceItem("boolean", _("Boolean"))
+    null = ChoiceItem("null", _("Null"))
+
+
+class JSONComplexVariableTypes(DjangoChoices):
+    object = ChoiceItem("object", _("Object"))
+    array = ChoiceItem("array", _("Array"))
+
+
+class JSONVariableTypes(JSONComplexVariableTypes, JSONPrimitiveVariableTypes):
+    pass
+
+
+class VariableSourceChoices(DjangoChoices):
+    component = ChoiceItem("component", _("Component"))
+    manual = ChoiceItem("manual", _("Manual"))

--- a/src/openforms/registrations/contrib/camunda/fields.py
+++ b/src/openforms/registrations/contrib/camunda/fields.py
@@ -11,6 +11,10 @@ class NullField(fields.Field):
     default_error_messages = {"invalid": _("Must be 'null'.")}
     initial = None
 
+    def __init__(self, *args, **kwargs):
+        kwargs["allow_null"] = True
+        super().__init__(*args, **kwargs)
+
     def to_internal_value(self, data):
         if data is not None:
             self.fail("invalid", input=data)

--- a/src/openforms/registrations/contrib/camunda/fields.py
+++ b/src/openforms/registrations/contrib/camunda/fields.py
@@ -1,0 +1,20 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import fields
+
+
+class NullField(fields.Field):
+    """
+    Field that only accepts the 'null' value.
+    """
+
+    default_error_messages = {"invalid": _("Must be 'null'.")}
+    initial = None
+
+    def to_internal_value(self, data):
+        if data is not None:
+            self.fail("invalid", input=data)
+        return None
+
+    def to_representation(self, value):
+        return None

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -69,6 +69,8 @@ def get_process_variables(
 class CamundaRegistration(BasePlugin):
     verbose_name = _("Camunda")
     configuration_options = CamundaOptionsSerializer
+    # may be a dict with user-supplied keys in both snake_case and/or camelCase
+    camel_case_ignore_fields = ("definition",)
 
     def register_submission(
         self, submission: Submission, options: dict

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -24,6 +24,7 @@ from ...base import BasePlugin
 from ...exceptions import NoSubmissionReference, RegistrationFailed
 from ...registry import register
 from .checks import check_config
+from .complex_variables import get_complex_process_variables
 from .serializers import CamundaOptionsSerializer
 from .type_mapping import to_python
 
@@ -61,6 +62,16 @@ def get_process_variables(
         value = merged_data.get(key, None)
         alias = simple_mappings[key]
         variables[alias] = to_python(component, value)
+
+    complex_variables = get_complex_process_variables(
+        options.get("complex_process_variables", []),
+        merged_data,
+    )
+
+    if intersection := set(complex_variables).intersection(set(variables)):
+        logger.warning("Complex variables overlap, check the keys %r", intersection)
+
+    variables.update(**complex_variables)
 
     return variables
 

--- a/src/openforms/registrations/contrib/camunda/serializers.py
+++ b/src/openforms/registrations/contrib/camunda/serializers.py
@@ -1,8 +1,16 @@
 from django.utils.translation import gettext_lazy as _
 
+from drf_polymorphic.serializers import PolymorphicSerializer
 from rest_framework import serializers
 
 from openforms.utils.mixins import JsonSchemaSerializerMixin
+
+from .constants import (
+    JSONComplexVariableTypes,
+    JSONVariableTypes,
+    VariableSourceChoices,
+)
+from .fields import NullField
 
 
 class MappedVariableSerializer(serializers.Serializer):
@@ -30,6 +38,136 @@ class MappedVariableSerializer(serializers.Serializer):
     )
 
 
+class StringTypeDefinitionSerializer(serializers.Serializer):
+    definition = serializers.CharField(
+        label=_("Definition"),
+        help_text=_("The string value for the variable"),
+    )
+
+
+class NumberTypeDefinitionSerializer(serializers.Serializer):
+    definition = serializers.FloatField(
+        label=_("Definition"),
+        help_text=_("The number value for the variable"),
+    )
+
+
+class BooleanTypeDefinitionSerializer(serializers.Serializer):
+    definition = serializers.BooleanField(
+        label=_("Definition"),
+        help_text=_("The boolean value for the variable"),
+    )
+
+
+class NullTypeDefinitionSerializer(serializers.Serializer):
+    definition = NullField(
+        label=_("Definition"),
+        help_text=_("The value must always be 'null' for the 'null' type."),
+    )
+
+
+class ManualVariableSerializer(PolymorphicSerializer):
+    type = serializers.ChoiceField(
+        choices=JSONVariableTypes,
+        required=True,
+        allow_blank=False,
+        label=_("Manual variable type"),
+        help_text=_("Select the JSON variable type (manual source only)."),
+    )
+
+    discriminator_field = "type"
+    serializer_mapping = {
+        JSONVariableTypes.string: StringTypeDefinitionSerializer,
+        JSONVariableTypes.number: NumberTypeDefinitionSerializer,
+        JSONVariableTypes.boolean: BooleanTypeDefinitionSerializer,
+        JSONVariableTypes.null: NullTypeDefinitionSerializer,
+        JSONVariableTypes.object: "",
+        JSONVariableTypes.array: "",
+    }
+
+
+class ComponentJSONLogicLookupSerializer(serializers.Serializer):
+    # TODO: this can be replaced in the future with full-fledged JSON logic
+
+    # TODO: add validator to check that the component exists? we need the form context
+    # for that though. See also :class:`MappedVariableSerializer`
+    var = serializers.CharField(
+        label=_("Component key"),
+        help_text=_("Key of the Formio.js component to take the value from."),
+        required=True,
+    )
+
+
+class ComponentVariableSerializer(serializers.Serializer):
+    definition = ComponentJSONLogicLookupSerializer()
+
+
+class VariableDefinitionSerializer(PolymorphicSerializer):
+    source = serializers.ChoiceField(
+        choices=VariableSourceChoices,
+        label=_("Variable source"),
+        help_text=_("Designates where the value of the variable is sourced."),
+    )
+
+    discriminator_field = "source"
+    serializer_mapping = {
+        VariableSourceChoices.component: ComponentVariableSerializer,
+        VariableSourceChoices.manual: ManualVariableSerializer,
+    }
+
+
+class ObjectVariableDefinitionSerializer(serializers.Serializer):
+    definition = serializers.DictField(
+        child=VariableDefinitionSerializer(),
+        label=_("Definition"),
+        help_text=_("The object with nested variable definitions"),
+    )
+
+
+class ArrayVariableDefinitionSerializer(serializers.Serializer):
+    definition = serializers.ListField(
+        child=VariableDefinitionSerializer(),
+        label=_("Definition"),
+        help_text=_("The list with nested variable definitions"),
+    )
+
+
+# recursive references, fun!
+VariableDefinitionSerializer.serializer_mapping[
+    JSONVariableTypes.object
+] = ObjectVariableDefinitionSerializer
+VariableDefinitionSerializer.serializer_mapping[
+    JSONVariableTypes.array
+] = ArrayVariableDefinitionSerializer
+
+
+class ComplexVariableSerializer(PolymorphicSerializer):
+    enabled = serializers.BooleanField(
+        label=_("enable"),
+        help_text=_("Only enabled variables are passed into the process"),
+    )
+    alias = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        label=_("Alias"),
+        help_text=_(
+            "Name of the variable in the Camunda process instance. For complex "
+            "variables, the name must be supplied."
+        ),
+    )
+    type = serializers.ChoiceField(
+        choices=JSONComplexVariableTypes.choices,
+        label=_("Type"),
+        help_text=_("The type determines how to interpret the variable definition."),
+    )
+
+    discriminator_field = "type"
+    serializer_mapping = {
+        JSONComplexVariableTypes.object: ObjectVariableDefinitionSerializer,
+        JSONComplexVariableTypes.array: ArrayVariableDefinitionSerializer,
+    }
+
+
 class CamundaOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     process_definition = serializers.CharField(
         required=True,
@@ -47,5 +185,7 @@ class CamundaOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer
         many=True,
         label=_("Mapped process variables"),
     )
-    # TODO: derived_variables, variables_to_include (from component keys) - might have
-    # to be done in react alltogether
+    complex_process_variables = ComplexVariableSerializer(
+        many=True,
+        label=_("Complex process variables"),
+    )

--- a/src/openforms/registrations/contrib/camunda/serializers.py
+++ b/src/openforms/registrations/contrib/camunda/serializers.py
@@ -133,10 +133,10 @@ class ArrayVariableDefinitionSerializer(serializers.Serializer):
 
 
 # recursive references, fun!
-VariableDefinitionSerializer.serializer_mapping[
+ManualVariableSerializer.serializer_mapping[
     JSONVariableTypes.object
 ] = ObjectVariableDefinitionSerializer
-VariableDefinitionSerializer.serializer_mapping[
+ManualVariableSerializer.serializer_mapping[
     JSONVariableTypes.array
 ] = ArrayVariableDefinitionSerializer
 

--- a/src/openforms/registrations/contrib/camunda/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/camunda/tests/test_backend.py
@@ -433,6 +433,16 @@ class ComplexProcessVariableTests(CamundaMixin, TestCase):
                             "type": "boolean",
                             "definition": False,
                         },
+                        {
+                            "source": "manual",
+                            "type": "number",
+                            "definition": 42,
+                        },
+                        {
+                            "source": "manual",
+                            "type": "number",
+                            "definition": 3.14,
+                        },
                     ],
                 },
             ],
@@ -444,7 +454,7 @@ class ComplexProcessVariableTests(CamundaMixin, TestCase):
 
         plugin.register_submission(self.submission, registration_backend_options)
 
-        expected_evaluated_value = [False]
+        expected_evaluated_value = [False, 42, 3.14]
         mock_start_process.assert_called_once_with(
             process_key="invoice",
             variables=serialize_variables(

--- a/src/openforms/registrations/contrib/camunda/tests/test_backend_options.py
+++ b/src/openforms/registrations/contrib/camunda/tests/test_backend_options.py
@@ -148,6 +148,7 @@ class FormRegistrationBackendOptionsTests(APITestCase):
         """
         Test that complex variables are not converted into camelCase.
         """
+        self.maxDiff = None
         form = FormFactory.create(
             generate_minimal_setup=True,
             registration_backend="camunda",

--- a/src/openforms/templates/debug.html
+++ b/src/openforms/templates/debug.html
@@ -1,0 +1,16 @@
+{% extends 'admin/change_form.html' %}
+{% load i18n static openforms admin_urls %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'bundles/core-css.css' %}">
+{% endblock %}
+
+{% block content %}<div id="content-main">
+<form>
+    <div id="react"></div>
+</form>
+</div>
+<script src="{% static 'bundles/core-js.js' %}"></script>
+{% endblock %}

--- a/src/openforms/urls.py
+++ b/src/openforms/urls.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic import TemplateView
 
 from decorator_include import decorator_include
 
@@ -90,6 +91,8 @@ if settings.DEBUG and apps.is_installed("debug_toolbar"):
     ] + urlpatterns
 
 if settings.DEBUG:
+    from openforms.forms.models import Form
+
     urlpatterns += [
         path(
             "dev/email/wrapper",
@@ -100,6 +103,13 @@ if settings.DEBUG:
             "dev/email/confirmation/<int:submission_id>",
             EmailWrapperTestView.as_view(),
             name="dev-email-confirm",
+        ),
+        path(
+            "dev/react",
+            TemplateView.as_view(
+                template_name="debug.html",
+                extra_context={"opts": Form._meta},
+            ),
         ),
     ]
 


### PR DESCRIPTION
Related to #326

**Changes**

Frontend:

* [x] Introduces a JSON editor where values can be JSON primitives, complex types or form field references
* [x] Form field reference values are to be evaluated using JSON logic
* [x] Variables are edited as complex camunda variables
* [ ] String variable values can interpolate form field reference values (using JSON logic) (separate PR)

Backend:

- [x] Persist complex variable in Camunda options form
- [x] Evaluate complex variables with the submission data and send to process instance create