### PR TITLE
Fix broken admin authentication for demo plugins

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1903,6 +1903,8 @@ paths:
           type: integer
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:
@@ -1932,6 +1934,8 @@ paths:
             schema:
               $ref: '#/components/schemas/Submission'
         required: true
+      security:
+      - cookieAuth: []
       responses:
         '201':
           content:
@@ -2096,6 +2100,8 @@ paths:
         required: true
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:
@@ -2130,6 +2136,8 @@ paths:
         required: true
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:
@@ -2199,6 +2207,8 @@ paths:
         required: true
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:
@@ -2248,6 +2258,8 @@ paths:
             schema:
               $ref: '#/components/schemas/SubmissionSuspension'
         required: true
+      security:
+      - cookieAuth: []
       responses:
         '201':
           content:
@@ -2272,6 +2284,8 @@ paths:
         required: true
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:

--- a/src/openforms/forms/templates/core/views/form/form_detail.html
+++ b/src/openforms/forms/templates/core/views/form/form_detail.html
@@ -9,4 +9,17 @@
 {% block card %}
     {% sdk_info_banner %}
     {% include "forms/sdk_snippet.html" %}
+
+    {% if request.user.is_staff %}
+        {% comment %}
+        Additional call for admin support, we need to set the CSRF Token in case admin users
+        are authenticated and use demo auth plugins. See Github issue 1410
+        {% endcomment %}
+        {{ csrf_token|cut:''|json_script:'csrftoken' }}
+        <script nonce="{{ request.csp_nonce }}">
+            var csrfToken = JSON.parse(document.getElementById('csrftoken').innerText);
+            OpenForms.setCSRFToken(csrfToken);
+        </script>
+    {% endif %}
+
 {% endblock %}

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
-from rest_framework import mixins, status, viewsets
+from rest_framework import authentication, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
@@ -81,7 +81,7 @@ class SubmissionViewSet(
         .order_by("created_on")
     )
     serializer_class = SubmissionSerializer
-    authentication_classes = ()
+    authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = [ActiveSubmissionPermission]
     lookup_field = "uuid"
     pagination_class = pagination.PageNumberPagination


### PR DESCRIPTION
Fixes #1410

Depends on https://github.com/open-formulieren/open-forms-sdk/pull/176

The admin auth was not recognized because of the missing `authentication_classes = (SessionAuthentication,)`, and adding this in turn activates the CSRF machinery. CSRF mechanisms have been added to the SDK with a hook for the backend to be able to set the value of the token.

We only set the value (and activate the CSRF machinery) if we're dealing with admin users, as that's the scope of the demo authentication plugins.