### PR TITLE
Enable hiding fieldset header

### DIFF
--- a/src/openforms/js/components/form/fieldset.js
+++ b/src/openforms/js/components/form/fieldset.js
@@ -30,10 +30,10 @@ const FIELDSET_BASIC = {
         },
         {
             type: 'checkbox',
-            key: 'showHeader',
-            label: 'Show fieldset header',
-            tooltip: 'Show a line and the label above the fieldset in the form',
-            defaultValue: true,
+            key: 'hideHeader',
+            label: 'Hide fieldset header',
+            tooltip: 'Hide the line and the label above the fieldset in the form',
+            defaultValue: false,
         }
     ]
 };

--- a/src/openforms/js/components/form/fieldset.js
+++ b/src/openforms/js/components/form/fieldset.js
@@ -32,7 +32,7 @@ const FIELDSET_BASIC = {
             type: 'checkbox',
             key: 'showHeader',
             label: 'Show fieldset header',
-            tooltip: 'Whether to show a line with the fieldset label in the form',
+            tooltip: 'Show a line and the label above the fieldset in the form',
             defaultValue: true,
         }
     ]

--- a/src/openforms/js/components/form/fieldset.js
+++ b/src/openforms/js/components/form/fieldset.js
@@ -28,20 +28,17 @@ const FIELDSET_BASIC = {
             label: 'Clear on hide',
             tooltip: 'Remove the value of this field from the submission if it is hidden',
         },
+        {
+            type: 'checkbox',
+            key: 'showHeader',
+            label: 'Show fieldset header',
+            tooltip: 'Whether to show a line with the fieldset label in the form',
+            defaultValue: true,
+        }
     ]
 };
 
 class FieldSet extends FormioFieldSet {
-    constructor(component, options, data) {
-        /* Field sets have both a 'legend' and a 'label' field. The label should be automatically populated to be equal
-        to the legend, but this doesn't seem to work in Formio 4.13.x. Since in open-forms we always use the label, in
-        this custom fieldset the legend is hidden and automatically filled with the value of the label.
-         */
-        if (component.label) {
-            component.legend = component.label;
-        }
-        super(component, options, data);
-    }
 
     static editForm(...extend) {
         const parentEditForm = FormioFieldSet.editForm();

--- a/src/openforms/js/components/formio_builder/customTemplates.js
+++ b/src/openforms/js/components/formio_builder/customTemplates.js
@@ -3,6 +3,7 @@ import coSign from './templates/coSign';
 import fieldTemplate from './templates/field.ejs';
 import columnsTemplate from './templates/columns.ejs';
 import componentTemplate from './templates/component.ejs';
+import fieldsetTemplate from './templates/fieldset.ejs';
 
 const TEMPLATES = {
     builderSidebar: {form: builderSidebar},
@@ -10,6 +11,7 @@ const TEMPLATES = {
     field: {form: fieldTemplate},
     columns: {form: columnsTemplate},
     component: {form: componentTemplate},
+    fieldset: {form: fieldsetTemplate}
 };
 
 export default TEMPLATES;

--- a/src/openforms/js/components/formio_builder/templates/fieldset.ejs
+++ b/src/openforms/js/components/formio_builder/templates/fieldset.ejs
@@ -1,5 +1,5 @@
 <fieldset class="{{ctx.ofPrefix}}fieldset">
-  {% if (ctx.component.label && ctx.component.showHeader) { %}
+  {% if (ctx.component.label && !ctx.component.hideHeader) { %}
   <legend ref="header" class="{{ctx.ofPrefix}}legend">
     {{ctx.t(ctx.component.label, { _userInput: true })}}
     {% if (ctx.component.tooltip) { %}

--- a/src/openforms/js/components/formio_builder/templates/fieldset.ejs
+++ b/src/openforms/js/components/formio_builder/templates/fieldset.ejs
@@ -1,0 +1,15 @@
+<fieldset class="{{ctx.ofPrefix}}fieldset">
+  {% if (ctx.component.label && ctx.component.showHeader) { %}
+  <legend ref="header" class="{{ctx.ofPrefix}}legend">
+    {{ctx.t(ctx.component.label, { _userInput: true })}}
+    {% if (ctx.component.tooltip) { %}
+      <i ref="tooltip" class="{{ctx.iconClass('question-sign')}} text-muted" data-tooltip="{{ctx.component.tooltip}}"></i>
+    {% } %}
+  </legend>
+  {% } %}
+  {% if (!ctx.collapsed) { %}
+  <div class="{{ctx.ofPrefix}}fieldset-body" ref="{{ctx.nestedKey}}">
+    {{ctx.children}}
+  </div>
+  {% } %}
+</fieldset>

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -289,6 +289,6 @@
   "Column sizes": "Grootte van de kolommen",
   "Specify the size of each column. The sum of all the widths should be 100%.": "Geef de grootte van elke kolom op. De som van alle breedtes moet 100% zijn.",
   "Hidden component": "Verborgen component",
-  "Show fieldset header": "Toon fieldset header",
-  "Show a line and the label above the fieldset in the form": "Toon de koptekst en een lijn boven de fieldset in het formulier"
+  "Hide fieldset header": "Verberg veldengroepheader",
+  "Hide the line and the label above the fieldset in the form": "Verberg de koptekst en de lijn boven de veldengroep in het formulier"
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -288,5 +288,7 @@
   "Remove the value of this field from the submission if it is hidden. Note: the value of this field is then also not used in logic rules!": "Verwijder de waarde van dit veld van de inzending als dit veld verborgen is. Let op: De waarde van dit veld wordt dan ook niet gebruikt in logica regels!",
   "Column sizes": "Grootte van de kolommen",
   "Specify the size of each column. The sum of all the widths should be 100%.": "Geef de grootte van elke kolom op. De som van alle breedtes moet 100% zijn.",
-  "Hidden component": "Verborgen component"
+  "Hidden component": "Verborgen component",
+  "Show fieldset header": "Toon fieldset header",
+  "Show a line and the label above the fieldset in the form": "Toon de koptekst en een lijn boven de fieldset in het formulier"
 }


### PR DESCRIPTION
Fixes #1391 

Front end PR: https://github.com/open-formulieren/open-forms-sdk/pull/173

**Changes**
- It is now possible to configure whether the header of the fieldset will be visible in the form
- Before the 'legend' property of the fieldset was used in the header. This was automatically changed to match the label. Now the label is used instead in the header, so we don't need to update the legend under the hood