### PR TITLE
do not create a pidfile for celery beat

### DIFF
--- a/bin/celery_beat.sh
+++ b/bin/celery_beat.sh
@@ -11,4 +11,6 @@ exec celery beat \
     --app openforms \
     -l $LOGLEVEL \
     --workdir src \
-    -s ../celerybeat/beat
+    -s ../celerybeat/beat \
+    --pidfile=  # empty on purpose, see #1182
+


### PR DESCRIPTION
Fixes #1182

Normally, celery beat cleans up the pidfile on exit (even if it
crashes), but there are code paths with python stdlib crashes that
apparently aren't expected.

This crash happens when the broker/redis server goes away while beat
is running - which would typically happen during a reboot or deploy
when redis is restarted. On startup, beat starts gracefully with
exponential backoff if the connection is not available (yet), so that's
not the cause.

This patch instructs beat to NOT use a pidfile, which should not have
impact on normal operation. On crashes/restarts, beat should
succesfully restart since there's no pidfile left in the modified
container filesystem.