### PR TITLE
[#1330] Warn user about logic errors

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -265,6 +265,36 @@
       "value": "Type"
     }
   ],
+  "8hSjw4": [
+    {
+      "type": 0,
+      "value": "Component "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "key"
+    },
+    {
+      "type": 0,
+      "value": ") uses a non-existent component key "
+    },
+    {
+      "type": 1,
+      "value": "missingKey"
+    },
+    {
+      "type": 0,
+      "value": " in the simple logic."
+    }
+  ],
   "8pemD3": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -269,6 +269,36 @@
       "value": "Type"
     }
   ],
+  "8hSjw4": [
+    {
+      "type": 0,
+      "value": "Component "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "key"
+    },
+    {
+      "type": 0,
+      "value": ") uses a non-existent component key "
+    },
+    {
+      "type": 1,
+      "value": "missingKey"
+    },
+    {
+      "type": 0,
+      "value": " in the simple logic."
+    }
+  ],
   "8pemD3": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/form_design/AuthenticationWarning.js
+++ b/src/openforms/js/components/admin/form_design/AuthenticationWarning.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import FormioUtils from 'formiojs/utils';
 import PropTypes from 'prop-types';
+import MessageList from './warnings/MessageList';
 
 
 const CUSTOM_FIELD_TYPES = ['npFamilyMembers'];
@@ -26,17 +27,7 @@ const AuthenticationWarning = ({loginRequired, configuration}) => {
         />
     ));
 
-    return (
-        <ul className="messagelist">
-            {
-                formattedWarnings.map((warning, index) => {
-                    return (
-                        <li key={index} className="warning">{warning}</li>
-                    );
-                })
-            }
-        </ul>
-    );
+    return (<MessageList warnings={formattedWarnings}/>);
 
 };
 

--- a/src/openforms/js/components/admin/form_design/ChangedFormDefinitionWarning.js
+++ b/src/openforms/js/components/admin/form_design/ChangedFormDefinitionWarning.js
@@ -4,6 +4,7 @@ import {FormattedMessage} from 'react-intl';
 
 import Modal from '../Modal';
 import {ChangelistTable, ChangelistColumn} from '../tables';
+import MessageList from './warnings/MessageList';
 
 
 const AffectedFormType = PropTypes.shape({
@@ -43,6 +44,21 @@ const ChangedFormDefinitionWarning = ({ changed, affectedForms=[] }) => {
     };
 
     if (!changed) return null;
+
+    const formattedWarning = (
+        <FormattedMessage
+            description="Warning when modifying existing form definitions"
+            defaultMessage="You are modifying an existing form definition! This change affects <link>{count, plural,
+                one {# form}
+                other {# forms}
+            }</link>"
+            values={{
+                count: affectedForms.length,
+                link: (chunks) => (<a href="#" onClick={onShowModal}>{chunks}</a>)
+            }}
+        />
+    );
+
     return (
         <>
             <Modal isOpen={modalOpen} closeModal={() => setModalOpen(false)} title={`Formulieren (${affectedForms.length})`}>
@@ -51,21 +67,7 @@ const ChangedFormDefinitionWarning = ({ changed, affectedForms=[] }) => {
                 </AffectedFormsTable>
             </Modal>
 
-            <ul className="messagelist">
-                <li className="warning">
-                    <FormattedMessage
-                        description="Warning when modifying existing form definitions"
-                        defaultMessage="You are modifying an existing form definition! This change affects <link>{count, plural,
-                            one {# form}
-                            other {# forms}
-                        }</link>"
-                        values={{
-                            count: affectedForms.length,
-                            link: (chunks) => (<a href="#" onClick={onShowModal}>{chunks}</a>)
-                        }}
-                    />
-                </li>
-            </ul>
+            <MessageList warnings={[formattedWarning]} />
         </>
     );
 };

--- a/src/openforms/js/components/admin/form_design/FormLogic.js
+++ b/src/openforms/js/components/admin/form_design/FormLogic.js
@@ -15,7 +15,7 @@ const EMPTY_RULE = {
     uuid: '',
     _generatedId: '',  // consumers should generate this, as it's used for the React key prop if no uuid exists
     form: '',
-    jsonLogicTrigger: {},
+    jsonLogicTrigger: {'': [{'var': ''}, null]},
     isAdvanced: false,
     actions: [],
 };

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -13,6 +13,8 @@ import useDetectConfigurationChanged from './useDetectConfigurationChanged';
 import ChangedFormDefinitionWarning from './ChangedFormDefinitionWarning';
 import PluginWarning from './PluginWarning';
 import AuthenticationWarning from './AuthenticationWarning';
+import useDetectSimpleLogicErrors from './useDetectSimpleLogicErrors';
+import LogicWarning from './LogicWarning';
 
 const emptyConfiguration = {
     display: 'form',
@@ -51,11 +53,14 @@ const FormStepDefinition = ({ url='', name='', internalName='', slug='', previou
     };
 
     const { changed, affectedForms } = useDetectConfigurationChanged(url, configuration);
+    const { warnings } = useDetectSimpleLogicErrors(configuration);
+
     return (
         <>
             <ChangedFormDefinitionWarning changed={changed} affectedForms={affectedForms} />
             <PluginWarning loginRequired={loginRequired} configuration={configuration}/>
             <AuthenticationWarning loginRequired={loginRequired} configuration={configuration}/>
+            <LogicWarning warnings={warnings}/>
 
             <fieldset className="module aligned">
                 <h2>

--- a/src/openforms/js/components/admin/form_design/LogicWarning.js
+++ b/src/openforms/js/components/admin/form_design/LogicWarning.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
-import MessageList from "./warnings/MessageList";
+import MessageList from './warnings/MessageList';
 
 
 

--- a/src/openforms/js/components/admin/form_design/LogicWarning.js
+++ b/src/openforms/js/components/admin/form_design/LogicWarning.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+
+
+
+const LogicWarning = ({warnings}) => {
+    if (!warnings.length) return null;
+
+    const formattedWarnings = warnings.map((warning, index) => (
+        <FormattedMessage
+            key={index}
+            description="Wrong simple logic warning"
+            defaultMessage="Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic."
+            values={{label: warning.component.label, key: warning.component.key, missingKey: warning.missingKey  }}
+        />
+    ));
+
+    return (
+        <ul className="messagelist">
+            {
+                formattedWarnings.map((warning, index) => {
+                    return (
+                        <li key={index} className="warning">{warning}</li>
+                    );
+                })
+            }
+        </ul>
+    );
+
+};
+
+
+LogicWarning.propTypes = {
+    warnings: PropTypes.arrayOf(PropTypes.object),
+};
+
+
+export default LogicWarning;

--- a/src/openforms/js/components/admin/form_design/LogicWarning.js
+++ b/src/openforms/js/components/admin/form_design/LogicWarning.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
+import MessageList from "./warnings/MessageList";
 
 
 
@@ -16,18 +17,7 @@ const LogicWarning = ({warnings}) => {
         />
     ));
 
-    return (
-        <ul className="messagelist">
-            {
-                formattedWarnings.map((warning, index) => {
-                    return (
-                        <li key={index} className="warning">{warning}</li>
-                    );
-                })
-            }
-        </ul>
-    );
-
+    return (<MessageList warnings={formattedWarnings}/>);
 };
 
 

--- a/src/openforms/js/components/admin/form_design/PluginWarning.js
+++ b/src/openforms/js/components/admin/form_design/PluginWarning.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
 import {PluginsContext} from './Context';
+import MessageList from './warnings/MessageList';
 
 
 const PluginWarning = ({loginRequired, configuration}) => {
@@ -71,19 +72,7 @@ const PluginWarning = ({loginRequired, configuration}) => {
     checkPrefillsAuth(configuration);
 
     if ( warnings.length > 0 ) {
-     const formattedWarnings = warnings.map((item, index) => {
-         return (
-            <li key={index} className="warning" >
-                {item}
-            </li>
-         )
-     })
-
-     return (
-        <ul className="messagelist">
-            {formattedWarnings}
-        </ul>
-     );
+        return (<MessageList warnings={warnings} />);
     }
 
     return null;

--- a/src/openforms/js/components/admin/form_design/logic/LiteralValueInput.js
+++ b/src/openforms/js/components/admin/form_design/logic/LiteralValueInput.js
@@ -47,7 +47,7 @@ const LiteralValueInput = ({name, componentType, value='', onChange, ...extraPro
 
 LiteralValueInput.propTypes = {
     name: PropTypes.string.isRequired,
-    componentType: PropTypes.string.isRequired,
+    componentType: PropTypes.string,
     value: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number,

--- a/src/openforms/js/components/admin/form_design/logic/Trigger.js
+++ b/src/openforms/js/components/admin/form_design/logic/Trigger.js
@@ -160,7 +160,7 @@ const reducer = (draft, action) => {
     }
 };
 
-const Trigger = ({ name, logic, onChange, children }) => {
+const Trigger = ({ name, logic, onChange, error, children }) => {
     const allComponents = useContext(ComponentsContext);
     // break down the json logic back into variables that can be managed by components state
     const parsedLogic = parseJsonLogic(logic, allComponents);
@@ -306,6 +306,7 @@ const Trigger = ({ name, logic, onChange, children }) => {
     return (
         <div className="logic-trigger">
             <div className="logic-trigger__editor">
+                {error && <div className="logic-trigger__error">{error}</div> }
                 <div className="dsl-editor">
                     <div className="dsl-editor__node">
                         <FormattedMessage description="Logic trigger prefix" defaultMessage="When" />
@@ -369,6 +370,7 @@ Trigger.propTypes = {
     name: PropTypes.string.isRequired,
     logic: PropTypes.object,
     onChange: PropTypes.func.isRequired,
+    error: PropTypes.string,
     children: PropTypes.node,
 };
 

--- a/src/openforms/js/components/admin/form_design/logic/hooks.js
+++ b/src/openforms/js/components/admin/form_design/logic/hooks.js
@@ -10,6 +10,8 @@ const useOnChanged = (value, callback) => {
     const previousValue = usePrevious(value);
     useEffect(
         () => {
+            // if it's the first render, do not fire an update
+            if (!previousValue) return;
             // if nothing changed, do not fire an update
             if (previousValue && isEqual(previousValue, value)) return;
             callback();

--- a/src/openforms/js/components/admin/form_design/useDetectSimpleLogicErrors.js
+++ b/src/openforms/js/components/admin/form_design/useDetectSimpleLogicErrors.js
@@ -1,0 +1,21 @@
+import FormioUtils from 'formiojs/utils';
+
+
+const useDetectSimpleLogicErrors = (configuration) => {
+    const components = FormioUtils.flattenComponents(configuration.components || [], true);
+    const componentsKeys = Object.keys(components);
+
+    let warnings = [];
+    for (const [componentKey, component] of Object.entries(components)) {
+        if (!!component?.conditional?.when && !componentsKeys.includes(component.conditional.when)) {
+            warnings.push({
+                component: component,
+                missingKey: component.conditional.when
+            });
+        }
+    }
+
+    return {warnings};
+};
+
+export default useDetectSimpleLogicErrors;

--- a/src/openforms/js/components/admin/form_design/utils.js
+++ b/src/openforms/js/components/admin/form_design/utils.js
@@ -44,5 +44,40 @@ const findComponent = (formSteps = [], test) => {
     return null;
 };
 
+const checkKeyChange = (mutationType, newComponent, oldComponent) => {
+    if (mutationType !== 'changed') return false;
 
-export {stripIdFromComponents, getFormComponents, findComponent};
+    return newComponent.key !== oldComponent.key;
+};
+
+const replaceComponentKeyInLogic = (existingLogicRules, originalKey, newKey) => {
+    return existingLogicRules.map((rule, index) => {
+        if (!JSON.stringify(rule).includes(originalKey)) {
+            return rule;
+        }
+
+        let newRule = {...rule};
+        // Replace the key in the JSON trigger
+        const stringJsonTrigger = JSON.stringify(rule.jsonLogicTrigger);
+        const compToReplace = JSON.stringify({var: originalKey});
+        newRule.jsonLogicTrigger = JSON.parse(
+            stringJsonTrigger.replace(compToReplace, JSON.stringify({var: newKey}))
+        );
+        // Replace the key in the actions
+        newRule.actions = newRule.actions.map((action, index) => {
+            if (action.component !== originalKey) {
+                return action;
+            }
+
+            return {
+                ...action,
+                component: newKey
+            };
+        })
+
+        return newRule;
+    });
+};
+
+
+export {stripIdFromComponents, getFormComponents, findComponent, checkKeyChange, replaceComponentKeyInLogic};

--- a/src/openforms/js/components/admin/form_design/warnings/MessageList.js
+++ b/src/openforms/js/components/admin/form_design/warnings/MessageList.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const MessageList = ({warnings}) => {
+
+    return (
+        <ul className="messagelist">
+            {
+                warnings.map((child, index) => {
+                    return (
+                        <li key={index} className="warning">{child}</li>
+                    );
+                })
+            }
+        </ul>
+    );
+};
+
+export default MessageList;

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -184,6 +184,11 @@
     "description": "JSON editor: 'type' header label",
     "originalDefault": "Type"
   },
+  "8hSjw4": {
+    "defaultMessage": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic.",
+    "description": "Wrong simple logic warning",
+    "originalDefault": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic."
+  },
   "8pemD3": {
     "defaultMessage": "Edit variable {name}",
     "description": "JSON editor: variable edit panel title",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -184,6 +184,11 @@
     "description": "JSON editor: 'type' header label",
     "originalDefault": "Type"
   },
+  "8hSjw4": {
+    "defaultMessage": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic.",
+    "description": "Wrong simple logic warning",
+    "originalDefault": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic."
+  },
   "8pemD3": {
     "defaultMessage": "Wijzig variabele {name}",
     "description": "JSON editor: variable edit panel title",


### PR DESCRIPTION
Fixes #1330 
Fixes #1296

**Changes**:
- Added a hook that checks whether the components used in 'simple logic' rules exist and shows a warning if they don't.
- When the key of a component is changed, the logic rules in 'the other tab' are updated to use the new key. 
- Show error returned by the backend when a logic rule is invalid.