### PR TITLE
Emit step submission validation errors

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2610,6 +2610,59 @@ paths:
           headers:
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
+  /api/v1/submissions/{submission_uuid}/steps/{step_uuid}/validate:
+    post:
+      operationId: submissions_steps_validate_create
+      description: |-
+        Validate the submission step data before persisting.
+
+        This endpoint runs the same validation logic as the PUT endpoint to store the
+        data. For invalid data, you will get an HTTP 400 response with error details.
+      summary: Store submission step data
+      parameters:
+      - in: path
+        name: step_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: submission_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - submissions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmissionStep'
+      responses:
+        '204':
+          description: No response body
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
   /api/v1/submissions/{uuid}:
     get:
       operationId: submissions_retrieve

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2557,6 +2557,24 @@ paths:
           headers:
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
   /api/v1/submissions/{submission_uuid}/steps/{step_uuid}/_check_logic:
     post:
       operationId: submissions_steps__check_logic_create

--- a/src/openforms/api/exception_handling.py
+++ b/src/openforms/api/exception_handling.py
@@ -28,6 +28,11 @@ def _translate_exceptions(exc):
 
 # TODO: see if we can re-use openforms.submissions.parsers.IgnoreDataJSONRenderer for
 # the camelize keys skipping?
+#
+# We are ignoring the 'data' key in snake -> camel case conversion. This is the key
+# that's used to submit formio data to the backend, which contains sub-keys set by
+# end-users and can't be automatically converted. Consequently, error messages for
+# those sub-keys should not be transformed.
 def get_validation_errors(validation_errors: dict, camelize=True):
     for field_name, error_list in validation_errors.items():
         new_name = underscore_to_camel(field_name) if camelize else field_name

--- a/src/openforms/api/exception_handling.py
+++ b/src/openforms/api/exception_handling.py
@@ -26,22 +26,26 @@ def _translate_exceptions(exc):
     return exc
 
 
-def get_validation_errors(validation_errors: dict):
+# TODO: see if we can re-use openforms.submissions.parsers.IgnoreDataJSONRenderer for
+# the camelize keys skipping?
+def get_validation_errors(validation_errors: dict, camelize=True):
     for field_name, error_list in validation_errors.items():
+        new_name = underscore_to_camel(field_name) if camelize else field_name
+
         # nested validation for fields where many=True
         if isinstance(error_list, list):
             for i, nested_error_dict in enumerate(error_list):
                 if isinstance(nested_error_dict, dict):
-                    for err in get_validation_errors(nested_error_dict):
-                        err[
-                            "name"
-                        ] = f"{underscore_to_camel(field_name)}.{i}.{err['name']}"
+                    for err in get_validation_errors(
+                        nested_error_dict, camelize=field_name != "data"
+                    ):
+                        err["name"] = f"{new_name}.{i}.{err['name']}"
                         yield err
 
         # nested validation - recursively call the function
         if isinstance(error_list, dict):
-            for err in get_validation_errors(error_list):
-                err["name"] = f"{underscore_to_camel(field_name)}.{err['name']}"
+            for err in get_validation_errors(error_list, camelize=field_name != "data"):
+                err["name"] = f"{new_name}.{err['name']}"
                 yield err
             continue
 
@@ -58,7 +62,12 @@ def get_validation_errors(validation_errors: dict):
                         [
                             # see https://tools.ietf.org/html/rfc7807#section-3.1
                             # ('type', 'about:blank'),
-                            ("name", underscore_to_camel(field_name)),
+                            (
+                                "name",
+                                underscore_to_camel(field_name)
+                                if camelize
+                                else field_name,
+                            ),
                             ("code", err.code),
                             ("reason", str(err)),
                         ]
@@ -68,7 +77,10 @@ def get_validation_errors(validation_errors: dict):
                     [
                         # see https://tools.ietf.org/html/rfc7807#section-3.1
                         # ('type', 'about:blank'),
-                        ("name", underscore_to_camel(field_name)),
+                        (
+                            "name",
+                            underscore_to_camel(field_name) if camelize else field_name,
+                        ),
                         ("code", error.code),
                         ("reason", str(error)),
                     ]

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -26,6 +26,7 @@ from openforms.forms.validators import (
 )
 
 from ...utils.urls import build_absolute_uri
+from ..attachments import validate_uploads
 from ..constants import ProcessingResults, ProcessingStatuses
 from ..form_logic import check_submission_logic, evaluate_form_logic
 from ..models import Submission, SubmissionStep, TemporaryFileUpload
@@ -273,6 +274,10 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         # update the config for serialization
         instance.form_step.form_definition.configuration = new_configuration
         return super().to_representation(instance)
+
+    def validate_data(self, data: dict):
+        validate_uploads(self.instance, data=data)
+        return data
 
 
 class FormDataSerializer(serializers.Serializer):

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Tuple
 
 from django.db import transaction
 from django.utils import timezone
@@ -6,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
-from rest_framework import authentication, mixins, status, viewsets
+from rest_framework import authentication, mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
@@ -369,6 +370,7 @@ class SubmissionStepViewSet(
             403: ExceptionSerializer,
         },
     )
+    @transaction.atomic()
     def update(self, request, *args, **kwargs):
         """
         The submission data is either created or updated, depending on whether there was
@@ -379,12 +381,8 @@ class SubmissionStepViewSet(
         in the future. I.e. - a step that is marked as not available will still be submitted
         at the time being.
         """
-        instance = self.get_object()
+        instance, serializer = self._validate_step_input(request)
         create = instance.pk is None
-        if create:
-            instance.uuid = SubmissionStep._meta.get_field("uuid").default()
-        serializer = self.get_serializer(instance, data=request.data)
-        serializer.is_valid(raise_exception=True)
         serializer.save()
 
         logevent.submission_step_fill(instance)
@@ -418,6 +416,38 @@ class SubmissionStepViewSet(
 
         status_code = status.HTTP_200_OK if not create else status.HTTP_201_CREATED
         return Response(serializer.data, status=status_code)
+
+    @extend_schema(
+        summary=_("Store submission step data"),
+        request=SubmissionStepSerializer,
+        responses={
+            204: None,
+            400: ValidationErrorSerializer,
+            403: ExceptionSerializer,
+        },
+    )
+    @action(detail=True, methods=["post"])
+    def validate(self, request, *args, **kwargs):
+        """
+        Validate the submission step data before persisting.
+
+        This endpoint runs the same validation logic as the PUT endpoint to store the
+        data. For invalid data, you will get an HTTP 400 response with error details.
+        """
+        self._validate_step_input(request)
+        # if no validation errors were raised, signal an OK to the client
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def _validate_step_input(
+        self, request
+    ) -> Tuple[SubmissionStep, SubmissionStepSerializer]:
+        instance = self.get_object()
+        create = instance.pk is None
+        if create:
+            instance.uuid = SubmissionStep._meta.get_field("uuid").default()
+        serializer = self.get_serializer(instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return instance, serializer
 
     @extend_schema(
         summary=_("Apply/check form logic"),

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -14,7 +14,7 @@ from rest_framework.reverse import reverse
 
 from openforms.api import pagination
 from openforms.api.filters import PermissionFilterMixin
-from openforms.api.serializers import ExceptionSerializer
+from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.config.models import GlobalConfiguration
 from openforms.logging import logevent
 from openforms.prefill import prefill_variables
@@ -361,7 +361,14 @@ class SubmissionStepViewSet(
         self.check_object_permissions(self.request, submission_step)
         return submission_step
 
-    @extend_schema(summary=_("Store submission step data"))
+    @extend_schema(
+        summary=_("Store submission step data"),
+        responses={
+            200: SubmissionStepSerializer,
+            400: ValidationErrorSerializer,
+            403: ExceptionSerializer,
+        },
+    )
     def update(self, request, *args, **kwargs):
         """
         The submission data is either created or updated, depending on whether there was

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -15,7 +15,7 @@ import magic
 import PIL
 from glom import glom
 from PIL import Image
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from openforms.api.exceptions import RequestEntityTooLarge
 from openforms.conf.utils import Filesize
@@ -126,7 +126,7 @@ def attach_uploads_to_submission_step(submission_step: SubmissionStep) -> list:
                 # 2048 bytes per recommendation of python-magic
                 file_mime_type = magic.from_buffer(infile.read(2048), mime=True)
 
-            invalid_file_type_error = ValidationError(
+            invalid_file_type_error = ErrorDetail(
                 _("The file '{filename}' is not a valid file type.").format(
                     filename=upload.file_name
                 ),

--- a/src/openforms/submissions/tests/test_submission_attachment.py
+++ b/src/openforms/submissions/tests/test_submission_attachment.py
@@ -35,8 +35,6 @@ from .mixins import VariablesTestMixin
 
 TEST_FILES_DIR = Path(__file__).parent / "files"
 
-TEST_FILES_DIR = Path(__file__).parent / "files"
-
 
 @temp_private_root()
 class SubmissionAttachmentTest(VariablesTestMixin, TestCase):
@@ -497,6 +495,58 @@ class SubmissionAttachmentTest(VariablesTestMixin, TestCase):
             validate_uploads(submission_step, data=data)
         except ValidationError:
             self.fail("Uploads should be accepted since the content types are valid")
+
+    @tag("GHSA-h85r-xv4w-cg8g")
+    def test_attach_upload_validates_file_content_types_implicit_wildcard(self):
+        with open(TEST_FILES_DIR / "image-256x256.png", "rb") as infile:
+            upload = TemporaryFileUploadFactory.create(
+                file_name="my-img.png",
+                content=File(infile),
+                content_type="image/png",
+            )
+
+        data = {
+            "my_file": [
+                {
+                    "url": f"http://server/api/v1/submissions/files/{upload.uuid}",
+                    "data": {
+                        "url": f"http://server/api/v1/submissions/files/{upload.uuid}",
+                        "form": "",
+                        "name": "my-img.png",
+                        "size": 585,
+                        "baseUrl": "http://server",
+                        "project": "",
+                    },
+                    "name": "my-img-12305610-2da4-4694-a341-ccb919c3d543.png",
+                    "size": 585,
+                    "type": "image/png",  # we are lying!
+                    "storage": "url",
+                    "originalName": "my-img.png",
+                },
+            ],
+        }
+        formio_components = {
+            "key": "my_file",
+            "type": "file",
+            "multiple": True,
+            "file": {
+                "name": "",
+            },
+            "filePattern": "",
+        }
+
+        submission = SubmissionFactory.from_components(
+            [formio_components],
+            submitted_data=data,
+        )
+        submission_step = submission.submissionstep_set.get()
+
+        try:
+            validate_uploads(submission_step, data=data)
+        except ValidationError:
+            self.fail(
+                "Uploads should be accepted since the content types match the wildcard"
+            )
 
     @tag("GHSA-h85r-xv4w-cg8g")
     def test_attach_upload_validates_file_content_types_wildcard(self):

--- a/src/openforms/submissions/tests/test_submission_attachment.py
+++ b/src/openforms/submissions/tests/test_submission_attachment.py
@@ -22,6 +22,7 @@ from ..attachments import (
     cleanup_submission_temporary_uploaded_files,
     resize_attachment,
     resolve_uploads_from_data,
+    validate_uploads,
 )
 from ..models import SubmissionFileAttachment
 from .factories import (
@@ -413,7 +414,7 @@ class SubmissionAttachmentTest(VariablesTestMixin, TestCase):
         submission_step = submission.submissionstep_set.get()
 
         with self.assertRaises(ValidationError) as err_context:
-            attach_uploads_to_submission_step(submission_step)
+            validate_uploads(submission_step, data=data)
 
         validation_error = err_context.exception.get_full_details()
         self.assertEqual(len(validation_error["my_file"]), 2)
@@ -493,7 +494,7 @@ class SubmissionAttachmentTest(VariablesTestMixin, TestCase):
         submission_step = submission.submissionstep_set.get()
 
         try:
-            attach_uploads_to_submission_step(submission_step)
+            validate_uploads(submission_step, data=data)
         except ValidationError:
             self.fail("Uploads should be accepted since the content types are valid")
 
@@ -550,7 +551,7 @@ class SubmissionAttachmentTest(VariablesTestMixin, TestCase):
         submission_step = submission.submissionstep_set.get()
 
         try:
-            attach_uploads_to_submission_step(submission_step)
+            validate_uploads(submission_step, data=data)
         except ValidationError:
             self.fail(
                 "Uploads should be accepted since the content types match the wildcard"

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -7,22 +7,16 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.forms.tests.factories import (
-    FormDefinitionFactory,
-    FormFactory,
-    FormStepFactory,
-    FormVariableFactory,
-)
+from openforms.forms.tests.factories import FormFactory, FormStepFactory
 
-from ..models import SubmissionValueVariable
 from .factories import SubmissionFactory, TemporaryFileUploadFactory
-from .mixins import SubmissionsMixin, VariablesTestMixin
+from .mixins import SubmissionsMixin
 
 TEST_FILES_DIR = Path(__file__).parent / "files"
 
 
 @temp_private_root()
-class SubmissionStepValidationTests(VariablesTestMixin, SubmissionsMixin, APITestCase):
+class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from django.core.files import File
+
+from privates.test import temp_private_root
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.forms.tests.factories import (
+    FormDefinitionFactory,
+    FormFactory,
+    FormStepFactory,
+    FormVariableFactory,
+)
+
+from ..models import SubmissionValueVariable
+from .factories import SubmissionFactory, TemporaryFileUploadFactory
+from .mixins import SubmissionsMixin, VariablesTestMixin
+
+TEST_FILES_DIR = Path(__file__).parent / "files"
+
+
+@temp_private_root()
+class SubmissionStepValidationTests(VariablesTestMixin, SubmissionsMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # ensure there is a form definition
+        cls.form = FormFactory.create()
+        cls.step1 = FormStepFactory.create(
+            form=cls.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "test-key",
+                        "type": "textfield",
+                    },
+                    {
+                        "key": "my_file",
+                        "type": "file",
+                    },
+                ]
+            },
+        )
+
+        cls.form_url = reverse(
+            "api:form-detail", kwargs={"uuid_or_slug": cls.form.uuid}
+        )
+
+        # ensure there is a submission
+        cls.submission = SubmissionFactory.create(form=cls.form)
+
+    def test_validate_bad_file_content_type(self):
+        with open(TEST_FILES_DIR / "image-256x256.pdf", "rb") as infile:
+            upload = TemporaryFileUploadFactory.create(
+                file_name="my-pdf.pdf",
+                content=File(infile),
+                content_type="application/pdf",
+            )
+        data = {
+            "test-key": "foo",
+            "my_file": [
+                {
+                    "url": f"http://server/api/v1/submissions/files/{upload.uuid}",
+                    "data": {
+                        "url": f"http://server/api/v1/submissions/files/{upload.uuid}",
+                        "form": "",
+                        "name": "my-pdf.pdf",
+                        "size": 585,
+                        "baseUrl": "http://server",
+                        "project": "",
+                    },
+                    "name": "my-pdf-12305610-2da4-4694-a341-ccb919c3d543.png",
+                    "size": 585,
+                    "type": "application/pdf",  # we are lying!
+                    "storage": "url",
+                    "originalName": "my-pdf.pdf",
+                },
+            ],
+        }
+        self._add_submission_to_session(self.submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={
+                "submission_uuid": self.submission.uuid,
+                "step_uuid": self.step1.uuid,
+            },
+        )
+
+        response = self.client.post(endpoint, {"data": data})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error_fields = [param["name"] for param in response.json()["invalidParams"]]
+        self.assertEqual(error_fields, ["data.my_file"])

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -97,7 +97,7 @@ class FormStepSubmissionTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
         self.assertEqual("example data", variable.value)
         self.assertEqual("2022-05-25T10:53:19+00:00", variable.created_at.isoformat())
 
-    @patch("openforms.submissions.api.viewsets.validate_uploads")
+    @patch("openforms.submissions.api.serializers.validate_uploads")
     def test_validation_hook_called(self, mock_validate):
         self._add_submission_to_session(self.submission)
         endpoint = reverse(

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -5,6 +5,8 @@ When a submission ("session") is started, the data for a single form step must b
 submitted to a submission step. Existing data can be overwritten and new data is created
 by using HTTP PUT.
 """
+from unittest.mock import patch
+
 from freezegun import freeze_time
 from privates.test import temp_private_root
 from rest_framework import status
@@ -94,6 +96,22 @@ class FormStepSubmissionTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
         self.assertEqual("test-key", variable.key)
         self.assertEqual("example data", variable.value)
         self.assertEqual("2022-05-25T10:53:19+00:00", variable.created_at.isoformat())
+
+    @patch("openforms.submissions.api.viewsets.validate_uploads")
+    def test_validation_hook_called(self, mock_validate):
+        self._add_submission_to_session(self.submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": self.submission.uuid,
+                "step_uuid": self.step1.uuid,
+            },
+        )
+        body = {"data": {"test-key": "example data"}}
+
+        response = self.client.put(endpoint, body)
+
+        mock_validate.assert_called_once()
 
     def test_create_step_wrong_step_id(self):
         """


### PR DESCRIPTION
Fixes #1687

**Changes**

* Added endpoint for explicit validation of submission step data
* Modified step serializer to run upload validation
* Refactored function to attach files to submission step to use common generator
* Fixed camelizing `data.foo_bar` in validation errors
* Fixed error messages being improperly serialized