### PR TITLE
Avoid CSRF error on form complete when authenticated (in the admin)

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2290,8 +2290,6 @@ paths:
         required: true
       tags:
       - submissions
-      security:
-      - cookieAuth: []
       responses:
         '200':
           content:
@@ -2341,8 +2339,6 @@ paths:
             schema:
               $ref: '#/components/schemas/SubmissionSuspension'
         required: true
-      security:
-      - cookieAuth: []
       responses:
         '201':
           content:

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -142,7 +142,9 @@ class SubmissionViewSet(
         },
     )
     @transaction.atomic()
-    @action(detail=True, methods=["post"], url_name="complete")
+    @action(
+        detail=True, methods=["post"], authentication_classes=(), url_name="complete"
+    )
     def _complete(self, request, *args, **kwargs):
         """
         Mark the submission as completed.
@@ -260,7 +262,9 @@ class SubmissionViewSet(
         },
     )
     @transaction.atomic()
-    @action(detail=True, methods=["post"], url_name="suspend")
+    @action(
+        detail=True, methods=["post"], authentication_classes=(), url_name="suspend"
+    )
     def _suspend(self, request, *args, **kwargs):
         """
         Suspend the submission.


### PR DESCRIPTION
Fixes #1627

We avoid CSRF checks by disabling authentication on the suspend/complete endpoints for a submission. Other endpoints are not affected, as they are PUT/DELETE methods instead of POST.