### PR TITLE
[#1643] Set default value for text validate.maxLength in Form Designer

### DIFF
--- a/src/openforms/js/components/form/edit/tabs.js
+++ b/src/openforms/js/components/form/edit/tabs.js
@@ -285,6 +285,7 @@ const TEXT_VALIDATION = {
       type: 'number',
       tooltip: 'The maximum length requirement this field must meet.',
       input: true,
+      defaultValue: 1000 * 10,
     },
     REGEX_VALIDATION,
   ],

--- a/src/openforms/js/components/form/textarea.js
+++ b/src/openforms/js/components/form/textarea.js
@@ -38,7 +38,17 @@ const textareaTabs = {
   components: [textareaBasicTab, ADVANCED, TEXT_VALIDATION],
 };
 
-class TextArea extends Formio.Components.components.textarea {
+const FormioTextarea = Formio.Components.components.textarea;
+
+class TextArea extends FormioTextarea {
+  static schema(...extend) {
+    return FormioTextarea.schema({validate: {maxLength: 10000}}, ...extend);
+  }
+
+  get defaultSchema() {
+    return TextArea.schema();
+  }
+
   static editForm() {
     return {components: [textareaTabs]};
   }


### PR DESCRIPTION
Fixes #1643