### PR TITLE
Date prefill

### DIFF
--- a/src/openforms/js/components/form/date.js
+++ b/src/openforms/js/components/form/date.js
@@ -1,5 +1,5 @@
 import {Formio} from 'formiojs';
-import {DEFAULT_TABS, ADVANCED, REGISTRATION, SENSITIVE_BASIC, VALIDATION} from './edit/tabs';
+import {DEFAULT_TABS, ADVANCED, REGISTRATION, SENSITIVE_BASIC, VALIDATION, PREFILL} from './edit/tabs';
 
 const DateTimeField = Formio.Components.components.datetime;
 
@@ -73,6 +73,7 @@ class DateField extends DateTimeField {
                 ADVANCED,
                 VALIDATION,
                 REGISTRATION,
+                PREFILL,
             ]
         };
         return {components: [TABS]};

--- a/src/openforms/prefill/tests/test_prefill_hook.py
+++ b/src/openforms/prefill/tests/test_prefill_hook.py
@@ -191,3 +191,111 @@ class PrefillHookTests(TransactionTestCase):
                 submission=submission,
                 register=register,
             )
+
+    @patch("openforms.prefill.tests.test_prefill_hook.DemoPrefill.get_prefill_values")
+    def test_prefill_date_isoformat(self, m_get_prefill_value):
+        m_get_prefill_value.return_value = {"random_isodate": "2020-12-12"}
+
+        configuration = {
+            "display": "form",
+            "components": [
+                {
+                    "id": "e4ty7zs",
+                    "key": "dateOfBirth",
+                    "type": "date",
+                    "input": True,
+                    "label": "Date of Birth",
+                    "prefill": {
+                        "plugin": "demo",
+                        "attribute": "random_isodate",
+                    },
+                    "multiple": False,
+                    "defaultValue": None,
+                }
+            ],
+        }
+        form_step = FormStepFactory.create(form_definition__configuration=configuration)
+        submission = SubmissionFactory.create(form=form_step.form)
+
+        new_configuration = apply_prefill(
+            configuration=form_step.form_definition.configuration,
+            submission=submission,
+            register=register,
+        )
+
+        field = new_configuration["components"][0]
+        self.assertIsNotNone(field["defaultValue"])
+        self.assertIsInstance(field["defaultValue"], str)
+        self.assertEqual("2020-12-12", field["defaultValue"])
+
+    @patch("openforms.prefill.tests.test_prefill_hook.DemoPrefill.get_prefill_values")
+    def test_prefill_date_stufbg_format(self, m_get_prefill_value):
+        m_get_prefill_value.return_value = {"random_stufbg_date": "20201212"}
+
+        configuration = {
+            "display": "form",
+            "components": [
+                {
+                    "id": "e4ty7zs",
+                    "key": "dateOfBirth",
+                    "type": "date",
+                    "input": True,
+                    "label": "Date of Birth",
+                    "prefill": {
+                        "plugin": "demo",
+                        "attribute": "random_stufbg_date",
+                    },
+                    "multiple": False,
+                    "defaultValue": None,
+                }
+            ],
+        }
+        form_step = FormStepFactory.create(form_definition__configuration=configuration)
+        submission = SubmissionFactory.create(form=form_step.form)
+
+        new_configuration = apply_prefill(
+            configuration=form_step.form_definition.configuration,
+            submission=submission,
+            register=register,
+        )
+
+        field = new_configuration["components"][0]
+        self.assertIsNotNone(field["defaultValue"])
+        self.assertIsInstance(field["defaultValue"], str)
+        self.assertEqual("2020-12-12", field["defaultValue"])
+
+    @patch("openforms.prefill.tests.test_prefill_hook.DemoPrefill.get_prefill_values")
+    def test_prefill_invalid_date(self, m_get_prefill_value):
+        m_get_prefill_value.return_value = {"invalid_date": "123456789"}
+
+        configuration = {
+            "display": "form",
+            "components": [
+                {
+                    "id": "e4ty7zs",
+                    "key": "dateOfBirth",
+                    "type": "date",
+                    "input": True,
+                    "label": "Date of Birth",
+                    "prefill": {
+                        "plugin": "demo",
+                        "attribute": "invalid_date",
+                    },
+                    "multiple": False,
+                    "defaultValue": None,
+                }
+            ],
+        }
+        form_step = FormStepFactory.create(form_definition__configuration=configuration)
+        submission = SubmissionFactory.create(form=form_step.form)
+
+        new_configuration = apply_prefill(
+            configuration=form_step.form_definition.configuration,
+            submission=submission,
+            register=register,
+        )
+
+        field = new_configuration["components"][0]
+        self.assertIsNotNone(field["defaultValue"])
+        self.assertIsInstance(field["defaultValue"], str)
+        self.assertEqual("", field["defaultValue"])


### PR DESCRIPTION
Fixes #1213

Changes:
- In the form builder in the admin, the date field also has a tab to configure a prefill
- When prefill values are processed, there is a check to see if the field is a date field. If it is, then the date is formatted to "YYYY-MM-DD" (expected by the json-logic-py package).

