### PR TITLE
Set up plumbing for FormIO in submission rendering

### DIFF
--- a/src/openforms/formio/rendering/__init__.py
+++ b/src/openforms/formio/rendering/__init__.py
@@ -1,0 +1,19 @@
+"""
+Implement the bindings with :mod:`openforms.submissions.rendering.Renderer`.
+
+Formio is currently the engine powering the form definitions/configurations which
+brings along some implementation details. The specifics of rendering Formio
+configurations together with the data of a submission are contained in this subpackage.
+
+The module :mod:`openforms.submissions.rendering.nodes` contains the (base) node
+classes with their public API. For specific Formio component types, you can register
+a more specific subclass using the registry. The vanilla Formio components requiring
+special attention are implemented in :mod:`openforms.submissions.rendering.default`.
+"""
+from .nodes import ComponentNode
+from .registry import register
+
+__all__ = [
+    "register",
+    "ComponentNode",
+]

--- a/src/openforms/formio/rendering/conf.py
+++ b/src/openforms/formio/rendering/conf.py
@@ -1,0 +1,18 @@
+from openforms.submissions.rendering.constants import RenderModes
+
+from .constants import RenderConfigurationOptions
+from .nodes import RenderConfiguration
+
+RENDER_CONFIGURATION = {
+    # RenderModes.cli: RenderConfiguration(key=None, default=True),
+    RenderModes.pdf: RenderConfiguration(
+        RenderConfigurationOptions.show_in_pdf, default=True
+    ),
+    RenderModes.confirmation_email: RenderConfiguration(
+        RenderConfigurationOptions.show_in_confirmation_email, default=False
+    ),
+    RenderModes.export: RenderConfiguration(key=None, default=True),
+}
+"""
+Map render modes to the component configuration key to check, with their defaults.
+"""

--- a/src/openforms/formio/rendering/constants.py
+++ b/src/openforms/formio/rendering/constants.py
@@ -1,0 +1,11 @@
+from django.utils.translation import gettext_lazy as _
+
+from djchoices import ChoiceItem, DjangoChoices
+
+
+class RenderConfigurationOptions(DjangoChoices):
+    show_in_summary = ChoiceItem("showInSummary", _("Show in summary"))
+    show_in_pdf = ChoiceItem("showInPDF", _("Show in PDF"))
+    show_in_confirmation_email = ChoiceItem(
+        "showInEmail", _("Show in confirmation email")
+    )

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional, Union
+
+from openforms.submissions.models import SubmissionStep
+from openforms.submissions.rendering import Renderer, RenderModes
+from openforms.submissions.rendering.base import Node
+
+from ..formatters.service import format_value
+from ..typing import Component
+from ..utils import iter_components
+
+
+@dataclass
+class RenderConfiguration:
+    """
+    Component-level property configuration to control output.
+
+    Whether a component should be emitted or not is/can be configured on the component
+    in the form designer. In the event that this key is missing from the component (
+    because it is not supported or is a form definition from before this feature
+    landed), then fall back using the ``default``.
+    """
+
+    key: Optional[str]
+    default: bool
+
+
+@dataclass
+class ComponentNode(Node):
+    component: Component
+    step: SubmissionStep
+    depth: int = 0
+    is_layout = False
+
+    @staticmethod
+    def build_node(
+        step: SubmissionStep,
+        component: Component,
+        renderer: "Renderer",
+        depth: int = 0,
+    ) -> "ComponentNode":
+        """
+        Instantiate the most specific node type for a given component type.
+        """
+        from .registry import register
+
+        node_cls = register[component["type"]]
+        nested_node = node_cls(
+            step=step, component=component, renderer=renderer, depth=depth
+        )
+        return nested_node
+
+    @property
+    def is_visible(self) -> bool:
+        """
+        Implement the logic to determine if a component is visible.
+
+        See https://github.com/open-formulieren/open-forms/issues/1451#issuecomment-1077506877
+        for a diagram of the logic powering this.
+
+        Summarized, a component is visible for a given render mode if the component-level
+        configuration says so (while falling back to some defaults for older configurations).
+
+        The exceptions to this are:
+        - fieldsets are visible if:
+          - any of the children is visible (no render_mode dependency)
+          - not `hidden` (no render_mode dependency)
+          - (not `hideHeader`) -> render children, but not the label
+        - fieldsets:
+          - never render the label
+        - wysiwyg:
+          - in PDF if visible
+
+        These exceptions are handled in more specific subclasses to avoid massive if-else
+        branches again, see :mod:`openforms.formio.rendering.default`.
+        """
+        from .conf import RENDER_CONFIGURATION  # circular import
+
+        # explicitly hidden components never show up. Note that this property can be set
+        # by form logic!
+        if self.component.get("hidden") is True:
+            return False
+
+        render_configuration = RENDER_CONFIGURATION[self.renderer.mode]
+        # it's possible the end-user cannot explicitly configure the visibility, in
+        # which case the system default is used.
+        if render_configuration.attribute is None:
+            return render_configuration.default
+
+        # if there is an attribute, try to read it but fall back to the system default
+        # if it's absent.
+        should_render = self.component.get(
+            render_configuration.attribute, render_configuration.default
+        )
+        return should_render
+
+    @property
+    def value(self) -> Any:
+        """
+        Obtain the value from the submission for this component.
+
+        Note that this returns an unformatted value. There also has not been done
+        any Formio type -> Python type casting, so a datetime will be an ISO-8601
+        datestring for example.
+
+        TODO: build and use the type conversion for Formio components.
+        """
+        key = self.component["key"]
+        value = self.step.data.get(key)
+        return value
+
+    def get_children(self) -> Iterator["ComponentNode"]:
+        """
+        Yield the child components if this component is a container type.
+        """
+        for component in iter_components(
+            configuration=self.component, recursive=False, _is_root=False
+        ):
+            yield ComponentNode.build_node(
+                step=self.step,
+                component=component,
+                renderer=self.renderer,
+                depth=self.depth + 1,
+            )
+
+    def __iter__(self) -> Iterator["ComponentNode"]:
+        """
+        Yield depth-first children, including itself.
+        """
+        if not self.is_visible:
+            return
+
+        yield self
+        for child in self.get_children():
+            if not child.is_visible:
+                continue
+            yield from child
+
+    @property
+    def layout_modifier(self) -> str:
+        """
+        For HTML based rendering, potentially emit a layout modifier.
+        """
+        return "root" if self.component.get("_is_root", False) else ""
+
+    @property
+    def label(self) -> str:
+        """
+        Obtain the (human-readable) label for the Formio component.
+        """
+        if self.renderer.mode == RenderModes.export:
+            return self.component.get("key") or "KEY_MISSING"
+        return self.component.get("label") or self.component.get("key", "")
+
+    @property
+    def display_value(self) -> Union[str, Any]:
+        """
+        Format the value according to the render mode and/or output content type.
+
+        This applies the registry of Formio formatters to the value based on the
+        component type, using :func:`openforms.formio.formatter.service.format_value`.
+        """
+        # in export mode, expose the raw datatype
+        if self.renderer.mode == RenderModes.export:
+            return self.value
+        return format_value(self.component, self.value, as_html=self.renderer.as_html)
+
+    def render(self) -> str:
+        """
+        Output a simple key-value pair of label and value.
+        """
+        indent = "    " * self.depth if not self.as_html else ""
+        return f"{indent}{self.label}: {self.display_value}"

--- a/src/openforms/formio/rendering/registry.py
+++ b/src/openforms/formio/rendering/registry.py
@@ -1,0 +1,36 @@
+from typing import Type
+
+from openforms.plugins.registry import BaseRegistry
+
+from .nodes import ComponentNode
+
+
+class Registry(BaseRegistry):
+    module = "formio"
+
+    def __call__(self, unique_identifier: str, *args, **kwargs) -> callable:
+        """
+        Overridden from base class because we register classes instead of instances.
+        """
+
+        def decorator(klass: Type[ComponentNode]) -> Type[ComponentNode]:
+            if unique_identifier in self._registry:
+                raise ValueError(
+                    f"The unique identifier '{unique_identifier}' is already present "
+                    "in the registry."
+                )
+            if not issubclass(klass, ComponentNode):
+                raise TypeError("Node class must subclass 'ComponentNode'")
+            self._registry[unique_identifier] = klass
+            return klass
+
+        return decorator
+
+    def __getitem__(self, key: str) -> Type[ComponentNode]:
+        try:
+            return self._registry[key]
+        except KeyError:
+            return ComponentNode
+
+
+register = Registry()

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -1,0 +1,318 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from openforms.forms.tests.factories import FormFactory
+from openforms.submissions.rendering import Renderer, RenderModes
+from openforms.submissions.tests.factories import (
+    SubmissionFactory,
+    SubmissionStepFactory,
+)
+
+from ..constants import RenderConfigurationOptions
+from ..nodes import ComponentNode
+from ..registry import Registry
+
+# from rest_framework.reverse import reverse
+
+
+class FormNodeTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        form = FormFactory.create(
+            name="public name",
+            internal_name="internal name",
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    # visible component, leaf node
+                    {
+                        "type": "textfield",
+                        "key": "input1",
+                        "label": "Input 1",
+                        "hidden": False,
+                    },
+                    # hidden component, leaf node
+                    {
+                        "type": "textfield",
+                        "key": "input2",
+                        "label": "Input 2",
+                        "hidden": True,
+                    },
+                    # visible in PDF and confirmation email component, leaf node
+                    {
+                        "type": "textfield",
+                        "key": "input3",
+                        "label": "Input 3",
+                        "hidden": False,
+                        RenderConfigurationOptions.show_in_pdf: True,
+                        RenderConfigurationOptions.show_in_confirmation_email: True,
+                    },
+                    # hidden in PDF and confirmation email component, leaf node
+                    {
+                        "type": "textfield",
+                        "key": "input4",
+                        "label": "Input 4",
+                        "hidden": False,
+                        RenderConfigurationOptions.show_in_pdf: False,
+                        RenderConfigurationOptions.show_in_confirmation_email: False,
+                    },
+                    # visible in PDF and hidden in confirmation email component, leaf node
+                    {
+                        "type": "textfield",
+                        "key": "input5",
+                        "label": "Input 5",
+                        "hidden": False,
+                        RenderConfigurationOptions.show_in_pdf: True,
+                        RenderConfigurationOptions.show_in_confirmation_email: False,
+                    },
+                    # hidden in PDF and visible in confirmation email component, leaf node
+                    {
+                        "type": "textfield",
+                        "key": "input6",
+                        "label": "Input 6",
+                        "hidden": False,
+                        RenderConfigurationOptions.show_in_pdf: False,
+                        RenderConfigurationOptions.show_in_confirmation_email: True,
+                    },
+                    # container: visible fieldset without visible children
+                    {
+                        "type": "fieldset",
+                        "label": "A container without visible children",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "input7",
+                                "label": "Input 7",
+                                "hidden": True,
+                            }
+                        ],
+                    },
+                    # container: visible fieldset with visible children
+                    {
+                        "type": "fieldset",
+                        "label": "A container with visible children",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "input8",
+                                "label": "Input 8",
+                                "hidden": True,
+                            },
+                            {
+                                "type": "textfield",
+                                "key": "input9",
+                                "label": "Input 9",
+                                "hidden": False,
+                            },
+                        ],
+                    },
+                    # container: hidden fieldset with 'visible' children
+                    {
+                        "type": "fieldset",
+                        "label": "A hidden container with visible children",
+                        "hidden": True,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "input10",
+                                "label": "Input 10",
+                                "hidden": False,
+                            }
+                        ],
+                    },
+                    # TODO container: columns
+                ]
+            },
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        step = SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form.formstep_set.get(),
+            data={
+                "input1": "aaaaa",
+                "input2": "bbbbb",
+                "input3": "ccccc",
+                "input4": "ddddd",
+                "input5": "eeeee",
+                "input6": "fffff",
+                "input7": "ggggg",
+                "input8": "hhhhh",
+                "input9": "iiiii",
+            },
+        )
+
+        # expose test data to test methods
+        cls.submission = submission
+        cls.step = step
+
+    def test_generic_node_builder(self):
+        """
+        Assert that ComponentNode.build_node produces node instances.
+        """
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take a simple component
+        component = self.step.form_step.form_definition.configuration["components"][0]
+        assert component["key"] == "input1"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertIsInstance(component_node, ComponentNode)
+        self.assertEqual(component_node.depth, 0)
+        self.assertTrue(component_node.is_visible)
+        self.assertEqual(component_node.value, "aaaaa")
+        self.assertEqual(component_node.display_value, "aaaaa")
+        self.assertEqual(component_node.label, "Input 1")
+        self.assertEqual(list(component_node.get_children()), [])
+        nodelist = list(component_node)
+        self.assertEqual(nodelist, [component_node])
+        self.assertEqual(component_node.render(), "Input 1: aaaaa")
+
+    def test_generic_node_builder_specific_subclasses(self):
+        # set up mock registry and component class for test
+        register = Registry()
+
+        @register("textfield")
+        class TextFieldNode(ComponentNode):
+            pass
+
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take a simple component
+        component = self.step.form_step.form_definition.configuration["components"][0]
+        assert component["key"] == "input1"
+
+        with patch("openforms.formio.rendering.registry.register", new=register):
+            component_node = ComponentNode.build_node(
+                step=self.step, component=component, renderer=renderer
+            )
+
+        self.assertIsInstance(component_node, TextFieldNode)
+
+    def test_explicitly_hidden_component_skipped(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+
+        with self.subTest("Simple hidden leaf component"):
+            component = self.step.form_step.form_definition.configuration["components"][
+                1
+            ]
+            assert component["key"] == "input2"
+            assert component["hidden"]
+
+            component_node = ComponentNode.build_node(
+                step=self.step, component=component, renderer=renderer
+            )
+
+            nodelist = list(component_node)
+
+            self.assertEqual(nodelist, [])
+
+        with self.subTest("Nested hidden component"):
+            fieldset = self.step.form_step.form_definition.configuration["components"][
+                6
+            ]
+            assert not fieldset["hidden"]
+
+            # set up mock registry and component class for test
+            register = Registry()
+
+            with patch("openforms.formio.rendering.registry.register", new=register):
+                component_node = ComponentNode.build_node(
+                    step=self.step, component=fieldset, renderer=renderer
+                )
+
+                nodelist = list(component_node)
+
+            self.assertEqual(len(nodelist), 1)
+            self.assertEqual(nodelist[0].label, "A container without visible children")
+
+    def test_export_always_emits_all_nodes(self):
+        renderer = Renderer(self.submission, mode=RenderModes.export, as_html=False)
+
+        nodelist = []
+        for component in self.step.form_step.form_definition.configuration[
+            "components"
+        ]:
+            component_node = ComponentNode.build_node(
+                step=self.step, component=component, renderer=renderer
+            )
+            nodelist += list(component_node)
+
+        self.assertEqual(len(nodelist), 10)
+        labels = [node.label for node in nodelist]
+        self.assertEqual(
+            labels,
+            [
+                "input1",
+                "input2",
+                "input3",
+                "input4",
+                "input5",
+                "input6",
+                "input7",
+                "input8",
+                "input9",
+                "input10",
+            ],
+        )
+
+    def test_render_mode_pdf(self):
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=True)
+        # set up mock registry without special fieldset behaviour
+        register = Registry()
+
+        nodelist = []
+        with patch("openforms.formio.rendering.registry.register", new=register):
+            for component in self.step.form_step.form_definition.configuration[
+                "components"
+            ]:
+                component_node = ComponentNode.build_node(
+                    step=self.step, component=component, renderer=renderer
+                )
+                nodelist += list(component_node)
+
+        self.assertEqual(len(nodelist), 6)
+        labels = [node.label for node in nodelist]
+        expected_labels = [
+            "Input 1",
+            "Input 3",
+            "Input 5",
+            "A container without visible children",
+            "A container with visible children",
+            "Input 9",
+        ]
+        self.assertEqual(labels, expected_labels)
+
+    def test_render_mode_confirmation_email(self):
+        renderer = Renderer(
+            self.submission, mode=RenderModes.confirmation_email, as_html=True
+        )
+        # set up mock registry without special fieldset behaviour
+        register = Registry()
+
+        nodelist = []
+        with patch("openforms.formio.rendering.registry.register", new=register):
+            for component in self.step.form_step.form_definition.configuration[
+                "components"
+            ]:
+                component_node = ComponentNode.build_node(
+                    step=self.step, component=component, renderer=renderer
+                )
+                nodelist += list(component_node)
+
+        self.assertEqual(len(nodelist), 2)
+        labels = [node.label for node in nodelist]
+        expected_labels = [
+            "Input 3",
+            "Input 6",
+        ]
+        self.assertEqual(labels, expected_labels)

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from rest_framework.reverse import reverse
 


### PR DESCRIPTION
Related to #1451

This adds a specialized Formio component node subclass, capable of emitting its own child nodes (if present) and formatting label/value appropriately.

On top of that, it puts the registry in place to register specific subclasses for formio components, and sets up the Formio component properties to control output in different render modes. This includes setting a default value for existing forms that don't have these keys defined (yet).

Commented out code and TODOs are still intentional and will follow in later PRs.