### PR TITLE
[#750, #1174] Fixed ordering of FormStep/components in Form.iter_components

### DIFF
--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -345,7 +345,9 @@ class Form(models.Model):
         return list(return_keys)
 
     def iter_components(self, recursive=True):
-        for form_step in self.formstep_set.select_related("form_definition"):
+        for form_step in self.formstep_set.order_by("order").select_related(
+            "form_definition"
+        ):
             yield from form_step.iter_components(recursive=recursive)
 
     @transaction.atomic


### PR DESCRIPTION
Also relates to `Submission.get_printable_data()` etc.