### PR TITLE
:arrow_up: Upgrade mozilla-django-oidc-db to 0.7.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -243,7 +243,7 @@ maykin-django-two-factor-auth[phonenumbers]==2.0.4
     # via -r requirements/base.in
 git+https://github.com/maykinmedia/json-logic-py.git@1ceb93ad165d69a5639edc623d5613d0229c05e2#egg=maykin-json-logic-py
     # via -r requirements/base.in
-mozilla-django-oidc-db==0.6.0
+mozilla-django-oidc-db==0.7.2
     # via -r requirements/base.in
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -457,7 +457,7 @@ git+https://github.com/maykinmedia/json-logic-py.git@1ceb93ad165d69a5639edc623d5
     #   -r requirements/base.txt
 mccabe==0.6.1
     # via flake8
-mozilla-django-oidc-db==0.6.0
+mozilla-django-oidc-db==0.7.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -535,7 +535,7 @@ mccabe==0.6.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   flake8
-mozilla-django-oidc-db==0.6.0
+mozilla-django-oidc-db==0.7.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
permission checking causes a lot of backend initializations, which in turn causes a lot of get_solo() calls for the OIDC config, leading to a lot of Redis lookups

See issue in library: https://github.com/maykinmedia/mozilla-django-oidc-db/issues/30