### PR TITLE
[#1083] Update is_applicable label after data change

### DIFF
--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -324,7 +324,7 @@ class FormAdminCopyTests(TestCase):
         )
         self.assertEqual(copied_form.authentication_backends, ["digid"])
 
-        copied_form_step = FormStep.objects.last()
+        copied_form_step = FormStep.objects.all().order_by("pk").last()
         self.assertNotEqual(copied_form_step.uuid, form_step.uuid)
         self.assertEqual(copied_form_step.form, copied_form)
 

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -159,7 +159,7 @@ class ImportExportTests(TestCase):
         self.assertEqual(fd2.name, form_definition.name)
         self.assertEqual(fd2.slug, old_form_definition_slug)
 
-        form_steps = FormStep.objects.all()
+        form_steps = FormStep.objects.all().order_by("pk")
         fs2 = form_steps.last()
         self.assertEqual(form_steps.count(), 2)
         self.assertNotEqual(fs2.pk, form_step_pk)
@@ -299,7 +299,7 @@ class ImportExportTests(TestCase):
         self.assertEqual(fd2.internal_name, form_definition.internal_name)
         self.assertEqual(fd2.slug, form_definition.slug)
 
-        form_steps = FormStep.objects.all()
+        form_steps = FormStep.objects.all().order_by("pk")
         fs2 = form_steps.last()
         self.assertEqual(form_steps.count(), 2)
         self.assertNotEqual(fs2.pk, form_step_pk)
@@ -363,7 +363,7 @@ class ImportExportTests(TestCase):
         self.assertEqual(fd2.internal_name, form_definition.internal_name)
         self.assertEqual(fd2.slug, f"{form_definition.slug}-2")
 
-        form_steps = FormStep.objects.all()
+        form_steps = FormStep.objects.all().order_by("pk")
         fs2 = form_steps.last()
         self.assertEqual(form_steps.count(), 2)
         self.assertNotEqual(fs2.pk, form_step_pk)

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -185,7 +185,7 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
         }
 
     def to_representation(self, instance):
-        check_submission_logic(instance)
+        check_submission_logic(instance, unsaved_data=self.context.get("unsaved_data"))
         return super().to_representation(instance)
 
 

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -408,6 +408,6 @@ class SubmissionStepViewSet(
             instance=SubmissionStateLogic(
                 submission=submission_step.submission, step=submission_step
             ),
-            context={"request": request},
+            context={"request": request, "unsaved_data": data},
         )
         return Response(submission_state_logic_serializer.data)

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -122,13 +122,16 @@ def evaluate_form_logic(
     return configuration
 
 
-def check_submission_logic(submission):
+def check_submission_logic(submission, unsaved_data=None):
     logic_rules = FormLogic.objects.filter(
         form=submission.form,
         actions__contains=[{"action": {"type": LogicActionTypes.step_not_applicable}}],
     )
 
     merged_data = submission.data
+    if unsaved_data:
+        merged_data = {**merged_data, **unsaved_data}
+
     submission_state = submission.load_execution_state()
 
     for rule in logic_rules:

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -1,0 +1,117 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.forms.tests.factories import FormFactory, FormStepFactory
+
+from ..factories import SubmissionFactory, SubmissionStepFactory
+from ..mixins import SubmissionsMixin
+from .factories import FormLogicFactory
+
+
+class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
+    def test_update_not_applicable_steps(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "select",
+                        "key": "pet",
+                        "data": {
+                            "values": [
+                                {"label": "Cat", "value": "cat"},
+                                {"label": "Dog", "value": "dog"},
+                            ]
+                        },
+                    }
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "step2",
+                    }
+                ]
+            },
+        )
+        form_step2_path = reverse(
+            "api:form-steps-detail",
+            kwargs={"form_uuid_or_slug": form.uuid, "uuid": step2.uuid},
+        )
+        step3 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "step3",
+                    }
+                ]
+            },
+        )
+        form_step3_path = reverse(
+            "api:form-steps-detail",
+            kwargs={"form_uuid_or_slug": form.uuid, "uuid": step3.uuid},
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [
+                    {"var": "pet"},
+                    "cat",
+                ]
+            },
+            actions=[
+                {
+                    "form_step": f"http://example.com{form_step2_path}",
+                    "action": {
+                        "name": "Step is not applicable",
+                        "type": "step-not-applicable",
+                    },
+                }
+            ],
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [
+                    {"var": "pet"},
+                    "dog",
+                ]
+            },
+            actions=[
+                {
+                    "form_step": f"http://example.com{form_step3_path}",
+                    "action": {
+                        "name": "Step is not applicable",
+                        "type": "step-not-applicable",
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={"pet": "dog"},  # With this data, step 3 is not applicable
+        )
+
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step1.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        # Make a change to the data, which causes step 2 to be not applicable (while step 3 is applicable again)
+        response = self.client.post(endpoint, data={"data": {"pet": "cat"}})
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertFalse(response.data["submission"]["steps"][1]["is_applicable"])
+        self.assertTrue(response.data["submission"]["steps"][2]["is_applicable"])


### PR DESCRIPTION
Fixes #1083

The issue was that when the `.to_representation()` of the `SubmissionSerializer` was re-running the logic using the data saved in the submission instead of the new data entered by the user (not saved yet).