### PR TITLE
Refactored submission models in multiple files

### DIFF
--- a/src/openforms/submissions/models/__init__.py
+++ b/src/openforms/submissions/models/__init__.py
@@ -1,0 +1,25 @@
+from .submission import Submission, get_default_bsn, get_default_kvk
+from .submission_files import (
+    SubmissionFileAttachment,
+    SubmissionFileAttachmentManager,
+    SubmissionFileAttachmentQuerySet,
+    TemporaryFileUpload,
+    submission_file_upload_to,
+    temporary_file_upload_to,
+)
+from .submission_report import SubmissionReport
+from .submission_step import SubmissionStep
+
+__all__ = [
+    "Submission",
+    "SubmissionStep",
+    "SubmissionReport",
+    "SubmissionFileAttachment",
+    "SubmissionFileAttachmentManager",
+    "SubmissionFileAttachmentQuerySet",
+    "TemporaryFileUpload",
+    "submission_file_upload_to",
+    "temporary_file_upload_to",
+    "get_default_bsn",
+    "get_default_kvk",
+]

--- a/src/openforms/submissions/models/submission_files.py
+++ b/src/openforms/submissions/models/submission_files.py
@@ -1,0 +1,174 @@
+import hashlib
+import logging
+import os.path
+import uuid
+from collections import defaultdict
+from datetime import date, timedelta
+from typing import List, Mapping, Optional, Tuple
+
+from django.core.files.base import File
+from django.db import models
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+from privates.fields import PrivateMediaFileField
+
+from openforms.utils.files import DeleteFileFieldFilesMixin, DeleteFilesQuerySetMixin
+
+from .submission import Submission
+from .submission_step import SubmissionStep
+
+logger = logging.getLogger(__name__)
+
+
+def fmt_upload_to(prefix, instance, filename):
+    name, ext = os.path.splitext(filename)
+    return "{p}/{d}/{u}{e}".format(
+        p=prefix, d=date.today().strftime("%Y/%m/%d"), u=instance.uuid, e=ext
+    )
+
+
+def temporary_file_upload_to(instance, filename):
+    return fmt_upload_to("temporary-uploads", instance, filename)
+
+
+def submission_file_upload_to(instance, filename):
+    return fmt_upload_to("submission-uploads", instance, filename)
+
+
+class TemporaryFileUploadQuerySet(DeleteFilesQuerySetMixin, models.QuerySet):
+    def select_prune(self, age: timedelta):
+        return self.filter(created_on__lt=timezone.now() - age)
+
+
+class TemporaryFileUpload(DeleteFileFieldFilesMixin, models.Model):
+    uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
+    content = PrivateMediaFileField(
+        verbose_name=_("content"),
+        upload_to=temporary_file_upload_to,
+        help_text=_("content of the file attachment."),
+    )
+    file_name = models.CharField(_("original name"), max_length=255)
+    content_type = models.CharField(_("content type"), max_length=255)
+    # store the file size to not have to do disk IO to get the file size
+    file_size = models.PositiveIntegerField(
+        _("file size"),
+        default=0,
+        help_text=_("Size in bytes of the uploaded file."),
+    )
+    created_on = models.DateTimeField(_("created on"), auto_now_add=True)
+
+    objects = TemporaryFileUploadQuerySet.as_manager()
+
+    class Meta:
+        verbose_name = _("temporary file upload")
+        verbose_name_plural = _("temporary file uploads")
+
+
+class SubmissionFileAttachmentQuerySet(DeleteFilesQuerySetMixin, models.QuerySet):
+    def for_submission(self, submission: Submission):
+        return self.filter(submission_step__submission=submission)
+
+    def as_form_dict(self) -> Mapping[str, List["SubmissionFileAttachment"]]:
+        files = defaultdict(list)
+        for file in self:
+            files[file.form_key].append(file)
+        return dict(files)
+
+
+class SubmissionFileAttachmentManager(models.Manager):
+    def create_from_upload(
+        self,
+        submission_step: SubmissionStep,
+        form_key: str,
+        upload: TemporaryFileUpload,
+        file_name: Optional[str] = None,
+    ) -> Tuple["SubmissionFileAttachment", bool]:
+        try:
+            return (
+                self.get(
+                    submission_step=submission_step,
+                    temporary_file=upload,
+                    form_key=form_key,
+                ),
+                False,
+            )
+        except self.model.DoesNotExist:
+            return (
+                self.create(
+                    submission_step=submission_step,
+                    temporary_file=upload,
+                    form_key=form_key,
+                    # wrap in File() so it will be physically copied
+                    content=File(upload.content, name=upload.file_name),
+                    content_type=upload.content_type,
+                    original_name=upload.file_name,
+                    file_name=file_name,
+                ),
+                True,
+            )
+
+
+class SubmissionFileAttachment(DeleteFileFieldFilesMixin, models.Model):
+    uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
+    submission_step = models.ForeignKey(
+        to="SubmissionStep",
+        on_delete=models.CASCADE,
+        verbose_name=_("submission"),
+        help_text=_("Submission step the file is attached to."),
+        related_name="attachments",
+    )
+    # TODO OneToOne?
+    temporary_file = models.ForeignKey(
+        to="TemporaryFileUpload",
+        on_delete=models.SET_NULL,
+        null=True,
+        verbose_name=_("temporary file"),
+        help_text=_("Temporary upload this file is sourced to."),
+        related_name="attachments",
+    )
+    form_key = models.CharField(_("form component key"), max_length=255)
+
+    content = PrivateMediaFileField(
+        verbose_name=_("content"),
+        upload_to=submission_file_upload_to,
+        help_text=_("Content of the submission file attachment."),
+    )
+    file_name = models.CharField(
+        _("file name"), max_length=255, help_text=_("reformatted file name"), blank=True
+    )
+    original_name = models.CharField(
+        _("original name"), max_length=255, help_text=_("original uploaded file name")
+    )
+    content_type = models.CharField(_("content type"), max_length=255)
+    created_on = models.DateTimeField(_("created on"), auto_now_add=True)
+
+    objects = SubmissionFileAttachmentManager.from_queryset(
+        SubmissionFileAttachmentQuerySet
+    )()
+
+    class Meta:
+        verbose_name = _("submission file attachment")
+        verbose_name_plural = _("submission file attachments")
+        # see https://docs.djangoproject.com/en/2.2/topics/db/managers/#using-managers-for-related-object-access
+        base_manager_name = "objects"
+
+    def get_display_name(self):
+        return self.file_name or self.original_name
+
+    def get_format(self):
+        return os.path.splitext(self.get_display_name())[1].lstrip(".")
+
+    @property
+    def content_hash(self) -> str:
+        """
+        Calculate the sha256 hash of the content.
+
+        MD5 is fast, but has known collisions, so we use sha256 instead.
+        """
+        chunk_size = 8192
+        sha256 = hashlib.sha256()
+        with self.content.open(mode="rb") as file_content:
+            while chunk := file_content.read(chunk_size):
+                sha256.update(chunk)
+        return sha256.hexdigest()

--- a/src/openforms/submissions/models/submission_report.py
+++ b/src/openforms/submissions/models/submission_report.py
@@ -1,0 +1,84 @@
+from typing import Optional
+
+from django.core.files.base import ContentFile
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from celery.result import AsyncResult
+from privates.fields import PrivateMediaFileField
+
+from openforms.utils.pdf import render_to_pdf
+
+from ..report import Report
+
+
+class SubmissionReport(models.Model):
+    title = models.CharField(
+        verbose_name=_("title"),
+        max_length=200,
+        help_text=_("Title of the submission report"),
+    )
+    content = PrivateMediaFileField(
+        verbose_name=_("content"),
+        upload_to="submission-reports/%Y/%m/%d",
+        help_text=_("Content of the submission report"),
+    )
+    submission = models.OneToOneField(
+        to="Submission",
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        verbose_name=_("submission"),
+        help_text=_("Submission the report is about."),
+        related_name="report",
+    )
+    last_accessed = models.DateTimeField(
+        verbose_name=_("last accessed"),
+        blank=True,
+        null=True,
+        help_text=_(
+            "When the submission report was last accessed. This value is "
+            "updated when the report is downloaded."
+        ),
+    )
+    task_id = models.CharField(
+        verbose_name=_("task id"),
+        max_length=200,
+        help_text=_(
+            "ID of the celery task creating the content of the report. This is "
+            "used to check the generation status."
+        ),
+        blank=True,
+    )
+
+    class Meta:
+        verbose_name = _("submission report")
+        verbose_name_plural = _("submission reports")
+
+    def __str__(self):
+        return self.title
+
+    def generate_submission_report_pdf(self) -> str:
+        """
+        Generate the submission report as a PDF.
+
+        :return: string with the HTML used for the PDF generation, so that contents
+          can be tested.
+        """
+        form = self.submission.form
+        html_report, pdf_report = render_to_pdf(
+            "report/submission_report.html",
+            context={"report": Report(self.submission)},
+        )
+        self.content = ContentFile(
+            content=pdf_report,
+            name=f"{form.name}.pdf",  # Takes care of replacing spaces with underscores
+        )
+        self.save()
+        return html_report
+
+    def get_celery_task(self) -> Optional[AsyncResult]:
+        if not self.task_id:
+            return
+
+        return AsyncResult(id=self.task_id)

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -1,0 +1,48 @@
+import uuid
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class SubmissionStep(models.Model):
+    """
+    Submission data.
+
+    TODO: This model (and therefore API) allows for the same form step to be
+    submitted multiple times. Can be useful for retrieving historical data or
+    changes made during filling out the form... but...
+    """
+
+    uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
+    submission = models.ForeignKey("submissions.Submission", on_delete=models.CASCADE)
+    form_step = models.ForeignKey("forms.FormStep", on_delete=models.CASCADE)
+    data = models.JSONField(_("data"), blank=True, null=True)
+    created_on = models.DateTimeField(_("created on"), auto_now_add=True)
+    modified = models.DateTimeField(_("modified on"), auto_now=True)
+
+    # can be modified by logic evaluations/checks
+    _can_submit = True
+    _is_applicable = True
+
+    class Meta:
+        verbose_name = _("Submission step")
+        verbose_name_plural = _("Submission steps")
+        unique_together = (("submission", "form_step"),)
+
+    def __str__(self):
+        return f"SubmissionStep {self.pk}: Submission {self.submission_id} submitted on {self.created_on}"
+
+    @property
+    def completed(self) -> bool:
+        # TODO: should check that all the data for the form definition is present?
+        # and validates?
+        # For now - if it's been saved, we assume that was because it was completed
+        return bool(self.pk and self.data is not None)
+
+    @property
+    def can_submit(self) -> bool:
+        return self._can_submit
+
+    @property
+    def is_applicable(self) -> bool:
+        return self._is_applicable

--- a/src/openforms/tests/test_csp.py
+++ b/src/openforms/tests/test_csp.py
@@ -90,7 +90,7 @@ class FormInlineStyleCSPTests(CSPMixin, APITestCase):
 
 @patch("openforms.submissions.status.AsyncResult")
 @patch(
-    "openforms.submissions.models.GlobalConfiguration.get_solo",
+    "openforms.submissions.models.submission.GlobalConfiguration.get_solo",
     return_value=GlobalConfiguration(),
 )
 class SubmissionConfirmationInlineStyleCSPTests(CSPMixin, APITestCase):
@@ -164,7 +164,7 @@ class SubmissionConfirmationInlineStyleCSPTests(CSPMixin, APITestCase):
 
 
 @patch(
-    "openforms.submissions.models.GlobalConfiguration.get_solo",
+    "openforms.submissions.models.submission.GlobalConfiguration.get_solo",
     return_value=GlobalConfiguration(),
 )
 class ConfigInlineStyleCSPTests(CSPMixin, SubmissionsMixin, APITestCase):


### PR DESCRIPTION
The `models.py` in the submission module was getting huge. So I moved the models to a `model` folder.