### PR TITLE
Ensure embedded SDK build is pinned to same release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
+          # PRs result in version 'merge' -> transform that into 'latest'
+          [ "$VERSION" == "merge" ] && VERSION=latest
+
           echo ::set-output name=tag::${VERSION}
           echo ::set-output name=git_hash::${GITHUB_SHA}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # stage re-using assets from the build stages. This keeps the final production
 # image minimal in size.
 
+# must be at the top to use it in FROM clauses
+ARG RELEASE=latest
+FROM openformulieren/open-forms-sdk:${RELEASE} as sdk-image
+
 # Stage 1 - Backend build environment
 # includes compilers and build tooling to create the environment
 FROM python:3.8-slim-buster AS backend-build
@@ -98,8 +102,9 @@ COPY --from=backend-build /app/src/ /app/src/
 # copy frontend build statics
 COPY --from=frontend-build /app/src/openforms/static /app/src/openforms/static
 COPY --from=frontend-build /app/node_modules/formiojs/dist/fonts /app/node_modules/formiojs/dist/fonts
+
 # Include SDK files
-COPY --from=openformulieren/open-forms-sdk:latest /sdk /app/static/sdk
+COPY --from=sdk-image /sdk /app/static/sdk
 
 # copy source code
 COPY ./src /app/src
@@ -111,7 +116,6 @@ RUN chown -R maykin /app
 USER maykin
 
 ARG COMMIT_HASH
-ARG RELEASE
 ENV GIT_SHA=${COMMIT_HASH}
 ENV RELEASE=${RELEASE}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,14 @@ services:
       - private_media:/private-media
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        RELEASE: ${TAG:-latest}
     image: openformulieren/open-forms:${TAG:-latest}
     environment: &web_env
       - DJANGO_SETTINGS_MODULE=openforms.conf.docker
-      - SECRET_KEY=${SECRET_KEY:-@r0w-0(&apjfde5fl6h23!vn)r1ldkp1c_d2#!$did4z5hun4a}
+      - SECRET_KEY=${SECRET_KEY:-@r0w-0(&apjfde5fl6h23!vn)r1ldkp1c_d2#!$$did4z5hun4a}
       - DB_NAME=openforms
       - DB_USER=openforms
       - DB_HOST=db


### PR DESCRIPTION
The SDK statics are embedded in the backend build for convenience, but the version should
match the version of the backend too.

COPY --from= does not allow build args inline, we can work around this by defining a separate
stage which does support build args.

Vaguele related to Taiga 380 which saw a deploy with pinned versions and incorrect paths.