### PR TITLE
Feature/1451 pdf rendering

### DIFF
--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -43,6 +43,13 @@ class FieldSetNode(ContainerMixin, ComponentNode):
     layout_modifier = "fieldset"
     display_value = ""
 
+    @property
+    def label(self) -> str:
+        header_hidden = self.component.get("hideHeader", False)
+        if header_hidden:
+            return ""
+        return super().label
+
     def render(self) -> str:
         return f"{self.indent}{self.label}"
 

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -235,6 +235,23 @@ class FormNodeTests(TestCase):
         self.assertFalse(component_node.is_visible)
         self.assertEqual(list(component_node), [])
 
+    def test_fieldset_with_hidden_label(self):
+        # we always need a renderer instance
+        renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
+        component = {
+            "type": "fieldset",
+            "key": "fieldset",
+            "label": "A hidden label",
+            "hidden": False,
+            "hideHeader": True,
+        }
+
+        component_node = ComponentNode.build_node(
+            step=self.step, component=component, renderer=renderer
+        )
+
+        self.assertEqual(component_node.label, "")
+
     def test_columns_hidden_if_all_children_hidden(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)

--- a/src/openforms/scss/pdfs/_page.scss
+++ b/src/openforms/scss/pdfs/_page.scss
@@ -2,9 +2,12 @@
 
 @page {
   size: A4;
+  margin-bottom: 10mm;
 
   @bottom-center {
     content: counter(page) "/" counter(pages);
+    font-size: 85%;
+    @include text;
   }
 }
 

--- a/src/openforms/scss/pdfs/_submission-step-row.scss
+++ b/src/openforms/scss/pdfs/_submission-step-row.scss
@@ -5,6 +5,10 @@
   justify-content: flex-start;
   align-items: flex-start;
 
+  & + & {
+    margin-top: 1mm;
+  }
+
   &:not(&--root) + &--root {
     padding-top: $grid-margin-1;
   }
@@ -30,6 +34,11 @@
   &__value {
     @include body();
     width: 60%;
+
+    // wysiwyg content
+    p {
+      margin: 0;
+    }
 
     > * {
       max-width: 100%;

--- a/src/openforms/submissions/management/commands/render_confirmation_pdf.py
+++ b/src/openforms/submissions/management/commands/render_confirmation_pdf.py
@@ -22,3 +22,4 @@ class Command(BaseCommand):
         report, _ = SubmissionReport.objects.get_or_create(submission=submission)
 
         report.generate_submission_report_pdf()
+        self.stdout.write(f"Generated pdf: {report.content.path}")

--- a/src/openforms/submissions/rendering/base.py
+++ b/src/openforms/submissions/rendering/base.py
@@ -32,6 +32,16 @@ class Node(ABC):
         """
         return True
 
+    @property
+    def has_children(self) -> bool:
+        generator = self.get_children()
+        try:
+            next(generator)
+        except StopIteration:
+            return False
+        else:
+            return True
+
     @abstractmethod
     def get_children(self) -> Iterator["Node"]:  # pragma: nocover
         """

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -3,73 +3,28 @@ Utility classes for the submission report rendering.
 """
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING
 
 from django.utils.safestring import SafeString
 
-from openforms.formio.formatters.service import format_value
-from openforms.formio.typing import Component
 from openforms.forms.models import Form
 
 if TYPE_CHECKING:
-    from .models import Submission, SubmissionStep
+    from .models import Submission
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class DataItem:
-    component: Component
-    value: Any
-
-    @property
-    def label(self) -> str:
-        return self.component.get("label") or self.component.get("key", "")
-
-    @property
-    def layout_modifier(self) -> str:
-        type = self.component.get("type")
-        if type == "fieldset":
-            return "fieldset"
-        elif type == "columns":
-            return "columns"
-        return "root" if self.component.get("_is_root", False) else ""
-
-    @property
-    def display_value(self) -> str:
-        return format_value(self.component, self.value, as_html=True)
-
-
-@dataclass
-class ReportStep:
-    """
-    A wrapper around a submission step outputting the step-specific data.
-    """
-
-    step: "SubmissionStep"
-
-    @property
-    def title(self) -> str:
-        return self.step.form_step.form_definition.name
-
-    def __iter__(self) -> Iterator[DataItem]:
-        """
-        Return the individual 'key-value' items for the data in the step.
-        """
-        # TODO: find a better mechanism to extract the "root" information instead of
-        # polluting the Formio component schema, preferably without breaking a lot of tests
-        iter_components = self.step.form_step.iter_components(
-            recursive=True, _mark_root=True
-        )
-        for component in iter_components:
-            key = component["key"]
-            value = self.step.data.get(key)
-            yield DataItem(component=component, value=value)
-
-
-@dataclass
 class Report:
     submission: "Submission"
+
+    def __post_init__(self):
+        from .rendering.renderer import Renderer, RenderModes
+
+        self.renderer = Renderer(
+            submission=self.submission, mode=RenderModes.pdf, as_html=True
+        )
 
     @property
     def form(self) -> Form:
@@ -78,11 +33,6 @@ class Report:
     @property
     def show_payment_info(self) -> bool:
         return self.submission.payment_required and self.submission.price
-
-    @property
-    def steps(self) -> Iterator[ReportStep]:
-        for step in self.submission.submissionstep_set.order_by("form_step__order"):
-            yield ReportStep(step=step)
 
     @property
     def co_signer(self) -> str:

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -40,24 +40,27 @@
                 {% endcomment %}
             </section>
 
-            {% for step in report.steps %}
-                <div class="submission-step">
-                    <h2 class="subtitle">{{ step.title }}</h2>
+            {% for submission_step_node in report.renderer.get_children %}
+                {% if submission_step_node.has_children %}
+                    <div class="submission-step">
+                        <h2 class="subtitle">{{ submission_step_node.render }}</h2>
+                        {% for component_node in submission_step_node.get_children %}
+                            {% if component_node.label or component_node.display_value %}
+                                <div class="submission-step-row {% if component_node.layout_modifier %}submission-step-row--{{ component_node.layout_modifier }}{% endif %}">
 
-                    {% for item in step %}
-                        <div class="submission-step-row {% if item.layout_modifier %}submission-step-row--{{ item.layout_modifier }}{% endif %}">
+                                    <div class="submission-step-row__label">
+                                        {{ component_node.label }}
+                                    </div>
 
-                            <div class="submission-step-row__label">
-                                {{ item.label }}
-                            </div>
+                                    <div class="submission-step-row__value">
+                                        {{ component_node.display_value }}
+                                    </div>
 
-                            <div class="submission-step-row__value">
-                                {{ item.display_value }}
-                            </div>
-
-                        </div>
-                    {% endfor %}
-                </div>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                {% endif %}
             {% endfor %}
 
             {% if report.co_signer %}


### PR DESCRIPTION
**Changes**

Refactored the PDF generator to make use of the renderer.

This was already pretty close with the `Report` data class, so that has been stripped and replaced with Renderer implementation bits. Added a couple tests for the actual core issue reported (hidden field labels still being visible -> no longer the case now).

Preview:
![image](https://user-images.githubusercontent.com/5518550/166654478-98a026f3-a018-4c80-bb5f-2c0bdd8c2714.png)
