### PR TITLE
Implement specific formio type nodes

### DIFF
--- a/docs/developers/backend/core/submission-renderer.rst
+++ b/docs/developers/backend/core/submission-renderer.rst
@@ -56,3 +56,34 @@ Node types
 
 .. autoclass:: openforms.submissions.rendering.nodes.SubmissionStepNode
    :members:
+
+
+Formio integration
+------------------
+
+The renderers extend to the FormIO component types.
+
+You can :ref:`extend <developers_extending>` your custom FormIO types by using the
+register hook, the mechanism is identical to the usual :ref:`plugin system <plugins_index>`.
+
+**Example**
+
+.. code-block:: python
+
+    from openforms.formio.rendering.nodes import ComponentNode
+    from openforms.formio.rendering.registry import register
+
+
+    @register("my-custom-component-type")
+    class MyCustomComponentType(ComponentNode):
+        ...
+
+.. automodule:: openforms.formio.rendering.nodes
+   :members:
+
+**Vanilla FormIO components**
+
+The following component types are automatically picked up by Open Forms
+
+.. automodule:: openforms.formio.rendering.default
+   :members:

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -174,6 +174,7 @@ INSTALLED_APPS = [
     "openforms.emails",
     "openforms.formio",
     "openforms.formio.formatters.apps.FormIOFormattersApp",
+    "openforms.formio.rendering",
     "openforms.forms",
     "openforms.multidomain",
     "openforms.products",

--- a/src/openforms/formio/rendering/__init__.py
+++ b/src/openforms/formio/rendering/__init__.py
@@ -10,10 +10,3 @@ classes with their public API. For specific Formio component types, you can regi
 a more specific subclass using the registry. The vanilla Formio components requiring
 special attention are implemented in :mod:`openforms.submissions.rendering.default`.
 """
-from .nodes import ComponentNode
-from .registry import register
-
-__all__ = [
-    "register",
-    "ComponentNode",
-]

--- a/src/openforms/formio/rendering/apps.py
+++ b/src/openforms/formio/rendering/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class FormioRenderingConfig(AppConfig):
+    name = "openforms.formio.rendering"
+    label = "formio_rendering"
+
+    def ready(self):
+        # register plugins
+        from . import default  # noqa

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,0 +1,102 @@
+from typing import Iterator, Union
+
+from django.utils.safestring import SafeString, mark_safe
+
+from openforms.emails.utils import strip_tags_plus  # TODO: put somewhere else
+from openforms.submissions.rendering.constants import RenderModes
+
+from ..utils import iter_components
+from .conf import RENDER_CONFIGURATION
+from .nodes import ComponentNode
+from .registry import register
+
+
+class ContainerMixin:
+    is_layout = True
+
+    @property
+    def is_visible(self) -> bool:
+        # fieldset does not support the showInFoo properties, so we don't use the super
+        # class.
+        if self.mode == RenderModes.export:
+            return True
+
+        if self.component.get("hidden") is True:
+            return False
+
+        render_configuration = RENDER_CONFIGURATION[self.mode]
+        if render_configuration.key is not None:
+            assert render_configuration.key not in self.component, (
+                f"Component type {self.component['type']} unexpectedly seems to support "
+                f"the {render_configuration.key} property!"
+            )
+
+        any_children_visible = any((child.is_visible for child in self.get_children()))
+        if not any_children_visible:
+            return False
+
+        return True
+
+
+@register("fieldset")
+class FieldSetNode(ContainerMixin, ComponentNode):
+    layout_modifier = "fieldset"
+
+
+@register("columns")
+class ColumnsNode(ContainerMixin, ComponentNode):
+    layout_modifier = "columns"
+
+    def get_children(self) -> Iterator["ComponentNode"]:
+        """
+        Columns has a extra nested structure contained within.
+
+
+        .. code-block:: python
+
+            {
+                "type": "columns",
+                "columns": [
+                    {
+                        "size": 6,
+                        "components": [...],
+                    },
+                    {
+                        "size": 6,
+                        "components": [...],
+                    }
+                ],
+            }
+        """
+        for column in self.component["columns"]:
+            for component in iter_components(
+                configuration=column, recursive=False, _is_root=False
+            ):
+                yield ComponentNode.build_node(
+                    step=self.step,
+                    component=component,
+                    renderer=self.renderer,
+                    depth=self.depth + 1,
+                )
+
+
+@register("content")
+class WYSIWYGNode(ComponentNode):
+    @property
+    def is_visible(self) -> bool:
+        visible_from_config = super().is_visible
+        if not visible_from_config:
+            return False
+        return self.mode in (
+            # RenderModes.cli,
+            RenderModes.pdf,
+        )
+
+    @property
+    def value(self) -> Union[str, SafeString]:
+        content = self.component["html"]
+        if self.as_html:
+            return mark_safe(content)
+
+        content_without_tags = strip_tags_plus(content)
+        return content_without_tags.rstrip()

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -51,7 +51,7 @@ class ColumnsNode(ContainerMixin, ComponentNode):
 
     def get_children(self) -> Iterator["ComponentNode"]:
         """
-        Columns has a extra nested structure contained within.
+        Columns has an extra nested structure contained within.
 
 
         .. code-block:: python

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -46,6 +46,8 @@ class FieldSetNode(ContainerMixin, ComponentNode):
 @register("columns")
 class ColumnsNode(ContainerMixin, ComponentNode):
     layout_modifier = "columns"
+    label = ""  # 1451 -> never output a label
+    value = None  # columns never have a value
 
     def get_children(self) -> Iterator["ComponentNode"]:
         """

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -62,13 +62,19 @@ class ComponentNode(Node):
         configuration says so (while falling back to some defaults for older configurations).
 
         The exceptions to this are:
+
         - fieldsets are visible if:
+
           - any of the children is visible (no render_mode dependency)
           - not `hidden` (no render_mode dependency)
           - (not `hideHeader`) -> render children, but not the label
+
         - fieldsets:
+
           - never render the label
+
         - wysiwyg:
+
           - in PDF if visible
 
         These exceptions are handled in more specific subclasses to avoid massive if-else

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -13,8 +13,6 @@ from ..constants import RenderConfigurationOptions
 from ..nodes import ComponentNode
 from ..registry import Registry
 
-# from rest_framework.reverse import reverse
-
 
 class FormNodeTests(TestCase):
     @classmethod

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -196,7 +196,6 @@ class FormNodeTests(TestCase):
     def test_fieldsets_hidden_if_all_children_hidden(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
-        # take
         component = self.step.form_step.form_definition.configuration["components"][0]
         assert component["type"] == "fieldset"
 
@@ -210,7 +209,6 @@ class FormNodeTests(TestCase):
     def test_fieldsets_visible_if_any_child_visible(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
-        # take
         component = self.step.form_step.form_definition.configuration["components"][1]
         assert component["type"] == "fieldset"
 
@@ -227,7 +225,6 @@ class FormNodeTests(TestCase):
     def test_fieldset_hidden_if_marked_as_such_and_visible_children(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
-        # take
         component = self.step.form_step.form_definition.configuration["components"][2]
         assert component["type"] == "fieldset"
 
@@ -241,7 +238,6 @@ class FormNodeTests(TestCase):
     def test_columns_hidden_if_all_children_hidden(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
-        # take
         component = self.step.form_step.form_definition.configuration["components"][3]
         assert component["type"] == "columns"
 
@@ -255,7 +251,6 @@ class FormNodeTests(TestCase):
     def test_columns_visible_if_any_child_visible(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
-        # take
         component = self.step.form_step.form_definition.configuration["components"][4]
         assert component["type"] == "columns"
 
@@ -266,13 +261,12 @@ class FormNodeTests(TestCase):
         self.assertTrue(component_node.is_visible)
         nodelist = list(component_node)
         self.assertEqual(len(nodelist), 2)
-        self.assertEqual(nodelist[0].label, "Columns 2")
+        self.assertEqual(nodelist[0].component["label"], "Columns 2")
         self.assertEqual(nodelist[1].label, "Input 7")
 
     def test_column_hidden_if_marked_as_such_and_visible_children(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
-        # take
         component = self.step.form_step.form_definition.configuration["components"][5]
         assert component["type"] == "columns"
 
@@ -282,6 +276,21 @@ class FormNodeTests(TestCase):
 
         self.assertFalse(component_node.is_visible)
         self.assertEqual(list(component_node), [])
+
+    def test_columns_never_output_label(self):
+        component = self.step.form_step.form_definition.configuration["components"][5]
+        assert component["type"] == "columns"
+
+        for render_mode in RenderModes.values:
+            with self.subTest(render_mode=render_mode):
+                renderer = Renderer(self.submission, mode=render_mode, as_html=False)
+
+                component_node = ComponentNode.build_node(
+                    step=self.step, component=component, renderer=renderer
+                )
+
+                self.assertEqual(component_node.label, "")
+                self.assertIsNone(component_node.value)
 
     def test_wysiwyg_component(self):
         """

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -1,0 +1,284 @@
+"""
+Test the render component node implementations for the built-in Formio component types.
+
+These can be considered integration tests for the Formio aspect, relying on the out
+of the box configuration in Open Forms through the registry.
+"""
+from django.test import TestCase
+
+from openforms.forms.tests.factories import FormFactory
+from openforms.submissions.rendering import Renderer, RenderModes
+from openforms.submissions.tests.factories import (
+    SubmissionFactory,
+    SubmissionStepFactory,
+)
+
+from ..nodes import ComponentNode
+
+
+class FormNodeTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        form = FormFactory.create(
+            name="public name",
+            internal_name="internal name",
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    # container: visible fieldset without visible children
+                    {
+                        "type": "fieldset",
+                        "label": "A container without visible children",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "input1",
+                                "label": "Input 1",
+                                "hidden": True,
+                            }
+                        ],
+                    },
+                    # container: visible fieldset with visible children
+                    {
+                        "type": "fieldset",
+                        "label": "A container with visible children",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "input2",
+                                "label": "Input 2",
+                                "hidden": True,
+                            },
+                            {
+                                "type": "textfield",
+                                "key": "input3",
+                                "label": "Input 3",
+                                "hidden": False,
+                            },
+                        ],
+                    },
+                    # container: hidden fieldset with 'visible' children
+                    {
+                        "type": "fieldset",
+                        "label": "A hidden container with visible children",
+                        "hidden": True,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "input4",
+                                "label": "Input 4",
+                                "hidden": False,
+                            }
+                        ],
+                    },
+                    # container: visible columns without visible children
+                    {
+                        "type": "columns",
+                        "key": "columns1",
+                        "label": "Columns 1",
+                        "hidden": False,
+                        "columns": [
+                            {
+                                "size": 6,
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "input5",
+                                        "label": "Input 5",
+                                        "hidden": True,
+                                    }
+                                ],
+                            },
+                            {
+                                "size": 6,
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "input6",
+                                        "label": "Input 6",
+                                        "hidden": True,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    # container: visible columns with visible children
+                    {
+                        "type": "columns",
+                        "key": "columns2",
+                        "label": "Columns 2",
+                        "hidden": False,
+                        "columns": [
+                            {
+                                "size": 6,
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "input7",
+                                        "label": "Input 7",
+                                        "hidden": False,
+                                    }
+                                ],
+                            },
+                            {
+                                "size": 6,
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "input8",
+                                        "label": "Input 8",
+                                        "hidden": True,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    # container: hidden columns with visible children
+                    {
+                        "type": "columns",
+                        "key": "columns3",
+                        "label": "Columns 3",
+                        "hidden": True,
+                        "columns": [
+                            {
+                                "size": 6,
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "input9",
+                                        "label": "Input 9",
+                                        "hidden": False,
+                                    }
+                                ],
+                            },
+                            {
+                                "size": 6,
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "input10",
+                                        "label": "Input 10",
+                                        "hidden": True,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ]
+            },
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        step = SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form.formstep_set.get(),
+            data={
+                "input1": "aaaaa",
+                "input2": "bbbbb",
+                "input3": "ccccc",
+                "input4": "ddddd",
+                "input6": "fffff",
+                "input7": "ggggg",
+                "input8": "hhhhh",
+                "input9": "iiiii",
+                "input10": "jjjjj",
+            },
+        )
+
+        # expose test data to test methods
+        cls.submission = submission
+        cls.step = step
+
+    def test_fieldsets_hidden_if_all_children_hidden(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take
+        component = self.step.form_step.form_definition.configuration["components"][0]
+        assert component["type"] == "fieldset"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertFalse(component_node.is_visible)
+        self.assertEqual(list(component_node), [])
+
+    def test_fieldsets_visible_if_any_child_visible(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take
+        component = self.step.form_step.form_definition.configuration["components"][1]
+        assert component["type"] == "fieldset"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertTrue(component_node.is_visible)
+        nodelist = list(component_node)
+        self.assertEqual(len(nodelist), 2)
+        self.assertEqual(nodelist[0].label, "A container with visible children")
+        self.assertEqual(nodelist[1].label, "Input 3")
+
+    def test_fieldset_hidden_if_marked_as_such_and_visible_children(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take
+        component = self.step.form_step.form_definition.configuration["components"][2]
+        assert component["type"] == "fieldset"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertFalse(component_node.is_visible)
+        self.assertEqual(list(component_node), [])
+
+    def test_columns_hidden_if_all_children_hidden(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take
+        component = self.step.form_step.form_definition.configuration["components"][3]
+        assert component["type"] == "columns"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertFalse(component_node.is_visible)
+        self.assertEqual(list(component_node), [])
+
+    def test_columns_visible_if_any_child_visible(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take
+        component = self.step.form_step.form_definition.configuration["components"][4]
+        assert component["type"] == "columns"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertTrue(component_node.is_visible)
+        nodelist = list(component_node)
+        self.assertEqual(len(nodelist), 2)
+        self.assertEqual(nodelist[0].label, "Columns 2")
+        self.assertEqual(nodelist[1].label, "Input 7")
+
+    def test_column_hidden_if_marked_as_such_and_visible_children(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        # take
+        component = self.step.form_step.form_definition.configuration["components"][5]
+        assert component["type"] == "columns"
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertFalse(component_node.is_visible)
+        self.assertEqual(list(component_node), [])


### PR DESCRIPTION
Relates to #1451

This PR builds on top of #1554 and implements component-type specifics for Formio components.

**Changes**

- Fieldset and columns type implemented: only render output if there are visible children.
- WYSIWYG: in non-HTML mode, output a plain-text variant of the HTML, and only output HTML in PDF render mode (for a complete summary of the entire form)
- Columns: never output a label