### PR TITLE
[#1325] Modify variables with logic

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2557,6 +2557,15 @@ paths:
           headers:
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionStep'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
         '400':
           content:
             application/json:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4614,6 +4614,7 @@ components:
           property: '#/components/schemas/LogicActionPolymorphicLogicPropertyAction'
           value: '#/components/schemas/LogicActionPolymorphicLogicValueAction'
           step-not-applicable: '#/components/schemas/LogicActionPolymorphicGenericObject'
+          variable: '#/components/schemas/LogicActionPolymorphicLogicValueAction'
     LogicActionPolymorphicGenericObject:
       allOf:
       - $ref: '#/components/schemas/LogicActionPolymorphicShared'
@@ -4659,6 +4660,7 @@ components:
       - disable-next
       - property
       - value
+      - variable
       type: string
     LogicComponentAction:
       type: object
@@ -4669,6 +4671,10 @@ components:
           description: 'Sleutel van de Form.io-component waarop de actie van toepassing
             is. Dit veld is optioneel als het actietype `disable-next` is, anders
             vereist. '
+        variable:
+          type: string
+          title: Key of the target variable
+          description: Key of the target variable whose value will be changed.
         formStep:
           type: string
           format: uri

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -9,10 +9,13 @@ class LogicActionTypes(DjangoChoices):
     )
     disable_next = ChoiceItem("disable-next", _("Disable the next step"))
     property = ChoiceItem("property", _("Modify a component property"))
-    value = ChoiceItem("value", _("Set the value of a component"))
+    value = ChoiceItem(
+        "value", _("Set the value of a component")
+    )  # TODO remove once variables are
     variable = ChoiceItem("variable", _("Set the value of a variable"))
 
     requires_component = {property.value, value.value}
+    requires_variable = {variable.value}
 
 
 class PropertyTypes(DjangoChoices):

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -10,6 +10,7 @@ class LogicActionTypes(DjangoChoices):
     disable_next = ChoiceItem("disable-next", _("Disable the next step"))
     property = ChoiceItem("property", _("Modify a component property"))
     value = ChoiceItem("value", _("Set the value of a component"))
+    variable = ChoiceItem("variable", _("Set the value of a variable"))
 
     requires_component = {property.value, value.value}
 

--- a/src/openforms/forms/tests/test_api_form_logic.py
+++ b/src/openforms/forms/tests/test_api_form_logic.py
@@ -948,13 +948,13 @@ class FormLogicAPITests(APITestCase):
                     {
                         "!=": [
                             {"var": "nLargeBoxes"},
-                            "",
+                            None,
                         ]
                     },
                     {
                         "!=": [
                             {"var": "nGiganticBoxes"},
-                            "",
+                            None,
                         ]
                     },
                 ]

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -1063,6 +1063,12 @@
       "value": "Initial value"
     }
   ],
+  "RvJXSo": [
+    {
+      "type": 0,
+      "value": "change the value of a variable/component"
+    }
+  ],
   "S6eF5o": [
     {
       "type": 0,
@@ -1413,6 +1419,12 @@
       "value": "Export this form"
     }
   ],
+  "dWNClE": [
+    {
+      "type": 0,
+      "value": "Optional category for internal organisation."
+    }
+  ],
   "ddDA6+": [
     {
       "type": 0,
@@ -1633,6 +1645,12 @@
       "value": "Name"
     }
   ],
+  "k5JYxu": [
+    {
+      "type": 0,
+      "value": "Show form"
+    }
+  ],
   "k9CT3p": [
     {
       "type": 0,
@@ -1649,6 +1667,12 @@
     {
       "type": 0,
       "value": "disabled"
+    }
+  ],
+  "koVh3m": [
+    {
+      "type": 0,
+      "value": "Category"
     }
   ],
   "l1fi1t": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -1067,6 +1067,12 @@
       "value": "Initial value"
     }
   ],
+  "RvJXSo": [
+    {
+      "type": 0,
+      "value": "change the value of a variable/component"
+    }
+  ],
   "S6eF5o": [
     {
       "type": 0,
@@ -1417,6 +1423,12 @@
       "value": "Exporteer dit formulier"
     }
   ],
+  "dWNClE": [
+    {
+      "type": 0,
+      "value": "Optional category for internal organisation."
+    }
+  ],
   "ddDA6+": [
     {
       "type": 0,
@@ -1637,6 +1649,12 @@
       "value": "Naam"
     }
   ],
+  "k5JYxu": [
+    {
+      "type": 0,
+      "value": "Show form"
+    }
+  ],
   "k9CT3p": [
     {
       "type": 0,
@@ -1653,6 +1671,12 @@
     {
       "type": 0,
       "value": "uitgeschakeld"
+    }
+  ],
+  "koVh3m": [
+    {
+      "type": 0,
+      "value": "Category"
     }
   ],
   "l1fi1t": [

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -22,6 +22,9 @@ FormContext.displayName = 'FormContext';
 const FeatureFlagsContext = React.createContext({});
 FeatureFlagsContext.displayName = 'FeatureFlagsContext';
 
+const FormVariablesContext = React.createContext({});
+FormVariablesContext.displayName = 'FormVariablesContext';
+
 export {
   FormContext,
   FormDefinitionsContext,
@@ -29,4 +32,5 @@ export {
   PluginsContext,
   TinyMceContext,
   FeatureFlagsContext,
+  FormVariablesContext,
 };

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -22,6 +22,7 @@ import {
   PluginsContext,
   FormStepsContext,
   FeatureFlagsContext,
+  FormVariablesContext,
 } from './Context';
 import FormSteps from './FormSteps';
 import {
@@ -1175,202 +1176,206 @@ const FormCreationForm = ({csrftoken, formUuid, formUrl, formHistoryUrl}) => {
 
       <ComponentsContext.Provider value={availableComponents}>
         <FormStepsContext.Provider value={state.formSteps}>
-          <PluginsContext.Provider
-            value={{
-              availableAuthPlugins: state.availableAuthPlugins,
-              selectedAuthPlugins: state.selectedAuthPlugins,
-              availablePrefillPlugins: state.availablePrefillPlugins,
-            }}
-          >
-            <Tabs defaultIndex={activeTab ? parseInt(activeTab, 10) : null}>
-              <TabList>
-                <Tab hasErrors={state.tabsWithErrors.includes('form')}>
-                  <FormattedMessage defaultMessage="Form" description="Form fields tab title" />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('form-steps')}>
-                  <FormattedMessage
-                    defaultMessage="Steps and fields"
-                    description="Form design tab title"
-                  />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('submission-confirmation')}>
-                  <FormattedMessage
-                    defaultMessage="Confirmation"
-                    description="Form confirmation options tab title"
-                  />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('registration')}>
-                  <FormattedMessage
-                    defaultMessage="Registration"
-                    description="Form registration options tab title"
-                  />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('literals')}>
-                  <FormattedMessage
-                    defaultMessage="Literals"
-                    description="Form literals tab title"
-                  />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('product-payment')}>
-                  <FormattedMessage
-                    defaultMessage="Product & payment"
-                    description="Product & payments tab title"
-                  />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('submission-removal-options')}>
-                  <FormattedMessage
-                    defaultMessage="Data removal"
-                    description="Data removal tab title"
-                  />
-                </Tab>
-                <Tab hasErrors={state.tabsWithErrors.includes('logic-rules')}>
-                  <FormattedMessage defaultMessage="Logic" description="Form logic tab title" />
-                </Tab>
-                <Tab>
-                  <FormattedMessage
-                    defaultMessage="Appointments"
-                    description="Appointments tab title"
-                  />
-                </Tab>
-                {featureFlags.enable_form_variables && (
-                  <Tab>
+          <FormVariablesContext.Provider value={state.formVariables}>
+            <PluginsContext.Provider
+              value={{
+                availableAuthPlugins: state.availableAuthPlugins,
+                selectedAuthPlugins: state.selectedAuthPlugins,
+                availablePrefillPlugins: state.availablePrefillPlugins,
+              }}
+            >
+              <Tabs defaultIndex={activeTab ? parseInt(activeTab, 10) : null}>
+                <TabList>
+                  <Tab hasErrors={state.tabsWithErrors.includes('form')}>
+                    <FormattedMessage defaultMessage="Form" description="Form fields tab title" />
+                  </Tab>
+                  <Tab hasErrors={state.tabsWithErrors.includes('form-steps')}>
                     <FormattedMessage
-                      defaultMessage="Variables"
-                      description="Variables tab title"
+                      defaultMessage="Steps and fields"
+                      description="Form design tab title"
                     />
                   </Tab>
-                )}
-              </TabList>
-
-              <TabPanel>
-                <FormMetaFields
-                  form={state.form}
-                  literals={state.literals}
-                  onChange={onFieldChange}
-                  availableAuthPlugins={state.availableAuthPlugins}
-                  selectedAuthPlugins={state.selectedAuthPlugins}
-                  availableCategories={state.availableCategories}
-                  onAuthPluginChange={onAuthPluginChange}
-                />
-              </TabPanel>
-
-              <TabPanel>
-                <Fieldset
-                  title={
+                  <Tab hasErrors={state.tabsWithErrors.includes('submission-confirmation')}>
                     <FormattedMessage
-                      defaultMessage="Form design"
-                      description="Form design/editor fieldset title"
+                      defaultMessage="Confirmation"
+                      description="Form confirmation options tab title"
                     />
-                  }
-                >
-                  <FormDefinitionsContext.Provider value={state.formDefinitions}>
-                    <FormContext.Provider value={{url: state.form.url}}>
-                      <StepsFieldSet
-                        steps={state.formSteps}
-                        loadingErrors={state.errors.loadingErrors}
-                        onEdit={onStepEdit}
-                        onComponentMutated={onComponentMutated}
-                        onFieldChange={onStepFieldChange}
-                        onLiteralFieldChange={onStepLiteralFieldChange}
-                        onDelete={onStepDelete}
-                        onReorder={onStepReorder}
-                        onReplace={onStepReplace}
-                        onAdd={e => {
-                          e.preventDefault();
-                          dispatch({type: 'ADD_STEP'});
-                        }}
-                        submitting={state.submitting}
+                  </Tab>
+                  <Tab hasErrors={state.tabsWithErrors.includes('registration')}>
+                    <FormattedMessage
+                      defaultMessage="Registration"
+                      description="Form registration options tab title"
+                    />
+                  </Tab>
+                  <Tab hasErrors={state.tabsWithErrors.includes('literals')}>
+                    <FormattedMessage
+                      defaultMessage="Literals"
+                      description="Form literals tab title"
+                    />
+                  </Tab>
+                  <Tab hasErrors={state.tabsWithErrors.includes('product-payment')}>
+                    <FormattedMessage
+                      defaultMessage="Product & payment"
+                      description="Product & payments tab title"
+                    />
+                  </Tab>
+                  <Tab hasErrors={state.tabsWithErrors.includes('submission-removal-options')}>
+                    <FormattedMessage
+                      defaultMessage="Data removal"
+                      description="Data removal tab title"
+                    />
+                  </Tab>
+                  <Tab hasErrors={state.tabsWithErrors.includes('logic-rules')}>
+                    <FormattedMessage defaultMessage="Logic" description="Form logic tab title" />
+                  </Tab>
+                  <Tab>
+                    <FormattedMessage
+                      defaultMessage="Appointments"
+                      description="Appointments tab title"
+                    />
+                  </Tab>
+                  {featureFlags.enable_form_variables && (
+                    <Tab>
+                      <FormattedMessage
+                        defaultMessage="Variables"
+                        description="Variables tab title"
                       />
-                    </FormContext.Provider>
-                  </FormDefinitionsContext.Provider>
-                </Fieldset>
-              </TabPanel>
+                    </Tab>
+                  )}
+                </TabList>
 
-              <TabPanel>
-                <Confirmation
-                  pageTemplate={state.form.submissionConfirmationTemplate}
-                  displayMainWebsiteLink={state.form.displayMainWebsiteLink}
-                  emailOption={state.form.confirmationEmailOption}
-                  emailTemplate={state.form.confirmationEmailTemplate || {}}
-                  onChange={onFieldChange}
-                />
-              </TabPanel>
-
-              <TabPanel>
-                <RegistrationFields
-                  backends={state.availableRegistrationBackends}
-                  selectedBackend={state.form.registrationBackend}
-                  backendOptions={state.form.registrationBackendOptions}
-                  onChange={onFieldChange}
-                />
-              </TabPanel>
-
-              <TabPanel>
-                <TextLiterals literals={state.literals} onChange={onFieldChange} />
-              </TabPanel>
-
-              <TabPanel>
-                <ProductFields selectedProduct={state.form.product} onChange={onFieldChange} />
-                <PaymentFields
-                  backends={state.availablePaymentBackends}
-                  selectedBackend={state.form.paymentBackend}
-                  backendOptions={state.form.paymentBackendOptions}
-                  onChange={onFieldChange}
-                />
-                <PriceLogic
-                  rules={state.priceRules}
-                  onChange={onPriceRuleChange}
-                  onDelete={index =>
-                    dispatch({type: 'DELETED_PRICE_RULE', payload: {index: index}})
-                  }
-                  onAdd={() => dispatch({type: 'ADD_PRICE_RULE'})}
-                />
-              </TabPanel>
-
-              <TabPanel>
-                <DataRemoval
-                  submissionsRemovalOptions={state.form.submissionsRemovalOptions}
-                  onChange={onFieldChange}
-                />
-              </TabPanel>
-
-              <TabPanel>
-                <FormLogic
-                  logicRules={state.logicRules}
-                  onChange={onRuleChange}
-                  onDelete={index => dispatch({type: 'DELETED_RULE', payload: {index: index}})}
-                  onAdd={ruleOverrides => dispatch({type: 'ADD_RULE', payload: ruleOverrides})}
-                />
-              </TabPanel>
-
-              <TabPanel>
-                <Appointments
-                  onChange={event => {
-                    dispatch({
-                      type: 'APPOINTMENT_CONFIGURATION_CHANGED',
-                      payload: event,
-                    });
-                  }}
-                />
-              </TabPanel>
-
-              {featureFlags.enable_form_variables && (
                 <TabPanel>
-                  <VariablesEditor
-                    variables={state.formVariables}
-                    onAdd={() => dispatch({type: 'ADD_USER_DEFINED_VARIABLE'})}
-                    onDelete={key => dispatch({type: 'DELETE_USER_DEFINED_VARIABLE', payload: key})}
-                    onChange={(key, propertyName, propertyValue) =>
-                      dispatch({
-                        type: 'CHANGE_USER_DEFINED_VARIABLE',
-                        payload: {key, propertyName, propertyValue},
-                      })
-                    }
+                  <FormMetaFields
+                    form={state.form}
+                    literals={state.literals}
+                    onChange={onFieldChange}
+                    availableAuthPlugins={state.availableAuthPlugins}
+                    selectedAuthPlugins={state.selectedAuthPlugins}
+                    availableCategories={state.availableCategories}
+                    onAuthPluginChange={onAuthPluginChange}
                   />
                 </TabPanel>
-              )}
-            </Tabs>
-          </PluginsContext.Provider>
+
+                <TabPanel>
+                  <Fieldset
+                    title={
+                      <FormattedMessage
+                        defaultMessage="Form design"
+                        description="Form design/editor fieldset title"
+                      />
+                    }
+                  >
+                    <FormDefinitionsContext.Provider value={state.formDefinitions}>
+                      <FormContext.Provider value={{url: state.form.url}}>
+                        <StepsFieldSet
+                          steps={state.formSteps}
+                          loadingErrors={state.errors.loadingErrors}
+                          onEdit={onStepEdit}
+                          onComponentMutated={onComponentMutated}
+                          onFieldChange={onStepFieldChange}
+                          onLiteralFieldChange={onStepLiteralFieldChange}
+                          onDelete={onStepDelete}
+                          onReorder={onStepReorder}
+                          onReplace={onStepReplace}
+                          onAdd={e => {
+                            e.preventDefault();
+                            dispatch({type: 'ADD_STEP'});
+                          }}
+                          submitting={state.submitting}
+                        />
+                      </FormContext.Provider>
+                    </FormDefinitionsContext.Provider>
+                  </Fieldset>
+                </TabPanel>
+
+                <TabPanel>
+                  <Confirmation
+                    pageTemplate={state.form.submissionConfirmationTemplate}
+                    displayMainWebsiteLink={state.form.displayMainWebsiteLink}
+                    emailOption={state.form.confirmationEmailOption}
+                    emailTemplate={state.form.confirmationEmailTemplate || {}}
+                    onChange={onFieldChange}
+                  />
+                </TabPanel>
+
+                <TabPanel>
+                  <RegistrationFields
+                    backends={state.availableRegistrationBackends}
+                    selectedBackend={state.form.registrationBackend}
+                    backendOptions={state.form.registrationBackendOptions}
+                    onChange={onFieldChange}
+                  />
+                </TabPanel>
+
+                <TabPanel>
+                  <TextLiterals literals={state.literals} onChange={onFieldChange} />
+                </TabPanel>
+
+                <TabPanel>
+                  <ProductFields selectedProduct={state.form.product} onChange={onFieldChange} />
+                  <PaymentFields
+                    backends={state.availablePaymentBackends}
+                    selectedBackend={state.form.paymentBackend}
+                    backendOptions={state.form.paymentBackendOptions}
+                    onChange={onFieldChange}
+                  />
+                  <PriceLogic
+                    rules={state.priceRules}
+                    onChange={onPriceRuleChange}
+                    onDelete={index =>
+                      dispatch({type: 'DELETED_PRICE_RULE', payload: {index: index}})
+                    }
+                    onAdd={() => dispatch({type: 'ADD_PRICE_RULE'})}
+                  />
+                </TabPanel>
+
+                <TabPanel>
+                  <DataRemoval
+                    submissionsRemovalOptions={state.form.submissionsRemovalOptions}
+                    onChange={onFieldChange}
+                  />
+                </TabPanel>
+
+                <TabPanel>
+                  <FormLogic
+                    logicRules={state.logicRules}
+                    onChange={onRuleChange}
+                    onDelete={index => dispatch({type: 'DELETED_RULE', payload: {index: index}})}
+                    onAdd={ruleOverrides => dispatch({type: 'ADD_RULE', payload: ruleOverrides})}
+                  />
+                </TabPanel>
+
+                <TabPanel>
+                  <Appointments
+                    onChange={event => {
+                      dispatch({
+                        type: 'APPOINTMENT_CONFIGURATION_CHANGED',
+                        payload: event,
+                      });
+                    }}
+                  />
+                </TabPanel>
+
+                {featureFlags.enable_form_variables && (
+                  <TabPanel>
+                    <VariablesEditor
+                      variables={state.formVariables}
+                      onAdd={() => dispatch({type: 'ADD_USER_DEFINED_VARIABLE'})}
+                      onDelete={key =>
+                        dispatch({type: 'DELETE_USER_DEFINED_VARIABLE', payload: key})
+                      }
+                      onChange={(key, propertyName, propertyValue) =>
+                        dispatch({
+                          type: 'CHANGE_USER_DEFINED_VARIABLE',
+                          payload: {key, propertyName, propertyValue},
+                        })
+                      }
+                    />
+                  </TabPanel>
+                )}
+              </Tabs>
+            </PluginsContext.Provider>
+          </FormVariablesContext.Provider>
         </FormStepsContext.Provider>
       </ComponentsContext.Provider>
 

--- a/src/openforms/js/components/admin/form_design/logic/AdvancedTrigger.js
+++ b/src/openforms/js/components/admin/form_design/logic/AdvancedTrigger.js
@@ -1,72 +1,9 @@
-import React, {useEffect, useState} from 'react';
-import jsonLogic from 'json-logic-js';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {useIntl} from 'react-intl';
 import classNames from 'classnames';
 
-import {TextArea} from '../../forms/Inputs';
 import DataPreview from './DataPreview';
-
-const JsonWidget = ({name, logic, onChange}) => {
-  const intl = useIntl();
-  const [jsonError, setJsonError] = useState('');
-  const [editorValue, setEditorValue] = useState(JSON.stringify(logic));
-
-  useEffect(() => {
-    setEditorValue(JSON.stringify(logic));
-  }, [logic]);
-
-  const invalidSyntaxMessage = intl.formatMessage({
-    description: 'Advanced logic rule invalid json message',
-    defaultMessage: 'Invalid JSON syntax',
-  });
-  const invalidLogicMessage = intl.formatMessage({
-    description: 'Advanced logic rule invalid JSON-logic message',
-    defaultMessage: 'Invalid JSON logic expression',
-  });
-
-  const onJsonChange = event => {
-    const newValue = event.target.value;
-    setEditorValue(newValue);
-    setJsonError('');
-
-    let updatedJson;
-
-    try {
-      updatedJson = JSON.parse(newValue);
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        setJsonError(invalidSyntaxMessage);
-        return;
-      } else {
-        throw error;
-      }
-    }
-
-    if (!jsonLogic.is_logic(updatedJson)) {
-      setJsonError(invalidLogicMessage);
-      return;
-    }
-
-    const fakeEvent = {target: {name: name, value: updatedJson}};
-    onChange(fakeEvent);
-  };
-
-  return (
-    <div className="json-widget">
-      <div className="json-widget__input">
-        <TextArea name={name} value={editorValue} onChange={onJsonChange} cols={60} />
-      </div>
-      {jsonError.length ? <div className="json-widget__error">{jsonError}</div> : null}
-    </div>
-  );
-};
-
-JsonWidget.propTypes = {
-  name: PropTypes.string.isRequired,
-  logic: PropTypes.object.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
+import JsonWidget from '../../forms/JsonWidget';
 
 const AdvancedTrigger = ({name, logic, onChange, error}) => {
   return (

--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {useIntl} from 'react-intl';
@@ -10,10 +10,13 @@ import DataPreview from '../DataPreview';
 import {ActionComponent} from './Actions';
 import {Action as ActionType, ActionError} from './types';
 import DSLEditorNode from '../DSLEditorNode';
+import {FeatureFlagsContext} from '../../Context';
 
 const Action = ({prefixText, action, errors = {}, onChange, onDelete}) => {
   const intl = useIntl();
   const hasErrors = Object.entries(errors).length > 0;
+
+  const featureFlags = useContext(FeatureFlagsContext);
 
   return (
     <div className="logic-action">
@@ -37,7 +40,10 @@ const Action = ({prefixText, action, errors = {}, onChange, onDelete}) => {
             <DSLEditorNode errors={errors.action?.type}>
               <Select
                 name="action.type"
-                choices={ACTION_TYPES}
+                choices={ACTION_TYPES.filter(actionType => {
+                  if (!featureFlags.enable_form_variables) return actionType[0] !== 'variable';
+                  return true;
+                })}
                 translateChoices
                 allowBlank
                 onChange={onChange}

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -10,6 +10,8 @@ import {ComponentsContext} from '../../../forms/Context';
 import StepSelection from '../StepSelection';
 import {Action as ActionType, ActionError} from './types';
 import DSLEditorNode from '../DSLEditorNode';
+import {FeatureFlagsContext, FormVariablesContext} from '../../Context';
+import JsonWidget from '../../../forms/JsonWidget';
 
 const ActionProperty = ({action, errors, onChange}) => {
   const modifiablePropertyChoices = Object.entries(MODIFIABLE_PROPERTIES).map(([key, info]) => [
@@ -133,6 +135,32 @@ const ActionValue = ({action, errors, onChange}) => {
   );
 };
 
+const ActionVariableValue = ({action, errors, onChange}) => {
+  const allVariables = useContext(FormVariablesContext);
+
+  const getVariableChoices = variables => {
+    return variables.map(variable => [variable.key, variable.name]);
+  };
+
+  return (
+    <>
+      <DSLEditorNode errors={errors.variable}>
+        {/*TODO: This should be a searchable select for when there are a billion variables?*/}
+        <Select
+          name="variable"
+          choices={getVariableChoices(allVariables)}
+          allowBlank
+          onChange={onChange}
+          value={action.variable}
+        />
+      </DSLEditorNode>
+      <DSLEditorNode errors={errors.action?.value}>
+        <JsonWidget name="action.value" logic={action.action.value} onChange={onChange} />
+      </DSLEditorNode>
+    </>
+  );
+};
+
 const ActionStepNotApplicable = ({action, errors, onChange}) => {
   return (
     <DSLEditorNode errors={errors.formStep}>
@@ -150,6 +178,10 @@ const ActionComponent = ({action, errors, onChange}) => {
     }
     case 'value': {
       Component = ActionValue;
+      break;
+    }
+    case 'variable': {
+      Component = ActionVariableValue;
       break;
     }
     case '':

--- a/src/openforms/js/components/admin/form_design/logic/constants.js
+++ b/src/openforms/js/components/admin/form_design/logic/constants.js
@@ -79,6 +79,13 @@ const ACTION_TYPES = [
     }),
   ],
   [
+    'variable',
+    defineMessage({
+      description: 'action type "variable" label',
+      defaultMessage: 'change the value of a variable/component',
+    }),
+  ],
+  [
     'step-not-applicable',
     defineMessage({
       description: 'action type "step-not-applicable" label',

--- a/src/openforms/js/components/admin/forms/JsonWidget.js
+++ b/src/openforms/js/components/admin/forms/JsonWidget.js
@@ -1,0 +1,69 @@
+import React, {useEffect, useState} from 'react';
+import jsonLogic from 'json-logic-js';
+import PropTypes from 'prop-types';
+import {useIntl} from 'react-intl';
+
+import {TextArea} from './Inputs';
+
+const JsonWidget = ({name, logic, onChange}) => {
+  const intl = useIntl();
+  const [jsonError, setJsonError] = useState('');
+  const [editorValue, setEditorValue] = useState(JSON.stringify(logic));
+
+  useEffect(() => {
+    setEditorValue(JSON.stringify(logic));
+  }, [logic]);
+
+  const invalidSyntaxMessage = intl.formatMessage({
+    description: 'Advanced logic rule invalid json message',
+    defaultMessage: 'Invalid JSON syntax',
+  });
+  const invalidLogicMessage = intl.formatMessage({
+    description: 'Advanced logic rule invalid JSON-logic message',
+    defaultMessage: 'Invalid JSON logic expression',
+  });
+
+  const onJsonChange = event => {
+    const newValue = event.target.value;
+    setEditorValue(newValue);
+    setJsonError('');
+
+    let updatedJson;
+
+    try {
+      updatedJson = JSON.parse(newValue);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        setJsonError(invalidSyntaxMessage);
+        return;
+      } else {
+        throw error;
+      }
+    }
+
+    if (!jsonLogic.is_logic(updatedJson)) {
+      setJsonError(invalidLogicMessage);
+      return;
+    }
+
+    const fakeEvent = {target: {name: name, value: updatedJson}};
+    onChange(fakeEvent);
+  };
+
+  return (
+    <div className="json-widget">
+      <div className="json-widget__input">
+        <TextArea name={name} value={editorValue} onChange={onJsonChange} cols={60} />
+      </div>
+      {jsonError.length ? <div className="json-widget__error">{jsonError}</div> : null}
+    </div>
+  );
+};
+
+JsonWidget.propTypes = {
+  name: PropTypes.string.isRequired,
+  logic: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default JsonWidget;

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -749,6 +749,11 @@
     "description": "Variable table initial value title",
     "originalDefault": "Initial value"
   },
+  "RvJXSo": {
+    "defaultMessage": "change the value of a variable/component",
+    "description": "action type \"variable\" label",
+    "originalDefault": "change the value of a variable/component"
+  },
   "S6eF5o": {
     "defaultMessage": "Data removal",
     "description": "Data removal tab title",
@@ -999,6 +1004,11 @@
     "description": "Export form button title",
     "originalDefault": "Export this form"
   },
+  "dWNClE": {
+    "defaultMessage": "Optional category for internal organisation.",
+    "description": "Form category field help text",
+    "originalDefault": "Optional category for internal organisation."
+  },
   "ddDA6+": {
     "defaultMessage": "Array",
     "description": "JSON variable type \"array\" representation",
@@ -1179,6 +1189,11 @@
     "description": "Form list 'name' column header",
     "originalDefault": "Name"
   },
+  "k5JYxu": {
+    "defaultMessage": "Show form",
+    "description": "Show form button",
+    "originalDefault": "Show form"
+  },
   "k9CT3p": {
     "defaultMessage": "Whether to show a link to the main website on the confirmation page.",
     "description": "Display main website link help text",
@@ -1193,6 +1208,11 @@
     "defaultMessage": "disabled",
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
+  },
+  "koVh3m": {
+    "defaultMessage": "Category",
+    "description": "Form category field label",
+    "originalDefault": "Category"
   },
   "l1fi1t": {
     "defaultMessage": "(missing information)",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -749,6 +749,11 @@
     "description": "Variable table initial value title",
     "originalDefault": "Initial value"
   },
+  "RvJXSo": {
+    "defaultMessage": "change the value of a variable/component",
+    "description": "action type \"variable\" label",
+    "originalDefault": "change the value of a variable/component"
+  },
   "S6eF5o": {
     "defaultMessage": "Gegevens opschonen",
     "description": "Data removal tab title",
@@ -999,6 +1004,11 @@
     "description": "Export form button title",
     "originalDefault": "Export this form"
   },
+  "dWNClE": {
+    "defaultMessage": "Optional category for internal organisation.",
+    "description": "Form category field help text",
+    "originalDefault": "Optional category for internal organisation."
+  },
   "ddDA6+": {
     "defaultMessage": "Lijst (array)",
     "description": "JSON variable type \"array\" representation",
@@ -1179,6 +1189,11 @@
     "description": "Form list 'name' column header",
     "originalDefault": "Name"
   },
+  "k5JYxu": {
+    "defaultMessage": "Show form",
+    "description": "Show form button",
+    "originalDefault": "Show form"
+  },
   "k9CT3p": {
     "defaultMessage": "Toon op de formulierbevestigingspagina een link om terug te gaan naar de hoofdwebsite. Deze is enkel zichtbaar als er geen betaling vereist is.",
     "description": "Display main website link help text",
@@ -1193,6 +1208,11 @@
     "defaultMessage": "uitgeschakeld",
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
+  },
+  "koVh3m": {
+    "defaultMessage": "Category",
+    "description": "Form category field label",
+    "originalDefault": "Category"
   },
   "l1fi1t": {
     "defaultMessage": "(ontbrekende informatie)",

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -10,8 +10,6 @@ from openforms.forms.constants import LogicActionTypes
 from openforms.forms.models import FormLogic
 from openforms.prefill import JSONObject
 
-from .constants import SubmissionValueVariableSources
-from .models import SubmissionValueVariable
 from .models.submission_step import DirtyData
 
 if TYPE_CHECKING:  # pragma: nocover

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -137,22 +137,21 @@ def evaluate_form_logic(
                     variable_form_definition = (
                         submission_variable.form_variable.form_definition
                     )
+                    updated_data[action["variable"]] = new_value
+
                     if (
                         not variable_form_definition
                         or variable_form_definition != step.form_step.form_definition
                     ):
-                        # Case 1: The variable is not related to a particular step
-                        # Case 2: The variable being changed is part of a different step than the step currently being edited
+                        # Cases where either:
+                        # 1. The variable is not related to a particular step
+                        # 2. The variable being changed is part of a different step than the step currently being edited
                         # In these cases, the changes are persisted to the database
                         submission_variable.value = new_value
                         submission_variable.source = (
                             SubmissionValueVariableSources.logic
                         )
                         submission_variables_to_update.append(submission_variable)
-                    else:
-                        # The variable being changed is part of the step currently being edited
-                        # The unsaved data will be persisted when the step is saved
-                        updated_data[action["variable"]] = new_value
 
     step.data = DirtyData(updated_data)
     SubmissionValueVariable.objects.bulk_create_or_update(

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -134,14 +134,15 @@ def evaluate_form_logic(
                     submission_variable = submission_variable_state.get_variable(
                         action["variable"]
                     )
-                    variable_form_definition = (
-                        submission_variable.form_variable.form_definition
-                    )
                     updated_data[action["variable"]] = new_value
 
+                    form_variable = submission_variable.form_variable
+
                     if (
-                        not variable_form_definition
-                        or variable_form_definition != step.form_step.form_definition
+                        not form_variable
+                        or not form_variable.form_definition
+                        or form_variable.form_definition
+                        != step.form_step.form_definition
                     ):
                         # Cases where either:
                         # 1. The variable is not related to a particular step

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -33,7 +33,7 @@ from ..query import SubmissionManager
 from ..serializers import CoSignDataSerializer
 from .submission_step import SubmissionStep
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: nocover
     from .submission_files import (
         SubmissionFileAttachment,
         SubmissionFileAttachmentQuerySet,

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -78,7 +78,7 @@ class SubmissionStep(models.Model):
                 from .submission_value_variable import SubmissionValueVariable
 
                 SubmissionValueVariable.objects.bulk_create_or_update_from_data(
-                    self, data, update_missing_variables=True
+                    data, self.submission, self, update_missing_variables=True
                 )
         else:
             self._data = data

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -77,7 +77,7 @@ class SubmissionStep(models.Model):
             else:
                 from .submission_value_variable import SubmissionValueVariable
 
-                SubmissionValueVariable.objects.bulk_create_or_update(
+                SubmissionValueVariable.objects.bulk_create_or_update_from_data(
                     self, data, update_missing_variables=True
                 )
         else:

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -113,24 +113,26 @@ class SubmissionValueVariableManager(models.Manager):
 
     def bulk_create_or_update_from_data(
         self,
-        submission_step: "SubmissionStep",
         data: dict,
+        submission: "Submission",
+        submission_step: "SubmissionStep" = None,
         update_missing_variables: bool = False,
     ) -> None:
-        submission = submission_step.submission
 
         submission_value_variables_state = (
             submission.load_submission_value_variables_state()
         )
-        submission_step_variables = (
-            submission_value_variables_state.get_variables_in_submission_step(
-                submission_step
+        submission_variables = submission_value_variables_state.variables
+        if submission_step:
+            submission_variables = (
+                submission_value_variables_state.get_variables_in_submission_step(
+                    submission_step
+                )
             )
-        )
 
         variables_to_create = []
         variables_to_update = []
-        for key, variable in submission_step_variables.items():
+        for key, variable in submission_variables.items():
             try:
                 variable.value = glom(data, key)
             except PathAccessError:

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from django.db import models
 from django.db.models import Q
@@ -22,6 +22,9 @@ class SubmissionValueVariablesState:
 
     def get_variable(self, key: str) -> Optional["SubmissionValueVariable"]:
         return self.variables[key]
+
+    def set_variable(self, key: str, value: Any) -> None:
+        self.variables[key].value = value
 
     def get_data(self, submission_step: Optional["SubmissionStep"] = None) -> dict:
         submission_variables = self.variables
@@ -93,7 +96,19 @@ class SubmissionValueVariablesState:
 
 
 class SubmissionValueVariableManager(models.Manager):
-    def bulk_create_or_update(
+    def bulk_create_or_update(self, variables: List["SubmissionValueVariable"], fields):
+        variables_to_create = []
+        variables_to_update = []
+        for variable in variables:
+            if not variable.pk:
+                variables_to_create.append(variable)
+            else:
+                variables_to_update.append(variable)
+
+        self.bulk_create(variables_to_create)
+        self.bulk_update(variables_to_update, fields=fields)
+
+    def bulk_create_or_update_from_data(
         self, submission_step, data, update_missing_variables: bool = False
     ):
         submission = submission_step.submission

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -97,7 +97,9 @@ class SubmissionValueVariablesState:
 
 
 class SubmissionValueVariableManager(models.Manager):
-    def bulk_create_or_update(self, variables: List["SubmissionValueVariable"], fields):
+    def bulk_create_or_update(
+        self, variables: List["SubmissionValueVariable"], fields: list
+    ) -> None:
         variables_to_create = []
         variables_to_update = []
         for variable in variables:
@@ -110,8 +112,11 @@ class SubmissionValueVariableManager(models.Manager):
         self.bulk_update(variables_to_update, fields=fields)
 
     def bulk_create_or_update_from_data(
-        self, submission_step, data, update_missing_variables: bool = False
-    ):
+        self,
+        submission_step: "SubmissionStep",
+        data: dict,
+        update_missing_variables: bool = False,
+    ) -> None:
         submission = submission_step.submission
 
         submission_value_variables_state = (

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -50,7 +50,8 @@ class SubmissionValueVariablesState:
         return {
             variable_key: variable
             for variable_key, variable in self.variables.items()
-            if variable.form_variable.form_definition == form_definition
+            if variable.form_variable
+            and variable.form_variable.form_definition == form_definition
         }
 
     @classmethod

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -12,7 +12,7 @@ from openforms.forms.models.form_variable import FormVariable
 from ..constants import SubmissionValueVariableSources
 from .submission import Submission
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: nocover
     from .submission_step import SubmissionStep
 
 
@@ -22,9 +22,6 @@ class SubmissionValueVariablesState:
 
     def get_variable(self, key: str) -> Optional["SubmissionValueVariable"]:
         return self.variables[key]
-
-    def set_variable(self, key: str, value: Any) -> None:
-        self.variables[key].value = value
 
     def get_data(self, submission_step: Optional["SubmissionStep"] = None) -> dict:
         submission_variables = self.variables
@@ -97,20 +94,6 @@ class SubmissionValueVariablesState:
 
 
 class SubmissionValueVariableManager(models.Manager):
-    def bulk_create_or_update(
-        self, variables: List["SubmissionValueVariable"], fields: list
-    ) -> None:
-        variables_to_create = []
-        variables_to_update = []
-        for variable in variables:
-            if not variable.pk:
-                variables_to_create.append(variable)
-            else:
-                variables_to_update.append(variable)
-
-        self.bulk_create(variables_to_create)
-        self.bulk_update(variables_to_update, fields=fields)
-
     def bulk_create_or_update_from_data(
         self,
         data: dict,

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -1,0 +1,255 @@
+from django.test import TestCase
+
+
+from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormStepFactory,
+    FormVariableFactory,
+)
+
+from ...form_logic import evaluate_form_logic
+from ...models import SubmissionValueVariable
+from ..factories import SubmissionFactory, SubmissionStepFactory
+from ..mixins import VariablesTestMixin
+from .factories import FormLogicFactory
+
+
+class VariableModificationTests(VariablesTestMixin, TestCase):
+    def test_modify_variable_related_to_step_being_edited(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nLargeBoxes",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nGiganticBoxes",
+                    },
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form, form_definition__configuration={"components": []}
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="nTotalBoxes",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.int,
+            form_definition=step2.form_definition,
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nLargeBoxes"},
+                            "",
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nGiganticBoxes"},
+                            "",
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "nTotalBoxes",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [{"var": "nLargeBoxes"}, {"var": "nGiganticBoxes"}]
+                        },
+                    },
+                }
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={"nLargeBoxes": 2, "nGiganticBoxes": 5},
+        )
+        # Step being edited
+        submission_step2 = SubmissionStepFactory.build(
+            submission=submission,
+            form_step=step2,
+            data={},
+        )
+
+        evaluate_form_logic(submission, submission_step2, submission.data)
+
+        updated_variable_value = submission_step2._unsaved_data.get("nTotalBoxes")
+
+        self.assertEqual(7, updated_variable_value)
+
+    def test_modify_variable_related_to_another_step_than_the_one_being_edited(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nLargeBoxes",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nGiganticBoxes",
+                    },
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form, form_definition__configuration={"components": []}
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="nTotalBoxes",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.int,
+            form_definition=step1.form_definition,
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nLargeBoxes"},
+                            "",
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nGiganticBoxes"},
+                            "",
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "nTotalBoxes",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [{"var": "nLargeBoxes"}, {"var": "nGiganticBoxes"}]
+                        },
+                    },
+                }
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={"nLargeBoxes": 2, "nGiganticBoxes": 5},
+        )
+        # Step being edited
+        submission_step2 = SubmissionStepFactory.build(
+            submission=submission,
+            form_step=step2,
+            data={},
+        )
+
+        evaluate_form_logic(submission, submission_step2, submission.data)
+
+        updated_variable = SubmissionValueVariable.objects.get(key="nTotalBoxes")
+
+        self.assertEqual(7, updated_variable.value)
+
+    def test_modify_variable_not_related_to_a_step(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nLargeBoxes",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nGiganticBoxes",
+                    },
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form, form_definition__configuration={"components": []}
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="nTotalBoxes",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.int,
+            form_definition=step1.form_definition,
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nLargeBoxes"},
+                            "",
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nGiganticBoxes"},
+                            "",
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "nTotalBoxes",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [{"var": "nLargeBoxes"}, {"var": "nGiganticBoxes"}]
+                        },
+                    },
+                }
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={"nLargeBoxes": 2, "nGiganticBoxes": 5},
+        )
+        # Step being edited
+        submission_step2 = SubmissionStepFactory.build(
+            submission=submission,
+            form_step=step2,
+            data={},
+        )
+
+        evaluate_form_logic(submission, submission_step2, submission.data)
+
+        submission_variable_state = submission.load_submission_value_variables_state()
+        updated_variable = submission_variable_state.get_variable("nTotalBoxes")
+
+        self.assertEqual(7, updated_variable.value)

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 
-
 from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -169,9 +169,7 @@ class VariableModificationTests(VariablesTestMixin, TestCase):
 
         evaluate_form_logic(submission, submission_step2, submission.data)
 
-        updated_variable = SubmissionValueVariable.objects.get(key="nTotalBoxes")
-
-        self.assertEqual(7, updated_variable.value)
+        self.assertEqual(7, submission_step2.data["nTotalBoxes"])
 
     def test_modify_variable_not_related_to_a_step(self):
         form = FormFactory.create()
@@ -248,7 +246,4 @@ class VariableModificationTests(VariablesTestMixin, TestCase):
 
         evaluate_form_logic(submission, submission_step2, submission.data)
 
-        submission_variable_state = submission.load_submission_value_variables_state()
-        updated_variable = submission_variable_state.get_variable("nTotalBoxes")
-
-        self.assertEqual(7, updated_variable.value)
+        self.assertEqual(7, submission_step2.data["nTotalBoxes"])

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -137,6 +137,5 @@ class FormNodeTests(TestCase):
         # 2. Getting the submission steps for the given submission
         # 3. Query the form logic rules for the submission form (and this is cached)
         # 4. & 5. Loading the submission execution state
-        # 6. & 7. Load the submission variables state
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             list(renderer)

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -135,7 +135,8 @@ class FormNodeTests(TestCase):
         # Expected queries:
         # 1. Getting the merged data of the submission steps
         # 2. Getting the submission steps for the given submission
-        # 3 & 4. Loading the submission execution state
-        # 5. Query the form logic rules for the submission form (and this is cached)
-        with self.assertNumQueries(5):
+        # 3. Query the form logic rules for the submission form (and this is cached)
+        # 4. & 5. Loading the submission execution state
+        # 6. & 7. Load the submission variables state
+        with self.assertNumQueries(7):
             list(renderer)

--- a/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
@@ -1,0 +1,503 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormStepFactory,
+    FormVariableFactory,
+)
+from openforms.submissions.tests.mixins import VariablesTestMixin
+
+from ...models import SubmissionValueVariable
+from ..factories import SubmissionFactory, SubmissionStepFactory
+from ..form_logic.factories import FormLogicFactory
+from ..mixins import SubmissionsMixin
+
+
+class UpdateVariablesWithLogicTests(VariablesTestMixin, SubmissionsMixin, APITestCase):
+    def test_update_data_in_step(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nGreenApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nRedApples",
+                    },
+                    {"type": "number", "key": "totApples"},
+                ]
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nGreenApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nRedApples"},
+                            None,
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "totApples",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [{"var": "nGreenApples"}, {"var": "nRedApples"}]
+                        },
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step1.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        response = self.client.post(
+            endpoint, data={"data": {"nGreenApples": 3, "nRedApples": 5}}
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {
+                "totApples": 8
+            },  # Only the changed data is sent back to the frontend after the logic check
+            response.data["step"]["data"],
+        )
+        # Check that no variables are persisted to the backend because the step has not been submitted yet
+        self.assertEqual(
+            0, SubmissionValueVariable.objects.filter(submission=submission).count()
+        )
+
+    def test_that_updated_data_is_used_by_subsequent_rules(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nGreenApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nRedApples",
+                    },
+                    {"type": "number", "key": "totApples"},
+                    {"type": "number", "key": "nPeaches"},
+                    {"type": "number", "key": "totFruit"},
+                ]
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nGreenApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nRedApples"},
+                            None,
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "totApples",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [{"var": "nGreenApples"}, {"var": "nRedApples"}]
+                        },
+                    },
+                }
+            ],
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nGreenApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nRedApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nPeaches"},
+                            None,
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "totFruit",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [
+                                {"var": "totApples"},
+                                {"var": "nPeaches"},
+                            ]  # This needs to use the calculated value of totApples
+                        },
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step1.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        response = self.client.post(
+            endpoint, data={"data": {"nGreenApples": 3, "nRedApples": 5, "nPeaches": 4}}
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {
+                "totApples": 8,
+                "totFruit": 12,
+            },  # Only the changed data is sent back to the frontend after the logic check
+            response.data["step"]["data"],
+        )
+        # Check that no variables are persisted to the backend because the step has not been submitted yet
+        self.assertEqual(
+            0, SubmissionValueVariable.objects.filter(submission=submission).count()
+        )
+
+    def test_that_updated_data_is_used_by_subsequent_actions(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nGreenApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nRedApples",
+                    },
+                    {"type": "number", "key": "totApples"},
+                    {"type": "number", "key": "nPeaches"},
+                    {"type": "number", "key": "totFruit"},
+                ]
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nGreenApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nRedApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nPeaches"},
+                            None,
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "totApples",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [{"var": "nGreenApples"}, {"var": "nRedApples"}]
+                        },
+                    },
+                },
+                {
+                    "variable": "totFruit",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [
+                                {"var": "totApples"},
+                                {"var": "nPeaches"},
+                            ]  # This needs to use the calculated value of totApples
+                        },
+                    },
+                },
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step1.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        response = self.client.post(
+            endpoint, data={"data": {"nGreenApples": 3, "nRedApples": 5, "nPeaches": 4}}
+        )
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {
+                "totApples": 8,
+                "totFruit": 12,
+            },  # Only the changed data is sent back to the frontend after the logic check
+            response.data["step"]["data"],
+        )
+        # Check that no variables are persisted to the backend because the step has not been submitted yet
+        self.assertEqual(
+            0, SubmissionValueVariable.objects.filter(submission=submission).count()
+        )
+
+    def test_update_data_based_on_previous_step(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nGreenApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nRedApples",
+                    },
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "number", "key": "nPeaches"},
+                    {"type": "number", "key": "totFruit"},
+                ]
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {
+                        "!=": [
+                            {"var": "nGreenApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nRedApples"},
+                            None,
+                        ]
+                    },
+                    {
+                        "!=": [
+                            {"var": "nPeaches"},
+                            None,
+                        ]
+                    },
+                ]
+            },
+            actions=[
+                {
+                    "variable": "totFruit",
+                    "action": {
+                        "name": "Update variable",
+                        "type": "variable",
+                        "value": {
+                            "+": [
+                                {"var": "nRedApples"},
+                                {"var": "nGreenApples"},
+                                {"var": "nPeaches"},
+                            ]
+                        },
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={"nGreenApples": 3, "nRedApples": 5},
+        )
+
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step2.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        response = self.client.post(endpoint, data={"data": {"nPeaches": 4}})
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {
+                "totFruit": 12,
+            },
+            response.data["step"]["data"],
+        )
+        self.assertFalse(
+            SubmissionValueVariable.objects.filter(
+                submission=submission, key="totFruit"
+            ).exists()
+        )
+
+    def test_variables_not_related_to_a_step_are_persisted(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nGreenApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nRedApples",
+                    },
+                ]
+            },
+        )
+        tot_apples_var = FormVariableFactory.create(
+            form=form,
+            key="totApples",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.int,
+            form_definition=None,
+        )
+
+        submission = SubmissionFactory.create(form=form)
+
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+        body = {
+            "data": {"nGreenApples": 3, "nRedApples": 5, "totApples": 8}
+        }  # Tot apples is added to the step data during the logic check call
+
+        # Persist the step
+        response = self.client.put(endpoint, body)
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+        variable = SubmissionValueVariable.objects.filter(
+            submission=submission, form_variable=tot_apples_var
+        ).first()
+
+        self.assertIsNotNone(variable)
+        self.assertEqual(8, variable.value)
+
+    def test_user_defined_variables_are_persisted(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nGreenApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nRedApples",
+                    },
+                ]
+            },
+        )
+        tot_apples_var = FormVariableFactory.create(
+            form=form,
+            key="totApples",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.int,
+            form_definition=form_step.form_definition,
+        )
+
+        submission = SubmissionFactory.create(form=form)
+
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+        body = {
+            "data": {"nGreenApples": 3, "nRedApples": 5, "totApples": 8}
+        }  # Tot apples is added to the step data during the logic check call
+
+        # Persist the step
+        response = self.client.put(endpoint, body)
+
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+        variable = SubmissionValueVariable.objects.filter(
+            submission=submission, form_variable=tot_apples_var
+        ).first()
+
+        self.assertIsNotNone(variable)
+        self.assertEqual(8, variable.value)


### PR DESCRIPTION
Part of #1325 

**Changes**
- In the admin form editor, for the actions there is a new type available, which is "variable". It gives the possibility to use JsonLogic to calculate the new value of a component. I think this will replace the action "value" once variables become the default.
- During logic evaluation, the value of the variables is updated.

Thing that currently happens if one uses a variable action: 
- User changes value of a field that triggers the update of a variable
- POST to `_check_logic` updates the step data with the new variable of the user defined variable
- I think the update of the step data triggers another POST to `_check_logic`
- The last POST to `_check_logic` updates the configuration with the data of the variables calculated in the first POST to `_check_logic`.

(So 2 calls to `_check_logic` instead of 1 if a field updates a variable)

**To do**
- Decide how much validation there should be? If the result of a calculation gives a value of a different type of the variable, what should we do?
