### PR TITLE
Set signed assertions for DigiD to True

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -828,6 +828,7 @@ DIGID = {
         "en": DIGID_SERVICE_NAME_EN,
     },
     "requested_attributes": ["bsn"],
+    "want_assertions_signed": True,
 }
 
 #


### PR DESCRIPTION
The DigiD-eHerkenning library now supports this and according to the DigiD deployment docs it needs to be enabled.