### PR TITLE
Bump mozilla-django-oidc-db version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -260,7 +260,7 @@ maykin-json-logic-py @ git+https://github.com/maykinmedia/json-logic-py.git@1ceb
     # via -r requirements/base.in
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db==0.9.0
+mozilla-django-oidc-db==0.10.0
     # via -r requirements/base.in
 o365==2.0.16
     # via -r requirements/base.in
@@ -288,9 +288,7 @@ prometheus-client==0.13.1
 prompt-toolkit==3.0.27
     # via click-repl
 psycopg2==2.8.6
-    # via
-    #   -r requirements/base.in
-    #   mozilla-django-oidc-db
+    # via -r requirements/base.in
 pycparser==2.20
     # via cffi
 pyjwt==1.7.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -487,7 +487,7 @@ mozilla-django-oidc==1.2.4
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.9.0
+mozilla-django-oidc-db==0.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -557,7 +557,6 @@ psycopg2==2.8.6
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   mozilla-django-oidc-db
 py==1.10.0
     # via pytest
 pycodestyle==2.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -562,7 +562,7 @@ mozilla-django-oidc==1.2.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.9.0
+mozilla-django-oidc-db==0.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -651,7 +651,6 @@ psycopg2==2.8.6
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   mozilla-django-oidc-db
 py==1.10.0
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
This version supports models.JSONField, so it's one less system check
warning in Open Forms.