### PR TITLE
[#944] Display submission authentication information in logevent logging 

### DIFF
--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:  # pragma: nocover
     from openforms.accounts.models import User
     from openforms.appointments.models import AppointmentInfo
     from openforms.forms.models import Form
+    from openforms.plugins.plugin import AbstractBasePlugin
     from openforms.submissions.models import (
         Submission,
         SubmissionPayment,
@@ -24,9 +25,7 @@ def _create_log(
     object: Model,
     event: str,
     extra_data: Optional[dict] = None,
-    plugin: Optional[
-        object
-    ] = None,  # TODO: define BasePlugin class in openforms.plugins
+    plugin: Optional["AbstractBasePlugin"] = None,
     error: Optional[Exception] = None,
     tags: Optional[list] = None,
     user: Optional["User"] = None,

--- a/src/openforms/logging/models.py
+++ b/src/openforms/logging/models.py
@@ -59,9 +59,15 @@ class TimelineLogProxy(TimelineLog):
 
     @property
     def fmt_user(self) -> str:
+        # if there is a .user they own the log line (usually AVG type logs)
         if self.user_id:
-            return '{} "{}"'.format(gettext("User"), str(self.user))
-        return gettext("Anonymous user")
+            return _("Staff user {user}").format(user=str(self.user))
+        if self.is_submission:
+            auth = self.content_object.get_auth_mode_display()
+            if auth:
+                return _("Authenticated via plugin {auth}").format(auth=auth)
+        else:
+            return gettext("Anonymous user")
 
     @property
     def fmt_form(self) -> str:

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -714,6 +714,21 @@ class Submission(models.Model):
         # TODO support partial payments
         return self.payments.filter(status=PaymentStatus.registered).exists()
 
+    def get_auth_mode_display(self):
+        # compact anonymous display of authentication method
+        auth = []
+        if self.bsn:
+            auth.append("bsn")
+        if self.kvk:
+            auth.append("kvk")
+        if self.pseudo:
+            auth.append("pseudo")
+
+        if self.auth_plugin:
+            return f"{self.auth_plugin} ({','.join(auth)})"
+        else:
+            return ""
+
 
 class SubmissionStep(models.Model):
     """

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -599,3 +599,8 @@ class SubmissionTests(TestCase):
                     submission.full_clean()
                 except ValidationError as exc:
                     self.fail(f"Unexpected validation error(s): {exc}")
+
+    def test_get_auth_mode_display(self):
+        submission = SubmissionFactory.build(auth_plugin="digid", bsn="123", kvk="123")
+
+        self.assertEqual(submission.get_auth_mode_display(), "digid (bsn,kvk)")


### PR DESCRIPTION
Fixes #944 