### PR TITLE
Use a unique reference number every time for StUF-ZDS requests

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/management/commands/stuf_zds_test_stp.py
+++ b/src/openforms/registrations/contrib/stuf_zds/management/commands/stuf_zds_test_stp.py
@@ -42,7 +42,6 @@ class Command(BaseCommand):
             "zds_zaaktype_status_code": "zt-st-code",
             "zds_zaaktype_status_omschrijving": "zt-st-omschrijving",
             "zds_documenttype_omschrijving_inzending": "dt-omschrijving",
-            "referentienummer": str(uuid.uuid4()),
         }
 
         client = StufZDSClient(service, client_options)

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -151,7 +151,6 @@ class StufZDSRegistration(BasePlugin):
         config.apply_defaults_to(options)
 
         options["omschrijving"] = submission.form.admin_name
-        options["referentienummer"] = str(submission.uuid)
 
         client = config.get_client(options)
 
@@ -224,7 +223,6 @@ class StufZDSRegistration(BasePlugin):
 
         options = {
             "omschrijving": "MyForm",
-            "referentienummer": "123",
             "zds_zaaktype_code": "test",
             "zds_zaaktype_omschrijving": "test",
             "zds_zaaktype_status_code": "test",

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -4,6 +4,7 @@ import os
 from collections import OrderedDict
 from datetime import timedelta
 from typing import Tuple
+from uuid import uuid4
 
 from django.template import loader
 from django.utils import timezone
@@ -124,7 +125,7 @@ class StufZDSClient:
             "zds_documenttype_omschrijving_inzending": self.options[
                 "zds_documenttype_omschrijving_inzending"
             ],
-            "referentienummer": self.options["referentienummer"],
+            "referentienummer": str(uuid4()),
             "global_config": self._global_config,
         }
 
@@ -161,6 +162,7 @@ class StufZDSClient:
         url = self.service.get_endpoint(endpoint_type)
 
         logger.debug("SOAP-request:\n%s\n%s", url, request_data)
+        ref_nr = context["referentienummer"]
 
         try:
             stuf_zds_request(self.service, url)
@@ -181,8 +183,8 @@ class StufZDSClient:
                 logger.debug("SOAP-response:\n%s", response.content)
                 error_text = parse_soap_error_text(response)
                 logger.error(
-                    "bad response for referentienummer/submission '%s'\n%s",
-                    self.options["referentienummer"],
+                    "bad response for referentienummer '%s'\n%s",
+                    ref_nr,
                     error_text,
                 )
                 stuf_zds_failure_response(self.service, url)
@@ -194,8 +196,8 @@ class StufZDSClient:
                 logger.debug("SOAP-response:\n%s", response.content)
         except RequestException as e:
             logger.error(
-                "bad request for referentienummer/submission '%s'",
-                self.options["referentienummer"],
+                "bad request for referentienummer '%s'",
+                ref_nr,
             )
             stuf_zds_failure_response(self.service, url)
             raise RegistrationFailed("error while making backend request") from e

--- a/src/stuf/stuf_zds/tests/test_backend.py
+++ b/src/stuf/stuf_zds/tests/test_backend.py
@@ -125,7 +125,6 @@ class StufZDSClientTests(StufTestBase):
             "zds_zaaktype_status_code": "zt-st-code",
             "zds_zaaktype_status_omschrijving": "zt-st-omschrijving",
             "zds_documenttype_omschrijving_inzending": "dt-omschrijving",
-            "referentienummer": str(uuid.uuid4()),
         }
         self.client = StufZDSClient(self.service, self.options)
 

--- a/src/stuf/stuf_zds/tests/test_client.py
+++ b/src/stuf/stuf_zds/tests/test_client.py
@@ -49,7 +49,6 @@ class StufZdsClientTest(TestCase):
             "zds_zaaktype_status_code": "zt-st-code",
             "zds_zaaktype_status_omschrijving": "zt-st-omschrijving",
             "zds_documenttype_omschrijving_inzending": "dt-omschrijving",
-            "referentienummer": "123-123-123",
         }
 
     def test_mutual_tls(self, m):


### PR DESCRIPTION
Fixes #1681

I'm not sure how to write tests for this, and I think I'd rather do #388 first, because there is now a lot of code and template duplication between stuf-bg and stuf-zds.