### PR TITLE
Move identifying attributes hashing to on_completion cleanup stage

### DIFF
--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -186,7 +186,6 @@ class SubmissionViewSet(
 
         submission.calculate_price(save=False)
         submission.completed_on = timezone.now()
-        submission.hash_identifying_attributes()
         submission.save()
 
         logevent.form_submit_success(submission)

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -404,7 +404,7 @@ class Submission(models.Model):
 
         self.save()
 
-    def hash_identifying_attributes(self):
+    def hash_identifying_attributes(self, save=False):
         """
         Generate a salted hash for each of the identifying attributes.
 
@@ -420,6 +420,8 @@ class Submission(models.Model):
             hashed = get_salted_hash(getattr(self, attr))
             setattr(self, attr, hashed)
         self.auth_attributes_hashed = True
+        if save:
+            self.save(update_fields=["auth_attributes_hashed", *attrs])
 
     def load_execution_state(self) -> SubmissionState:
         """

--- a/src/openforms/submissions/tasks/__init__.py
+++ b/src/openforms/submissions/tasks/__init__.py
@@ -94,6 +94,11 @@ def finalize_completion(submission_id: int) -> None:
     send_confirmation_email_task = maybe_send_confirmation_email.si(submission_id)
     send_confirmation_email_task.delay()
 
+    hash_identifying_attributes_task = maybe_hash_identifying_attributes.si(
+        submission_id
+    )
+    hash_identifying_attributes_task.delay()
+
 
 def on_completion_retry(submission_id: int) -> chain:
     """

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -35,9 +35,6 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
                 lambda s: s.completed_on - timedelta(hours=4)
             ),
             price=factory.PostGenerationMethodCall("calculate_price"),
-            _hashed_id_attrs=factory.PostGenerationMethodCall(
-                "hash_identifying_attributes"
-            ),
         )
         registration_failed = factory.Trait(
             completed=True,
@@ -70,6 +67,11 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
                 "openforms.submissions.tests.factories.SubmissionReportFactory",
                 factory_related_name="submission",
             )
+        )
+        with_hashed_identifying_attributes = factory.Trait(
+            _hashed_id_attrs=factory.PostGenerationMethodCall(
+                "hash_identifying_attributes"
+            ),
         )
 
     @classmethod

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -722,7 +722,11 @@ class SubmissionTests(TestCase):
             "kvk": "123455789",
             "pseudo": "some-pseudo",
         }
-        submission = SubmissionFactory.create(**attrs, completed=True)
+        submission = SubmissionFactory.create(
+            **attrs,
+            completed=True,
+            with_hashed_identifying_attributes=True,
+        )
 
         submission.refresh_from_db()
 

--- a/src/openforms/submissions/tests/test_tasks_cleanup.py
+++ b/src/openforms/submissions/tests/test_tasks_cleanup.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from ..tasks import maybe_hash_identifying_attributes
+from .factories import SubmissionFactory
+
+
+class HashIdentifyingAttributesTaskTests(TestCase):
+    @patch("openforms.submissions.tasks.cleanup.Submission.hash_identifying_attributes")
+    def test_registration_not_succesful(self, mock_hash):
+        submissions = [
+            SubmissionFactory.create(
+                completed=True,
+                with_hashed_identifying_attributes=False,
+                registration_failed=True,
+            ),
+            SubmissionFactory.create(
+                completed=True,
+                with_hashed_identifying_attributes=False,
+                registration_pending=True,
+            ),
+            SubmissionFactory.create(
+                completed=True,
+                with_hashed_identifying_attributes=False,
+                registration_in_progress=True,
+            ),
+        ]
+
+        for submission in submissions:
+            with self.subTest(registration_status=submission.registration_status):
+                maybe_hash_identifying_attributes(submission.id)
+
+                submission.refresh_from_db()
+                self.assertFalse(submission.auth_attributes_hashed)
+                mock_hash.assert_not_called()
+
+    def test_already_hashed(self):
+        submission = SubmissionFactory.create(
+            completed=True,
+            with_hashed_identifying_attributes=True,
+            registration_success=True,
+        )
+
+        maybe_hash_identifying_attributes(submission.id)
+
+        submission.refresh_from_db()
+        self.assertTrue(submission.auth_attributes_hashed)


### PR DESCRIPTION
Fixes #1395

Ensure that the attributes are only hashed when the registration has succeeded, as
they may be/are used during the registration stage.