### PR TITLE
Remove docs.github.com from linkcheck ignore list again

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,5 +85,4 @@ linkcheck_ignore = [
     r"https://portal.azure.com*",
     r"https://.*kvk\.nl*",
     r"https://gdpr.eu*",
-    r"https://docs.github.com/*",
 ]


### PR DESCRIPTION
Looks like github made some changes on their end, as these are passing again (locally) without any changes