### PR TITLE
Permanently delete forms

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -355,11 +355,10 @@ class FormAdmin(
         Split between soft and hard deletes here.
 
         The admin has mutually exclusive filters, but let's not rely on that assumption.
+        Hard deletes need to be performed first, otherwise non-deleted forms get
+        soft-deleted and in the next steps _all_ (including the just created) soft-
+        deletes get hard-deleted.
         """
-
-        # soft-deletes
-        queryset.filter(_is_deleted=False).update(_is_deleted=True)
-
         # hard deletes - ensure we cascade delete the single-use form definitions as well
         soft_deleted = queryset.filter(_is_deleted=True)
         fds = list(
@@ -369,3 +368,6 @@ class FormAdmin(
         )
         soft_deleted.delete()
         FormDefinition.objects.filter(id__in=fds).delete()
+
+        # soft-deletes
+        queryset.filter(_is_deleted=False).update(_is_deleted=True)


### PR DESCRIPTION
Fixes #988

For both bulk (from list page) and detail (from edit page, currently not exposed in React):

* First time deleting a form just marks it as deleted and keeps the related steps/form definitions
* Second time deleting permanently removes the form from the database, cascading the form steps. Single-use form definitions are also cascade-deleted, form definitions that are marked as re-usable are kept.