### PR TITLE
Delete dead code on custom fields

### DIFF
--- a/src/openforms/authentication/fields.py
+++ b/src/openforms/authentication/fields.py
@@ -1,9 +1,10 @@
 from django.contrib.postgres.fields import ArrayField
 from django.db.models.fields import CharField
 
-from ..plugins.constants import UNIQUE_ID_MAX_LENGTH
-from ..plugins.validators import PluginExistsValidator
-from ..utils.validators import UniqueValuesValidator
+from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
+from openforms.plugins.validators import PluginExistsValidator
+from openforms.utils.validators import UniqueValuesValidator
+
 from .registry import register
 
 
@@ -28,16 +29,3 @@ class BackendChoiceField(CharField):
         super().__init__(*args, **kwargs)
 
         self.validators.append(PluginExistsValidator(self.registry))
-
-    def formfield(self, **kwargs):
-        """
-        Force this into a choices field.
-        """
-        monkeypatch = not self.choices
-        if monkeypatch:
-            _old = self.choices
-            self.choices = self.registry.get_choices()
-        field = super().formfield(**kwargs)
-        if monkeypatch:
-            self.choices = _old
-        return field

--- a/src/openforms/payments/fields.py
+++ b/src/openforms/payments/fields.py
@@ -1,7 +1,8 @@
 from django.db.models.fields import CharField
 
-from ..plugins.constants import UNIQUE_ID_MAX_LENGTH
-from ..plugins.validators import PluginExistsValidator
+from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
+from openforms.plugins.validators import PluginExistsValidator
+
 from .registry import register
 
 
@@ -16,19 +17,3 @@ class PaymentBackendChoiceField(CharField):
         super().__init__(*args, **kwargs)
 
         self.validators.append(PluginExistsValidator(self.registry))
-
-    def formfield(self, **kwargs):
-        """
-        Force this into a choices field.
-        """
-        monkeypatch = not self.choices
-        if monkeypatch:
-            _old = self.choices
-            self.choices = self._get_plugin_choices()
-        field = super().formfield(**kwargs)
-        if monkeypatch:
-            self.choices = _old
-        return field
-
-    def _get_plugin_choices(self):
-        return self.registry.get_choices()

--- a/src/openforms/registrations/fields.py
+++ b/src/openforms/registrations/fields.py
@@ -16,19 +16,3 @@ class RegistrationBackendChoiceField(CharField):
         super().__init__(*args, **kwargs)
 
         self.validators.append(PluginExistsValidator(self.registry))
-
-    def formfield(self, **kwargs):
-        """
-        Force this into a choices field.
-        """
-        monkeypatch = not self.choices
-        if monkeypatch:
-            _old = self.choices
-            self.choices = self._get_plugin_choices()
-        field = super().formfield(**kwargs)
-        if monkeypatch:
-            self.choices = _old
-        return field
-
-    def _get_plugin_choices(self):
-        return self.registry.get_choices()


### PR DESCRIPTION
This was only relevant when building a Django form field for the
respective custom fields, but we don't render Django forms anymore
after removing the enable_react_form feature flag in #1414