### PR TITLE
[#1747] Bugs default values with variables

### DIFF
--- a/src/openforms/formio/formatters/registry.py
+++ b/src/openforms/formio/formatters/registry.py
@@ -17,6 +17,6 @@ class Registry(BaseRegistry):
         return formatter(info, value, as_html=as_html)
 
 
-# Sentinel to provide the default registry. You an easily instantiate another
+# Sentinel to provide the default registry. You can easily instantiate another
 # :class:`Registry` object to use as dependency injection in tests.
 register = Registry()

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -81,6 +81,15 @@ def get_component_datatype(component):
     return COMPONENT_DATATYPES.get(component_type, "string")
 
 
+def get_component_default_value(component):
+    # Formio has a getter for the:
+    # - emptyValue: https://github.com/formio/formio.js/blob/4.13.x/src/components/textfield/TextField.js#L58
+    # - defaultValue:
+    #    https://github.com/formio/formio.js/blob/4.13.x/src/components/_classes/component/Component.js#L2302
+    # If the defaultValue is empty, then the field will be populated with the emptyValue in the form data.
+    return component.get("defaultValue")
+
+
 def mimetype_allowed(mime_type: str, allowed_mime_types: List[str]) -> bool:
     """
     Test if the file mime type passes the allowed_mime_types Formio configuration.

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -11,6 +11,7 @@ from glom import Path, glom
 
 from openforms.formio.utils import (
     get_component_datatype,
+    get_component_default_value,
     is_layout_component,
     iter_components,
 )
@@ -86,7 +87,7 @@ class FormVariableManager(models.Manager):
                     is_sensitive_data=component.get("isSensitiveData", False),
                     source=FormVariableSources.component,
                     data_type=get_component_datatype(component),
-                    initial_value=component.get("defaultValue"),
+                    initial_value=get_component_default_value(component),
                 )
             )
 

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -33,28 +33,6 @@ def get_now() -> str:
 
 STATIC_INITIAL_VALUES = {FormVariableStaticInitialValues.now: get_now}
 
-INITIAL_VALUES = {
-    FormVariableDataTypes.string: "",
-    FormVariableDataTypes.boolean: False,
-    FormVariableDataTypes.object: {},
-    FormVariableDataTypes.array: [],
-    FormVariableDataTypes.float: None,
-    FormVariableDataTypes.datetime: "",
-    FormVariableDataTypes.time: "",
-}
-
-COMPONENT_DATATYPES = {
-    "date": "datetime",
-    "time": "time",
-    "file": "array",
-    "currency": "float",
-    "number": "float",
-    "checkbox": "boolean",
-    "selectboxes": "object",
-    "npFamilyMembers": "object",
-    "map": "array",
-}
-
 
 class FormVariableManager(models.Manager):
     @transaction.atomic
@@ -88,33 +66,29 @@ class FormVariableManager(models.Manager):
             ):
                 continue
 
-            new_variable = self.model(
-                form=form_step.form,
-                form_definition=form_step.form_definition,
-                prefill_plugin=glom(
-                    component,
-                    Path("prefill", "plugin"),
-                    default="",
-                    skip_exc=KeyError,
-                ),
-                prefill_attribute=glom(
-                    component,
-                    Path("prefill", "attribute"),
-                    default="",
-                    skip_exc=KeyError,
-                ),
-                key=component["key"],
-                is_sensitive_data=component.get("isSensitiveData", False),
-                source=FormVariableSources.component,
-                data_type=get_component_datatype(component),
+            form_variables.append(
+                self.model(
+                    form=form_step.form,
+                    form_definition=form_step.form_definition,
+                    prefill_plugin=glom(
+                        component,
+                        Path("prefill", "plugin"),
+                        default="",
+                        skip_exc=KeyError,
+                    ),
+                    prefill_attribute=glom(
+                        component,
+                        Path("prefill", "attribute"),
+                        default="",
+                        skip_exc=KeyError,
+                    ),
+                    key=component["key"],
+                    is_sensitive_data=component.get("isSensitiveData", False),
+                    source=FormVariableSources.component,
+                    data_type=get_component_datatype(component),
+                    initial_value=component.get("defaultValue"),
+                )
             )
-            default_value = component.get("defaultValue")
-            if default_value is not None:
-                new_variable.initial_value = default_value
-            else:
-                new_variable.initial_value = new_variable.get_initial_value()
-
-            form_variables.append(new_variable)
 
         return self.bulk_create(form_variables)
 

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -136,7 +136,7 @@ class FormVariableFactory(factory.django.DjangoModelFactory):
     form_definition = factory.SubFactory(FormDefinitionFactory)
     source = FormVariableSources.user_defined
     data_type = FormVariableDataTypes.string
-    initial_value = {}
+    initial_value = None
 
     class Meta:
         model = "forms.FormVariable"

--- a/src/openforms/forms/tests/variables/test_initial_values.py
+++ b/src/openforms/forms/tests/variables/test_initial_values.py
@@ -33,8 +33,9 @@ class FormVariablesTests(TestCase):
                 "Some text value", user_defined_variable.get_initial_value()
             )
 
+        # If no initial value is specified, the initial value is None
         component_variable = FormVariableFactory.create(
             source=FormVariableSources.component, data_type=FormVariableDataTypes.array
         )
         with self.subTest(part="component variable"):
-            self.assertEqual([], component_variable.get_initial_value())
+            self.assertIsNone(component_variable.get_initial_value())

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -57,7 +57,7 @@ import {
   replaceComponentKeyInLogic,
   getUniqueKey,
 } from './utils';
-import {getEmptyValue, updateFormVariables} from './variables/utils';
+import {updateFormVariables} from './variables/utils';
 import VariablesEditor from './variables/VariablesEditor';
 import {EMPTY_VARIABLE} from './variables/constants';
 
@@ -360,7 +360,7 @@ function reducer(draft, action) {
 
       // Issue #1729 - Workaround for bug in FormIO
       if (mutationType === 'changed' && !schema.multiple && Array.isArray(schema.defaultValue)) {
-        schema.defaultValue = getEmptyValue(schema);
+        schema.defaultValue = null;
       }
 
       // Check if the formVariables need updating

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -360,6 +360,12 @@ function reducer(draft, action) {
 
       // Issue #1729 - Workaround for bug in FormIO
       if (mutationType === 'changed' && !schema.multiple && Array.isArray(schema.defaultValue)) {
+        // Formio has a getter for the:
+        // - emptyValue: https://github.com/formio/formio.js/blob/4.13.x/src/components/textfield/TextField.js#L58
+        // - defaultValue:
+        //    https://github.com/formio/formio.js/blob/4.13.x/src/components/_classes/component/Component.js#L2302
+        // By setting the defaultValue to null, then the component will be populated with the emptyValue
+        // in the form data.
         schema.defaultValue = null;
       }
 

--- a/src/openforms/js/components/admin/form_design/variables/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/constants.js
@@ -12,16 +12,6 @@ const COMPONENT_DATATYPES = {
   map: 'array',
 };
 
-const COMPONENT_EMPTY_VALUE = {
-  object: {},
-  boolean: false,
-  array: [],
-  string: '',
-  float: null,
-  datetime: '',
-  time: '',
-};
-
 const DATATYPES_CHOICES = [
   [
     'string',
@@ -99,10 +89,4 @@ const EMPTY_VARIABLE = {
   initial_value: '',
 };
 
-export {
-  COMPONENT_DATATYPES,
-  VARIABLE_SOURCES,
-  DATATYPES_CHOICES,
-  EMPTY_VARIABLE,
-  COMPONENT_EMPTY_VALUE,
-};
+export {COMPONENT_DATATYPES, VARIABLE_SOURCES, DATATYPES_CHOICES, EMPTY_VARIABLE};

--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {Utils as FormioUtils} from 'formiojs';
 
-import {COMPONENT_DATATYPES, COMPONENT_EMPTY_VALUE, VARIABLE_SOURCES} from './constants';
+import {COMPONENT_DATATYPES, VARIABLE_SOURCES} from './constants';
 
 const getComponentDatatype = component => {
   if (component.multiple) {
@@ -44,7 +44,7 @@ const updateFormVariables = (
         prefillPlugin: newComponent.prefill?.plugin || '',
         prefillAttribute: newComponent.prefill?.attribute || '',
         dataType: getComponentDatatype(newComponent),
-        initialValue: newComponent.defaultValue || '',
+        initialValue: getDefaultValue(newComponent),
       });
 
       // This is the case where the key of a component has been changed
@@ -64,7 +64,7 @@ const updateFormVariables = (
           prefillPlugin: newComponent.prefill?.plugin || '',
           prefillAttribute: newComponent.prefill?.attribute || '',
           isSensitiveData: newComponent.isSensitiveData,
-          initialValue: newComponent.defaultValue || '',
+          initialValue: getDefaultValue(newComponent),
         };
       });
     }
@@ -78,9 +78,11 @@ const updateFormVariables = (
   return updatedFormVariables;
 };
 
-const getEmptyValue = component => {
-  const dataType = COMPONENT_DATATYPES[component.type] || 'string';
-  return COMPONENT_EMPTY_VALUE[dataType];
+const getDefaultValue = component => {
+  if (component.hasOwnProperty('defaultValue') && component.defaultValue !== null)
+    return component.defaultValue;
+
+  return null;
 };
 
-export {updateFormVariables, getEmptyValue};
+export {updateFormVariables};

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -33,6 +33,7 @@ from ..tasks import on_completion
 from ..tokens import submission_status_token_generator
 from ..utils import (
     add_submmission_to_session,
+    initialise_variables_unrelated_to_a_step,
     persist_submission_variables_unrelated_to_a_step,
     remove_submission_from_session,
     remove_submission_uploads_from_session,
@@ -119,6 +120,7 @@ class SubmissionViewSet(
         conf = GlobalConfiguration.get_solo()
         if conf.enable_form_variables:
             prefill_variables(serializer.instance)
+            initialise_variables_unrelated_to_a_step(serializer.instance)
 
     @extend_schema(
         summary=_("Retrieve co-sign state"),

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -431,7 +431,7 @@ class Submission(models.Model):
         # circular import
         from .submission_value_variable import SubmissionValueVariablesState
 
-        self._variables_state = SubmissionValueVariablesState.get_state(self)
+        self._variables_state = SubmissionValueVariablesState(submission=self)
         return self._variables_state
 
     def load_execution_state(self) -> SubmissionState:

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -61,7 +61,11 @@ class SubmissionStep(models.Model):
         config = GlobalConfiguration.get_solo()
         if config.enable_form_variables:
             values_state = self.submission.load_submission_value_variables_state()
-            step_data = values_state.get_data(submission_step=self)
+            # This is used in the evaluate_form_logic function, which only returns the data that has been changed to the
+            # frontend.
+            step_data = values_state.get_data(
+                submission_step=self, return_unchanged_data=False
+            )
             if self._unsaved_data:
                 return {**step_data, **self._unsaved_data}
             return step_data

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -9,7 +9,6 @@ from glom import Assign, PathAccessError, glom
 
 from openforms.forms.models.form_variable import FormVariable
 
-from ...forms.constants import FormVariableDataTypes
 from ..constants import SubmissionValueVariableSources
 from .submission import Submission
 
@@ -21,6 +20,17 @@ if TYPE_CHECKING:  # pragma: nocover
 class SubmissionValueVariablesState:
     variables: Dict[str, "SubmissionValueVariable"]
 
+    def __init__(self, submission: "Submission"):
+        self.variables = self.collect_variables(submission)
+
+    @property
+    def saved_variables(self):
+        return {
+            variable_key: variable
+            for variable_key, variable in self.variables.items()
+            if variable.pk
+        }
+
     def get_variable(self, key: str) -> Optional["SubmissionValueVariable"]:
         return self.variables[key]
 
@@ -29,10 +39,10 @@ class SubmissionValueVariablesState:
         submission_step: Optional["SubmissionStep"] = None,
         return_unchanged_data: bool = True,
     ) -> dict:
-        submission_variables = self.variables
+        submission_variables = self.saved_variables
         if submission_step:
             submission_variables = self.get_variables_in_submission_step(
-                submission_step
+                submission_step, include_unsaved=False
             )
 
         data = {}
@@ -50,18 +60,33 @@ class SubmissionValueVariablesState:
         return data
 
     def get_variables_in_submission_step(
-        self, submission_step: "SubmissionStep"
+        self,
+        submission_step: "SubmissionStep",
+        include_unsaved=True,
     ) -> Dict[str, "SubmissionValueVariable"]:
         form_definition = submission_step.form_step.form_definition
+
+        variables = self.variables
+        if not include_unsaved:
+            variables = self.saved_variables
+
         return {
             variable_key: variable
-            for variable_key, variable in self.variables.items()
+            for variable_key, variable in variables.items()
             if variable.form_variable
             and variable.form_variable.form_definition == form_definition
         }
 
-    @classmethod
-    def get_state(cls, submission: "Submission") -> "SubmissionValueVariablesState":
+    def get_variables_unrelated_to_a_step(self):
+        return {
+            variable_key: variable
+            for variable_key, variable in self.variables.items()
+            if not variable.form_variable.form_definition
+        }
+
+    def collect_variables(
+        self, submission: "Submission"
+    ) -> Dict[str, "SubmissionValueVariable"]:
         # Get the SubmissionValueVariables already saved in the database
         saved_submission_value_variables = (
             submission.submissionvaluevariable_set.all().select_related(
@@ -91,15 +116,10 @@ class SubmissionValueVariablesState:
             )
             unsaved_value_variables[key] = unsaved_submission_var
 
-        return cls(
-            variables={
-                **{
-                    variable.key: variable
-                    for variable in saved_submission_value_variables
-                },
-                **unsaved_value_variables,
-            }
-        )
+        return {
+            **{variable.key: variable for variable in saved_submission_value_variables},
+            **unsaved_value_variables,
+        }
 
 
 class SubmissionValueVariableManager(models.Manager):
@@ -124,12 +144,17 @@ class SubmissionValueVariableManager(models.Manager):
 
         variables_to_create = []
         variables_to_update = []
+        variables_ids_to_delete = []
         for key, variable in submission_variables.items():
             try:
                 variable.value = glom(data, key)
             except PathAccessError:
                 if update_missing_variables:
-                    variable.value = variable.form_variable.get_initial_value()
+                    if variable.pk:
+                        variables_ids_to_delete.append(variable.id)
+                    else:
+                        variable.value = variable.form_variable.get_initial_value()
+                    continue
 
             if not variable.pk:
                 variables_to_create.append(variable)
@@ -138,6 +163,12 @@ class SubmissionValueVariableManager(models.Manager):
 
         self.bulk_create(variables_to_create)
         self.bulk_update(variables_to_update, fields=["value"])
+        self.filter(id__in=variables_ids_to_delete).delete()
+
+        # Variables that are deleted are not automatically updated in the state
+        # (i.e. they remain present with their pk)
+        if variables_ids_to_delete:
+            submission.load_submission_value_variables_state(refresh=True)
 
 
 class SubmissionValueVariable(models.Model):

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -18,10 +18,17 @@ if TYPE_CHECKING:  # pragma: nocover
 
 @dataclass
 class SubmissionValueVariablesState:
-    variables: Dict[str, "SubmissionValueVariable"]
+    submission: "Submission"
+    _variables: Dict[str, "SubmissionValueVariable"] = None
 
     def __init__(self, submission: "Submission"):
-        self.variables = self.collect_variables(submission)
+        self.submission = submission
+
+    @property
+    def variables(self):
+        if not self._variables:
+            self._variables = self.collect_variables(self.submission)
+        return self._variables
 
     @property
     def saved_variables(self):

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -38,7 +38,7 @@ class VariableModificationTests(VariablesTestMixin, TestCase):
             form=form,
             key="nTotalBoxes",
             source=FormVariableSources.user_defined,
-            data_type=FormVariableDataTypes.int,
+            data_type=FormVariableDataTypes.float,
             form_definition=step2.form_definition,
         )
 
@@ -117,7 +117,7 @@ class VariableModificationTests(VariablesTestMixin, TestCase):
             form=form,
             key="nTotalBoxes",
             source=FormVariableSources.user_defined,
-            data_type=FormVariableDataTypes.int,
+            data_type=FormVariableDataTypes.float,
             form_definition=step1.form_definition,
         )
 
@@ -128,13 +128,13 @@ class VariableModificationTests(VariablesTestMixin, TestCase):
                     {
                         "!=": [
                             {"var": "nLargeBoxes"},
-                            "",
+                            None,
                         ]
                     },
                     {
                         "!=": [
                             {"var": "nGiganticBoxes"},
-                            "",
+                            None,
                         ]
                     },
                 ]
@@ -194,7 +194,7 @@ class VariableModificationTests(VariablesTestMixin, TestCase):
             form=form,
             key="nTotalBoxes",
             source=FormVariableSources.user_defined,
-            data_type=FormVariableDataTypes.int,
+            data_type=FormVariableDataTypes.float,
             form_definition=step1.form_definition,
         )
 

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -40,11 +40,6 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
                     "key": "otherField",
                     "type": "selectboxes",
                     "inputType": "checkbox",
-                    "values": [
-                        {"label": "a", "value": "a"},
-                        {"label": "b", "value": "b"},
-                    ],
-                    "defaultValue": {"a": False, "b": False},
                 },
             ]
         }
@@ -93,16 +88,11 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
                             "key": "otherField",
                             "type": "selectboxes",
                             "inputType": "checkbox",
-                            "values": [
-                                {"label": "a", "value": "a"},
-                                {"label": "b", "value": "b"},
-                            ],
-                            "defaultValue": {"a": False, "b": False},
                         },
                     ]
                 },
             },
-            "data": {"otherField": {"a": False, "b": False}},
+            "data": {},
             "isApplicable": True,
             "completed": False,
             "optional": False,
@@ -139,16 +129,11 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
                             "type": "selectboxes",
                             "key": "otherField",
                             "inputType": "checkbox",
-                            "values": [
-                                {"label": "a", "value": "a"},
-                                {"label": "b", "value": "b"},
-                            ],
-                            "defaultValue": {"a": False, "b": False},
                         },
                     ]
                 },
             },
-            "data": {"otherField": {"a": False, "b": False}},
+            "data": {},
             "isApplicable": True,
             "completed": False,
             "optional": False,
@@ -196,5 +181,5 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["data"],
-            {"dummy": "data", "otherField": {"a": False, "b": False}},
+            {"dummy": "data"},
         )

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -40,6 +40,11 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
                     "key": "otherField",
                     "type": "selectboxes",
                     "inputType": "checkbox",
+                    "values": [
+                        {"label": "a", "value": "a"},
+                        {"label": "b", "value": "b"},
+                    ],
+                    "defaultValue": {"a": False, "b": False},
                 },
             ]
         }
@@ -88,11 +93,16 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
                             "key": "otherField",
                             "type": "selectboxes",
                             "inputType": "checkbox",
+                            "values": [
+                                {"label": "a", "value": "a"},
+                                {"label": "b", "value": "b"},
+                            ],
+                            "defaultValue": {"a": False, "b": False},
                         },
                     ]
                 },
             },
-            "data": {"otherField": {}},
+            "data": {"otherField": {"a": False, "b": False}},
             "isApplicable": True,
             "completed": False,
             "optional": False,
@@ -129,11 +139,16 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
                             "type": "selectboxes",
                             "key": "otherField",
                             "inputType": "checkbox",
+                            "values": [
+                                {"label": "a", "value": "a"},
+                                {"label": "b", "value": "b"},
+                            ],
+                            "defaultValue": {"a": False, "b": False},
                         },
                     ]
                 },
             },
-            "data": {"otherField": {}},
+            "data": {"otherField": {"a": False, "b": False}},
             "isApplicable": True,
             "completed": False,
             "optional": False,
@@ -181,5 +196,5 @@ class ReadSubmissionStepTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["data"],
-            {"dummy": "data", "otherField": {}},
+            {"dummy": "data", "otherField": {"a": False, "b": False}},
         )

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -258,11 +258,11 @@ class SubmissionTests(VariablesTestMixin, TestCase):
         submission_step.refresh_from_db()
         submission_step_2.refresh_from_db()
 
-        self.assertEqual(submission_step.data["textFieldSensitive"], "")
+        self.assertNotIn("textFieldSensitive", submission_step.data)
         self.assertEqual(
             submission_step.data["textFieldNotSensitive"], "this is not sensitive"
         )
-        self.assertEqual(submission_step_2.data["textFieldSensitive2"], "")
+        self.assertNotIn("textFieldSensitive2", submission_step_2.data)
         self.assertEqual(
             submission_step_2.data["textFieldNotSensitive2"], "this is not sensitive"
         )

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -210,13 +210,12 @@ class FormStepSubmissionTests(VariablesTestMixin, SubmissionsMixin, APITestCase)
             submission=self.submission
         )
 
-        self.assertEqual(2, submission_variables.count())
+        # The submission variable for 'foo' has been deleted
+        self.assertEqual(1, submission_variables.count())
 
-        submission_variable1 = submission_variables.get(key="foo")
-        submission_variable2 = submission_variables.get(key="modified")
+        submission_variable = submission_variables.get(key="modified")
 
-        self.assertEqual("", submission_variable1.value)
-        self.assertEqual("data", submission_variable2.value)
+        self.assertEqual("data", submission_variable.value)
 
     def test_data_not_underscored(self):
         form_definition = FormDefinitionFactory.create(

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -118,7 +118,12 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         # 2. Retrieve all logic rules related to a form
         # 3. Load submission state: Retrieve formsteps,
         # 4. Load submission state: Retrieve submission steps
-        # 6.-10. Delete Submission variables of not-applicable step
+        # 5. Retrieve the submission variables to be deleted
+        # 6. Retrieve the submission attachment files to be deleted
+        # 7. SAVEPOINT
+        # 8. Delete submission attachment files
+        # 9. RELEASE SAVEPOINT
+        # 10. Delete submission values
         with self.assertNumQueries(10):
             evaluate_form_logic(submission, submission_step2, data)
 

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -119,8 +119,7 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         # 3. Load submission state: Retrieve formsteps,
         # 4. Load submission state: Retrieve submission steps
         # 6.-10. Delete Submission variables of not-applicable step
-        # 11.-12. Reload submission state
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(10):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_update_step_data(self):
@@ -213,7 +212,7 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         # 1. Get the submission variables that are already in the database
         # 2. Get the form variables for which there is no corresponding submission variable in the database
         with self.assertNumQueries(2):
-            SubmissionValueVariablesState(submission)
+            SubmissionValueVariablesState(submission).variables
 
     def test_get_variables_state_two_submission_variables(self):
         form = FormFactory.create()
@@ -253,7 +252,7 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         # 1. Get the submission variables that are already in the database
         # 2. Get the form variables for which there is no corresponding submission variable in the database
         with self.assertNumQueries(2):
-            SubmissionValueVariablesState(submission)
+            SubmissionValueVariablesState(submission).variables
 
     def test_get_variables_state_all_saved_submission_variables(self):
         form = FormFactory.create()
@@ -294,7 +293,7 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         # 1. Get the submission variables that are already in the database
         # 2. Get the form variables for which there is no corresponding submission variable in the database
         with self.assertNumQueries(2):
-            SubmissionValueVariablesState(submission)
+            SubmissionValueVariablesState(submission).variables
 
     def test_value_variables_state_get_data(self):
         form = FormFactory.create()
@@ -331,6 +330,8 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         )
 
         state = SubmissionValueVariablesState(submission)
+        # Load variables
+        state.variables
 
         # The queries should have been done in the get_state function
         with self.assertNumQueries(0):

--- a/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
@@ -421,7 +421,7 @@ class UpdateVariablesWithLogicTests(VariablesTestMixin, SubmissionsMixin, APITes
             form=form,
             key="totApples",
             source=FormVariableSources.user_defined,
-            data_type=FormVariableDataTypes.int,
+            data_type=FormVariableDataTypes.float,
             form_definition=None,
         )
 
@@ -472,7 +472,7 @@ class UpdateVariablesWithLogicTests(VariablesTestMixin, SubmissionsMixin, APITes
             form=form,
             key="totApples",
             source=FormVariableSources.user_defined,
-            data_type=FormVariableDataTypes.int,
+            data_type=FormVariableDataTypes.float,
             form_definition=form_step.form_definition,
         )
 

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -163,3 +163,11 @@ def persist_submission_variables_unrelated_to_a_step(
         SubmissionValueVariable.objects.bulk_create_or_update_from_data(
             filtered_data, submission
         )
+
+
+def initialise_variables_unrelated_to_a_step(submission: Submission):
+    state = submission.load_submission_value_variables_state()
+    variables = state.get_variables_unrelated_to_a_step()
+    SubmissionValueVariable.objects.bulk_create(
+        [variable for key, variable in variables.items() if not variable.pk]
+    )


### PR DESCRIPTION
Fixes #1747 

**Changes**

- Before, all variables related to a step were included in the step data with their default value at the beginning of the step.
Now, if a variable is not in the configuration (i.e. its hidden) then it is not added to the data.
- The component without an explicit default value have a corresponding component variable with `initial_value=None`.
- The function `bulk_create_or_update_from_data` deletes any saved variables which are no longer present in the data.
- User defined variables are initialised (saved) at the beginning of filling out the form (after prefills). 