### PR TITLE
[#1237] Set RELEASE environment var from Git tag in CI and use for django admin and docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           docker build . \
             --tag $IMAGE_NAME:$RELEASE_VERSION \
             --build-arg COMMIT_HASH=${{ steps.vars.outputs.git_hash }} \
-            --build-arg RELEASE=${RELEASE_VERSION}
+            --build-arg RELEASE=${{ steps.vars.outputs.tag }} \
         env:
           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,10 +111,18 @@ RUN chown -R maykin /app
 USER maykin
 
 ARG COMMIT_HASH
+ARG RELEASE
 ENV GIT_SHA=${COMMIT_HASH}
+ENV RELEASE=${RELEASE}
+
 ENV DJANGO_SETTINGS_MODULE=openforms.conf.docker
 
 ARG SECRET_KEY=dummy
+
+LABEL org.label-schema.vcs-ref=$COMMIT_HASH \
+      org.label-schema.vcs-url="https://github.com/open-formulieren/open-forms" \
+      org.label-schema.version=$RELEASE \
+      org.label-schema.name="Open Forms"
 
 # Run collectstatic and compilemessages, so the result is already included in
 # the image

--- a/src/openforms/templates/admin/base_site.html
+++ b/src/openforms/templates/admin/base_site.html
@@ -49,7 +49,7 @@
 
 {% block footer %}
     <div id="footer">
-        <div class="version" title="Git SHA: {{ settings.GIT_SHA|default:'' }}">
+        <div class="version" title="Release: {{ settings.RELEASE|default:'' }}">
             {% blocktrans with version=settings.RELEASE %}version: {{version}}{% endblocktrans %}
         </div>
     </div>

--- a/src/openforms/templates/admin/base_site.html
+++ b/src/openforms/templates/admin/base_site.html
@@ -49,8 +49,8 @@
 
 {% block footer %}
     <div id="footer">
-        <div class="version" title="Release: {{ settings.RELEASE|default:'' }}">
-            {% blocktrans with version=settings.RELEASE %}version: {{version}}{% endblocktrans %}
+        <div class="version" title="Git SHA: {{ settings.GIT_SHA|default:'' }}">
+            {% blocktrans with version=settings.RELEASE %}version {{version}}{% endblocktrans %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #1237 

Note this also sets the docker label like the open-forms example.