### PR TITLE
Fix prefill fields in columns not working

### DIFF
--- a/src/openforms/formio/typing.py
+++ b/src/openforms/formio/typing.py
@@ -5,7 +5,10 @@ Formio components are JSON blobs adhering to a formio-specific schema. We define
 (subsets) of these schema's to make it easier to reason about the code operating on
 (parts of) the schema.
 """
+# TODO: on python 3.11+ we can use typing.NotRequired to mark keys that may be absent
 from typing import TypedDict
+
+from openforms.typing import JSONValue
 
 
 class OptionDict(TypedDict):
@@ -18,6 +21,11 @@ class OptionDict(TypedDict):
 
     value: str
     label: str
+
+
+class PrefillConfiguration(TypedDict):
+    plugin: str
+    attribute: str
 
 
 class Component(TypedDict):
@@ -40,3 +48,5 @@ class Component(TypedDict):
     label: str
     multiple: bool
     hidden: bool
+    defaultValue: JSONValue
+    prefill: PrefillConfiguration

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict
+from typing import Any, Dict, Iterator
+
+from .typing import Component
 
 
 def iter_components(
     configuration: dict, recursive=True, _is_root=True, _mark_root=False
-) -> dict:
+) -> Iterator[Component]:
     components = configuration.get("components")
     if configuration.get("type") == "columns" and recursive:
         assert not components, "Both nested components and columns found"


### PR DESCRIPTION
Fixes #1560

Refactored prefill extract/set-values to use `openforms.formio.utils.iter_components` so that we get all components in the tree (and thus all layout variants).