### PR TITLE
Deprecated Submission.get_next_step as it's not actually used

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4651,6 +4651,7 @@ components:
           format: uri
           readOnly: true
           nullable: true
+          deprecated: true
         submissionAllowed:
           allOf:
           - $ref: '#/components/schemas/SubmissionAllowedEnum'

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -112,6 +113,7 @@ class NestedSubmissionPaymentDetailSerializer(serializers.ModelSerializer):
         )
 
 
+@extend_schema_serializer(deprecate_fields=["next_step"])
 class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
     steps = NestedSubmissionStepSerializer(
         label=_("Submission steps"),

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+import warnings
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
@@ -87,6 +88,10 @@ class SubmissionState:
 
         If there are no more steps, the result is None.
         """
+        warnings.warn(
+            "'SubmissionState.get_next_step' is deprecated and scheduled for removal.",
+            DeprecationWarning,
+        )
         offset = self._get_step_offset()
         candidates = (
             step
@@ -467,6 +472,10 @@ class Submission(models.Model):
         """
         Determine which is the next step for the current submission.
         """
+        warnings.warn(
+            "'Submission.get_next_step' is deprecated and scheduled for removal.",
+            DeprecationWarning,
+        )
         submission_state = self.load_execution_state()
         return submission_state.get_next_step()
 


### PR DESCRIPTION
To be removed when we go for `2.0` together with all other deprecated code.