### PR TITLE
Fix logo sizing for PDFs — [#1715]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__
 
 local.py
 /env/
+/venv/
 /media/
 /private_media/
 /static/

--- a/src/openforms/scss/pdfs/_header.scss
+++ b/src/openforms/scss/pdfs/_header.scss
@@ -1,7 +1,6 @@
 @use 'sass:math';
 
 @import '~microscope-sass/lib/typography';
-@import './vars';
 
 $padding-size: 10mm;
 
@@ -21,6 +20,10 @@ $padding-size: 10mm;
     page: haslogo;
   }
 
+  &:not(&--has-logo) {
+    display: none;
+  }
+
   &__logo {
     min-width: 100px;
     min-height: 50px;
@@ -28,7 +31,7 @@ $padding-size: 10mm;
 
     width: var(--of-header-logo-width, auto);
     height: var(--of-header-logo-height, 50px);
-    background-image: $page-header-logo-url;
+    background-image: var(--of-header-logo-url);
     background-position: 50%;
     background-repeat: no-repeat;
     background-size: contain;

--- a/src/openforms/scss/pdfs/_header.scss
+++ b/src/openforms/scss/pdfs/_header.scss
@@ -1,6 +1,7 @@
 @use 'sass:math';
 
 @import '~microscope-sass/lib/typography';
+@import './vars';
 
 $padding-size: 10mm;
 
@@ -20,10 +21,6 @@ $padding-size: 10mm;
     page: haslogo;
   }
 
-  &:not(&--has-logo) {
-    display: none;
-  }
-
   &__logo {
     min-width: 100px;
     min-height: 50px;
@@ -31,5 +28,10 @@ $padding-size: 10mm;
 
     width: var(--of-header-logo-width, auto);
     height: var(--of-header-logo-height, 50px);
+    background-image: $page-header-logo-url;
+    background-position: 50%;
+    background-repeat: no-repeat;
+    background-size: contain;
+    display: block;
   }
 }

--- a/src/openforms/scss/pdfs/_header.scss
+++ b/src/openforms/scss/pdfs/_header.scss
@@ -32,7 +32,6 @@ $padding-size: 10mm;
     width: var(--of-header-logo-width, auto);
     height: var(--of-header-logo-height, 50px);
     background-image: var(--of-header-logo-url);
-    background-position: 50%;
     background-repeat: no-repeat;
     background-size: contain;
     display: block;

--- a/src/openforms/scss/pdfs/_vars.scss
+++ b/src/openforms/scss/pdfs/_vars.scss
@@ -1,7 +1,0 @@
-// colors
-$page-header-background: var(--of-page-header-bg);
-
-// logo
-$page-header-logo-url: var(--of-header-logo-url);
-$page-header-logo-width: var(--of-header-logo-width);
-$page-header-logo-height: var(--of-header-logo-height);

--- a/src/openforms/scss/pdfs/_vars.scss
+++ b/src/openforms/scss/pdfs/_vars.scss
@@ -1,0 +1,7 @@
+// colors
+$page-header-background: var(--of-page-header-bg);
+
+// logo
+$page-header-logo-url: var(--of-header-logo-url);
+$page-header-logo-width: var(--of-header-logo-width);
+$page-header-logo-height: var(--of-header-logo-height);

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -31,11 +31,10 @@
 
         <section class="sheet padding-10mm">
             <header class="header {% if config.logo %}header--has-logo{% endif %}">
-                <a
+                <span
                     class="header__logo"
-                    href="{% firstof config.main_website '#' %}"
                     {% if config.logo %}role="img"{% endif %}
-                ></a>
+                ></span>
             </header>
 
             <h1 class="title">{{ report.form.name }}</h1>

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -18,6 +18,12 @@
         :root {{% for token, value in design_tokens.items %}
           {{ token }}: {{ value }};{% endfor %}
         }
+
+        {% if config.logo %}
+        .header {
+            --of-header-logo-url: url('{{ config.logo.url }}');
+        }
+        {% endif %}
         </style>
     </head>
 
@@ -25,7 +31,11 @@
 
         <section class="sheet padding-10mm">
             <header class="header {% if config.logo %}header--has-logo{% endif %}">
-                {% if config.logo %}<img class="header__logo" src="{{ config.logo.url }}" />{% endif %}
+                <a
+                    class="header__logo"
+                    href="{% firstof config.main_website '#' %}"
+                    {% if config.logo %}role="img"{% endif %}
+                ></a>
             </header>
 
             <h1 class="title">{{ report.form.name }}</h1>


### PR DESCRIPTION
Fixes #1715

### Example output

Input image:

> JPEG image data, JFIF standard 1.02, resolution (DPI), density 72x72, segment length 16, Exif Standard: [TIFF image data, big-endian, direntries=5, xresolution=206, yresolution=214, resolutionunit=2], baseline, precision 8, 4000x4000, components 3


![pdf_output](https://user-images.githubusercontent.com/58147939/176221514-11ab482c-9771-4110-bd8f-4f794338c8ed.png)
 