### PR TITLE
[#1255] Warnings in reusable steps for date fields

### DIFF
--- a/src/openforms/forms/api/parsers.py
+++ b/src/openforms/forms/api/parsers.py
@@ -1,4 +1,5 @@
 from djangorestframework_camel_case.parser import CamelCaseJSONParser
+from djangorestframework_camel_case.render import CamelCaseJSONRenderer
 
 from .drf_camel_case import FormCamelCaseMixin
 
@@ -12,6 +13,13 @@ class IgnoreConfigurationFieldCamelCaseJSONParser(CamelCaseJSONParser):
     # variant can sometimes overwrite the camelCase variant, which breaks the pre-fill
     # functionality. This can happen because JSON objects DO NOT HAVE inherent ordering
     # and the spec is non-deterministic.
+    json_underscoreize = {"ignore_fields": ("configuration",)}
+
+
+class IgnoreConfigurationFieldCamelCaseJSONRenderer(CamelCaseJSONRenderer):
+    # This is needed for fields in the JSON configuration that have an underscore
+    # For example: time_24hr in the date component. See github issue
+    # https://github.com/open-formulieren/open-forms/issues/1255
     json_underscoreize = {"ignore_fields": ("configuration",)}
 
 

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -33,6 +33,7 @@ from .filters import FormLogicFilter, FormPriceLogicFilter
 from .parsers import (
     FormCamelCaseJSONParser,
     IgnoreConfigurationFieldCamelCaseJSONParser,
+    IgnoreConfigurationFieldCamelCaseJSONRenderer,
 )
 from .permissions import FormAPIPermissions
 from .renderers import FormCamelCaseJSONRenderer
@@ -150,6 +151,7 @@ class FormPriceLogicViewSet(viewsets.ModelViewSet):
 )
 class FormDefinitionViewSet(viewsets.ModelViewSet):
     parser_classes = (IgnoreConfigurationFieldCamelCaseJSONParser,)
+    renderer_classes = (IgnoreConfigurationFieldCamelCaseJSONRenderer,)
     queryset = FormDefinition.objects.order_by("slug")
     serializer_class = FormDefinitionSerializer
     pagination_class = PageNumberPagination

--- a/src/openforms/js/components/form/date.js
+++ b/src/openforms/js/components/form/date.js
@@ -88,6 +88,26 @@ class DateField extends DateTimeField {
         return DateField.schema();
     }
 
+    constructor(component, options, data) {
+        super(component, options, data);
+
+        // These fields get automatically added to the configuration in the builder, and their value is `undefined`.
+        // For some reason, their value is then not saved in the backend. So, when comparing the configuration with the
+        // saved configuration (useDetectConfigurationChanged), they look different and cause a warning that the
+        // configuration has changed.
+        // By giving them a value when first build, then the values are saved in the backend. (Github #1255)
+        this.component.widget = {
+            ...this.component.widget,
+            disabledDates: null,
+            disableWeekends: null,
+            disableWeekdays: null,
+            disableFunction: null,
+            readOnly: false,
+            submissionTimezone: null,
+            timezone: '',
+        };
+  }
+
 }
 
 export default DateField;


### PR DESCRIPTION
Fixes #1255 

The `time_24hr` was not the only problem.

The following fields in the widget for the date:
```
disabledDates
disableWeekends
disableWeekdays
disableFunction
readOnly
submissionTimezone
timezone
```

were being initialised to `undefined` and for some reason their value is not saved in the backend. So then when updating a form, these fields are automatically re-added to the configuration and that causes the configuration to not match the saved configuration => which causes the warning.

Not sure what the best way to fix this is, I attempted something.
