### PR TITLE
Fix error in console caused by fix for issue 1422

### DIFF
--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -114,8 +114,10 @@ class WebformBuilder extends WebformBuilderFormio {
       this.updateComponent(event.data.componentJson || event.data, event.changed);
     };
 
-    this.editForm.events._events['formio.change'][existingOnChangeHandlers.length - 1].fn =
-      modifiedOnChangeCallback;
+    if (existingOnChangeHandlers.length) {
+      this.editForm.events._events['formio.change'][existingOnChangeHandlers.length - 1].fn =
+        modifiedOnChangeCallback;
+    }
     return parentEditResult;
   }
 }


### PR DESCRIPTION
Fix error that `this.editForm.events._events['formio.change'][existingOnChangeHandlers.length - 1] is undefined`