### PR TITLE
Ensure postal code field prefill values are normalized

### DIFF
--- a/src/openforms/formio/normalization.py
+++ b/src/openforms/formio/normalization.py
@@ -1,0 +1,65 @@
+import logging
+from abc import abstractmethod
+from typing import Any
+
+from openforms.plugins.plugin import AbstractBasePlugin
+from openforms.plugins.registry import BaseRegistry
+
+from .typing import Component
+from .utils import conform_to_mask
+
+__all__ = ["normalize_value_for_component", "register", "Normalizer"]
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_value_for_component(component: Component, value: Any) -> Any:
+    """
+    Given a value (actual or default value) and the component, apply the component-
+    specific normalization.
+    """
+    if (component_type := component.get("type")) not in register:
+        return value
+    normalizer = register[component_type]
+    return normalizer(component, value)
+
+
+class Registry(BaseRegistry):
+    """
+    A registry for FormIO normalization functions.
+    """
+
+    pass
+
+
+class Normalizer(AbstractBasePlugin):
+    def __call__(self, component: Component, value: Any) -> Any:
+        return self.normalize(component, value)
+
+    @abstractmethod
+    def normalize(self, component: Component, value: Any) -> Any:
+        raise NotImplementedError  # pragma: nocover
+
+
+# Sentinel to provide the default registry. You an easily instantiate another
+# :class:`Registry` object to use as dependency injection in tests.
+register = Registry()
+
+
+@register("postcode")
+class PostalCodeNormalizer(Normalizer):
+    def normalize(self, component: Component, value: str) -> str:
+        if not value:
+            return value
+
+        input_mask = component.get("inputMask")
+        if not input_mask:
+            return value
+
+        try:
+            return conform_to_mask(value, input_mask)
+        except ValueError:
+            logger.warning(
+                "Could not conform value '%s' to input mask '%s', returning original value."
+            )
+            return value

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -10,6 +10,7 @@ from openforms.forms.custom_field_types import handle_custom_types
 from openforms.prefill import _set_default_values, apply_prefill
 from openforms.submissions.models import Submission, SubmissionValueVariable
 
+from .normalization import normalize_value_for_component  # noqa
 from .utils import format_date_value, iter_components, mimetype_allowed  # noqa
 
 

--- a/src/openforms/formio/tests/test_conform_to_mask.py
+++ b/src/openforms/formio/tests/test_conform_to_mask.py
@@ -1,0 +1,43 @@
+from django.test import SimpleTestCase
+
+from ..utils import conform_to_mask
+
+
+class ConformToMaskTests(SimpleTestCase):
+    def test_valid_conversions(self):
+        valid = (
+            ("9999 AA", "1000AA", "1000 AA"),
+            ("9999 AA", "1000 AA", "1000 AA"),
+            ("9999 AA", "1000  AA", "1000 AA"),
+            ("9999 AA", "1000 aA", "1000 aA"),
+            ("9999AA", "1000AA", "1000AA"),
+            ("9999AA", "1015 CJ", "1015CJ"),
+            ("9999AA", "1015 cj", "1015cj"),
+            ("9999AA", "1015 cJ", "1015cJ"),
+            ("ab:a9", "Zb:Y3", "zb:y3"),
+            ("(999) 999-99", "(123)456-78", "(123) 456-78"),
+            ("(999) 999-99", "(123) 456-78", "(123) 456-78"),
+            ("**-99", "E3-55", "E3-55"),
+        )
+
+        for mask, value, expected in valid:
+            with self.subTest(mask=mask, input=value, expected=expected):
+                result = conform_to_mask(value, mask)
+
+                self.assertEqual(result, expected)
+
+    def test_invalid_conversions(self):
+        invalid = (
+            ("9999 AA", "abc8 CJ"),
+            ("9999 AA", "1234 30"),
+            # TODO: we probably *could* convert non-input characters from the mask
+            ("ab:a9", "Zb-Y3"),
+            ("**-99", "^%-55"),
+            ("9999 AA", "1000 A"),
+            ("9999 AA", "1000A"),
+        )
+
+        for mask, value in invalid:
+            with self.subTest(mask=mask, input=value):
+                with self.assertRaises(ValueError):
+                    conform_to_mask(value, mask)

--- a/src/openforms/formio/tests/test_normalization.py
+++ b/src/openforms/formio/tests/test_normalization.py
@@ -1,0 +1,58 @@
+from django.test import SimpleTestCase
+
+from ..service import normalize_value_for_component
+
+
+class NormalizationTests(SimpleTestCase):
+    def test_postcode_normalization_with_space(self):
+        component = {
+            "type": "postcode",
+            "inputMask": "9999 AA",
+        }
+        values = ["1015CJ", "1015 CJ", "1015 cj", "1015cj"]
+
+        for value in values:
+            with self.subTest(value=value):
+                result = normalize_value_for_component(component, value)
+
+                self.assertEqual(result.upper(), "1015 CJ")
+
+    def test_postcode_normalization_without_space(self):
+        component = {
+            "type": "postcode",
+            "inputMask": "9999AA",
+        }
+        values = ["1015CJ", "1015 CJ", "1015 cj", "1015cj"]
+
+        for value in values:
+            with self.subTest(value=value):
+                result = normalize_value_for_component(component, value)
+
+                self.assertEqual(result.upper(), "1015CJ")
+
+    def test_empty_value(self):
+        component = {
+            "type": "postcode",
+            "inputMask": "9999AA",
+        }
+
+        result = normalize_value_for_component(component, "")
+
+        self.assertEqual(result, "")
+
+    def test_value_invalid_for_mask(self):
+        component = {
+            "type": "postcode",
+            "inputMask": "9999AA",
+        }
+
+        result = normalize_value_for_component(component, "AAAA 34")
+
+        self.assertEqual(result, "AAAA 34")
+
+    def test_no_input_mask_given(self):
+        component = {"type": "postcode"}
+
+        result = normalize_value_for_component(component, "AAAA 34")
+
+        self.assertEqual(result, "AAAA 34")

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -94,3 +94,104 @@ def mimetype_allowed(mime_type: str, allowed_mime_types: List[str]) -> bool:
         return True
 
     return mime_type in allowed_mime_types
+
+
+# See https://help.form.io/userguide/forms/form-components#input-mask for the
+# semantics, and FormioUtils.getInputMask for the implementation.
+def conform_to_mask(value: str, mask: str) -> str:
+    """
+    Given an input and a Formio mask, try to conform the value to the mask.
+
+    If the value is not compatible with the mask, a ``ValueError`` is raised.
+    """
+    # loop through all the characters of the value and test them against the mask. Note
+    # that the value and mask may have different lengths due to non-input characters
+    # such as spaces/dashes... Formio only recognizes alphanumeric inputs as variable
+    # user input, the rest is part of the mask.
+    # NOTE: we don't check for numeric masks or not, let that be handled by Formio itself
+
+    # the final result characters, build from the value and mask
+    result: List[str] = []
+    char_index, mask_index = 0, 0
+    LOOP_GUARD, iterations = 1000, 0
+
+    # maps the formio mask characters to rules to test for alphanumeric chars etc.
+    TEST_RULES = {
+        "9": lambda c: c.isnumeric(),
+        "A": lambda c: c.isalpha(),
+        "a": lambda c: c.isalpha(),
+        "*": lambda c: c.isalnum(),
+    }
+
+    # the loop indices are reset within an iteration, but in the end either a ValueError
+    # is raised because of mismatch with the mask, or the value has been re-formatted
+    # conforming to the mask and thus has the same length.
+    while len(result) != len(mask):
+        if iterations > LOOP_GUARD:  # pragma: nocover
+            raise RuntimeError("Infinite while-loop detected!")
+        iterations += 1
+
+        try:
+            char, mask_char = value[char_index], mask[mask_index]
+        except IndexError as exc:
+            raise ValueError("Ran out of mask or value characters to process") from exc
+
+        test = TEST_RULES.get(mask_char)
+
+        # check if the character matches the mask - if it does, post-process and put
+        # it in the result list
+        if test and test(char) is True:
+            # check if we need to allow uppercase
+            if mask_char.islower() and char.isupper():
+                char = char.lower()
+            result.append(char)
+            # at the end of processing a character, advance the indices for the next
+            # character
+            char_index += 1
+            mask_index += 1
+            continue
+        elif char == mask_char:  # literal match -> good to go
+            result.append(char)
+            # at the end of processing a character, advance the indices for the next
+            # character
+            char_index += 1
+            mask_index += 1
+            continue
+        elif test is not None:  # there is a test, but it didn't pass
+            # there was a test, meaning this is an alphanumeric mask of some form. We
+            # may potentially skip some separator/formatting chars but ONLY if the
+            # current char is not alphanumeric at all. If it is, it doesn't match
+            # the expected pattern and we raise a ValueError.
+            if char.isalnum():
+                raise ValueError(
+                    f"Character {char} did not match expected pattern {mask_char}"
+                )
+            elif mask_char == "*":
+                raise ValueError(f"Character {char} was expected to be alphanumeric")
+            # at the end of processing a character, advance the indices for the next
+            # character
+            char_index += 1
+            continue
+        elif test is None:  # no test -> it's a formatting character
+            # if we encounter a formatting character that isn't the current input character,
+            # check if the current character is possibly an input (by checking if it's
+            # alphanumeric). If it's not, then we have a mismatch, otherwise we insert
+            # the formatting character in the result list and process the char again
+            # against the next mask char.
+            if not char.isalnum():
+                raise ValueError(
+                    f"Character {char} did not match expected formatting character {mask_char}"
+                )
+
+            # the character is probably input, so add the formatter to the result list and
+            # keep the current char_index so that we process it again
+            result.append(mask_char)
+            mask_index += 1
+            continue
+
+        else:  # pragma: nocover
+            raise RuntimeError(
+                f"Unexpected situation! Mask: {mask}, input value: {value}"
+            )
+
+    return "".join(result)

--- a/src/openforms/prefill/tests/test_prefill_hook.py
+++ b/src/openforms/prefill/tests/test_prefill_hook.py
@@ -620,3 +620,43 @@ class PrefillHookTests(TransactionTestCase):
         # (recurring from step one)
         field = new_configuration_two["components"][2]
         self.assertEqual(field["defaultValue"], "alpha_one_value")
+
+    def test_value_is_normalized(self):
+        """
+        Regression integration test for #1693.
+
+        Ensure that values retrieved from prefill plugins are normalized according
+        to the postal code inputMask.
+        """
+        configuration = {
+            "components": [
+                {
+                    "type": "postcode",
+                    "key": "postcode",
+                    "inputMask": "9999 AA",
+                    "prefill": {
+                        "plugin": "postcode",
+                        "attribute": "static",
+                    },
+                    "defaultValue": "",
+                }
+            ]
+        }
+
+        form_step = FormStepFactory.create(form_definition__configuration=configuration)
+        submission = SubmissionFactory.create(form=form_step.form)
+
+        register = Registry()
+
+        @register("postcode")
+        class HavePlugin(DemoPrefill):
+            @staticmethod
+            def get_prefill_values(submission, attributes):
+                return {"static": "1015CJ"}
+
+        new_configuration = apply_prefill(
+            configuration=configuration, submission=submission, register=register
+        )
+
+        field = new_configuration["components"][0]
+        self.assertEqual(field["defaultValue"], "1015 CJ")


### PR DESCRIPTION
... before they are passed to Formio.

Fixes #1693

This patch respects the input mask configured on a formio component (for postcode type components) and adds the machinery to perform normalization for other compnent types in a pluggable way.