### PR TITLE
Bump zgw-consumers version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -439,7 +439,7 @@ xmltodict==0.12.0
     # via -r requirements/base.in
 zeep==4.1.0
     # via -r requirements/base.in
-zgw-consumers==0.18.1
+zgw-consumers==0.18.2
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -884,7 +884,7 @@ zeep==4.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-zgw-consumers==0.18.1
+zgw-consumers==0.18.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1066,7 +1066,7 @@ zeep==4.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-zgw-consumers==0.18.1
+zgw-consumers==0.18.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Fixes #1655

Django admin can't handle `gettext_lazy` in some places apparently.