### PR TITLE
Implement DMN API endpoints

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -331,6 +331,198 @@ paths:
           headers:
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
+  /api/v1/dmn/decision-definitions:
+    get:
+      operationId: dmn_decision_definitions_list
+      description: List the available decision definitions for a given plugin.
+      summary: List available decision definitions
+      parameters:
+      - in: query
+        name: engine
+        schema:
+          type: string
+          enum:
+          - camunda7
+        description: Identifier of the decision engine to query. Note that some engines
+          may be disabled at runtime.
+        required: true
+      tags:
+      - dmn
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DecisionDefinition'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+  /api/v1/dmn/decision-definitions/{definition}/xml:
+    get:
+      operationId: dmn_decision_definitions_xml_retrieve
+      summary: Retrieve the decision definition XML
+      parameters:
+      - in: path
+        name: definition
+        schema:
+          type: string
+        required: true
+      - in: query
+        name: engine
+        schema:
+          type: string
+          enum:
+          - camunda7
+        description: Identifier of the decision engine to query. Note that some engines
+          may be disabled at runtime.
+        required: true
+      - in: query
+        name: version
+        schema:
+          type: string
+      tags:
+      - dmn
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDefinitionXML'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+  /api/v1/dmn/decision-definitions/versions:
+    get:
+      operationId: dmn_decision_definitions_versions_list
+      description: |-
+        List the available versions of a given definition.
+
+        If the selected engine supports multiple versions of decision definitions, they can
+        be retrieved through this endpoint. You must specify the engine and selected
+        definition ID.
+      summary: List available decision definition versions
+      parameters:
+      - in: query
+        name: definition
+        schema:
+          type: string
+        description: Identifier of the definition to retrieve available versions for.
+        required: true
+      - in: query
+        name: engine
+        schema:
+          type: string
+          enum:
+          - camunda7
+        description: Identifier of the decision engine to query. Note that some engines
+          may be disabled at runtime.
+        required: true
+      tags:
+      - dmn
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DecisionDefinitionVersion'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+  /api/v1/dmn/plugins:
+    get:
+      operationId: dmn_plugins_retrieve
+      description: List all decision plugins that have been registered.
+      summary: List available decision plugins
+      tags:
+      - dmn
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionPlugin'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
   /api/v1/form-definitions:
     get:
       operationId: form_definitions_list
@@ -3659,6 +3851,54 @@ components:
           format: date
       required:
       - date
+    DecisionDefinition:
+      type: object
+      properties:
+        id:
+          type: string
+          title: Identifier
+          description: The (unique) identifier pointing to a particular decision definition.
+        label:
+          type: string
+          description: Human readable name/label identifying the decision definition.
+      required:
+      - id
+      - label
+    DecisionDefinitionVersion:
+      type: object
+      properties:
+        id:
+          type: string
+          title: version identifier
+          description: The (unique) identifier pointing to a particular decision definition
+            version.
+        label:
+          type: string
+          description: Textual representation of the definition version.
+      required:
+      - id
+      - label
+    DecisionDefinitionXML:
+      type: object
+      properties:
+        xml:
+          type: string
+          title: DMN XML
+          description: If no XML can be obtained, the value will be an empty string.
+      required:
+      - xml
+    DecisionPlugin:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique plugin identifier
+        label:
+          type: string
+          description: The human-readable name for a plugin.
+      required:
+      - id
+      - label
     Exception:
       type: object
       description: |-

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -380,61 +380,6 @@ paths:
           headers:
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
-  /api/v1/dmn/decision-definitions/{definition}/xml:
-    get:
-      operationId: dmn_decision_definitions_xml_retrieve
-      summary: Retrieve the decision definition XML
-      parameters:
-      - in: path
-        name: definition
-        schema:
-          type: string
-        required: true
-      - in: query
-        name: engine
-        schema:
-          type: string
-          enum:
-          - camunda7
-        description: Identifier of the decision engine to query. Note that some engines
-          may be disabled at runtime.
-        required: true
-      - in: query
-        name: version
-        schema:
-          type: string
-      tags:
-      - dmn
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DecisionDefinitionXML'
-          description: ''
-          headers:
-            X-Session-Expires-In:
-              $ref: '#/components/headers/X-Session-Expires-In'
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ValidationError'
-          description: ''
-          headers:
-            X-Session-Expires-In:
-              $ref: '#/components/headers/X-Session-Expires-In'
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Exception'
-          description: ''
-          headers:
-            X-Session-Expires-In:
-              $ref: '#/components/headers/X-Session-Expires-In'
   /api/v1/dmn/decision-definitions/versions:
     get:
       operationId: dmn_decision_definitions_versions_list
@@ -495,9 +440,65 @@ paths:
           headers:
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
+  /api/v1/dmn/decision-definitions/xml:
+    get:
+      operationId: dmn_decision_definitions_xml_retrieve
+      summary: Retrieve the decision definition XML
+      parameters:
+      - in: query
+        name: definition
+        schema:
+          type: string
+        description: Identifier of the definition to retrieve available versions for.
+        required: true
+      - in: query
+        name: engine
+        schema:
+          type: string
+          enum:
+          - camunda7
+        description: Identifier of the decision engine to query. Note that some engines
+          may be disabled at runtime.
+        required: true
+      - in: query
+        name: version
+        schema:
+          type: string
+      tags:
+      - dmn
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDefinitionXML'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
   /api/v1/dmn/plugins:
     get:
-      operationId: dmn_plugins_retrieve
+      operationId: dmn_plugins_list
       description: List all decision plugins that have been registered.
       summary: List available decision plugins
       tags:
@@ -509,7 +510,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DecisionPlugin'
+                type: array
+                items:
+                  $ref: '#/components/schemas/DecisionPlugin'
           description: ''
           headers:
             X-Session-Expires-In:

--- a/src/openforms/api/drf_spectacular/functional.py
+++ b/src/openforms/api/drf_spectacular/functional.py
@@ -1,0 +1,7 @@
+from typing import Callable
+
+from django.utils.functional import lazy
+
+
+def lazy_enum(func: Callable[[], list]) -> Callable[[], list]:
+    return lazy(func, list)()

--- a/src/openforms/api/mixins.py
+++ b/src/openforms/api/mixins.py
@@ -1,0 +1,34 @@
+from typing import Dict, Iterable, Optional
+
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import OpenApiParameter
+from rest_framework import serializers
+
+
+class ValidateQueryStringParametersMixin:
+    validate_params: Iterable[OpenApiParameter] = ()
+
+    def validate_query_parameters(self) -> Dict[OpenApiParameter, Optional[str]]:
+        errors, extracted = {}, {}
+
+        for param in self.validate_params:
+            value = self.request.GET.get(param.name)
+            if not value and param.required:
+                errors[param.name] = _(
+                    "The '{param}' query parameter is required."
+                ).format(param=param.name)
+            elif value and param.enum and value not in param.enum:
+                errors[param.name] = _(
+                    "The value '{value}' is not a valid value for the '{param}' query "
+                    "parameter. Valid values are: {valid_values}."
+                ).format(
+                    param=param.name, value=value, valid_values=", ".join(param.enum)
+                )
+            else:
+                extracted[param] = value
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return extracted

--- a/src/openforms/api/mixins.py
+++ b/src/openforms/api/mixins.py
@@ -15,9 +15,12 @@ class ValidateQueryStringParametersMixin:
         for param in self.validate_params:
             value = self.request.GET.get(param.name)
             if not value and param.required:
-                errors[param.name] = _(
-                    "The '{param}' query parameter is required."
-                ).format(param=param.name)
+                error_message = _("The '{param}' query parameter is required.").format(
+                    param=param.name
+                )
+                errors[param.name] = serializers.ErrorDetail(
+                    error_message, code="required"
+                )
             elif value and param.enum and value not in param.enum:
                 errors[param.name] = _(
                     "The value '{value}' is not a valid value for the '{param}' query "

--- a/src/openforms/api/tests/utils.py
+++ b/src/openforms/api/tests/utils.py
@@ -1,0 +1,11 @@
+class APITestAssertions:
+    def assertValidationErrorCode(self, response, field: str, code="invalid"):
+        response_body = response.json()
+        self.assertIn("invalidParams", response_body)
+        invalid_params = response_body["invalidParams"]
+        relevant_errors = [err for err in invalid_params if err["name"] == field]
+        self.assertIn(
+            code,
+            {err["code"] for err in relevant_errors},
+            f"No error with code {code} found in errors: {relevant_errors}.",
+        )

--- a/src/openforms/api/urls.py
+++ b/src/openforms/api/urls.py
@@ -88,6 +88,7 @@ urlpatterns = [
                 path("authentication/", include("openforms.authentication.api.urls")),
                 path("registration/", include("openforms.registrations.api.urls")),
                 path("payment/", include("openforms.payments.api.urls")),
+                path("dmn/", include("openforms.dmn.api.urls")),
                 path("translations/", include("openforms.translations.urls")),
                 path(
                     "appointments/",

--- a/src/openforms/dmn/api/serializers.py
+++ b/src/openforms/dmn/api/serializers.py
@@ -1,0 +1,43 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+
+from openforms.plugins.api.serializers import PluginBaseSerializer
+
+
+class DecisionPluginSerializer(PluginBaseSerializer):
+    pass
+
+
+class DecisionDefinitionSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        source="identifier",
+        label=_("Identifier"),
+        help_text=_(
+            "The (unique) identifier pointing to a particular decision definition."
+        ),
+    )
+    label = serializers.CharField(
+        label=_("Label"),
+        help_text=_("Human readable name/label identifying the decision definition."),
+    )
+
+
+class DecisionDefinitionVersionSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        label=_("version identifier"),
+        help_text=_(
+            "The (unique) identifier pointing to a particular decision definition version."
+        ),
+    )
+    label = serializers.CharField(
+        label=_("Label"),
+        help_text=_("Textual representation of the definition version."),
+    )
+
+
+class DecisionDefinitionXMLSerializer(serializers.Serializer):
+    xml = serializers.CharField(
+        label=_("DMN XML"),
+        help_text=_("If no XML can be obtained, the value will be an empty string."),
+    )

--- a/src/openforms/dmn/api/urls.py
+++ b/src/openforms/dmn/api/urls.py
@@ -1,0 +1,27 @@
+from django.urls import path
+
+from .views import (
+    DecisionDefinitionListView,
+    DecisionDefinitionVersionListView,
+    DecisionDefinitionXMLView,
+    PluginListView,
+)
+
+urlpatterns = [
+    path("plugins", PluginListView.as_view(), name="dmn-plugin-list"),
+    path(
+        "decision-definitions",
+        DecisionDefinitionListView.as_view(),
+        name="dmn-definition-list",
+    ),
+    path(
+        "decision-definitions/versions",
+        DecisionDefinitionVersionListView.as_view(),
+        name="dmn-definition-version-list",
+    ),
+    path(
+        "decision-definitions/<str:definition>/xml",
+        DecisionDefinitionXMLView.as_view(),
+        name="dmn-definition-xml",
+    ),
+]

--- a/src/openforms/dmn/api/urls.py
+++ b/src/openforms/dmn/api/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="dmn-definition-version-list",
     ),
     path(
-        "decision-definitions/<str:definition>/xml",
+        "decision-definitions/xml",
         DecisionDefinitionXMLView.as_view(),
         name="dmn-definition-xml",
     ),

--- a/src/openforms/dmn/api/views.py
+++ b/src/openforms/dmn/api/views.py
@@ -58,6 +58,10 @@ VERSION_PARAMETER = OpenApiParameter(
 @extend_schema_view(
     get=extend_schema(
         summary=_("List available decision plugins"),
+        responses={
+            200: DecisionPluginSerializer,
+            403: ExceptionSerializer,
+        },
     ),
 )
 class PluginListView(ListMixin, APIView):
@@ -80,6 +84,7 @@ class PluginListView(ListMixin, APIView):
         responses={
             200: DecisionDefinitionSerializer(many=True),
             400: ValidationErrorSerializer,
+            403: ExceptionSerializer,
         },
     ),
 )
@@ -109,6 +114,7 @@ class DecisionDefinitionListView(
         responses={
             200: DecisionDefinitionVersionSerializer(many=True),
             400: ValidationErrorSerializer,
+            403: ExceptionSerializer,
         },
     ),
 )
@@ -147,6 +153,7 @@ class DecisionDefinitionVersionListView(
         responses={
             200: DecisionDefinitionXMLSerializer,
             400: ValidationErrorSerializer,
+            403: ExceptionSerializer,
         },
     ),
 )

--- a/src/openforms/dmn/api/views.py
+++ b/src/openforms/dmn/api/views.py
@@ -59,7 +59,7 @@ VERSION_PARAMETER = OpenApiParameter(
     get=extend_schema(
         summary=_("List available decision plugins"),
         responses={
-            200: DecisionPluginSerializer,
+            200: DecisionPluginSerializer(many=True),
             403: ExceptionSerializer,
         },
     ),
@@ -148,6 +148,7 @@ class DecisionDefinitionVersionListView(
         summary=_("Retrieve the decision definition XML"),
         parameters=[
             ENGINE_PARAMETER,
+            DEFINITION_PARAMETER,
             VERSION_PARAMETER,
         ],
         responses={
@@ -160,13 +161,14 @@ class DecisionDefinitionVersionListView(
 class DecisionDefinitionXMLView(ValidateQueryStringParametersMixin, APIView):
     authentication_classes = (authentication.SessionAuthentication,)
     permission_classes = (permissions.IsAdminUser,)
-    validate_params = (ENGINE_PARAMETER, VERSION_PARAMETER)
+    validate_params = (ENGINE_PARAMETER, DEFINITION_PARAMETER, VERSION_PARAMETER)
 
-    def get(self, request, definition: str, **kwargs):
+    def get(self, request, **kwargs):
         query_params = self.validate_query_parameters()
         engine = query_params[ENGINE_PARAMETER]
+        definition_id = query_params[DEFINITION_PARAMETER]
         version = query_params[VERSION_PARAMETER]
         plugin = register[engine]
-        xml = plugin.get_definition_xml(definition, version=version) or ""
+        xml = plugin.get_definition_xml(definition_id, version=version) or ""
         serializer = DecisionDefinitionXMLSerializer(instance={"xml": xml})
         return Response(serializer.data)

--- a/src/openforms/dmn/api/views.py
+++ b/src/openforms/dmn/api/views.py
@@ -1,0 +1,164 @@
+from typing import List
+
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from rest_framework import authentication, permissions
+from rest_framework.exceptions import NotFound
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from openforms.api.drf_spectacular.functional import lazy_enum
+from openforms.api.mixins import ValidateQueryStringParametersMixin
+from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
+from openforms.utils.api.views import ListMixin
+
+from ..base import DecisionDefinition
+from ..registry import register
+from .serializers import (
+    DecisionDefinitionSerializer,
+    DecisionDefinitionVersionSerializer,
+    DecisionDefinitionXMLSerializer,
+    DecisionPluginSerializer,
+)
+
+
+def get_available_engines() -> List[str]:
+    return [engine.identifier for engine in register.iter_enabled_plugins()]
+
+
+ENGINE_PARAMETER = OpenApiParameter(
+    name="engine",
+    type=str,
+    location=OpenApiParameter.QUERY,
+    required=True,
+    description=_(
+        "Identifier of the decision engine to query. Note that some engines "
+        "may be disabled at runtime."
+    ),
+    enum=lazy_enum(get_available_engines),
+)
+
+DEFINITION_PARAMETER = OpenApiParameter(
+    name="definition",
+    type=str,
+    location=OpenApiParameter.QUERY,
+    required=True,
+    description=_("Identifier of the definition to retrieve available versions for."),
+)
+
+VERSION_PARAMETER = OpenApiParameter(
+    name="version",
+    type=str,
+    location=OpenApiParameter.QUERY,
+    required=False,
+)
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary=_("List available decision plugins"),
+    ),
+)
+class PluginListView(ListMixin, APIView):
+    """
+    List all decision plugins that have been registered.
+    """
+
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = DecisionPluginSerializer
+
+    def get_objects(self):
+        return list(register.iter_enabled_plugins())
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary=_("List available decision definitions"),
+        parameters=[ENGINE_PARAMETER],
+        responses={
+            200: DecisionDefinitionSerializer(many=True),
+            400: ValidationErrorSerializer,
+        },
+    ),
+)
+class DecisionDefinitionListView(
+    ValidateQueryStringParametersMixin, ListMixin, APIView
+):
+    """
+    List the available decision definitions for a given plugin.
+    """
+
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = DecisionDefinitionSerializer
+    validate_params = (ENGINE_PARAMETER,)
+
+    def get_objects(self) -> List[DecisionDefinition]:
+        engine = self.validate_query_parameters()[ENGINE_PARAMETER]
+        plugin = register[engine]
+        definitions = plugin.get_available_decision_definitions()
+        return definitions
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary=_("List available decision definition versions"),
+        parameters=[ENGINE_PARAMETER, DEFINITION_PARAMETER],
+        responses={
+            200: DecisionDefinitionVersionSerializer(many=True),
+            400: ValidationErrorSerializer,
+        },
+    ),
+)
+class DecisionDefinitionVersionListView(
+    ValidateQueryStringParametersMixin, ListMixin, APIView
+):
+    """
+    List the available versions of a given definition.
+    If the selected engine supports multiple versions of decision definitions, they can
+    be retrieved through this endpoint. You must specify the engine and selected
+    definition ID.
+    """
+
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = DecisionDefinitionVersionSerializer
+    validate_params = (ENGINE_PARAMETER, DEFINITION_PARAMETER)
+
+    def get_objects(self) -> List[DecisionDefinition]:
+        query_params = self.validate_query_parameters()
+        engine = query_params[ENGINE_PARAMETER]
+        definition_id = query_params[DEFINITION_PARAMETER]
+        plugin = register[engine]
+        versions = plugin.get_decision_definition_versions(definition_id)
+        return versions
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary=_("List available decision definition versions"),
+        parameters=[
+            ENGINE_PARAMETER,
+            VERSION_PARAMETER,
+        ],
+        responses={
+            200: DecisionDefinitionXMLSerializer,
+            400: ValidationErrorSerializer,
+        },
+    ),
+)
+class DecisionDefinitionXMLView(ValidateQueryStringParametersMixin, APIView):
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    validate_params = (ENGINE_PARAMETER, VERSION_PARAMETER)
+
+    def get(self, request, definition: str, **kwargs):
+        query_params = self.validate_query_parameters()
+        engine = query_params[ENGINE_PARAMETER]
+        version = query_params[VERSION_PARAMETER]
+        plugin = register[engine]
+        xml = plugin.get_definition_xml(definition, version=version) or ""
+        serializer = DecisionDefinitionXMLSerializer(instance={"xml": xml})
+        return Response(serializer.data)

--- a/src/openforms/dmn/api/views.py
+++ b/src/openforms/dmn/api/views.py
@@ -117,6 +117,7 @@ class DecisionDefinitionVersionListView(
 ):
     """
     List the available versions of a given definition.
+
     If the selected engine supports multiple versions of decision definitions, they can
     be retrieved through this endpoint. You must specify the engine and selected
     definition ID.
@@ -138,7 +139,7 @@ class DecisionDefinitionVersionListView(
 
 @extend_schema_view(
     get=extend_schema(
-        summary=_("List available decision definition versions"),
+        summary=_("Retrieve the decision definition XML"),
         parameters=[
             ENGINE_PARAMETER,
             VERSION_PARAMETER,

--- a/src/openforms/dmn/tests/test_api.py
+++ b/src/openforms/dmn/tests/test_api.py
@@ -122,7 +122,7 @@ class AccessControlTests(MockRegistryMixin, APITestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
 
     def test_definition_xml(self):
-        endpoint = reverse("api:dmn-definition-xml", kwargs={"definition": "test-1"})
+        endpoint = reverse("api:dmn-definition-xml")
 
         with self.subTest("anonymous"):
             response = self.client.get(endpoint)
@@ -245,7 +245,7 @@ class XMLRetrieveTests(APITestAssertions, MockRegistryMixin, APITestCase):
         cls.user = StaffUserFactory.create()
 
     def test_retrieve_xml_endpoint(self):
-        endpoint = reverse("api:dmn-definition-xml", kwargs={"definition": "test-1"})
+        endpoint = reverse("api:dmn-definition-xml")
         self.client.force_authenticate(user=self.user)
 
         with self.subTest("Engine param is required"):
@@ -254,7 +254,15 @@ class XMLRetrieveTests(APITestAssertions, MockRegistryMixin, APITestCase):
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             self.assertValidationErrorCode(response, "engine", "required")
 
-        with self.subTest("No XML available"):
+        with self.subTest("Definition param is required"):
             response = self.client.get(endpoint, {"engine": "test"})
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertValidationErrorCode(response, "definition", "required")
+
+        with self.subTest("No XML available"):
+            response = self.client.get(
+                endpoint, {"engine": "test", "definition": "test-1"}
+            )
 
             self.assertEqual(response.json(), {"xml": ""})

--- a/src/openforms/dmn/tests/test_api.py
+++ b/src/openforms/dmn/tests/test_api.py
@@ -1,0 +1,136 @@
+from typing import Dict
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
+
+from ..base import BasePlugin, DecisionDefinition
+from ..registry import Registry
+
+register = Registry()
+
+
+@register("test")
+class TestPlugin(BasePlugin):
+    @staticmethod
+    def get_available_decision_definitions():
+        return [DecisionDefinition(identifier="test-1", label="Test definition")]
+
+    @staticmethod
+    def evaluate(
+        definition_id, *, version: str = "", input_values: Dict[str, int]
+    ) -> Dict[str, int]:
+        return {"sum": sum([input_values["a"], input_values["b"]])}
+
+
+class MockRegistryMixin:
+    def setUp(self):
+        super().setUp()
+
+        patcher = patch("openforms.dmn.api.views.register", new=register)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class AccessControlTests(MockRegistryMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = UserFactory.create()
+        cls.admin_user = StaffUserFactory.create()
+
+    def test_plugin_list(self):
+        endpoint = reverse("api:dmn-plugin-list")
+
+        with self.subTest("anonymous"):
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("authenticated, not staff"):
+            self.client.force_authenticate(user=self.user)
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("staff user"):
+            self.client.force_authenticate(user=self.admin_user)
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+    def test_definition_list(self):
+        endpoint = reverse("api:dmn-definition-list")
+
+        with self.subTest("anonymous"):
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("authenticated, not staff"):
+            self.client.force_authenticate(user=self.user)
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("staff user"):
+            self.client.force_authenticate(user=self.admin_user)
+
+            response = self.client.get(endpoint, {"engine": "test"})
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+    def test_definition_version_list(self):
+        endpoint = reverse("api:dmn-definition-version-list")
+
+        with self.subTest("anonymous"):
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("authenticated, not staff"):
+            self.client.force_authenticate(user=self.user)
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("staff user"):
+            self.client.force_authenticate(user=self.admin_user)
+
+            response = self.client.get(
+                endpoint, {"engine": "test", "definition": "test-1"}
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+    def test_definition_xml(self):
+        endpoint = reverse("api:dmn-definition-xml", kwargs={"definition": "test-1"})
+
+        with self.subTest("anonymous"):
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("authenticated, not staff"):
+            self.client.force_authenticate(user=self.user)
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("staff user"):
+            self.client.force_authenticate(user=self.admin_user)
+
+            response = self.client.get(
+                endpoint, {"engine": "test", "definition": "test-1"}
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())


### PR DESCRIPTION
Related to #1680

**Changes**

- Added API endpoint to obtain a list of enabled/available plugins/engines
- Added API endpoint to get a list of available definitions for a given engine
- Added API endpoint to get a list of available versions for a given engine/definition
- Added API endpoint to retrieve the DMN XML for a given engine/definition