### PR TITLE
[#1574] Dropped Django 2.x SameSiteNoneCookieMiddlware

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -460,9 +460,9 @@ LOGOUT_REDIRECT_URL = reverse_lazy("admin:index")
 #
 SESSION_COOKIE_SECURE = IS_HTTPS
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SAMESITE = (
-    None  # from Lax -> None to enable the SDK to send CORS requests
-)
+# set same-site attribute to None to allow emdedding the SDK for making cross domain
+# requests.
+SESSION_COOKIE_SAMESITE = config("SESSION_COOKIE_SAMESITE", default="None")
 
 CSRF_COOKIE_SECURE = IS_HTTPS
 

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -217,7 +217,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "openforms.middleware.SameSiteNoneCookieMiddlware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     # 'django.middleware.locale.LocaleMiddleware',
     "corsheaders.middleware.CorsMiddleware",

--- a/src/openforms/middleware.py
+++ b/src/openforms/middleware.py
@@ -1,29 +1,8 @@
 from datetime import timedelta
 
-from django.conf import settings
-
 from openforms.config.models import GlobalConfiguration
 
-# for CORS, the session cookie must be set with SameSite "None" to be sent.
-# This is a breaking change by Chrome, which was not going to be backported in Django
-# 2.2.x. It's available from Django 3.1 onwards.
-SAMESITE_VALUE = "None"
-
 SESSION_EXPIRES_IN_HEADER = "X-Session-Expires-In"
-
-
-class SameSiteNoneCookieMiddlware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        origin = request.headers.get("Origin")
-        response = self.get_response(request)
-        if settings.SESSION_COOKIE_NAME in response.cookies:
-            # only set to None if we're in a cross-origin context (indicated by the Origin header)
-            value = SAMESITE_VALUE if origin and not settings.DEBUG else "Lax"
-            response.cookies[settings.SESSION_COOKIE_NAME]["samesite"] = value
-        return response
 
 
 class SessionTimeoutMiddleware:


### PR DESCRIPTION
Closes #1574