### PR TITLE
:bricks: Ensure uwsgi runs in master process mode

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -34,6 +34,7 @@ exec uwsgi \
     --static-map /media=/app/media  \
     --chdir src \
     --enable-threads \
+    --master \
     --processes $uwsgi_processes \
     --threads $uwsgi_threads \
     --post-buffering=8192 \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -410,7 +410,7 @@ urllib3==1.26.6
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.19.1
+uwsgi==2.0.20
     # via -r requirements/base.in
 vine==5.0.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -825,7 +825,7 @@ urllib3==1.26.6
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.19.1
+uwsgi==2.0.20
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -996,7 +996,7 @@ urllib3==1.26.6
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.19.1
+uwsgi==2.0.20
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
The master process is required for proper concurrency, as this process
monitors the worker processes and restarts them if they die (
unexpectedly).