### PR TITLE
[#1560] Fix to execute prefill on fields within a column format field

### DIFF
--- a/src/openforms/prefill/__init__.py
+++ b/src/openforms/prefill/__init__.py
@@ -174,10 +174,10 @@ def _fetch_prefill_values(
 def _extract_prefill_fields(configuration: JSONObject) -> List[Dict[str, str]]:
     prefills = []
 
-    if ("type" in configuration):
+    if "type" in configuration:
         fieldType = configuration.get("type")
 
-        if (fieldType == "columns"):
+        if fieldType == "columns":
             columns = configuration.get("columns", [])
 
             for column in columns:
@@ -240,10 +240,10 @@ def _set_default_values(
     is inspected for prefill configuration, which is then looked up in
     ``prefilled_values`` to set the component ``defaultValue``.
     """
-    if ("type" in configuration):
+    if "type" in configuration:
         fieldType = configuration.get("type")
 
-        if (fieldType == "columns"):
+        if fieldType == "columns":
             columns = configuration.get("columns", [])
 
             for column in columns:

--- a/src/openforms/utils/tests/html_assert.py
+++ b/src/openforms/utils/tests/html_assert.py
@@ -15,14 +15,14 @@ class HTMLAssertMixin:
         """
         check for html tags and their content while ignoring tag attributes
         """
-        if not re.search(fr"<{tag}(?: [^>]*)?>\s*{text}", document_str):
+        if not re.search(rf"<{tag}(?: [^>]*)?>\s*{text}", document_str):
             self.fail(f"cannot find <{tag}..>{text} in: {document_str}")
 
     def assertNotTagWithTextIn(self, tag, text, document_str):
         """
         check for html tags and their content while ignoring tag attributes
         """
-        if re.search(fr"<{tag}(?: [^>]*)?>\s*{text}", document_str):
+        if re.search(rf"<{tag}(?: [^>]*)?>\s*{text}", document_str):
             self.fail(f"unexpectedly found <{tag}..>{text} in: {document_str}")
 
     def assertHTMLValid(self, html_text):


### PR DESCRIPTION
Fields within a column field were not rendering the selected prefill options.

Fixes: #1560

Changes:
 - Execute prefill configuration within column format fields.