### PR TITLE
Bump to microscope-sass 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5395,9 +5395,9 @@
       }
     },
     "node_modules/microscope-sass": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/microscope-sass/-/microscope-sass-1.0.4.tgz",
-      "integrity": "sha512-0G0VnYcd+1XHnlIVOXeXRI2tYdcRULUijQvwaPCNj4rgGK6FwuNhgHmYvhwooFehOOQ37yQ2c+pQURQ+sHoH3A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/microscope-sass/-/microscope-sass-1.1.0.tgz",
+      "integrity": "sha512-eM4lwsJJSWPGiLboRxI/nWj3g2QObPCmkdozu8or5SMWiTeVLVkkSnSEbM695VYgEfCez+HBDv0KicejLoseLQ=="
     },
     "node_modules/mime-db": {
       "version": "1.49.0",
@@ -12888,9 +12888,9 @@
       }
     },
     "microscope-sass": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/microscope-sass/-/microscope-sass-1.0.4.tgz",
-      "integrity": "sha512-0G0VnYcd+1XHnlIVOXeXRI2tYdcRULUijQvwaPCNj4rgGK6FwuNhgHmYvhwooFehOOQ37yQ2c+pQURQ+sHoH3A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/microscope-sass/-/microscope-sass-1.1.0.tgz",
+      "integrity": "sha512-eM4lwsJJSWPGiLboRxI/nWj3g2QObPCmkdozu8or5SMWiTeVLVkkSnSEbM695VYgEfCez+HBDv0KicejLoseLQ=="
     },
     "mime-db": {
       "version": "1.49.0",


### PR DESCRIPTION
This release has the BEM mixins and fixed the `/` div deprecations which will be removed in dart-sass 2