### PR TITLE
Updated issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Probleem melden / Bug report
+description: Meldt een probleem om ons te helpen verbeteren  / Create a report to help us improve
+title: "Title here"
+labels: ["bug", "triage"]
+assignees: []
+body:
+  - type: input
+    id: product-version
+    attributes:
+      label: Product versie / Product version
+      description: Welke versie gebruikt u? / Which version do you use?
+      placeholder: "1.1.0"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Omschrijf het probleem / Describe the bug
+      description: Een duidelijke omschrijving van het probleem (de "bug") / A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Stappen om te reproduceren / Steps to reproduce
+      description: Stappen die leiden tot het probleem / Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: false
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Verwacht gedrag / Expected behavior
+      description: Een duidelijke omschrijving van wat de verwachting is / A clear and concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: dropdown
+    id: screen-resolution
+    attributes:
+      label: Screen resolution
+      options:
+        - "smaller"
+        - "1024 x 768"
+        - "1366 x 768"
+        - "1920 x 1080"
+        - "bigger"
+        - "unknown"
+    validations:
+      required: false
+  - type: dropdown
+    id: device
+    attributes:
+      label: Browser
+      options:
+        - Desktop
+        - Mobile
+        - Tablet
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - Windows
+        - Linux
+        - MacOS
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Browser
+      multiple: true
+      options:
+        - Edge
+        - Chrome
+        - Safari
+        - Firefox
+        - Other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,6 +59,7 @@ body:
         - Desktop
         - Mobile
         - Tablet
+        - Anders / Other
     validations:
       required: false
   - type: dropdown
@@ -69,6 +70,9 @@ body:
         - Windows
         - Linux
         - MacOS
+        - iOS
+        - Android
+        - Anders / Other
     validations:
       required: false
   - type: dropdown
@@ -81,6 +85,6 @@ body:
         - Chrome
         - Safari
         - Firefox
-        - Other
+        - Anders / Other
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-- name: Report a security vulnerability
+  - name: Meldt een veiligheidsprobleem / Report a security vulnerability
     url: https://github.com/open-formulieren/open-forms/security/policy
-    about: Please review our security policy for more details
-- name: Priority support
-    url: https://opengem.nl
-    about: Contact us directly to get priority support.
+    about: Bekijk ons beveiligingsbeleid voor meer informatie / Please review our security policy for more details
+  - name: Ondersteuning met prioriteit / Priority support
+    url: https://opengem.nl/contact/
+    about: Neem direct contact met ons op / Contact us directly to get priority support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Verzoek tot verbetering / Feature request
+description: Stel een idee voor om het project beter te maken / Suggest an idea for this project
+title: "Title here"
+labels: ["enhancement", "triage"]
+assignees: []
+body:
+  - type: dropdown
+    id: theme
+    attributes:
+      label: Thema / Theme
+      options:
+        - "Frontend"
+        - "API"
+        - "Admin"
+        - "Form designer"
+        - "Plugins"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Omschrijving / Description
+      description: Omschrijf duidelijk het idee of de behoefte, eventueel aangevuld met een bepaalde oplossingsrichting / Clearly describe the idea or need, possibly supplemented with a specific solution direction
+    validations:
+      required: true
+  - type: textarea
+    id: added-value
+    attributes:
+      label: Added value / Toegevoegde waarde
+      description: Omschrijf de toegevoegde waarde voor de bedrijfsvoering of dienstverlening / Describe the added value for business operations or services
+    validations:
+      required: false
+  - type: textarea
+    id: remarks
+    attributes:
+      label: Aanvullende opmerkingen / Additional context
+      description: Voeg aanvullingen of mockups toe voor deze verbetering / Add any other context or screenshots about the feature request
+    validations:
+      required: false


### PR DESCRIPTION
Added templates for issues to streamline issues.

The label "triage" is added to indicate issues that have not been checked yet by us. You can remove that label once it's checked.