### PR TITLE
Require admin user for demo auth plugins

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2507,6 +2507,7 @@ paths:
       tags:
       - auth
       security:
+      - cookieAuth: []
       - {}
       responses:
         '302':
@@ -2614,6 +2615,7 @@ paths:
               type: object
               additionalProperties: {}
       security:
+      - cookieAuth: []
       - {}
       responses:
         '200':
@@ -2736,6 +2738,7 @@ paths:
       tags:
       - auth
       security:
+      - cookieAuth: []
       - {}
       responses:
         '200':

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3163,8 +3163,6 @@ components:
       - providesAuth
     AuthenticationBackendsEnum:
       enum:
-      - demo
-      - demo-kvk
       - digid
       - eherkenning
       - eidas

--- a/src/openforms/authentication/contrib/demo/plugin.py
+++ b/src/openforms/authentication/contrib/demo/plugin.py
@@ -97,15 +97,19 @@ class DemoBaseAuthentication(BasePlugin):
         return HttpResponseRedirect(submitted.cleaned_data["next"])
 
 
+# client requested demo and demo-kvk to no longer be 'demo' (Github #805), but that
+# conflicts with the required admin/staff user check from #1322. This has been
+# overruled, as demo plugins can be enabled via a feature flag and other demo plugins
+# can be disabled in the global configuration if considered annoying (see #1103).
+
+
 @register("demo")
 class DemoBSNAuthentication(DemoBaseAuthentication):
     verbose_name = _("Demo BSN")
     form_class = BSNForm
     provides_auth = AuthAttribute.bsn
     form_field = "bsn"
-
-    # client requested this to no longer be demo (Github #805)
-    is_demo_plugin = False
+    is_demo_plugin = True
 
 
 @register("demo-kvk")
@@ -114,6 +118,4 @@ class DemoKVKAuthentication(DemoBaseAuthentication):
     form_class = KVKForm
     provides_auth = AuthAttribute.kvk
     form_field = "kvk"
-
-    # client requested this to no longer be demo (Github #805)
-    is_demo_plugin = False
+    is_demo_plugin = True

--- a/src/openforms/authentication/contrib/digid_mock/tests/test_plugin.py
+++ b/src/openforms/authentication/contrib/digid_mock/tests/test_plugin.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from furl import furl
 
+from openforms.accounts.tests.factories import StaffUserFactory
 from openforms.config.models import GlobalConfiguration
 from openforms.forms.tests.factories import FormStepFactory
 from openforms.submissions.tests.factories import SubmissionFactory
@@ -25,6 +26,9 @@ class LoginTests(TestCase):
         )
         form = step.form
         plugin = register["digid-mock"]
+        # demo plugins require staff users
+        staff_user = StaffUserFactory.create()
+        self.client.force_login(user=staff_user)
 
         # we need an arbitrary request
         factory = RequestFactory()
@@ -85,6 +89,9 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, TestCase):
         self._add_submission_to_session(submission)
         form = submission.form
         plugin = register["digid-mock"]
+        # demo plugins require staff users
+        staff_user = StaffUserFactory.create()
+        self.client.force_login(user=staff_user)
         # we need an arbitrary request
         factory = RequestFactory()
         request = factory.get("/foo")

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.exceptions import PermissionDenied
 from django.dispatch import Signal, receiver
 
 from rest_framework.request import Request
@@ -8,6 +9,7 @@ from openforms.submissions.models import Submission
 from openforms.submissions.signals import submission_complete, submission_start
 
 from .constants import FORM_AUTH_SESSION_KEY
+from .registry import register
 from .utils import store_auth_details
 
 logger = logging.getLogger(__name__)

--- a/src/openforms/authentication/tests/mocks.py
+++ b/src/openforms/authentication/tests/mocks.py
@@ -4,6 +4,7 @@ from unittest.mock import PropertyMock, patch
 from django.http import HttpResponse, HttpResponseRedirect
 
 from ..base import BasePlugin
+from ..constants import AuthAttribute
 from ..registry import Registry
 
 
@@ -39,6 +40,7 @@ class FailingPlugin(BasePlugin):
 
 class RequiresAdminPlugin(BasePlugin):
     verbose_name = "plugin requiring staff user session"
+    provides_auth = AuthAttribute.bsn
     is_demo_plugin = True
 
     def start_login(self, request, form, form_url):
@@ -70,5 +72,6 @@ def mock_register(register: Registry):
         return_value=register,
     )
     patcher3 = patch("openforms.submissions.serializers.register", new=register)
-    with patcher1, patcher2, patcher3:
+    patcher4 = patch("openforms.authentication.signals.register", new=register)
+    with patcher1, patcher2, patcher3, patcher4:
         yield

--- a/src/openforms/authentication/tests/mocks.py
+++ b/src/openforms/authentication/tests/mocks.py
@@ -37,6 +37,26 @@ class FailingPlugin(BasePlugin):
         raise Exception("return")
 
 
+class RequiresAdminPlugin(BasePlugin):
+    verbose_name = "plugin requiring staff user session"
+    is_demo_plugin = True
+
+    def start_login(self, request, form, form_url):
+        return HttpResponse("start")
+
+    def handle_return(self, request, form):
+        return HttpResponseRedirect(request.GET.get("next"))
+
+    def handle_co_sign(self, request, form):
+        return {
+            "identifier": "mock-id",
+            "fields": {
+                "mock_field_1": "field 1",
+                "mock_field_2": "",
+            },
+        }
+
+
 @contextmanager
 def mock_register(register: Registry):
     patcher1 = patch(

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -1,0 +1,71 @@
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+
+from rest_framework.test import APIRequestFactory, APITestCase
+
+from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
+from openforms.submissions.tests.factories import SubmissionFactory
+
+from ..constants import FORM_AUTH_SESSION_KEY
+from ..registry import Registry
+from ..signals import set_auth_attribute_on_session
+from .mocks import RequiresAdminPlugin, mock_register
+
+factory = APIRequestFactory()
+
+
+class SetSubmissionIdentifyingAttributesTests(APITestCase):
+    def test_attributes_not_set_for_demo_plugin_without_staff(self):
+        register = Registry()
+        register("plugin1")(RequiresAdminPlugin)
+        instance = SubmissionFactory.create()
+        request = factory.get("/foo")
+        request.session = {
+            FORM_AUTH_SESSION_KEY: {
+                "plugin": "plugin1",
+                "attribute": RequiresAdminPlugin.provides_auth,
+                "value": "123",
+            }
+        }
+
+        invalid_users = (
+            AnonymousUser(),
+            UserFactory.build(),
+        )
+
+        for user in invalid_users:
+            with self.subTest(user_type=str(type(user)), is_staff=user.is_staff):
+                request.user = user
+
+                with mock_register(register):
+                    with self.assertRaises(PermissionDenied):
+                        set_auth_attribute_on_session(
+                            sender=None, instance=instance, request=request
+                        )
+
+                instance.refresh_from_db()
+                value = getattr(instance, RequiresAdminPlugin.provides_auth)
+                self.assertEqual(value, "")
+
+    def test_attribute_set_for_demo_plugin_with_staff_user(self):
+        register = Registry()
+        register("plugin1")(RequiresAdminPlugin)
+        instance = SubmissionFactory.create()
+        request = factory.get("/foo")
+        request.user = StaffUserFactory.build()
+        request.session = {
+            FORM_AUTH_SESSION_KEY: {
+                "plugin": "plugin1",
+                "attribute": RequiresAdminPlugin.provides_auth,
+                "value": "123",
+            }
+        }
+
+        with mock_register(register):
+            set_auth_attribute_on_session(
+                sender=None, instance=instance, request=request
+            )
+
+        instance.refresh_from_db()
+        value = getattr(instance, RequiresAdminPlugin.provides_auth)
+        self.assertEqual(value, "123")

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from furl import furl
-from rest_framework import permissions, serializers
+from rest_framework import authentication, permissions, serializers
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.renderers import TemplateHTMLRenderer
@@ -38,7 +38,7 @@ BACKEND_OUTAGE_RESPONSE_PARAMETER = "of-auth-problem"
 
 
 class AuthenticationFlowBaseView(RetrieveAPIView):
-    authentication_classes = ()
+    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (permissions.AllowAny,)
     # these 'endpoints' are not meant to take or return JSON
     parser_classes = (FormParser, MultiPartParser)

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -162,6 +162,11 @@ class AuthenticationStartView(AuthenticationFlowBaseView):
         if plugin_id not in form.authentication_backends:
             return HttpResponseBadRequest("plugin not allowed")
 
+        # demo plugins should require admin authentication to protect against random
+        # people spoofing other people's credentials.
+        if plugin.is_demo_plugin and not request.user.is_staff:
+            raise PermissionDenied(_("Demo plugins require an active admin session."))
+
         form_url = request.GET.get("next")
         if not form_url:
             return HttpResponseBadRequest("missing 'next' parameter")

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -297,6 +297,11 @@ class AuthenticationReturnView(AuthenticationFlowBaseView):
         if plugin.return_method.upper() != request.method.upper():
             return HttpResponseNotAllowed([plugin.return_method])
 
+        # demo plugins should require admin authentication to protect against random
+        # people spoofing other people's credentials.
+        if plugin.is_demo_plugin and not request.user.is_staff:
+            raise PermissionDenied(_("Demo plugins require an active admin session."))
+
         try:
             self._handle_co_sign(form, plugin)
         except serializers.ValidationError:


### PR DESCRIPTION
Fixes #1322 

* Added staff user checks for demo plugins in start/return auth flow
* Added staff user check for demo plugins in submission start signal handler
* Reverted #805 and documented reasoning