### PR TITLE
[#1127] Configuration hidden fields

### DIFF
--- a/src/openforms/js/components/form/edit/tabs.js
+++ b/src/openforms/js/components/form/edit/tabs.js
@@ -41,7 +41,13 @@ const BASIC = {
             type: 'checkbox',
             key: 'hidden',
             label: 'Hidden',
-            tooltip: 'A hidden field is still a part of the form, but is hidden from view.'
+            tooltip: 'Hide a field from the form.'
+        },
+        {
+            type: 'checkbox',
+            key: 'clearOnHide',
+            label: 'Clear on hide',
+            tooltip: 'Remove the value of this field from the submission if it is hidden. Note: the value of this field is then also not used in logic rules!',
         },
         {
             type: 'checkbox',

--- a/src/openforms/js/components/form/fieldset.js
+++ b/src/openforms/js/components/form/fieldset.js
@@ -21,7 +21,13 @@ const FIELDSET_BASIC = {
             key: 'hidden',
             label: 'Hidden',
             tooltip: 'A hidden field is still a part of the form, but is hidden from view.'
-        }
+        },
+        {
+            type: 'checkbox',
+            key: 'clearOnHide',
+            label: 'Clear on hide',
+            tooltip: 'Remove the value of this field from the submission if it is hidden',
+        },
     ]
 };
 

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -111,7 +111,7 @@
   "The legend for this Fieldset.": "De legende voor deze veldengroep.",
   "Adds a tooltip to the side of this field.": "Voegt een tooltip toe aan de zijkant van het veld.",
   "Custom CSS class to add to this component.": "Aangepaste CSS class om aan dit component toe te voegen.",
-  "A hidden field is still a part of the form, but is hidden from view.": "Een verborgen veld is nog steeds onderdeel van het formulier, maar niet langer zichtbaar.",
+  "Hide a field from the form.": "Verberg een veld in het formulier.",
   "Disable the form input.": "Schakel de formulierinput uit.",
   "Opens up a modal to edit the value of this component.": "Opent een popup om de waarde van deze component te bewerken.",
   "The name of this field in the API endpoint.": "De naam van dit veld in de API.",
@@ -278,5 +278,7 @@
   "Placeholder": "Placeholder",
   "The placeholder text that will appear when this field is empty.": "De placeholder tekst die verschijnt als dit veld leeg is.",
   "Special fields": "Speciale velden",
-  "Invalid Postcode": "Ongeldige Postcode"
+  "Invalid Postcode": "Ongeldige Postcode",
+  "Clear on hide": "Wissen als veld verborgen is",
+  "Remove the value of this field from the submission if it is hidden. Note: the value of this field is then also not used in logic rules!": "Verwijder de waarde van dit veld van de inzending als dit veld verborgen is. Let op: De waarde van dit veld wordt dan ook niet gebruikt in logica regels!"
 }


### PR DESCRIPTION
Fixes #1127 

Add the field `clearOnHide` to the configurations in the builder, so that the value of hidden fields can be included in the submission.