### PR TITLE
Fix header padding on login page

### DIFF
--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -61,6 +61,10 @@ $djai-border-width: 8px;
       }
     }
   }
+  
+  @at-root body.login #header {
+    padding-bottom: 15px !important;
+  }
 }
 
 /* Secondary submit row */


### PR DESCRIPTION
Should fix this missing padding: 
![image](https://user-images.githubusercontent.com/5518550/159011213-a138a032-5da8-4db9-9fd9-9dce439557b3.png)
