### PR TITLE
Camunda integration: allow for strings with interpolated form fields

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -639,6 +639,12 @@
       "value": "Submissions will be deleted"
     }
   ],
+  "InHf6+": [
+    {
+      "type": 0,
+      "value": "Text with (embedded) form field(s)"
+    }
+  ],
   "Iv+lBL": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -8,7 +8,7 @@
   "+BicbW": [
     {
       "type": 0,
-      "value": "Configure"
+      "value": "Configureren"
     }
   ],
   "+hAGg7": [
@@ -58,7 +58,7 @@
   "1ArmQ5": [
     {
       "type": 0,
-      "value": "Confirm"
+      "value": "Bevestigen"
     }
   ],
   "1fD+K4": [
@@ -76,7 +76,7 @@
   "2MK7iF": [
     {
       "type": 0,
-      "value": "Number"
+      "value": "Getal (number)"
     }
   ],
   "2Z/hNo": [
@@ -112,7 +112,7 @@
   "4FQxD/": [
     {
       "type": 0,
-      "value": "Configure"
+      "value": "Configureren"
     }
   ],
   "4iGsG1": [
@@ -272,7 +272,7 @@
   "8pemD3": [
     {
       "type": 0,
-      "value": "Edit variable "
+      "value": "Wijzig variabele "
     },
     {
       "type": 1,
@@ -297,7 +297,7 @@
           "value": [
             {
               "type": 0,
-              "value": "(1 variable defined)"
+              "value": "(1 variabele ingesteld)"
             }
           ]
         },
@@ -313,7 +313,7 @@
             },
             {
               "type": 0,
-              "value": " variables defined)"
+              "value": " variabelen ingesteld)"
             }
           ]
         }
@@ -338,7 +338,7 @@
   "9y3/ek": [
     {
       "type": 0,
-      "value": "Confirm"
+      "value": "Bevestigen"
     }
   ],
   "9zJefY": [
@@ -412,7 +412,7 @@
   "BR6rKB": [
     {
       "type": 0,
-      "value": "Check to include the field as process variable"
+      "value": "Vink aan om het veld op te nemen als procesvariabele"
     }
   ],
   "BStu9Z": [
@@ -478,7 +478,7 @@
   "DEAqyQ": [
     {
       "type": 0,
-      "value": "Boolean"
+      "value": "Waar/Niet waar (boolean)"
     }
   ],
   "DGpAyT": [
@@ -580,7 +580,7 @@
   "GjcAY2": [
     {
       "type": 0,
-      "value": "Null"
+      "value": "Leeg (null)"
     }
   ],
   "H3dRU6": [
@@ -643,6 +643,12 @@
       "value": "Inzendingen worden permanent verwijderd"
     }
   ],
+  "InHf6+": [
+    {
+      "type": 0,
+      "value": "Tekst met (ingesloten) formulierveldwaarde(n)"
+    }
+  ],
   "Iv+lBL": [
     {
       "type": 0,
@@ -694,7 +700,7 @@
   "KjDolH": [
     {
       "type": 0,
-      "value": "Manually defined"
+      "value": "Handmatig ingesteld"
     }
   ],
   "L0g8AL": [
@@ -706,7 +712,7 @@
   "LHBcNe": [
     {
       "type": 0,
-      "value": "Variable definition"
+      "value": "Variabeledefinitie"
     }
   ],
   "LN58C1": [
@@ -754,7 +760,7 @@
   "O/wKJh": [
     {
       "type": 0,
-      "value": "Value"
+      "value": "Waarde"
     }
   ],
   "O3l+pQ": [
@@ -882,7 +888,7 @@
   "T0OLUV": [
     {
       "type": 0,
-      "value": "Add key-value pair"
+      "value": "Voeg sleutel-waarde paar toe"
     }
   ],
   "TCQic2": [
@@ -958,7 +964,7 @@
   "VUOOSy": [
     {
       "type": 0,
-      "value": "Name"
+      "value": "Naam"
     }
   ],
   "VV2TCH": [
@@ -1012,7 +1018,7 @@
   "YdIu8k": [
     {
       "type": 0,
-      "value": "Add item"
+      "value": "Voeg item toe"
     }
   ],
   "YzLSHY": [
@@ -1078,7 +1084,7 @@
   "cID9dz": [
     {
       "type": 0,
-      "value": "(complex value)"
+      "value": "(complexe waarde)"
     }
   ],
   "cUVVbl": [
@@ -1108,7 +1114,7 @@
   "d1W41c": [
     {
       "type": 0,
-      "value": "From form field"
+      "value": "Van formulierveld"
     }
   ],
   "d45v2X": [
@@ -1120,7 +1126,7 @@
   "ddDA6+": [
     {
       "type": 0,
-      "value": "Array"
+      "value": "Lijst (array)"
     }
   ],
   "ddR92A": [
@@ -1150,7 +1156,7 @@
   "evbysh": [
     {
       "type": 0,
-      "value": "Variable definition"
+      "value": "Variabeledefinitie"
     }
   ],
   "f590Rb": [
@@ -1216,13 +1222,13 @@
   "hZl34s": [
     {
       "type": 0,
-      "value": "Enabled"
+      "value": "Ingeschakeld"
     }
   ],
   "huHjRm": [
     {
       "type": 0,
-      "value": "Configure"
+      "value": "Configureren"
     }
   ],
   "hzx+WF": [
@@ -1268,7 +1274,7 @@
   "jU/t8O": [
     {
       "type": 0,
-      "value": "Edit complex variable"
+      "value": "Wijzig complexe waarde"
     }
   ],
   "jZIu+e": [
@@ -1292,7 +1298,7 @@
   "kHn5Yw": [
     {
       "type": 0,
-      "value": "Edit definition"
+      "value": "Wijzig definitie"
     }
   ],
   "kNOyt+": [
@@ -1304,7 +1310,7 @@
   "l1fi1t": [
     {
       "type": 0,
-      "value": "(missing information)"
+      "value": "(ontbrekende informatie)"
     }
   ],
   "l2Wag+": [
@@ -1340,13 +1346,13 @@
   "mZ5Rrx": [
     {
       "type": 0,
-      "value": "Form field"
+      "value": "Formulierveld"
     }
   ],
   "myvtu0": [
     {
       "type": 0,
-      "value": "Manage process variables"
+      "value": "Beheer procesvariabelen"
     }
   ],
   "n4Y2ex": [
@@ -1370,7 +1376,7 @@
   "o8CfuS": [
     {
       "type": 0,
-      "value": "String"
+      "value": "Tekst (string)"
     }
   ],
   "ow5AAO": [
@@ -1388,7 +1394,7 @@
   "p18yml": [
     {
       "type": 0,
-      "value": "Complex process variables"
+      "value": "Complexe procesvariabelen"
     }
   ],
   "p8LSwF": [
@@ -1400,7 +1406,7 @@
   "pWHOT1": [
     {
       "type": 0,
-      "value": "Value"
+      "value": "Waarde"
     }
   ],
   "piUWzT": [
@@ -1418,7 +1424,7 @@
   "pyX2Tl": [
     {
       "type": 0,
-      "value": "Confirm"
+      "value": "Bevestigen"
     }
   ],
   "qUYLVg": [
@@ -1448,7 +1454,7 @@
   "r5Olb9": [
     {
       "type": 0,
-      "value": "Manage complex process variables"
+      "value": "Beheer complexe procesvariabelen"
     }
   ],
   "r6Wa2m": [
@@ -1478,7 +1484,7 @@
   "twWsC2": [
     {
       "type": 0,
-      "value": "Name"
+      "value": "Naam"
     }
   ],
   "uBO/Al": [
@@ -1514,13 +1520,13 @@
   "vng/5K": [
     {
       "type": 0,
-      "value": "Set a key name before you can configure this variable"
+      "value": "Er moet een sleutelnaam ingesteld worden voordat deze variabele geconfigureerd kan worden"
     }
   ],
   "vp12ou": [
     {
       "type": 0,
-      "value": "The variable name to be used for the process instance."
+      "value": "De variabelenaam om te gebruiken in de procesinstantie."
     }
   ],
   "wIaGgb": [
@@ -1532,7 +1538,7 @@
   "wOMoEs": [
     {
       "type": 0,
-      "value": "Source"
+      "value": "Bron"
     }
   ],
   "wjwFwT": [
@@ -1550,7 +1556,7 @@
   "x4gaYf": [
     {
       "type": 0,
-      "value": "Cancel"
+      "value": "Annuleren"
     }
   ],
   "xJBMaf": [
@@ -1580,7 +1586,7 @@
   "yTpHh0": [
     {
       "type": 0,
-      "value": "(unset)"
+      "value": "(niet ingesteld)"
     }
   ],
   "yYw2Rb": [
@@ -1604,7 +1610,7 @@
   "zV3nNZ": [
     {
       "type": 0,
-      "value": "Object"
+      "value": "Sleutel-waarde paar (object)"
     }
   ],
   "zeXZzX": [

--- a/src/openforms/js/components/admin/debug/index.js
+++ b/src/openforms/js/components/admin/debug/index.js
@@ -23,12 +23,26 @@ const allComponents = {
 };
 
 
+const definition = [
+    {
+        source: 'component',
+        definition: {'var': 'comp2'},
+    },
+];
+
 
 const Debug = () => {
     return (
         <IntlProvider messages={{}} locale="en" defaultLocale="en">
             <ComponentsContext.Provider value={allComponents}>
-                <ComplexProcessVariable />
+                <div style={{position: 'relative'}}>
+                    <ComplexProcessVariable
+                        name="debug"
+                        type="array"
+                        definition={definition}
+                        onConfirm={console.log}
+                    />
+                </div>
             </ComponentsContext.Provider>
         </IntlProvider>
     );

--- a/src/openforms/js/components/admin/debug/index.js
+++ b/src/openforms/js/components/admin/debug/index.js
@@ -25,8 +25,13 @@ const allComponents = {
 
 const definition = [
     {
-        source: 'component',
-        definition: {'var': 'comp2'},
+        source: 'interpolate',
+        definition: {
+            cat: [
+                'interpolation test: ',
+                {var: 'comp2'},
+            ],
+        },
     },
 ];
 

--- a/src/openforms/js/components/admin/json_editor/TypeRepresentation.js
+++ b/src/openforms/js/components/admin/json_editor/TypeRepresentation.js
@@ -58,6 +58,10 @@ const TypeRepresentation = ({ definition=null }) => {
             typeRepresentationMessage = TYPE_MESSAGES[definition.type] || TYPE_MESSAGES.unset;
             break;
         }
+        case 'interpolate': {
+            typeRepresentationMessage = TYPE_MESSAGES.string;
+            break;
+        }
     }
 
     return intl.formatMessage(typeRepresentationMessage);

--- a/src/openforms/js/components/admin/json_editor/ValueRepresentation.js
+++ b/src/openforms/js/components/admin/json_editor/ValueRepresentation.js
@@ -5,6 +5,7 @@ import {FormattedMessage} from 'react-intl';
 import FormioComponentRepresentation from '../FormioComponentRepresentation'
 
 import Types from './types';
+import {displayInterpolateExpression} from './edit_panel/InterpolatedVariable';
 
 
 const ValueRepresentation = ({ definition=null }) => {
@@ -51,6 +52,13 @@ const ValueRepresentation = ({ definition=null }) => {
                     break;
                 }
             }
+            break;
+        }
+        case 'interpolate': {
+            valueRepresentation = displayInterpolateExpression(
+                definition?.definition || {},
+                true,
+            );
             break;
         }
     }

--- a/src/openforms/js/components/admin/json_editor/edit_panel/EditPanel.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/EditPanel.js
@@ -12,6 +12,7 @@ import EditVariable from './EditVariable';
 const initialState = {
     source: 'component',
     component: '',
+    expression: {},
     manual: {
         type: '',
         definition: null,
@@ -33,6 +34,10 @@ const reducer = (draft, action) => {
                 case 'manual': {
                     draft.manual.type = type;
                     draft.manual.definition = definition;
+                    break;
+                }
+                case 'interpolate': {
+                    draft.expression = definition;
                     break;
                 }
                 default: {
@@ -80,7 +85,7 @@ const EditPanel = ({ name, definition=null, parent=null, onEditDefinition, onCha
     // hooks
     const intl = useIntl();
     const [
-        {source, component, manual},
+        {source, component, manual, expression},
         dispatch,
     ] = useImmerReducer(reducer, initialState)
 
@@ -118,7 +123,7 @@ const EditPanel = ({ name, definition=null, parent=null, onEditDefinition, onCha
         switch (source) {
             case 'component': {
                 // most simple json logic expression initially, later this can become
-                // more complex
+                // more complex - see also the interpolate variant.
                 variableDefinition = {
                     definition: {var: component}
                 };
@@ -129,6 +134,10 @@ const EditPanel = ({ name, definition=null, parent=null, onEditDefinition, onCha
                     type: manual.type,
                     definition: manual.definition,
                 };
+                break;
+            }
+            case 'interpolate': {
+                variableDefinition = {definition: expression};
                 break;
             }
             // TODO: if none match, throw error/render validation errors
@@ -148,6 +157,10 @@ const EditPanel = ({ name, definition=null, parent=null, onEditDefinition, onCha
         }
         case 'manual': {
             dependentFieldsOnChange = onManualChange;
+            break;
+        }
+        case 'interpolate': {
+            dependentFieldsOnChange = onFieldChange;
             break;
         }
     }
@@ -179,6 +192,7 @@ const EditPanel = ({ name, definition=null, parent=null, onEditDefinition, onCha
                     source={source}
                     component={component}
                     manual={manual}
+                    expression={expression}
                     parent={originalParent}
                     onFieldChange={onFieldChange}
                     onManualChange={onManualChange}

--- a/src/openforms/js/components/admin/json_editor/edit_panel/EditVariable.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/EditVariable.js
@@ -9,6 +9,7 @@ import FormRow from '../../forms/FormRow';
 import Types from '../types';
 
 import ComplexManualVariable from './ComplexManualVariable';
+import InterpolatedVariable from './InterpolatedVariable';
 import PrimitiveManualVariable from './PrimitiveManualVariable';
 import VariableSourceSelector from './VariableSourceSelector';
 
@@ -32,7 +33,7 @@ ComponentSelectionRow.propTypes = {
 };
 
 
-const DependentFields = ({ source, component, manual, onChange }) => {
+const DependentFields = ({ source, component, expression, manual, onChange }) => {
     let fields = null;
 
     switch (source) {
@@ -43,6 +44,12 @@ const DependentFields = ({ source, component, manual, onChange }) => {
         case 'manual': {
             fields = (
                 <PrimitiveManualVariable {...manual} onChange={onChange} />
+            );
+            break;
+        }
+        case 'interpolate': {
+            fields = (
+                <InterpolatedVariable expression={expression} onChange={onChange} />
             );
             break;
         }
@@ -57,12 +64,13 @@ DependentFields.propTypes = {
         type: Types.VariableType,
         definition: Types.LeafVariableDefinition,
     }),
+    expression: PropTypes.object,  // JSON logic expression
     onChange: PropTypes.func.isRequired,
 };
 
 
 const EditVariable = ({
-    name, source, component='', manual, parent=null,
+    name, source, component='', manual, expression, parent=null,
     onFieldChange, onManualChange, dependentFieldsOnChange, onEditDefinition,
 }) => {
     return (
@@ -81,6 +89,7 @@ const EditVariable = ({
                 <DependentFields
                     source={source}
                     component={component}
+                    expression={expression}
                     manual={manual}
                     onChange={dependentFieldsOnChange}
                 />
@@ -107,6 +116,7 @@ EditVariable.propTypes = {
     name: Types.VariableIdentifier.isRequired,
     source: Types.VariableSource.isRequired,
     component: PropTypes.string,
+    expression: PropTypes.object,
     manual: PropTypes.shape({
         type: Types.VariableType,
         definition: Types.LeafVariableDefinition,

--- a/src/openforms/js/components/admin/json_editor/edit_panel/InterpolatedVariable.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/InterpolatedVariable.js
@@ -1,0 +1,185 @@
+// TODO: this could probably be built nicer using Draft.js, if we get time to
+// look into that :-)
+import React from 'react';
+import PropTypes from 'prop-types';
+import {produce} from 'immer';
+
+import DeleteIcon from '../../DeleteIcon';
+import ButtonContainer from '../../forms/ButtonContainer';
+import ComponentSelection from '../../forms/ComponentSelection';
+import Field from '../../forms/Field';
+import {TextInput} from '../../forms/Inputs';
+import Fieldset from '../../forms/Fieldset';
+import FormRow from '../../forms/FormRow';
+import Types from '../types';
+
+
+const isString = (arg) => {
+    return (typeof arg === 'string' || arg instanceof String);
+};
+
+
+export const displayInterpolateExpression = (expression, useJSX=false) => {
+    const bits = expression.cat || [];
+    const formattedBits = bits.map((bit, index) => {
+        if (isString(bit)) return bit;
+
+        // otherwise it's an object
+        const {var: component} = bit;
+        const stringRepr = `\$\{${component}\}`;
+        if (!useJSX) return stringRepr;
+        return (<code key={index}>{stringRepr}</code>);
+    });
+    return useJSX ? formattedBits : formattedBits.join('');
+};
+
+
+const PartWrapper = ({ onDelete, children }) => {
+    return (
+        <span style={{display: 'inline-flex', alignItems: 'center'}}>
+            <DeleteIcon onConfirm={onDelete} />
+            {children}
+        </span>
+    );
+};
+
+
+const InterpolationBuilder = ({parts=[], onChange}) => {
+
+    const onStringChange = (index, event) => {
+        const {value} = event.target;
+        const newParts = produce(parts, draft => {
+            draft[index] = value;
+        });
+        onChange(newParts);
+    };
+
+    const onComponentChange = (index, event) => {
+        const {value} = event.target;
+        const newParts = produce(parts, draft => {
+            draft[index].var = value;
+        });
+        onChange(newParts);
+    };
+
+    const onAddPart = (type, event) => {
+        event.preventDefault();
+
+        let newPart;
+        switch (type) {
+            case 'string': {
+                newPart = '';
+                break;
+            }
+            case 'component': {
+                newPart = {var: ''};
+                break;
+            }
+        }
+        onChange([...parts, newPart]);
+    };
+
+    const onDeletePart = (index) => {
+        const {value} = event.target;
+        const newParts = produce(parts, draft => {
+            draft.splice(index, 1);
+        });
+        onChange(newParts);
+    };
+
+    return (
+        <>
+            <span style={{display: 'flex', flexWrap: 'wrap'}}>
+            {
+                parts.map((part, index) => (
+                    isString(part)
+                    ? (
+                        <PartWrapper key={index} onDelete={onDeletePart.bind(null, index)}>
+                            <textarea
+                                name="string"
+                                rows="1"
+                                columns={part.length || 10}
+                                value={part}
+                                onChange={onStringChange.bind(null, index)}
+                                style={{width: 'auto'}}
+                            />
+                        </PartWrapper>
+                    )
+                    : (
+                        <PartWrapper key={index} onDelete={onDeletePart.bind(null, index)}>
+                            <ComponentSelection
+                                name="component"
+                                value={part.var}
+                                onChange={onComponentChange.bind(null, index)}
+                            />
+                        </PartWrapper>
+                    )
+                ))
+            }
+            </span>
+
+            <div style={{display: 'flex', marginLeft: 'calc(160px - 1em)', width: '100%'}}>
+                <ButtonContainer onClick={onAddPart.bind(null, 'string')}>
+                    Add text part
+                </ButtonContainer>
+                <ButtonContainer onClick={onAddPart.bind(null, 'component')}>
+                    Add form field
+                </ButtonContainer>
+            </div>
+
+        </>
+    );
+};
+
+InterpolationBuilder.propTypes = {
+    parts: PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({var: PropTypes.string}),
+    ])),
+    onChange: PropTypes.func.isRequired,
+};
+
+
+
+const InterpolatedVariable = ({ expression={}, onChange }) => {
+
+    const onDefinitionChange = (newParts) => {
+        const newDefinition = {cat: newParts};
+        onChange({target: {name: 'expression', value: newDefinition}});
+    };
+
+    return (
+        <>
+            <FormRow>
+                <Field name="expression" label="Text">
+                    <InterpolationBuilder
+                        parts={expression.cat || []}
+                        onChange={onDefinitionChange}
+                    />
+                </Field>
+            </FormRow>
+            <FormRow>
+                <Field name="_expression" label="Resulting string">
+                    <textarea
+                        cols="40" rows="5"
+                        value={displayInterpolateExpression(expression)}
+                        readOnly
+                    />
+                </Field>
+            </FormRow>
+        </>
+    );
+};
+
+InterpolatedVariable.propTypes = {
+    expression: PropTypes.shape({
+        cat: PropTypes.arrayOf(PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.shape({var: PropTypes.string}),
+        ])),
+    }),  // JSON logic expression, using the cat operator. {cat: ["foo ", {"var": "bar"}, " baz"]}
+    onChange: PropTypes.func.isRequired,
+};
+
+
+export default InterpolatedVariable;

--- a/src/openforms/js/components/admin/json_editor/edit_panel/VariableSourceSelector.js
+++ b/src/openforms/js/components/admin/json_editor/edit_panel/VariableSourceSelector.js
@@ -15,6 +15,10 @@ const VARIABLE_SOURCES = {
         description: 'JSON editor: "manual" variable source label',
         defaultMessage: 'Manually defined',
     }),
+    interpolate: defineMessage({
+        description: 'JSON editor: "interpolate" variable source label',
+        defaultMessage: 'Text with (embedded) form field(s)',
+    }),
 };
 
 

--- a/src/openforms/js/components/admin/json_editor/types.js
+++ b/src/openforms/js/components/admin/json_editor/types.js
@@ -48,7 +48,8 @@ export const LeafVariableDefinition = PropTypes.oneOfType([
 export const VariableSource = PropTypes.oneOf([
     '',
     'manual',
-    'component'
+    'component',
+    'interpolate',
 ]);
 
 

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -439,6 +439,11 @@
     "description": "delete_permanently removal method option label",
     "originalDefault": "Submissions will be deleted"
   },
+  "InHf6+": {
+    "defaultMessage": "Text with (embedded) form field(s)",
+    "description": "JSON editor: \"interpolate\" variable source label",
+    "originalDefault": "Text with (embedded) form field(s)"
+  },
   "Iv+lBL": {
     "defaultMessage": "The text that will be displayed in the form step to go to the next step. Leave blank to get value from global configuration.",
     "description": "Form step next text field help text",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -439,6 +439,11 @@
     "description": "delete_permanently removal method option label",
     "originalDefault": "Submissions will be deleted"
   },
+  "InHf6+": {
+    "defaultMessage": "Tekst met (ingesloten) formulierveldwaarde(n)",
+    "description": "JSON editor: \"interpolate\" variable source label",
+    "originalDefault": "Text with (embedded) form field(s)"
+  },
   "Iv+lBL": {
     "defaultMessage": "De tekst op de knop om de gegevens van de huidige stap op te slaan en de volgende stap te activeren. Laat dit veld leeg om de standaardinstelling te gebruiken.",
     "description": "Form step next text field help text",

--- a/src/openforms/registrations/contrib/camunda/constants.py
+++ b/src/openforms/registrations/contrib/camunda/constants.py
@@ -22,3 +22,4 @@ class JSONVariableTypes(JSONComplexVariableTypes, JSONPrimitiveVariableTypes):
 class VariableSourceChoices(DjangoChoices):
     component = ChoiceItem("component", _("Component"))
     manual = ChoiceItem("manual", _("Manual"))
+    interpolate = ChoiceItem("interpolate", _("Interpolation"))

--- a/src/openforms/registrations/contrib/camunda/serializers.py
+++ b/src/openforms/registrations/contrib/camunda/serializers.py
@@ -99,8 +99,18 @@ class ComponentJSONLogicLookupSerializer(serializers.Serializer):
     )
 
 
+class CatJSONLogicSerializer(serializers.Serializer):
+    # TODO: this can be replaced in the future with full-fledged JSON logic, see
+    # ComponentJSONLogicLookupSerializer
+    cat = serializers.JSONField()  # can be strings or nested objects in a list...
+
+
 class ComponentVariableSerializer(serializers.Serializer):
     definition = ComponentJSONLogicLookupSerializer()
+
+
+class InterpolateVariableSerializer(serializers.Serializer):
+    definition = CatJSONLogicSerializer(label=_("Definition"))
 
 
 class VariableDefinitionSerializer(PolymorphicSerializer):
@@ -114,6 +124,7 @@ class VariableDefinitionSerializer(PolymorphicSerializer):
     serializer_mapping = {
         VariableSourceChoices.component: ComponentVariableSerializer,
         VariableSourceChoices.manual: ManualVariableSerializer,
+        VariableSourceChoices.interpolate: InterpolateVariableSerializer,
     }
 
 


### PR DESCRIPTION
Related to #326 

This is another step in the direction of allowing generic JSON logic expressions.

The UI is workable and an MVP approach - in the future, we can make this prettier using an editor-builder like Draft.js, but that was too much to get into. This replaces the existing prototype functionality where django templates can be used in the form of:

```django
Inzending

Contactpersoon: {{ contactName }}
```

which is used as values for JSON keys, for example.

TODO

- [x] Backend -> allow interpolate + interpret correctly (generic JSON logic evaluation)