### PR TITLE
Fix signature display in pdf & email

### DIFF
--- a/src/openforms/emails/templates/emails/templatetags/form_summary.html
+++ b/src/openforms/emails/templates/emails/templatetags/form_summary.html
@@ -2,7 +2,7 @@
 {% if submitted_data %}
     <h2 style="margin: 1em 0; font-size: 1.5em;">{% trans "Summary" %}</h2>
 
-    <table style="width: 100%; border: none; border-collapse: collapse;" cellpadding="0" cellspacing="0" width="100%">
+    <table style="width: 100%; border: none; border-collapse: collapse; table-layout: fixed;" cellpadding="0" cellspacing="0" width="100%">
         {% for key, value in submitted_data %}
             <tr>
                 <td width="25%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;">{{ key }}</td>

--- a/src/openforms/emails/templatetags/form_summary.py
+++ b/src/openforms/emails/templatetags/form_summary.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from django import template
 from django.template.loader import get_template
+from django.utils.encoding import force_str
 
 from openforms.forms.models import FormDefinition
 
@@ -23,6 +24,7 @@ def filter_data_to_show_in_email(context: dict) -> dict:
     :param context: dict, contains the submitted data as well as the form object
     :return: dict, with filtered data
     """
+    _is_html = not context.get("rendering_text", False)
     form = context["_form"]
     submission = context["_submission"]
 
@@ -33,7 +35,9 @@ def filter_data_to_show_in_email(context: dict) -> dict:
         data_to_show_in_email += keys
 
     filtered_data = submission.get_printable_data(
-        limit_keys_to=data_to_show_in_email, use_merged_data_fallback=True
+        limit_keys_to=data_to_show_in_email,
+        use_merged_data_fallback=True,
+        as_html=_is_html,
     )
     return {"submitted_data": filtered_data}
 
@@ -57,4 +61,4 @@ def display_value(context, value: Any):
         return ""
     else:
         # fall back to default of string representation
-        return str(value)
+        return force_str(value)

--- a/src/openforms/emails/utils.py
+++ b/src/openforms/emails/utils.py
@@ -117,6 +117,8 @@ def strip_tags_plus(text: str) -> str:
     copied and modified from https://bitbucket.org/maykinmedia/werkbezoek/src/develop/src/werkbezoek/utils/email.py
     """
     text = unwrap_anchors(text)
+    # <br> is eaten completely by strip_tags, so replace them by newlines
+    text = text.replace("<br>", "\n")
     text = django_strip_tags(text)
     lines = text.splitlines()
     transformed_lines = transform_lines(lines)

--- a/src/openforms/emails/views.py
+++ b/src/openforms/emails/views.py
@@ -1,15 +1,18 @@
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
 
-from openforms.emails.confirmation_emails import (
+from openforms.submissions.models import Submission
+
+from .confirmation_emails import (
     get_confirmation_email_context_data,
     get_confirmation_email_templates,
     render_confirmation_email_template,
 )
-from openforms.emails.context import get_wrapper_context
-from openforms.submissions.models import Submission
+from .context import get_wrapper_context
+from .utils import strip_tags_plus
 
 
 class EmailWrapperTestView(TemplateView):
@@ -20,6 +23,11 @@ class EmailWrapperTestView(TemplateView):
             raise PermissionDenied()
         return super().dispatch(request, *args, **kwargs)
 
+    def _get_mode(self) -> str:
+        mode = self.request.GET.get("mode", "html")
+        assert mode in ("html", "text"), f"Unknown mode: {mode}"
+        return mode
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()
         content = "<b>content goes here</b>"
@@ -29,8 +37,21 @@ class EmailWrapperTestView(TemplateView):
 
             content_template = get_confirmation_email_templates(submission)[1]
             context = get_confirmation_email_context_data(submission)
+            mode = self._get_mode()
+            if mode == "text":
+                context["rendering_text"] = True
             content = render_confirmation_email_template(content_template, context)
+            if mode == "text":
+                content = strip_tags_plus(content)
 
         ctx.update(get_wrapper_context(content))
         ctx.update(kwargs)
         return ctx
+
+    def render_to_response(self, context, **response_kwargs):
+        mode = self._get_mode()
+        if mode == "text":
+            return HttpResponse(
+                context["content"].encode("utf-8"), content_type="text/plain"
+            )
+        return super().render_to_response(context, **response_kwargs)

--- a/src/openforms/formio/formatters/default.py
+++ b/src/openforms/formio/formatters/default.py
@@ -232,7 +232,12 @@ class SignatureFormatter(FormioFormatter):
             "data:image/"
         ), "Expected 'data:' URI with image mime type"
 
-        return format_html("""<img src="{src}" alt="{alt}" />""", src=value, alt=text)
+        # max-width is required for e-mail styling where it may overflow a table cell
+        return format_html(
+            """<img src="{src}" alt="{alt}" style="max-width: 100%;" />""",
+            src=value,
+            alt=text,
+        )
 
 
 @register("map")

--- a/src/openforms/formio/formatters/default.py
+++ b/src/openforms/formio/formatters/default.py
@@ -5,6 +5,7 @@ from django.template.defaultfilters import date as fmt_date, time as fmt_time, y
 from django.utils.dateparse import parse_date, parse_time
 from django.utils.encoding import force_str
 from django.utils.formats import number_format
+from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 
 from glom import glom
@@ -40,6 +41,13 @@ class FormioFormatter(AbstractBasePlugin):
     Defaults to semi-colon, as formatted numbers already use comma's which hurts
     readability.
     """
+    as_html = False
+    """
+    Format for HTML output or not.
+
+    The default is to format for plain text output, but toggling this will emit
+    HTML where relevant.
+    """
 
     # there is an interesting open question on what to do for empty values
     # currently we're eating them in normalise_value_to_list()
@@ -57,14 +65,20 @@ class FormioFormatter(AbstractBasePlugin):
     def join_formatted_values(
         self, component: Component, formatted_values: Iterable[str]
     ) -> str:
-        return self.multiple_separator.join(formatted_values)
+        if self.as_html:
+            args_generator = ((formatted,) for formatted in formatted_values)
+            return format_html_join(self.multiple_separator, "{}", args_generator)
+        else:
+            return self.multiple_separator.join(formatted_values)
 
     def process_result(self, component: Component, formatted: str) -> str:
         return formatted
 
-    def __call__(self, component: Component, value: Any) -> str:
+    def __call__(self, component: Component, value: Any, as_html=False) -> str:
+        self.as_html = as_html
         # note all this depends on value not being unexpected type or shape
         values = self.normalise_value_to_list(component, value)
+
         formatted_values = (
             force_str(self.format(component, value)) for value in values
         )
@@ -210,7 +224,15 @@ class RadioFormatter(FormioFormatter):
 @register("signature")
 class SignatureFormatter(FormioFormatter):
     def format(self, component: Component, value: str) -> str:
-        return _("signature added")
+        text = _("signature added")
+        if not self.as_html:
+            return text
+
+        assert value.startswith(
+            "data:image/"
+        ), "Expected 'data:' URI with image mime type"
+
+        return format_html("""<img src="{src}" alt="{alt}" />""", src=value, alt=text)
 
 
 @register("map")

--- a/src/openforms/formio/formatters/registry.py
+++ b/src/openforms/formio/formatters/registry.py
@@ -10,11 +10,11 @@ class Registry(BaseRegistry):
     A registry for the FormIO formatters.
     """
 
-    def format(self, info: Component, value: Any):
+    def format(self, info: Component, value: Any, as_html=False):
         formatter = (
             register[info["type"]] if info["type"] in register else register["default"]
         )
-        return formatter(info, value)
+        return formatter(info, value, as_html=as_html)
 
 
 # Sentinel to provide the default registry. You an easily instantiate another

--- a/src/openforms/formio/formatters/service.py
+++ b/src/openforms/formio/formatters/service.py
@@ -7,5 +7,5 @@ from .registry import register
 __all__ = ["format_value", "filter_printable"]
 
 
-def format_value(info: Component, value: Any):
-    return register.format(info, value)
+def format_value(info: Component, value: Any, as_html=False):
+    return register.format(info, value, as_html=as_html)

--- a/src/openforms/formio/formatters/tests/test_default_formatters.py
+++ b/src/openforms/formio/formatters/tests/test_default_formatters.py
@@ -107,3 +107,17 @@ class DefaultFormatterTestCase(TestCase):
             ([1234.56, 1, 0], "1.234,56; 1,00; 0,00"),
         ]
         self.run_test_cases(component, expected)
+
+    def test_signature_as_html(self):
+        component = {
+            "type": "signature",
+            "multiple": False,
+            "key": "signature",
+        }
+        value = "data:image/png;base64,iVBO[truncated]"
+
+        formatted_html = format_value(component, value, as_html=True)
+
+        self.assertHTMLEqual(
+            formatted_html, f"""<img src="{value}" alt="{_('signature added')}" />"""
+        )

--- a/src/openforms/formio/formatters/tests/test_default_formatters.py
+++ b/src/openforms/formio/formatters/tests/test_default_formatters.py
@@ -119,5 +119,6 @@ class DefaultFormatterTestCase(TestCase):
         formatted_html = format_value(component, value, as_html=True)
 
         self.assertHTMLEqual(
-            formatted_html, f"""<img src="{value}" alt="{_('signature added')}" />"""
+            formatted_html,
+            f"""<img src="{value}" alt="{_('signature added')}" style="max-width: 100%;" />""",
         )

--- a/src/openforms/scss/pdfs/_submission-step-row.scss
+++ b/src/openforms/scss/pdfs/_submission-step-row.scss
@@ -30,5 +30,9 @@
   &__value {
     @include body();
     width: 60%;
+
+    > * {
+      max-width: 100%;
+    }
   }
 }

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -596,6 +596,7 @@ class Submission(models.Model):
         self,
         limit_keys_to: Optional[List[str]] = None,
         use_merged_data_fallback=False,
+        as_html=False,
     ) -> List[Tuple[str, str]]:
         printable_data = []
         attachment_data = self.get_merged_attachments()
@@ -612,7 +613,9 @@ class Submission(models.Model):
             if enable_formio_formatters:
                 info, value = info
                 label = info["label"]
-                printable_data.append((label, format_value(info, value)))
+                printable_data.append(
+                    (label, format_value(info, value, as_html=as_html))
+                )
             else:
                 warnings.warn(
                     "Formatting without using the formio formatters registry is deprecated. "

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -37,7 +37,7 @@ class DataItem:
 
     @property
     def display_value(self) -> str:
-        return format_value(self.component, self.value)
+        return format_value(self.component, self.value, as_html=True)
 
 
 @dataclass


### PR DESCRIPTION
Fixes #1293 

Building on top of #949, the formio formatters gained a "as_html" rendering mode. This allows us to output HTML image tags for the signature.

The e-mail rendering is more complex as it relies on `Submission.get_printable_data` which in the old variant has no idea about text/HTML rendering. So I decided to only support an actual image if the new Formio formatters are used, otherwise the bland text version is rendered.