### PR TITLE
Versioning policy proposal

### DIFF
--- a/docs/developers/index.rst
+++ b/docs/developers/index.rst
@@ -31,3 +31,4 @@ familiarize yourself with the design principles.
    npm
    roadmap
    releases
+   versioning

--- a/docs/developers/releases.rst
+++ b/docs/developers/releases.rst
@@ -16,6 +16,12 @@ Open Forms follows `semantic versioning <https://semver.org/>`_. This means that
 have versions ``MAJOR.minor.patch``, optionally suffixed with a pre-release identifier
 such as ``-beta.0`` or ``-rc.1``.
 
+Note that Open Forms itself has a version, and the API provided by Open Forms has its
+own version. API changes must also be judged based on semver and result in a matching
+version number change. This is tracked in the ``API_VERSION`` setting.
+
+See also the :ref:`developers_versioning`.
+
 Preparing a release
 -------------------
 

--- a/docs/developers/sdk/embedding.rst
+++ b/docs/developers/sdk/embedding.rst
@@ -9,6 +9,9 @@ The SDK can be embedded by loading the Javascript code and stylesheet.
 Assuming the SDK is hosted on ``https://example.com/sdk/1.0.0/``, two resources need to be
 loaded.
 
+Before you embed a particular version of the SDK, please familiarize yourself with the
+:ref:`versioning policy <developers_versioning>`.
+
 Loading static assets
 =====================
 

--- a/docs/developers/versioning.rst
+++ b/docs/developers/versioning.rst
@@ -1,0 +1,94 @@
+.. _developers_versioning:
+
+Versioning policy
+=================
+
+Because Open Forms ("as a suite") is a collection of components developed individually
+from each other, it's important to be aware of the compatible versions to guarantee
+that the application(s) keep working as expected.
+
+We identify three major components having their own version numbers:
+
+* Open Forms API, the API implemented by the Open Forms backend
+* Open Forms SDK, the client application consuming the API
+* Open Forms backend, implements the API, administrative interface and various
+  modules/plugins (see :ref:`developers_architecture`).
+
+The Open Forms SDK and Open Forms API versions must be aligned with each other for
+correct functioning of the forms.
+
+All versions adhere to `semantic versioning <https://semver.org/>`_, meaning major
+versions may introduce breaking changes and minor versions are backwards compatible.
+
+Open Forms SDK
+--------------
+
+We aim to align the SDK major version with the API major version. This means that SDK
+``1.x`` requires API ``1.x`` and SDK ``2.x`` will require API ``2.x``.
+
+It is possible an SDK minor version (e.g. ``1.1``) requires the same minimal minor
+version of the API, but this is not a guarantee.
+
+Newer minor API versions are compatible with a given minor SDK version, per the semantic
+versioning principles.
+
+The table below documents the required API version ranges for a given SDK version. The
+maximum API version should usually not be applicable, unless the SDK relies on
+experimental feature changes (see :ref:`developers_versioning_api`).
+
+.. table:: Required API version ranges
+   :widths: auto
+
+   =========== =================== ===================
+   SDK version minimum API version maximum API version
+   =========== =================== ===================
+   1.0.x       1.0.y               n/a
+   =========== =================== ===================
+
+.. _developers_versioning_api:
+
+Open Forms API
+--------------
+
+The Open Forms API adheres to semantic versioning with one exception: experimental
+functionality.
+
+We use the `specification extension`_ pattern in the API spec to mark functionality
+as experimental, using the ``x-experimental: true`` flag. Experimental functionality
+may introduce breaking changes in minor versions, but not in patch versions.
+
+We use this to mark parts of the API that we are not yet convinced about that they
+are the right implementation. Release notes of Open Forms backend will include which
+experimental functionality was changed.
+
+.. _specification extension: https://swagger.io/specification/#specification-extensions
+
+Open Forms backend
+------------------
+
+The Open Forms backend implements the Open Forms API, form submission processing and
+various features related to forms happening at runtime.
+
+Changes in the backend may result in changes to the API schema, but this is not a
+guarantee. Many things happen "under the hood" that change or improve the API behaviour
+in a backwards-compatible way without affecting the API schema.
+
+This means that:
+
+* the Open Forms backend version may be greater than the Open Forms API version (=
+  changes did not affect the API schema)
+* the backend version is always *at least* the API version - changes affecting the
+  schema result in an API version bump.
+* Breaking changes result in an major version increase for both backend and API
+
+The matrix below documents which API version ranges are implemented by which Open Forms
+backend version.
+
+.. table:: API version offered by backend version
+   :widths: auto
+
+   =============== ===========
+   Backend version API version
+   =============== ===========
+   1.0.x           1.0.y
+   =============== ===========

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2176,6 +2176,14 @@ paths:
         This guarantees that the submission is removed from the session without having
         to rely on the client being able to make another call. IF it is detected in the
         status endpoint that a retry is needed, the ID is added back to the session.
+
+        ---
+        **Warning**
+
+        The schema of the validation errors response is currently marked as
+        experimental. See our versioning policy in the developer documentation for
+        what this means.
+        ---
       summary: Complete a submission
       parameters:
       - in: path
@@ -3189,6 +3197,7 @@ components:
       required:
       - incompleteSteps
       - submissionAllowed
+      x-experimental: true
     ComponentProperty:
       type: object
       properties:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Open Forms API
-  version: 1.0.0-alpha
+  version: 1.0.0-rc.3
   description: |2
 
     Open Forms provides an API to manage multi-page or multi-step forms.

--- a/src/openforms/api/utils.py
+++ b/src/openforms/api/utils.py
@@ -5,7 +5,9 @@ from djangorestframework_camel_case.util import (
     camelize_re,
     underscore_to_camel as _underscore_to_camel,
 )
+from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework.serializers import Serializer
+from rest_framework.views import APIView
 
 
 def underscore_to_camel(input_: Union[str, int]) -> str:
@@ -31,3 +33,14 @@ def get_from_serializer_data_or_instance(
 
     serializer_field = serializer.fields[field]
     return serializer_field.get_attribute(instance)
+
+
+def mark_experimental(func_or_class):
+    if issubclass(func_or_class, Serializer):
+        extend_fn = extend_schema_serializer
+    elif issubclass(func_or_class, APIView):
+        extend_fn = extend_schema
+    else:
+        raise NotImplementedError(f"Type {type(func_or_class)} is not supported yet.")
+    decorator = extend_fn(extensions={"x-experimental": True})
+    return decorator(func_or_class)

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -766,6 +766,8 @@ Open Forms fits in the [Common Ground](https://commonground.nl) vision and archi
 and it plays nice with other available components.
 """
 
+API_VERSION = "1.0.0-rc.3"
+
 SPECTACULAR_SETTINGS = {
     "SCHEMA_PATH_PREFIX": "/api/v1",
     "TITLE": "Open Forms API",
@@ -785,7 +787,7 @@ SPECTACULAR_SETTINGS = {
     "LICENSE": {
         "name": "UNLICENSED",
     },
-    "VERSION": "1.0.0-alpha",
+    "VERSION": API_VERSION,
     # Tags defined in the global scope
     "TAGS": [],
     # Optional: MUST contain 'url', may contain "description"

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from rest_framework import serializers
 from rest_framework.request import Request
 
+from openforms.api.utils import mark_experimental
 from openforms.forms.constants import SubmissionAllowedChoices
 
 from ..form_logic import check_submission_logic
@@ -48,6 +49,7 @@ class IncompleteStepSerializer(serializers.Serializer):
     )
 
 
+@mark_experimental
 class CompletionValidationSerializer(serializers.Serializer):
     incomplete_steps = IncompleteStepSerializer(many=True)
     submission_allowed = serializers.ChoiceField(

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -163,6 +163,14 @@ class SubmissionViewSet(
         This guarantees that the submission is removed from the session without having
         to rely on the client being able to make another call. IF it is detected in the
         status endpoint that a retry is needed, the ID is added back to the session.
+
+        ---
+        **Warning**
+
+        The schema of the validation errors response is currently marked as
+        experimental. See our versioning policy in the developer documentation for
+        what this means.
+        ---
         """
         submission = self.get_object()
         validation_serializer = validate_submission_completion(


### PR DESCRIPTION
Closes #1264

* Boils down to SEMVER
* Documented SDK <-> API compatible ranges
* Added escape hatch through "experimental features" -> can be marked in code/API schema
* Documented which API version is implemented in which Open Forms version