### PR TITLE
[#1584] Use the original filename when downloading submission attachments

### DIFF
--- a/src/openforms/submissions/tests/test_attachment_download_view.py
+++ b/src/openforms/submissions/tests/test_attachment_download_view.py
@@ -112,9 +112,11 @@ class SubmissionAttachmentDownloadTest(WebTest):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Content-Disposition", response.headers)
-        self.assertTrue(
-            response.headers["Content-Disposition"].startswith("attachment;")
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f'attachment; filename="{submission_file_attachment.get_display_name()}"',
         )
+
         self.assertIn("X-Accel-Redirect", response.headers)
 
 

--- a/src/openforms/submissions/views.py
+++ b/src/openforms/submissions/views.py
@@ -190,7 +190,7 @@ class SubmissionAttachmentDownloadView(LoginRequiredMixin, PrivateMediaView):
         submission_attachment = self.get_object()
         opts = {
             "attachment": True,
-            "attachment_filename": submission_attachment.file_name,
+            "attachment_filename": submission_attachment.get_display_name(),
             "mimetype": submission_attachment.content_type,
         }
         return opts


### PR DESCRIPTION
Fixes #1584