### PR TITLE
:arrow_up: Upgrade microscope-sass to 1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "immer": "^9.0.6",
         "json-logic-js": "^2.0.1",
         "leaflet": "^1.7.1",
-        "microscope-sass": "^1.0.4",
+        "microscope-sass": "^1.1.0",
         "paper-css": "^0.4.1",
         "proj4leaflet": "^1.0.2",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "immer": "^9.0.6",
     "json-logic-js": "^2.0.1",
     "leaflet": "^1.7.1",
-    "microscope-sass": "^1.0.4",
+    "microscope-sass": "^1.1.0",
     "paper-css": "^0.4.1",
     "proj4leaflet": "^1.0.2",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
This resolves the last deprecation warnings about using slash for
division instead of math.div, which will be removed in dart-sass v2.