### PR TITLE
Deal with file upload "attachments"

### DIFF
--- a/docs/configuration/registration/email.rst
+++ b/docs/configuration/registration/email.rst
@@ -14,3 +14,19 @@ building the form.
     
     Email should be configured by the Open Forms supplier and also requires
     proper setup of SPF and/or DMARC-records.
+
+File uploads/attachments
+------------------------
+
+Any files uploaded as part of the submission are not added as email attachments.
+Instead, the e-mail contains download links to the individual files. These links require
+users to be authenticated and have the correct permissions:
+
+* users must be staff users
+* users must have permission to read file attachments. The standard group "Behandelaars"
+  offers this permission.
+
+.. note::
+
+    Email attachments are typicall restricted in size, making it impossible to actually
+    deliver the emails for further processing.

--- a/src/openforms/accounts/tests/factories.py
+++ b/src/openforms/accounts/tests/factories.py
@@ -16,8 +16,17 @@ class UserFactory(factory.django.DjangoModelFactory):
         if extracted:
             for permission in extracted:
                 if isinstance(permission, str):
-                    # TODO support appname/model/action, for now lets assume we have unique codenames
-                    permission = Permission.objects.get(codename=permission)
+                    try:
+                        label, codename = permission.split(".")
+                    except ValueError:
+                        label = ""
+                        codename = permission
+
+                    filters = {"codename": codename}
+                    if label:
+                        filters["content_type__app_label"] = label
+
+                    permission = Permission.objects.get(**filters)
                 self.user_permissions.add(permission)
 
     class Meta:

--- a/src/openforms/registrations/contrib/email/presentation.py
+++ b/src/openforms/registrations/contrib/email/presentation.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import Any
+
+from django.urls import reverse
+from django.utils.html import format_html_join
+
+from furl import furl
+
+from openforms.utils.urls import build_absolute_uri
+
+
+@dataclass
+class SubmittedDataWrapper:
+    value: Any
+    is_file: bool = False
+
+    def __str__(self):
+        return self.as_html()
+
+    def as_html(self):
+        if self.is_file:
+            return self.display_files(html=True)
+
+        # bit of duplication from display_value... recurse!
+        elif isinstance(self.value, (list, tuple)):
+            return ", ".join(
+                [SubmittedDataWrapper(value=v).as_html() for v in self.value]
+            )
+
+        return str(self.value)
+
+    def as_plain_text(self):
+        if self.is_file:
+            return self.display_files(html=False)
+        # bit of duplication from display_value... recurse!
+        elif isinstance(self.value, (list, tuple)):
+            return ", ".join(
+                [SubmittedDataWrapper(value=v).as_plain_text() for v in self.value]
+            )
+        return str(self.value)
+
+    def display_files(self, html=True) -> str:
+        files = []
+        for submission_file_attachment in self.value:
+            display_name = submission_file_attachment.get_display_name()
+            download_link = build_absolute_uri(
+                reverse(
+                    "submissions:attachment-download",
+                    kwargs={"uuid": submission_file_attachment.uuid},
+                )
+            )
+            url = furl(download_link)
+            url.args["hash"] = submission_file_attachment.content_hash
+            files.append((url, display_name))
+
+        if html:
+            return format_html_join(
+                ", ",
+                '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
+                files,
+            )
+
+        else:
+            return ", ".join(f"{link} ({display})" for link, display in files)

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -927,9 +927,6 @@ class SubmissionFileAttachmentQuerySet(models.QuerySet):
             files[file.form_key].append(file)
         return dict(files)
 
-    def as_mail_tuples(self) -> List[Tuple[str, Any, str]]:
-        return [(f.get_display_name(), f.content.read(), f.content_type) for f in self]
-
 
 class SubmissionFileAttachmentManager(models.Manager):
     def create_from_upload(

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os.path
 import uuid
@@ -1014,3 +1015,17 @@ class SubmissionFileAttachment(models.Model):
 
     def get_format(self):
         return os.path.splitext(self.get_display_name())[1].lstrip(".")
+
+    @property
+    def content_hash(self) -> str:
+        """
+        Calculate the sha256 hash of the content.
+
+        MD5 is fast, but has known collisions, so we use sha256 instead.
+        """
+        chunk_size = 8192
+        sha256 = hashlib.sha256()
+        with self.content.open(mode="rb") as file_content:
+            while chunk := file_content.read(chunk_size):
+                sha256.update(chunk)
+        return sha256.hexdigest()

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -77,7 +77,8 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         **kwargs,
     ) -> Submission:
         """
-        generate a complete Form/FormStep/FormDefinition + Submission/SubmissionStep tree from a list of formio components
+        generate a complete Form/FormStep/FormDefinition + Submission/SubmissionStep
+        tree from a list of formio components
 
         remember to generate from privates.test import temp_private_root
         """
@@ -127,7 +128,9 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
 
 class SubmissionStepFactory(factory.django.DjangoModelFactory):
     submission = factory.SubFactory(SubmissionFactory)
-    form_step = factory.SubFactory(FormStepFactory)
+    form_step = factory.SubFactory(
+        FormStepFactory, form=factory.SelfAttribute("..submission.form")
+    )
 
     class Meta:
         model = SubmissionStep

--- a/src/openforms/submissions/tests/test_attachment_download_view.py
+++ b/src/openforms/submissions/tests/test_attachment_download_view.py
@@ -1,0 +1,82 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from furl import furl
+from privates.test import temp_private_root
+
+from .factories import SubmissionFileAttachmentFactory
+
+
+@override_settings(SENDFILE_BACKEND="django_sendfile.backends.nginx")
+@temp_private_root()
+class SubmissionAttachmentDownloadTest(TestCase):
+    def test_incomplete_submission_404(self):
+        submission_file_attachment = SubmissionFileAttachmentFactory.create(
+            submission_step__submission__completed=False,
+        )
+        path = reverse(
+            "submissions:attachment-download",
+            kwargs={"uuid": submission_file_attachment.uuid},
+        )
+        url = furl(path).add({"hash": "dummy-hash"})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_submission_not_registered_yet_404(self):
+        submission_file_attachments = [
+            SubmissionFileAttachmentFactory.create(
+                submission_step__submission__completed=True,
+                submission_step__submission__registration_failed=True,
+            ),
+            SubmissionFileAttachmentFactory.create(
+                submission_step__submission__completed=True,
+                submission_step__submission__registration_pending=True,
+            ),
+            SubmissionFileAttachmentFactory.create(
+                submission_step__submission__completed=True,
+                submission_step__submission__registration_in_progress=True,
+            ),
+        ]
+
+        for submission_file_attachment in submission_file_attachments:
+            with self.subTest(submission_file_attachment):
+                path = reverse(
+                    "submissions:attachment-download",
+                    kwargs={"uuid": submission_file_attachment.uuid},
+                )
+                url = furl(path).add({"hash": "dummy-hash"})
+
+                response = self.client.get(url)
+
+                self.assertEqual(response.status_code, 404)
+
+    def test_valid_preconditions_missing_hash_403(self):
+        submission_file_attachment = SubmissionFileAttachmentFactory.create(
+            submission_step__submission__completed=True,
+            submission_step__submission__registration_success=True,
+        )
+        path = reverse(
+            "submissions:attachment-download",
+            kwargs={"uuid": submission_file_attachment.uuid},
+        )
+
+        response = self.client.get(path)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_valid_preconditions_invalid_hash_403(self):
+        submission_file_attachment = SubmissionFileAttachmentFactory.create(
+            submission_step__submission__completed=True,
+            submission_step__submission__registration_success=True,
+        )
+        path = reverse(
+            "submissions:attachment-download",
+            kwargs={"uuid": submission_file_attachment.uuid},
+        )
+        url = furl(path).add({"hash": "badhash"})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 403)

--- a/src/openforms/submissions/tests/test_submission_attachment.py
+++ b/src/openforms/submissions/tests/test_submission_attachment.py
@@ -433,3 +433,14 @@ class SubmissionAttachmentTest(TestCase):
 
         actual = clean_mime_type("")
         self.assertEqual("application/octet-stream", actual)
+
+    def test_content_hash_calculation(self):
+        submission_file_attachment = SubmissionFileAttachmentFactory.create(
+            content__data=b"a predictable hash source"
+        )
+        # generated using https://passwordsgenerator.net/sha256-hash-generator/
+        expected_content_hash = (
+            "21bfcc609236ad74408c0e9c73e2e9ef963f676e36c4586f18d75e65c3b0e0df"
+        )
+
+        self.assertEqual(submission_file_attachment.content_hash, expected_content_hash)

--- a/src/openforms/submissions/urls.py
+++ b/src/openforms/submissions/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import ResumeSubmissionView
+from .views import ResumeSubmissionView, SubmissionAttachmentDownloadView
 
 app_name = "submissions"
 
@@ -9,5 +9,10 @@ urlpatterns = [
         "<uuid:submission_uuid>/<str:token>/resume",
         ResumeSubmissionView.as_view(),
         name="resume",
-    )
+    ),
+    path(
+        "attachment/<uuid:uuid>/download/",
+        SubmissionAttachmentDownloadView.as_view(),
+        name="attachment-download",
+    ),
 ]

--- a/src/openforms/templates/403.html
+++ b/src/openforms/templates/403.html
@@ -1,10 +1,23 @@
-{% extends 'master.html' %}
+{% extends 'ui/views/abstract/detail.html' %}
+{% load i18n %}
 
-{% block menu %}{% endblock %}
+{% block card %}
+    <div class="card">
+        <header class="card__header">
+            <h1 class="title">
+                {% trans "Sorry, you don't have access to this page (403)" %}
+            </h1>
+        </header>
 
-{% block content %}
-
-  <h1>Sorry, you don't have access to this page (403)</h1>
-
-
-{% endblock content %}
+        <div class="card__body">
+            {% block card_body %}
+                <p class="body">
+                    {% blocktrans trimmed %}
+                        You don't appear to have sufficient permissions to view this content.
+                        Please contact an administrator if you believe this to be an error.
+                    {% endblocktrans %}
+                </p>
+            {% endblock %}
+        </div>
+    </div>
+{% endblock %}

--- a/src/openforms/utils/tests/auth_assert.py
+++ b/src/openforms/utils/tests/auth_assert.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.shortcuts import resolve_url
+
+from furl import furl
+
+
+class AuthAssertMixin:
+    def assertLoginRequired(self, response, redirect_to: str, **kwargs):
+        expected_url = furl(resolve_url(settings.LOGIN_URL))
+        expected_url.args["next"] = redirect_to
+        self.assertRedirects(response, expected_url, **kwargs)


### PR DESCRIPTION
Partially solves #1193

* End-user uploads are no longer added as attachment to the email
* Instead, HTML mails have a clickable link and plain text emails have a link that can be copy-pasted
* The link points to a "standard" django view to download a submission attachment, using sendfile to optimize file IO/serving
* Access control on the view consists of:
    * user must be logged in
    * user must be staff user (as the admin login page is the configured login page)
    * user must have the `submissions.view_submissionfileattachment` permission, included in the groups fixture with the "Behandelaars" group

As part of this PR, some more refactoring was done to the displaying of form values in e-mails, it now checks if the rendering is set to text mode or not (if no information is available, the current behaviour is kept and html is assumed). There's also a helper interface to format a value as text/html, which will probably be implemented on the `openforms.formio.formatters` in the future. This helper allows us to tackle our concrete problem without needing the entire refactor and having to wait on #1301 