### PR TITLE
add translation for validation error key

### DIFF
--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -296,5 +296,6 @@
   "Make this component read only": "Maak dit component alleen-lezen",
   "(optional)": "(optioneel)",
   "Uploading file...": "Bezig met uploaden...",
-  "Please wait for the file(s) upload to finish before continuing.": "Wacht tot het uploaden van de bestanden is voltooid voordat u verdergaat."
+  "Please wait for the file(s) upload to finish before continuing.": "Wacht tot het uploaden van de bestanden is voltooid voordat u verdergaat.",
+  "array_nonempty": "Dit veld moet minstens één waarde hebben."
 }


### PR DESCRIPTION
Fixes #1344

Formio runs both the multiple and required validators, leading to
multiple error messages being shown, which is not ideal.

![image](https://user-images.githubusercontent.com/5518550/167637622-8fa36704-1c4e-4932-ac00-dd7f7265e3a2.png)
