### PR TITLE
Add management command to check for template tag usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ omit =
     src/openforms/plugins/management/commands/disable_demo_plugins.py
     src/openforms/payments/management/commands/checkpaymentemaildupes.py
     src/openforms/registrations/contrib/email/views.py
+    src/openforms/utils/management/commands/detect_deprecated_tags_usage.py
 
 [coverage:report]
 omit =
@@ -64,3 +65,4 @@ omit =
     src/openforms/plugins/management/commands/disable_demo_plugins.py
     src/openforms/payments/management/commands/checkpaymentemaildupes.py
     src/openforms/registrations/contrib/email/views.py
+    src/openforms/utils/management/commands/detect_deprecated_tags_usage.py

--- a/src/openforms/utils/management/commands/detect_deprecated_tags_usage.py
+++ b/src/openforms/utils/management/commands/detect_deprecated_tags_usage.py
@@ -1,0 +1,47 @@
+from typing import Tuple
+
+from django.apps import apps
+from django.core.management import BaseCommand
+
+DEPRECATED_TAGS = ("{% display_value",)
+
+
+MODELS_AND_FIELDS = (
+    (
+        "config.GlobalConfiguration",
+        (
+            "submission_confirmation_template",
+            "confirmation_email_subject",
+            "confirmation_email_content",
+        ),
+    ),
+    (
+        "forms.Form",
+        (
+            "submission_confirmation_template",
+            "explanation_template",
+        ),
+    ),
+)
+
+
+class Command(BaseCommand):
+    help = "Detect deprecated template tag usage in user-templates"
+
+    def handle(self, **options):
+        for model, fields in MODELS_AND_FIELDS:
+            self.check_model(model, fields)
+
+        self.stdout.write("Done checking.")
+
+    def check_model(self, model: str, fields: Tuple[str]):
+        model_cls = apps.get_model(model)
+
+        for tag in DEPRECATED_TAGS:
+            filters = {f"{field}__contains": tag for field in fields}
+            queryset = model_cls.objects.filter(**filters).values_list("id", flat=True)
+            if not queryset:
+                continue
+            self.stdout.write(
+                f"Model {model} instances containing deprecated tag '{tag}': {', '.join(queryset)}"
+            )


### PR DESCRIPTION
Should also be easily copy-pasteable in running production instances without deploying 1.1.0, to get a clear picture.

Related to #1451 