### PR TITLE
[#1299] Celery 5 update

### DIFF
--- a/bin/celery_beat.sh
+++ b/bin/celery_beat.sh
@@ -7,10 +7,8 @@ LOGLEVEL=${CELERY_LOGLEVEL:-INFO}
 mkdir -p celerybeat
 
 echo "Starting celery beat"
-exec celery beat \
-    --app openforms \
+exec celery --app openforms  --workdir src beat \
     -l $LOGLEVEL \
-    --workdir src \
     -s ../celerybeat/beat \
     --pidfile=  # empty on purpose, see #1182
 

--- a/bin/celery_flower.sh
+++ b/bin/celery_flower.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec celery flower --app openforms --workdir src
+exec celery --app openforms --workdir src flower

--- a/bin/celery_worker.sh
+++ b/bin/celery_worker.sh
@@ -9,11 +9,9 @@ QUEUE=${1:-${CELERY_WORKER_QUEUE:=celery}}
 WORKER_NAME=${2:-${CELERY_WORKER_NAME:="${QUEUE}"@%n}}
 
 echo "Starting celery worker $WORKER_NAME with queue $QUEUE"
-exec celery worker \
-    --app openforms \
+exec celery --workdir src --app openforms.celery worker \
     -Q $QUEUE \
     -n $WORKER_NAME \
     -l $LOGLEVEL \
-    --workdir src \
     -O fair \
     -c $CONCURRENCY

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -20,7 +20,7 @@ weasyprint
 zeep
 # Pinned setuptools to a version lower than 58 to allow pyzmail36 to be
 # installed, as required by django-yubin.
-setuptools < 58
+setuptools
 
 # Framework libraries
 django < 3.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 # Core python libraries
-celery < 5  # Flower does not work with Celery 5
+celery ~= 5.0  # Celery 5.2 requires setuptools<59.7.0,>=59.1.1
 celery-once
 defusedxml
 furl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -153,7 +153,7 @@ django-timeline-logger==1.1.2
     # via -r requirements/base.in
 django-tinymce==3.4.0
     # via -r requirements/base.in
-django-yubin==1.6.0
+django-yubin==1.7.1
     # via -r requirements/base.in
 django==2.2.27
     # via
@@ -253,6 +253,8 @@ lxml==4.7.1
     #   python3-saml
     #   xmlsec
     #   zeep
+mail-parser==3.15.0
+    # via django-yubin
 maykin-django-two-factor-auth[phonenumbers]==2.0.4
     # via -r requirements/base.in
 git+https://github.com/maykinmedia/json-logic-py.git@1ceb93ad165d69a5639edc623d5613d0229c05e2#egg=maykin-json-logic-py
@@ -325,8 +327,6 @@ pyyaml==5.4.1
     # via
     #   drf-spectacular
     #   gemma-zds-client
-pyzmail36==1.0.4
-    # via django-yubin
 qrcode==6.1
     # via maykin-django-two-factor-auth
 redis==3.5.3
@@ -360,6 +360,8 @@ self-certifi==1.0.0
     # via -r requirements/base.in
 sentry-sdk==0.17.3
     # via -r requirements/base.in
+simplejson==3.17.6
+    # via mail-parser
 six==1.15.0
     # via
     #   click-repl
@@ -369,6 +371,7 @@ six==1.15.0
     #   html5lib
     #   isodate
     #   jsonschema
+    #   mail-parser
     #   mozilla-django-oidc
     #   orderedmultidict
     #   pyopenssl
@@ -437,5 +440,4 @@ setuptools==57.5.0
     #   drf-jsonschema
     #   josepy
     #   jsonschema
-    #   pyzmail36
     #   weasyprint

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    ./bin/compile_dependencies.sh
 #
-amqp==2.6.1
+amqp==5.0.9
     # via kombu
 attrs==20.3.0
     # via
@@ -29,7 +29,7 @@ cairosvg==2.5.2
     # via weasyprint
 celery-once==3.0.1
     # via -r requirements/base.in
-celery==4.4.7
+celery==5.1.2
     # via
     #   -r requirements/base.in
     #   celery-once
@@ -47,6 +47,18 @@ cffi==1.14.3
     #   weasyprint
 charset-normalizer==2.0.2
     # via requests
+click-didyoumean==0.3.0
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
+click==7.1.2
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 cryptography==3.4.7
     # via
     #   josepy
@@ -199,7 +211,7 @@ face==20.1.1
     # via glom
 faker==7.0.1
     # via zgw-consumers
-flower==0.9.7
+flower==1.0.0
     # via -r requirements/base.in
 furl==2.1.2
     # via
@@ -213,7 +225,7 @@ html5lib==1.1
     # via
     #   -r requirements/base.in
     #   weasyprint
-humanize==3.5.0
+humanize==3.14.0
     # via flower
 idna==2.10
     # via requests
@@ -231,7 +243,7 @@ jsonschema==3.2.0
     # via
     #   drf-jsonschema
     #   drf-spectacular
-kombu==4.6.11
+kombu==5.2.3
     # via celery
 lockfile==0.12.2
     # via django-yubin
@@ -266,8 +278,10 @@ pillow==9.0.0
     #   weasyprint
 platformdirs==2.2.0
     # via zeep
-prometheus-client==0.8.0
+prometheus-client==0.13.1
     # via flower
+prompt-toolkit==3.0.27
+    # via click-repl
 psycopg2==2.8.6
     # via
     #   -r requirements/base.in
@@ -348,6 +362,7 @@ sentry-sdk==0.17.3
     # via -r requirements/base.in
 six==1.15.0
     # via
+    #   click-repl
     #   django-choices
     #   django-compat
     #   furl
@@ -391,11 +406,13 @@ urllib3==1.26.6
     #   sentry-sdk
 uwsgi==2.0.19.1
     # via -r requirements/base.in
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
-    #   flower
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
 weasyprint==52.5
     # via -r requirements/base.in
 webencodings==0.5.1
@@ -416,8 +433,8 @@ zgw-consumers==0.17.0
 setuptools==57.5.0
     # via
     #   -r requirements/base.in
+    #   celery
     #   drf-jsonschema
-    #   humanize
     #   josepy
     #   jsonschema
     #   pyzmail36

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ cairosvg==2.5.2
     # via weasyprint
 celery-once==3.0.1
     # via -r requirements/base.in
-celery==5.1.2
+celery==5.2.3
     # via
     #   -r requirements/base.in
     #   celery-once
@@ -53,7 +53,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-click==7.1.2
+click==8.0.3
     # via
     #   celery
     #   click-didyoumean
@@ -313,7 +313,7 @@ python-dotenv==0.14.0
     # via -r requirements/base.in
 git+https://github.com/maykinmedia/python3-saml.git@e000b39ed0ce38270e6351ec6634e6b3a53bbc3d#egg=python3_saml
     # via -r requirements/base.in
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/base.in
     #   celery
@@ -433,7 +433,7 @@ zgw-consumers==0.17.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==57.5.0
+setuptools==59.6.0
     # via
     #   -r requirements/base.in
     #   celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-amqp==2.6.1
+amqp==5.0.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -60,7 +60,7 @@ celery-once==3.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-celery==4.4.7
+celery==5.1.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -86,8 +86,30 @@ charset-normalizer==2.0.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   requests
+click-didyoumean==0.3.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   celery
 click==7.1.2
-    # via black
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   black
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 commonmark==0.9.1
     # via recommonmark
 coverage==4.5.4
@@ -357,7 +379,7 @@ faker==7.0.1
     #   zgw-consumers
 flake8==3.9.2
     # via -r requirements/test-tools.in
-flower==0.9.7
+flower==1.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -382,7 +404,7 @@ html5lib==1.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
-humanize==3.5.0
+humanize==3.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -423,7 +445,7 @@ jsonschema==3.2.0
     #   -r requirements/base.txt
     #   drf-jsonschema
     #   drf-spectacular
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -514,11 +536,16 @@ platformdirs==2.2.0
     #   zeep
 pluggy==0.13.1
     # via pytest
-prometheus-client==0.8.0
+prometheus-client==0.13.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   flower
+prompt-toolkit==3.0.27
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   click-repl
 psycopg2==2.8.6
     # via
     #   -c requirements/base.txt
@@ -679,6 +706,7 @@ six==1.15.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   click-repl
     #   django-choices
     #   django-compat
     #   freezegun
@@ -792,15 +820,20 @@ uwsgi==2.0.19.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-vine==1.3.0
+vine==5.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   amqp
     #   celery
-    #   flower
+    #   kombu
 waitress==1.4.4
     # via webtest
+wcwidth==0.2.5
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   prompt-toolkit
 weasyprint==52.5
     # via
     #   -c requirements/base.txt
@@ -839,8 +872,8 @@ setuptools==57.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   celery
     #   drf-jsonschema
-    #   humanize
     #   josepy
     #   jsonschema
     #   pyzmail36

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -60,7 +60,7 @@ celery-once==3.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-celery==5.1.2
+celery==5.2.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -101,7 +101,7 @@ click-repl==0.2.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -619,7 +619,7 @@ git+https://github.com/maykinmedia/python3-saml.git@e000b39ed0ce38270e6351ec6634
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-pytz==2021.1
+pytz==2021.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -874,7 +874,7 @@ zgw-consumers==0.17.0
     #   -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==57.5.0
+setuptools==59.6.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -283,7 +283,7 @@ django-tinymce==3.4.0
     #   -r requirements/base.txt
 django-webtest==1.9.7
     # via -r requirements/test-tools.in
-django-yubin==1.6.0
+django-yubin==1.7.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -463,6 +463,11 @@ lxml==4.7.1
     #   python3-saml
     #   xmlsec
     #   zeep
+mail-parser==3.15.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-yubin
 markdown==3.3.4
     # via sphinx-markdown-tables
 markupsafe==1.1.1
@@ -632,11 +637,6 @@ pyyaml==5.4.1
     #   -r requirements/base.txt
     #   drf-spectacular
     #   gemma-zds-client
-pyzmail36==1.0.4
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   django-yubin
 qrcode==6.1
     # via
     #   -c requirements/base.txt
@@ -702,6 +702,11 @@ sentry-sdk==0.17.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+simplejson==3.17.6
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   mail-parser
 six==1.15.0
     # via
     #   -c requirements/base.txt
@@ -714,6 +719,7 @@ six==1.15.0
     #   html5lib
     #   isodate
     #   jsonschema
+    #   mail-parser
     #   mozilla-django-oidc
     #   orderedmultidict
     #   pyopenssl
@@ -876,6 +882,5 @@ setuptools==57.5.0
     #   drf-jsonschema
     #   josepy
     #   jsonschema
-    #   pyzmail36
     #   sphinx
     #   weasyprint

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -320,7 +320,7 @@ django-webtest==1.9.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-yubin==1.6.0
+django-yubin==1.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -530,6 +530,11 @@ lxml==4.7.1
     #   python3-saml
     #   xmlsec
     #   zeep
+mail-parser==3.15.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-yubin
 markdown==3.3.4
     # via
     #   -c requirements/ci.txt
@@ -748,11 +753,6 @@ pyyaml==5.4.1
     #   -r requirements/ci.txt
     #   drf-spectacular
     #   gemma-zds-client
-pyzmail36==1.0.4
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   django-yubin
 qrcode==6.1
     # via
     #   -c requirements/ci.txt
@@ -826,6 +826,11 @@ sentry-sdk==0.17.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+simplejson==3.17.6
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   mail-parser
 six==1.15.0
     # via
     #   -c requirements/ci.txt
@@ -839,6 +844,7 @@ six==1.15.0
     #   html5lib
     #   isodate
     #   jsonschema
+    #   mail-parser
     #   mozilla-django-oidc
     #   orderedmultidict
     #   pyopenssl
@@ -1059,6 +1065,5 @@ setuptools==57.5.0
     #   drf-jsonschema
     #   josepy
     #   jsonschema
-    #   pyzmail36
     #   sphinx
     #   weasyprint

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ alabaster==0.7.12
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   sphinx
-amqp==2.6.1
+amqp==5.0.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -72,7 +72,7 @@ celery-once==3.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-celery==4.4.7
+celery==5.1.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -98,11 +98,30 @@ charset-normalizer==2.0.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   requests
+click-didyoumean==0.3.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   celery
 click==7.1.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   black
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   pip-tools
 commonmark==0.9.1
     # via
@@ -407,7 +426,7 @@ flake8==3.9.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-flower==0.9.7
+flower==1.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -440,7 +459,7 @@ html5lib==1.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-humanize==3.5.0
+humanize==3.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -493,7 +512,7 @@ jsonschema==3.2.0
     #   -r requirements/ci.txt
     #   drf-jsonschema
     #   drf-spectacular
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -611,11 +630,16 @@ pluggy==0.13.1
     #   pytest
 polib==1.1.0
     # via django-rosetta
-prometheus-client==0.8.0
+prometheus-client==0.13.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   flower
+prompt-toolkit==3.0.27
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   click-repl
 psycopg2==2.8.6
     # via
     #   -c requirements/ci.txt
@@ -806,6 +830,7 @@ six==1.15.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   click-repl
     #   django-choices
     #   django-compat
     #   django-rosetta
@@ -967,18 +992,23 @@ uwsgi==2.0.19.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-vine==1.3.0
+vine==5.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   amqp
     #   celery
-    #   flower
+    #   kombu
 waitress==1.4.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   webtest
+wcwidth==0.2.5
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   prompt-toolkit
 weasyprint==52.5
     # via
     #   -c requirements/ci.txt
@@ -1025,8 +1055,8 @@ setuptools==57.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   celery
     #   drf-jsonschema
-    #   humanize
     #   josepy
     #   jsonschema
     #   pyzmail36

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ celery-once==3.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-celery==5.1.2
+celery==5.2.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -113,7 +113,7 @@ click-repl==0.2.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -734,7 +734,7 @@ git+https://github.com/maykinmedia/python3-saml.git@e000b39ed0ce38270e6351ec6634
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-pytz==2021.1
+pytz==2021.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1057,7 +1057,7 @@ zgw-consumers==0.17.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
     # via pip-tools
-setuptools==57.5.0
+setuptools==59.6.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/setuptools.txt
+++ b/requirements/setuptools.txt
@@ -1,1 +1,1 @@
-setuptools<58
+setuptools


### PR DESCRIPTION
Fixes #1299 

Flower does not work with Celery 5 in version 1.0.0 (latest version on PiPy). It should be supported from version 1.0.1.