### PR TITLE
Fix visual state when deleting logic rules

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormLogic.js
+++ b/src/openforms/js/components/admin/form_design/FormLogic.js
@@ -13,6 +13,7 @@ import {ValidationErrorContext} from '../forms/ValidationErrors';
 
 const EMPTY_RULE = {
     uuid: '',
+    _generatedId: '',  // consumers should generate this, as it's used for the React key prop if no uuid exists
     form: '',
     jsonLogicTrigger: {},
     isAdvanced: false,
@@ -92,7 +93,7 @@ const FormLogicRules = ({rules, onAdd, onChange, onDelete}) => {
                 rules.map(([index, rule], _) => {
                     return (
                         <Rule
-                            key={index}
+                            key={rule.uuid || rule._generatedId}
                             {...rule}
                             onChange={onChange.bind(null, index)}
                             onDelete={onDelete.bind(null, index)}

--- a/src/openforms/js/components/admin/form_design/PriceLogic.js
+++ b/src/openforms/js/components/admin/form_design/PriceLogic.js
@@ -15,6 +15,7 @@ import Trigger from './logic/Trigger';
 
 export const EMPTY_PRICE_RULE = {
     uuid: '',
+    _generatedId: '',  // consumers should generate this, as it's used for the React key prop if no uuid exists
     form: '',
     jsonLogicTrigger: {},
     price: '',
@@ -100,7 +101,7 @@ export const PriceLogic = ({ rules=[], onChange, onDelete, onAdd }) => {
             {
                 rules.map((rule, i) => (
                     <Rule
-                        key={i}
+                        key={rule.uuid || rule._generatedId}
                         {...rule}
                         onChange={onChange.bind(null, i)}
                         onDelete={onDelete.bind(null, i)}

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -10,6 +10,7 @@ import {Tab as ReactTab, Tabs, TabList, TabPanel} from 'react-tabs';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {apiDelete, get, post, put, ValidationErrors} from '../../../utils/fetch';
+import {getUniqueRandomString} from '../../../utils/random';
 import FAIcon from '../FAIcon';
 import {ComponentsContext} from '../forms/Context';
 import Fieldset from '../forms/Fieldset';
@@ -439,7 +440,8 @@ function reducer(draft, action) {
             draft.logicRules.push({
                 ...EMPTY_RULE,
                 ...ruleOverrides,
-                form: url
+                form: url,
+                _generatedId: getUniqueRandomString(),
             });
             break;
         }
@@ -487,7 +489,8 @@ function reducer(draft, action) {
             const {form: {url}} = draft;
             draft.priceRules.push({
                 ...EMPTY_PRICE_RULE,
-                form: url
+                form: url,
+                _generatedId: getUniqueRandomString(),
             });
             break;
         }

--- a/src/openforms/js/utils/random.js
+++ b/src/openforms/js/utils/random.js
@@ -1,0 +1,20 @@
+const usedKeys = {};
+
+
+const getUniqueRandomString = (length=7, scope='') => {
+  if (!usedKeys[scope]) usedKeys[scope] = [];
+  let randomString;
+  do {
+    randomString = getRandomString(length);
+  } while (usedKeys[scope].includes(randomString));
+  return randomString;
+};
+
+
+// Inspired on FormioUtils.getRandomComponentId and react-key-string
+const getRandomString = (length=7) => {
+  return `e${Math.random().toString(36).substring(length)}`;
+};
+
+
+export {getRandomString, getUniqueRandomString};


### PR DESCRIPTION
Fixes #1222

The UI now correctly renders the state when you delete a logic rule
other than the last one.

This was caused by React's key prop functionality combined with a bad
choice for the key value. React does not re-render a component if the
key has not changed, even if other props have changed (!).

Logic rules used their Array index as key value, so unless you delete
the last logic rule, the visual state will update incorrectly.

Deleting a logic rule removes it from the the Array - causing all
following rules to get an index value of  - 1. From
React's perspective, the keys have not changed - only there is now one
element less in the Array so the last rule is instead removed.
The internal state (for API calls) was correctly updated, however the
visual representation of this state was wrong.

This is fixed by using an actual unique value for each rule as key (
rule.uuid) if it's available, while falling back to a temporary
generated unique string for new rules that don't have a UUID yet. This
results in a guaranteed unique key value for every logic rule and the
correct React re-renders in turn.