### PR TITLE
Feature/1451 submission rendering api

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,6 +23,7 @@ zeep
 # Pinned setuptools to a version lower than 58 to allow pyzmail36 to be
 # installed, as required by django-yubin.
 setuptools
+tabulate
 
 # Framework libraries
 django ~= 3.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -392,6 +392,8 @@ stringcase==1.2.0
     # via o365
 tablib[xlsx]==3.0.0
     # via -r requirements/base.in
+tabulate==0.8.9
+    # via -r requirements/base.in
 text-unidecode==1.3
     # via faker
 tinycss2==1.1.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -781,6 +781,10 @@ tablib[xlsx]==3.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+tabulate==0.8.9
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 tblib==1.7.0
     # via -r requirements/test-tools.in
 testfixtures==6.17.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -937,6 +937,10 @@ tablib[xlsx]==3.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+tabulate==0.8.9
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 tblib==1.7.0
     # via
     #   -c requirements/ci.txt

--- a/src/openforms/emails/confirmation_emails.py
+++ b/src/openforms/emails/confirmation_emails.py
@@ -48,8 +48,8 @@ def get_confirmation_email_context_data(submission: "Submission") -> Dict[str, A
         # starting with underscores are blocked by the Django template engine.
         "_submission": submission,
         "_form": submission.form,  # should be the same as self.form
-        # TODO: this should use the printable data but be keyed by component.key instead of the label,
-        # which submission.get_printable_data does.
+        # TODO: this should use the :func:`openforms.formio.formatters.service.format_value`
+        # but be keyed by component.key instead of the label, which submission.get_printable_data does.
         **submission.data,
         "public_reference": submission.public_registration_reference,
         "form_name": submission.form.name,

--- a/src/openforms/emails/templates/emails/templatetags/form_summary.html
+++ b/src/openforms/emails/templates/emails/templatetags/form_summary.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% if renderer %}
+{% if renderer.get_children %}
     <h2 style="margin: 1em 0; font-size: 1.5em;">{% trans "Summary" %}</h2>
 
     <table style="width: 100%; border: none; border-collapse: collapse; table-layout: fixed;" cellpadding="0" cellspacing="0" width="100%">

--- a/src/openforms/emails/templates/emails/templatetags/form_summary.html
+++ b/src/openforms/emails/templates/emails/templatetags/form_summary.html
@@ -1,13 +1,25 @@
 {% load i18n %}
-{% if submitted_data %}
+{% if renderer %}
     <h2 style="margin: 1em 0; font-size: 1.5em;">{% trans "Summary" %}</h2>
 
     <table style="width: 100%; border: none; border-collapse: collapse; table-layout: fixed;" cellpadding="0" cellspacing="0" width="100%">
-        {% for key, value in submitted_data %}
+        {% for submission_step_node in renderer.get_children %}
+            {# row for step title #}
             <tr>
-                <td width="25%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;">{{ key }}</td>
-                <td width="75%" style="padding: 4px 10px 4px 0; text-align: left;">{% display_value value %}</td>
+                <td width="100%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;" colspan="2">
+                    <h3 style="margin: 1em 0; font-size: 1.2em;">{{ submission_step_node.render }}</h3>
+                </td>
             </tr>
+
+            {# row for every visible form field within the step #}
+            {% for component_node in submission_step_node.get_children %}
+                <tr>
+                    <td width="25%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;">{{ component_node.label }}</td>
+                    <td width="75%" style="padding: 4px 10px 4px 0; text-align: left;">{{ component_node.display_value }}</td>
+                </tr>
+            {% endfor %}
+
         {% endfor %}
     </table>
+
 {% endif %}

--- a/src/openforms/emails/templates/emails/templatetags/form_summary.txt
+++ b/src/openforms/emails/templates/emails/templatetags/form_summary.txt
@@ -1,4 +1,8 @@
-{% load i18n %}{% autoescape off %}{% if submitted_data %}{% trans "Summary" %}
+{% load i18n %}{% autoescape off %}{% if renderer.get_children %}{% trans "Summary" %}
 
-{% for key, value in submitted_data %}
-- {{ key }}: {% display_value value %}{% endfor %}{% endif %}{% endautoescape %}
+{% for submission_step_node in renderer.get_children %}
+{{ submission_step_node.render }}
+
+{% for component_node in submission_step_node.get_children %}
+{% whitespace component_node.depth base='  ' %}- {{ component_node.label }}{% if not component_node.is_layout %}:{% endif %} {{ component_node.display_value }}{% endfor %}
+{% endfor %}{% endif %}{% endautoescape %}

--- a/src/openforms/emails/templatetags/form_summary.py
+++ b/src/openforms/emails/templatetags/form_summary.py
@@ -4,41 +4,28 @@ from django import template
 from django.template.loader import get_template
 from django.utils.encoding import force_str
 
-from openforms.forms.models import FormDefinition
+from openforms.submissions.rendering.constants import RenderModes
+
+# from openforms.forms.models import FormDefinition
+from openforms.submissions.rendering.renderer import Renderer
 
 register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
 def summary(context):
-    if context.get("rendering_text"):
+    as_text = context.get("rendering_text")
+    renderer = Renderer(
+        submission=context["_submission"],
+        mode=RenderModes.confirmation_email,
+        as_html=not as_text,
+    )
+    if as_text:
         name = "emails/templatetags/form_summary.txt"
     else:
         name = "emails/templatetags/form_summary.html"
-    return get_template(name).render(filter_data_to_show_in_email(context.flatten()))
-
-
-def filter_data_to_show_in_email(context: dict) -> dict:
-    """Extract data that should be shown as a summary of submission in the confirmation email
-
-    :param context: dict, contains the submitted data as well as the form object
-    :return: dict, with filtered data
-    """
-    _is_html = not context.get("rendering_text", False)
-    form = context["_form"]
-    submission = context["_submission"]
-
-    # From the form definition, see which fields should be shown in the confirmation email
-    data_to_show_in_email = []
-    for form_definition in FormDefinition.objects.filter(formstep__form=form):
-        keys = [item[0] for item in form_definition.get_keys_for_email_summary()]
-        data_to_show_in_email += keys
-
-    filtered_data = submission.get_printable_data(
-        keys_to_include=data_to_show_in_email,
-        as_html=_is_html,
-    )
-    return {"submitted_data": filtered_data}
+    context["renderer"] = renderer
+    return get_template(name).render(context.flatten())
 
 
 @register.simple_tag(takes_context=True)

--- a/src/openforms/emails/templatetags/form_summary.py
+++ b/src/openforms/emails/templatetags/form_summary.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 from django import template
@@ -28,8 +29,18 @@ def summary(context):
     return get_template(name).render(context.flatten())
 
 
+@register.simple_tag()
+def whitespace(amount: int, base=" ") -> str:
+    return base * amount
+
+
 @register.simple_tag(takes_context=True)
 def display_value(context, value: Any):
+    warnings.warn(
+        "{% display_value %} template tag is deprecated, please use "
+        "'openforms.submissions.rendering.renderer.Renderer' instead.",
+        DeprecationWarning,
+    )
     _is_html = not context.get("rendering_text", False)
     if isinstance(value, dict) and value.get("originalName"):
         # uploads

--- a/src/openforms/emails/views.py
+++ b/src/openforms/emails/views.py
@@ -42,7 +42,7 @@ class EmailWrapperTestView(TemplateView):
                 context["rendering_text"] = True
             content = render_confirmation_email_template(content_template, context)
             if mode == "text":
-                content = strip_tags_plus(content)
+                content = strip_tags_plus(content, keep_leading_whitespace=True)
 
         ctx.update(get_wrapper_context(content))
         ctx.update(kwargs)

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -51,6 +51,7 @@ class ComponentNode(Node):
     component: Component
     step: SubmissionStep
     depth: int = 0
+    is_layout = False
 
     @staticmethod
     def build_node(
@@ -160,6 +161,8 @@ class ComponentNode(Node):
 
 
 class ContainerMixin:
+    is_layout = True
+
     @property
     def is_visible(self) -> bool:
         # fieldset does not support the showInFoo properties, so we don't use the super

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -136,6 +136,13 @@ class ComponentNode(Node):
             yield from child
 
     @property
+    def layout_modifier(self) -> str:
+        """
+        For HTML based rendering, potentially emit a layout modifier.
+        """
+        return "root" if self.component.get("_is_root", False) else ""
+
+    @property
     def label(self) -> str:
         if self.renderer.mode == RenderModes.export:
             return self.component.get("key") or "KEY_MISSING"
@@ -176,12 +183,12 @@ class ContainerMixin:
 
 @register("fieldset")
 class FieldSetNode(ContainerMixin, ComponentNode):
-    pass
+    layout_modifier = "fieldset"
 
 
 @register("columns")
 class ColumnsNode(ContainerMixin, ComponentNode):
-    pass
+    layout_modifier = "columns"
 
 
 @register("content")
@@ -213,21 +220,7 @@ class FormioConfigurationNode(Node):
     def render(self) -> str:
         return ""
 
-    @property
-    def is_visible(self) -> bool:
-        # TODO: move to SubmissionStepNode
-        # determine if the step as a whole is relevant or not. The stap may be not
-        # applicable because of form logic.
-        logic_evaluated = getattr(self.step, "_form_logic_evaluated", False)
-        assert (
-            logic_evaluated
-        ), "You should ensure that the form logic is evaluated before rendering steps!"
-        return self.step.is_applicable
-
     def __iter__(self) -> Iterator[ComponentNode]:
-        if not self.is_visible:
-            return
-
         for component in self.step.form_step.iter_components(
             recursive=False, _mark_root=True
         ):

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -47,16 +47,22 @@ Map render modes to the component configuration key to check with their defaults
 class ComponentNode(Node):
     component: Component
     step: SubmissionStep
+    depth: int = 0
 
     @staticmethod
     def build_node(
-        step: SubmissionStep, component: Component, renderer: "Renderer"
+        step: SubmissionStep,
+        component: Component,
+        renderer: "Renderer",
+        depth: int = 0,
     ) -> "ComponentNode":
         """
         Instantiate the most specific node type for a given component type.
         """
         node_cls = COMPONENT_TYPE_NODES.get(component["type"], ComponentNode)
-        nested_node = node_cls(step=step, component=component, renderer=renderer)
+        nested_node = node_cls(
+            step=step, component=component, renderer=renderer, depth=depth
+        )
         return nested_node
 
     @property
@@ -105,7 +111,10 @@ class ComponentNode(Node):
             configuration=self.component, recursive=False, _is_root=False
         ):
             yield ComponentNode.build_node(
-                step=self.step, component=component, renderer=self.renderer
+                step=self.step,
+                component=component,
+                renderer=self.renderer,
+                depth=self.depth + 1,
             )
 
     def __iter__(self) -> Iterator["ComponentNode"]:

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -14,6 +14,13 @@ class ComponentNode(Node):
     value: Any
 
     @property
+    def visible(self) -> bool:
+        if self.renderer.mode == "pdf":
+            return self.component.get("showInPdf", True)
+        elif self.renderer.mode == "confirmation_email":
+            ...
+
+    @property
     def label(self) -> str:
         return self.component.get("label") or self.component.get("key", "")
 
@@ -34,9 +41,15 @@ class FormioConfigurationNode(Node):
         return ""
 
     def __iter__(self) -> Iterator[ComponentNode]:
+        if not self.visible:
+            return
+
         for component in self.step.form_step.iter_components(
             recursive=True, _mark_root=True
         ):
+            if not component.visible:
+                continue
+
             key = component["key"]
             value = self.step.data.get(key)
             yield ComponentNode(

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -164,6 +164,22 @@ class FieldSetNode(ComponentNode):
         return True
 
 
+@register("columns")
+class ColumnsNode(ComponentNode):
+    @property
+    def is_visible(self) -> bool:
+        visible_from_config = super().is_visible
+
+        if not visible_from_config:
+            return False
+
+        any_children_visible = any((child.is_visible for child in self.get_children()))
+        if not any_children_visible:
+            return False
+
+        return True
+
+
 @dataclass
 class FormioConfigurationNode(Node):
     # TODO: use dynamic SubmissionStep configuration instead which has the logic evaluated!

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -129,7 +129,6 @@ class ComponentNode(Node):
             if not child.is_visible:
                 continue
 
-            yield child
             yield from child
 
     @property

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+from openforms.submissions.models import SubmissionStep
+from openforms.submissions.rendering.base import Node
+
+from .formatters.service import format_value
+from .typing import Component
+
+
+@dataclass
+class ComponentNode(Node):
+    component: Component
+    value: Any
+
+    @property
+    def label(self) -> str:
+        return self.component.get("label") or self.component.get("key", "")
+
+    @property
+    def display_value(self) -> str:
+        return format_value(self.component, self.value, as_html=self.renderer.as_html)
+
+    def render(self) -> str:
+        return f"{self.label}\t\t\t{self.display_value}"
+
+
+@dataclass
+class FormioConfigurationNode(Node):
+    # TODO: use dynamic SubmissionStep configuration instead which has the logic evaluated!
+    step: SubmissionStep
+
+    def render(self) -> str:
+        return ""
+
+    def __iter__(self) -> Iterator[ComponentNode]:
+        for component in self.step.form_step.iter_components(
+            recursive=True, _mark_root=True
+        ):
+            key = component["key"]
+            value = self.step.data.get(key)
+            yield ComponentNode(
+                component=component, value=value, renderer=self.renderer
+            )

--- a/src/openforms/formio/rendering.py
+++ b/src/openforms/formio/rendering.py
@@ -1,24 +1,113 @@
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, Optional
 
 from openforms.submissions.models import SubmissionStep
 from openforms.submissions.rendering.base import Node
+from openforms.submissions.rendering.constants import RenderModes
 
 from .formatters.service import format_value
 from .typing import Component
+from .utils import iter_components
+
+if TYPE_CHECKING:
+    from openforms.submissions.rendering.renderer import Renderer
+
+
+COMPONENT_TYPE_NODES = {}
+
+
+@dataclass
+class RenderConfiguration:
+    attribute: Optional[str]
+    default: bool
+
+
+VISIBILITY_ATTRIBUTE_MAP = {
+    RenderModes.cli: RenderConfiguration(attribute=None, default=True),
+    RenderModes.pdf: RenderConfiguration(attribute="showInPDF", default=True),
+    RenderModes.confirmation_email: RenderConfiguration(
+        attribute="showInEmail", default=False
+    ),
+    RenderModes.export: RenderConfiguration(attribute=None, default=True),
+}
+"""
+Map render modes to the component configuration key to check with their defaults.
+"""
 
 
 @dataclass
 class ComponentNode(Node):
     component: Component
-    value: Any
+    step: SubmissionStep
+
+    @staticmethod
+    def build_node(
+        step: SubmissionStep, component: Component, renderer: "Renderer"
+    ) -> "ComponentNode":
+        """
+        Instantiate the most specific node type for a given component type.
+        """
+        node_cls = COMPONENT_TYPE_NODES.get(component["type"], ComponentNode)
+        nested_node = node_cls(step=step, component=component, renderer=renderer)
+        return nested_node
 
     @property
-    def visible(self) -> bool:
-        if self.renderer.mode == "pdf":
-            return self.component.get("showInPdf", True)
-        elif self.renderer.mode == "confirmation_email":
-            ...
+    def is_visible(self) -> bool:
+        """
+        Implement the logic to determine if a component is visible.
+
+        See https://github.com/open-formulieren/open-forms/issues/1451#issuecomment-1077506877
+        for a diagram of the logic powering this.
+
+        Summarized, a component is visible for a given render mode if the component-level
+        configuration says so (while falling back to some defaults for older configurations).
+
+        The exceptions to this are:
+
+        - fieldsets are visible if:
+          - any of the children is visible (no render_mode dependency)
+          - not `hidden` (no render_mode dependency)
+          - (not `hideHeader`) -> render children, but not the label
+
+        - fieldsets:
+          - never render the label
+
+        - wysiwyg:
+          - in PDF if visible
+        """
+        render_configuration = VISIBILITY_ATTRIBUTE_MAP[self.renderer.mode]
+        if render_configuration.attribute is None:
+            return render_configuration.default
+        should_render = self.component.get(
+            render_configuration.attribute, render_configuration.default
+        )
+        return should_render
+
+    @property
+    def value(self) -> Any:
+        key = self.component["key"]
+        value = self.step.data.get(key)
+        return value
+
+    def __iter__(self) -> Iterator["ComponentNode"]:
+        """
+        Yield depth-first children.
+        """
+        if not self.is_visible:
+            return
+
+        yield self
+
+        for component in iter_components(
+            configuration=self.component, recursive=False, _is_root=False
+        ):
+            nested_node = ComponentNode.build_node(
+                step=self.step, component=component, renderer=self.renderer
+            )
+            if not nested_node.is_visible:
+                continue
+            yield nested_node
+            yield from nested_node
 
     @property
     def label(self) -> str:
@@ -40,18 +129,25 @@ class FormioConfigurationNode(Node):
     def render(self) -> str:
         return ""
 
+    @property
+    def is_visible(self) -> bool:
+        # TODO: move to SubmissionStepNode
+        # determine if the step as a whole is relevant or not. The stap may be not
+        # applicable because of form logic.
+        logic_evaluated = getattr(self.step, "_form_logic_evaluated", False)
+        assert (
+            logic_evaluated
+        ), "You should ensure that the form logic is evaluated before rendering steps!"
+        return self.step.is_applicable
+
     def __iter__(self) -> Iterator[ComponentNode]:
-        if not self.visible:
+        if not self.is_visible:
             return
 
         for component in self.step.form_step.iter_components(
-            recursive=True, _mark_root=True
+            recursive=False, _mark_root=True
         ):
-            if not component.visible:
-                continue
-
-            key = component["key"]
-            value = self.step.data.get(key)
-            yield ComponentNode(
-                component=component, value=value, renderer=self.renderer
+            nested_node = ComponentNode.build_node(
+                step=self.step, component=component, renderer=self.renderer
             )
+            yield from nested_node

--- a/src/openforms/forms/models/form_definition.py
+++ b/src/openforms/forms/models/form_definition.py
@@ -131,16 +131,6 @@ class FormDefinition(models.Model):
         keys = [field["key"] for field in self.iter_components(recursive=True)]
         return keys
 
-    def get_keys_for_email_summary(self) -> List[Tuple[str, str]]:
-        """Return the key and the label of fields to include in the email summary"""
-        keys_for_email_summary = []
-
-        for component in self.iter_components(recursive=True):
-            if component.get("showInEmail"):
-                keys_for_email_summary.append((component["key"], component["label"]))
-
-        return keys_for_email_summary
-
     def get_keys_for_email_confirmation(self) -> List[Tuple[str, str]]:
         """Return the key and the label of fields to include in the confirmation email"""
         keys_for_email_confirmation = []

--- a/src/openforms/forms/tests/test_models.py
+++ b/src/openforms/forms/tests/test_models.py
@@ -256,24 +256,6 @@ class FormDefinitionTestCase(TestCase):
             _("{name} (copy)").format(name="A internal"),
         )
 
-    def test_get_keys_for_email_summary(self):
-        form_definition = FormDefinitionFactory.create(
-            configuration={
-                "display": "form",
-                "components": [
-                    {"key": "aaa", "label": "AAA", "showInEmail": True},
-                    {"key": "bbb", "label": "BBB", "showInEmail": False},
-                    {"key": "ccc", "label": "CCC", "showInEmail": True},
-                ],
-            }
-        )
-
-        keys = form_definition.get_keys_for_email_summary()
-
-        self.assertIn(("aaa", "AAA"), keys)
-        self.assertNotIn(("bbb", "BBB"), keys)
-        self.assertIn(("ccc", "CCC"), keys)
-
     def test_get_keys_for_email_confirmation(self):
         form_definition = FormDefinitionFactory.create(
             configuration={

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -58,6 +58,7 @@ class EmailRegistration(BasePlugin):
         options: EmailOptions,
         extra_context=None,
     ):
+        # TODO: refactor to use openforms.submissions.rendering.renderer.Renderer
         # extract the formatted data first
         printable_data: list = submission.get_printable_data()
         # get the attachment data, keyed by form component key, value is a model instance

--- a/src/openforms/submissions/management/commands/render_confirmation_pdf.py
+++ b/src/openforms/submissions/management/commands/render_confirmation_pdf.py
@@ -22,3 +22,4 @@ class Command(BaseCommand):
         report, _ = SubmissionReport.objects.get_or_create(submission=submission)
 
         report.generate_submission_report_pdf()
+        self.stdout.write(f"Generated pdf: {report.content.path}")

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "submission_id",
             type=int,
+            nargs="+",
             help="Submission ID to display data from.",
         )
         parser.add_argument(
@@ -41,17 +42,22 @@ class Command(BaseCommand):
         if not settings.DEBUG:
             raise CommandError("This command is only allowed in dev environments")
 
-        submission = Submission.objects.get(pk=options["submission_id"])
-        limit_value_keys = options["limit_value_key"]
+        self.limit_value_keys = options["limit_value_key"]
+        for submission_id in options["submission_id"]:
+            self.render_submission(submission_id)
+
+    def render_submission(self, submission_id: int):
+        submission = Submission.objects.get(pk=submission_id)
 
         renderer = Renderer(
             submission=submission,
             mode=RenderModes.cli,
             as_html=False,
-            limit_value_keys=limit_value_keys or None,
+            limit_value_keys=self.limit_value_keys or None,
         )
 
         self.stdout.write("")
+        self.stdout.write(f"Submission {submission.id} - ", ending="")
 
         prev_node_type, tabulate_data = None, []
 

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -3,6 +3,8 @@ from django.core.management import BaseCommand, CommandError
 
 from tabulate import tabulate
 
+from openforms.formio.rendering import ComponentNode
+
 from ...models import Submission
 from ...rendering.renderer import Renderer, RenderModes
 
@@ -65,10 +67,10 @@ class Command(BaseCommand):
             indent_size = INDENT_SIZES.get(node.type, 0)
             lead = INDENT * indent_size
 
-            if node.type == "ComponentNode":
+            if isinstance(node, ComponentNode):
                 # extract label + value for tabulate data
                 tabulate_data.append([node.label, node.display_value])
-                prev_node_type = node.type
+                prev_node_type = "ComponentNode"
                 continue
             else:
                 # changed from component node to something else -> print the tabular data

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -10,7 +10,7 @@ from ...rendering.renderer import Renderer, RenderModes
 
 INDENT_SIZES = {
     "FormNode": 0,
-    "FormStepNode": 1,
+    "SubmissionStepNode": 1,
     "ComponentNode": 2,
 }
 
@@ -92,10 +92,6 @@ class Command(BaseCommand):
                 if prev_node_type == "ComponentNode":
                     self._print_tabulate_data(tabulate_data)
                     tabulate_data = []
-
-            if node.type == "SubmissionStepNode":
-                prev_node_type = node.type
-                continue
 
             if lead:
                 self.stdout.write(lead, ending="")

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -42,7 +42,13 @@ class Command(BaseCommand):
         parser.add_argument(
             "--as-html",
             action="store_true",
-            help=("Enable HTML output instead of plain text."),
+            help="Enable HTML output instead of plain text.",
+        )
+        parser.add_argument(
+            "--render-mode",
+            choices=[c[0] for c in RenderModes.choices],
+            default=RenderModes.cli,
+            help=f"Simulate a particular render mode. Defaults to {RenderModes.cli}",
         )
 
     def handle(self, **options):
@@ -51,14 +57,18 @@ class Command(BaseCommand):
 
         self.limit_value_keys = options["limit_value_key"]
         for submission_id in options["submission_id"]:
-            self.render_submission(submission_id, as_html=options["as_html"])
+            self.render_submission(
+                submission_id,
+                render_mode=options["render_mode"],
+                as_html=options["as_html"],
+            )
 
-    def render_submission(self, submission_id: int, as_html=False):
+    def render_submission(self, submission_id: int, render_mode: str, as_html=False):
         submission = Submission.objects.get(pk=submission_id)
 
         renderer = Renderer(
             submission=submission,
-            mode=RenderModes.cli,
+            mode=render_mode,
             as_html=as_html,
             limit_value_keys=self.limit_value_keys or None,
         )

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -39,6 +39,11 @@ class Command(BaseCommand):
                 "specified multiple times."
             ),
         )
+        parser.add_argument(
+            "--as-html",
+            action="store_true",
+            help=("Enable HTML output instead of plain text."),
+        )
 
     def handle(self, **options):
         if not settings.DEBUG:
@@ -46,15 +51,15 @@ class Command(BaseCommand):
 
         self.limit_value_keys = options["limit_value_key"]
         for submission_id in options["submission_id"]:
-            self.render_submission(submission_id)
+            self.render_submission(submission_id, as_html=options["as_html"])
 
-    def render_submission(self, submission_id: int):
+    def render_submission(self, submission_id: int, as_html=False):
         submission = Submission.objects.get(pk=submission_id)
 
         renderer = Renderer(
             submission=submission,
             mode=RenderModes.cli,
-            as_html=False,
+            as_html=as_html,
             limit_value_keys=self.limit_value_keys or None,
         )
 

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -1,0 +1,34 @@
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+
+from ...models import Submission
+
+
+class Command(BaseCommand):
+    help = (
+        "Display the submission data in the terminal. This is a proof of concept of a "
+        "generic rendering API capable of outputting to different modes."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "submission_id",
+            type=int,
+            help="Submission ID to display data from.",
+        )
+        parser.add_argument(
+            "-l",
+            "--limit-value-key",
+            nargs="+",
+            help=(
+                "If provided, limits the output data keys to the specified set. Can be "
+                "specified multiple times."
+            ),
+        )
+
+    def handle(self, **options):
+        if not settings.DEBUG:
+            raise CommandError("This command is only allowed in dev environments")
+
+        submission = Submission.objects.get(pk=options["submission_id"])
+        limit_value_keys = options["limit_value_key"]

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -7,6 +7,7 @@ from ...rendering.renderer import Renderer, RenderModes
 INDENT_SIZES = {
     "FormNode": 0,
     "FormStepNode": 1,
+    "ComponentNode": 2,
 }
 
 

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -4,6 +4,11 @@ from django.core.management import BaseCommand, CommandError
 from ...models import Submission
 from ...rendering.renderer import Renderer, RenderModes
 
+INDENT_SIZES = {
+    "FormNode": 0,
+    "FormStepNode": 1,
+}
+
 
 class Command(BaseCommand):
     help = (
@@ -41,5 +46,14 @@ class Command(BaseCommand):
             limit_value_keys=limit_value_keys or None,
         )
 
+        self.stdout.write("")
         for node in renderer.render():
+            if node.type == "SubmissionStepNode":
+                continue
+
+            indent_size = INDENT_SIZES[node.type]
+            lead = "    " * indent_size
+            if lead:
+                self.stdout.write(lead, ending="")
+
             self.stdout.write(node.render())

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 
 from ...models import Submission
+from ...rendering.renderer import Renderer, RenderModes
 
 
 class Command(BaseCommand):
@@ -32,3 +33,13 @@ class Command(BaseCommand):
 
         submission = Submission.objects.get(pk=options["submission_id"])
         limit_value_keys = options["limit_value_key"]
+
+        renderer = Renderer(
+            submission=submission,
+            mode=RenderModes.cli,
+            as_html=False,
+            limit_value_keys=limit_value_keys or None,
+        )
+
+        for node in renderer.render():
+            self.stdout.write(node.render())

--- a/src/openforms/submissions/models.py
+++ b/src/openforms/submissions/models.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os.path
 import uuid
+import warnings
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from datetime import date, timedelta
@@ -579,6 +580,12 @@ class Submission(models.Model):
         keys_to_include: Optional[List[str]] = None,
         as_html=False,
     ) -> List[Tuple[str, str]]:
+        warnings.warn(
+            "Submission.get_printable_data() is deprecated - instead, use "
+            "'openforms.submissions.rendering.renderer.Renderer' with an appropriate "
+            "render mode.",
+            DeprecationWarning,
+        )
         printable_data = []
 
         for key, (

--- a/src/openforms/submissions/rendering/base.py
+++ b/src/openforms/submissions/rendering/base.py
@@ -1,0 +1,46 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .renderer import Renderer
+
+NODE_TYPES = {}
+
+
+@dataclass
+class Node(ABC):
+    """
+    Abstract node base class.
+
+    All specific render node types must inherit from this class.
+    """
+
+    renderer: "Renderer"
+
+    def __init_subclass__(cls, **kwargs):
+        # register subclasses as node types so we can pass this to django template
+        # rendering context
+        NODE_TYPES[cls.__name__] = cls
+
+    @property
+    def type(self) -> str:
+        """
+        Name of the node type
+        """
+        return type(self).__name__
+
+    @property
+    def mode(self) -> str:
+        return self.renderer.mode
+
+    @property
+    def as_html(self) -> bool:
+        return self.renderer.as_html
+
+    @abstractmethod
+    def render(self) -> str:
+        """
+        Output the result of rendering the particular type of node given a context.
+        """
+        ...

--- a/src/openforms/submissions/rendering/constants.py
+++ b/src/openforms/submissions/rendering/constants.py
@@ -1,0 +1,11 @@
+from django.utils.translation import gettext_lazy as _
+
+from djchoices import ChoiceItem, DjangoChoices
+
+
+class RenderModes(DjangoChoices):
+    cli = ChoiceItem("cli", _("CLI"))
+    pdf = ChoiceItem("pdf", _("PDF"))
+    confirmation_email = ChoiceItem("confirmation_email", _("Confirmation email"))
+    export = ChoiceItem("export", _("Submission export"))
+    # registration_email = ChoiceItem('registration_email', _("Registration email"))

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -1,7 +1,6 @@
 """
 High-level submission renderer capable of outputting to different modes.
 """
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Iterator, List, Optional
 
@@ -9,11 +8,11 @@ from django.utils.translation import gettext_lazy as _
 
 from djchoices import ChoiceItem, DjangoChoices
 
+from openforms.formio.rendering import FormioConfigurationNode
 from openforms.forms.models import Form, FormStep
 
 from ..models import Submission, SubmissionStep
-
-NODE_TYPES = {}
+from .base import Node
 
 
 class RenderModes(DjangoChoices):
@@ -50,44 +49,11 @@ class Renderer:
         for step in steps_qs:
             yield SubmissionStepNode(step=step, **common_kwargs)
             yield FormStepNode(step=step.form_step, **common_kwargs)
-
-
-@dataclass
-class Node(ABC):
-    """
-    Abstract node base class.
-
-    All specific render node types must inherit from this class.
-    """
-
-    renderer: Renderer
-
-    def __init_subclass__(cls, **kwargs):
-        # register subclasses as node types so we can pass this to django template
-        # rendering context
-        NODE_TYPES[cls.__name__] = cls
-
-    @property
-    def type(self) -> str:
-        """
-        Name of the node type
-        """
-        return type(self).__name__
-
-    @property
-    def mode(self) -> str:
-        return self.renderer.mode
-
-    @property
-    def as_html(self) -> bool:
-        return self.renderer.as_html
-
-    @abstractmethod
-    def render(self) -> str:
-        """
-        Output the result of rendering the particular type of node given a context.
-        """
-        ...
+            # at this point, hand over to the formio specific implementation details
+            formio_configuration_node = FormioConfigurationNode(
+                step=step, **common_kwargs
+            )
+            yield from formio_configuration_node
 
 
 @dataclass

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -65,12 +65,21 @@ class Renderer:
             # an instance here without persisting it to the backend on purpose!
             # this replicates the run-time behaviour while filling out the form
             step.form_step.form_definition.configuration = new_configuration
-            yield SubmissionStepNode(step=step, **common_kwargs)
-            yield FormStepNode(step=step.form_step, **common_kwargs)
-            # at this point, hand over to the formio specific implementation details
+
+            submission_step_node = SubmissionStepNode(step=step, **common_kwargs)
+            form_step_node = FormStepNode(step=step.form_step, **common_kwargs)
             formio_configuration_node = FormioConfigurationNode(
                 step=step, **common_kwargs
             )
+            has_any_children = any(
+                child.is_visible for child in formio_configuration_node
+            )
+            if not has_any_children:
+                continue
+
+            yield submission_step_node
+            yield form_step_node
+            # at this point, hand over to the formio specific implementation details
             yield from formio_configuration_node
 
 

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -1,0 +1,34 @@
+"""
+High-level submission renderer capable of outputting to different modes.
+"""
+from dataclasses import dataclass
+from typing import List, Optional
+
+from django.utils.translation import gettext_lazy as _
+
+from djchoices import ChoiceItem, DjangoChoices
+
+from openforms.forms.models import Form
+
+from ..models import Submission
+
+
+class RenderModes(DjangoChoices):
+    cli = ChoiceItem("cli", _("CLI"))
+    pdf = ChoiceItem("pdf", _("PDF"))
+    confirmation_email = ChoiceItem("confirmation_email", _("Confirmation email"))
+    export = ChoiceItem("export", _("Submission export"))
+    # registration_email = ChoiceItem('registration_email', _("Registration email"))
+
+
+@dataclass
+class Renderer:
+    # render context
+    submission: Submission
+    mode: str
+    as_html: bool
+    limit_value_keys: Optional[List[str]] = None
+
+    @property
+    def form(self) -> Form:
+        return self.submission.form

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -11,7 +11,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 
 from openforms.formio.rendering import FormioConfigurationNode
-from openforms.forms.models import Form, FormStep
+from openforms.forms.models import Form
 
 from ..form_logic import evaluate_form_logic
 from ..models import Submission, SubmissionStep
@@ -37,37 +37,41 @@ class Renderer:
     as_html: bool
     limit_value_keys: Optional[List[str]] = None
 
+    def __post_init__(self):
+        self.dummy_request = get_request()
+
     @property
     def form(self) -> Form:
         return self.submission.form
 
-    def render(self) -> Iterator["Node"]:
-        common_kwargs = {"renderer": self}
-        dummy_request = get_request()
-
-        # emit a FormNode so the form itself is accessible
-        yield FormNode(**common_kwargs)
-
-        # now emit the form steps, which in turn emit their children in a depth-first
-        # pattern.
+    @property
+    def steps(self):
         steps_qs = self.submission.submissionstep_set.select_related(
             "form_step", "form_step__form_definition"
         ).order_by("form_step__order")
-        for step in steps_qs:
+        return steps_qs
+
+    def get_children(self) -> Iterator["SubmissionStepNode"]:
+        """
+        Produce only the direct child nodes.
+        """
+        common_kwargs = {"renderer": self}
+        for step in self.steps:
             new_configuration = evaluate_form_logic(
                 submission=self.submission,
                 step=step,
                 data=self.submission.data,
                 dirty=False,
-                request=dummy_request,
+                request=self.dummy_request,
             )
             # update the configuration for introspection - note that we are mutating
             # an instance here without persisting it to the backend on purpose!
             # this replicates the run-time behaviour while filling out the form
             step.form_step.form_definition.configuration = new_configuration
-
             submission_step_node = SubmissionStepNode(step=step, **common_kwargs)
-            form_step_node = FormStepNode(step=step.form_step, **common_kwargs)
+            if not submission_step_node.is_visible:
+                continue
+
             formio_configuration_node = FormioConfigurationNode(
                 step=step, **common_kwargs
             )
@@ -76,11 +80,19 @@ class Renderer:
             )
             if not has_any_children:
                 continue
-
             yield submission_step_node
-            yield form_step_node
-            # at this point, hand over to the formio specific implementation details
-            yield from formio_configuration_node
+
+    def render(self) -> Iterator["Node"]:
+        common_kwargs = {"renderer": self}
+
+        # emit a FormNode so the form itself is accessible
+        yield FormNode(**common_kwargs)
+
+        # now emit the form steps, which in turn emit their children in a depth-first
+        # pattern.
+        for submission_step_node in self.get_children():
+            yield submission_step_node
+            yield from submission_step_node.get_children()
 
 
 @dataclass
@@ -94,14 +106,26 @@ class FormNode(Node):
 class SubmissionStepNode(Node):
     step: SubmissionStep
 
+    @property
+    def is_visible(self) -> bool:
+        # determine if the step as a whole is relevant or not. The stap may be not
+        # applicable because of form logic.
+        logic_evaluated = getattr(self.step, "_form_logic_evaluated", False)
+        assert (
+            logic_evaluated
+        ), "You should ensure that the form logic is evaluated before rendering steps!"
+        return self.step.is_applicable
+
     def render(self) -> str:
-        return ""
-
-
-@dataclass
-class FormStepNode(Node):
-    step: FormStep
-
-    def render(self) -> str:
-        form_definition = self.step.form_definition
+        form_definition = self.step.form_step.form_definition
         return form_definition.name
+
+    def get_children(self) -> Iterator["Node"]:
+        if not self.is_visible:
+            return
+
+        # at this point, hand over to the formio specific implementation details
+        formio_configuration_node = FormioConfigurationNode(
+            step=self.step, renderer=self.renderer
+        )
+        yield from formio_configuration_node

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -1,16 +1,19 @@
 """
 High-level submission renderer capable of outputting to different modes.
 """
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from django.utils.translation import gettext_lazy as _
 
 from djchoices import ChoiceItem, DjangoChoices
 
-from openforms.forms.models import Form
+from openforms.forms.models import Form, FormStep
 
-from ..models import Submission
+from ..models import Submission, SubmissionStep
+
+NODE_TYPES = {}
 
 
 class RenderModes(DjangoChoices):
@@ -32,3 +35,80 @@ class Renderer:
     @property
     def form(self) -> Form:
         return self.submission.form
+
+    def render(self) -> Iterator["Node"]:
+        common_kwargs = {"renderer": self}
+
+        # emit a FormNode so the form itself is accessible
+        yield FormNode(**common_kwargs)
+
+        # now emit the form steps, which in turn emit their children in a depth-first
+        # pattern.
+        steps_qs = self.submission.submissionstep_set.select_related(
+            "form_step", "form_step__form_definition"
+        ).order_by("form_step__order")
+        for step in steps_qs:
+            yield SubmissionStepNode(step=step, **common_kwargs)
+            yield FormStepNode(step=step.form_step, **common_kwargs)
+
+
+@dataclass
+class Node(ABC):
+    """
+    Abstract node base class.
+
+    All specific render node types must inherit from this class.
+    """
+
+    renderer: Renderer
+
+    def __init_subclass__(cls, **kwargs):
+        # register subclasses as node types so we can pass this to django template
+        # rendering context
+        NODE_TYPES[cls.__name__] = cls
+
+    @property
+    def type(self) -> str:
+        """
+        Name of the node type
+        """
+        return type(self).__name__
+
+    @property
+    def mode(self) -> str:
+        return self.renderer.mode
+
+    @property
+    def as_html(self) -> bool:
+        return self.renderer.as_html
+
+    @abstractmethod
+    def render(self) -> str:
+        """
+        Output the result of rendering the particular type of node given a context.
+        """
+        ...
+
+
+@dataclass
+class FormNode(Node):
+    def render(self) -> str:
+        form = self.renderer.form
+        return form.name
+
+
+@dataclass
+class SubmissionStepNode(Node):
+    step: SubmissionStep
+
+    def render(self) -> str:
+        return ""
+
+
+@dataclass
+class FormStepNode(Node):
+    step: FormStep
+
+    def render(self) -> str:
+        form_definition = self.step.form_definition
+        return form_definition.name

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -3,73 +3,28 @@ Utility classes for the submission report rendering.
 """
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING
 
 from django.utils.safestring import SafeString
 
-from openforms.formio.formatters.service import format_value
-from openforms.formio.typing import Component
 from openforms.forms.models import Form
 
 if TYPE_CHECKING:
-    from .models import Submission, SubmissionStep
+    from .models import Submission
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class DataItem:
-    component: Component
-    value: Any
-
-    @property
-    def label(self) -> str:
-        return self.component.get("label") or self.component.get("key", "")
-
-    @property
-    def layout_modifier(self) -> str:
-        type = self.component.get("type")
-        if type == "fieldset":
-            return "fieldset"
-        elif type == "columns":
-            return "columns"
-        return "root" if self.component.get("_is_root", False) else ""
-
-    @property
-    def display_value(self) -> str:
-        return format_value(self.component, self.value, as_html=True)
-
-
-@dataclass
-class ReportStep:
-    """
-    A wrapper around a submission step outputting the step-specific data.
-    """
-
-    step: "SubmissionStep"
-
-    @property
-    def title(self) -> str:
-        return self.step.form_step.form_definition.name
-
-    def __iter__(self) -> Iterator[DataItem]:
-        """
-        Return the individual 'key-value' items for the data in the step.
-        """
-        # TODO: find a better mechanism to extract the "root" information instead of
-        # polluting the Formio component schema, preferably without breaking a lot of tests
-        iter_components = self.step.form_step.iter_components(
-            recursive=True, _mark_root=True
-        )
-        for component in iter_components:
-            key = component["key"]
-            value = self.step.data.get(key)
-            yield DataItem(component=component, value=value)
-
-
-@dataclass
 class Report:
     submission: "Submission"
+
+    def __post_init__(self):
+        from .rendering.renderer import Renderer, RenderModes
+
+        self.renderer = Renderer(
+            submission=self.submission, mode=RenderModes.pdf, as_html=True
+        )
 
     @property
     def form(self) -> Form:
@@ -78,11 +33,6 @@ class Report:
     @property
     def show_payment_info(self) -> bool:
         return self.submission.payment_required and self.submission.price
-
-    @property
-    def steps(self) -> Iterator[ReportStep]:
-        for step in self.submission.submissionstep_set.order_by("form_step__order"):
-            yield ReportStep(step=step)
 
     @property
     def co_signer(self) -> str:

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -40,19 +40,18 @@
                 {% endcomment %}
             </section>
 
-            {% for step in report.steps %}
+            {% for submission_step_node in report.renderer.get_children %}
                 <div class="submission-step">
-                    <h2 class="subtitle">{{ step.title }}</h2>
-
-                    {% for item in step %}
-                        <div class="submission-step-row {% if item.layout_modifier %}submission-step-row--{{ item.layout_modifier }}{% endif %}">
+                    <h2 class="subtitle">{{ submission_step_node.render }}</h2>
+                    {% for component_node in submission_step_node.get_children %}
+                        <div class="submission-step-row {% if component_node.layout_modifier %}submission-step-row--{{ component_node.layout_modifier }}{% endif %}">
 
                             <div class="submission-step-row__label">
-                                {{ item.label }}
+                                {{ component_node.label }}
                             </div>
 
                             <div class="submission-step-row__value">
-                                {{ item.display_value }}
+                                {{ component_node.display_value }}
                             </div>
 
                         </div>

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -127,7 +127,8 @@ def send_confirmation_email(submission: Submission):
     text_content = strip_tags_plus(
         render_confirmation_email_template(
             content_template, context, rendering_text=True
-        )
+        ),
+        keep_leading_whitespace=True,
     )
 
     try:


### PR DESCRIPTION
Replaces #1468
Fixes #1451

Implements a renderer utility class to output submissions in different "render modes". This deprecates `Submission.get_printable_data` and the `{% display_value %}` template tag.

TODO:

- [x] Clean up implementation and commit history
- [x] Document management command and Python API
- [x] Add/update tests
- [ ] Write management command/diagnostic to detect usage of deprecated template tags/functionalities
- [ ] Add formio options for `showInFoo`