### PR TITLE
:truck: Move FormLogicFactory from submissions to forms app

### DIFF
--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -15,7 +15,7 @@ from django_webtest import WebTest
 
 from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
 from openforms.config.models import GlobalConfiguration, RichTextColor
-from openforms.submissions.tests.form_logic.factories import FormLogicFactory
+from openforms.forms.tests.factories import FormLogicFactory
 from openforms.tests.utils import disable_2fa
 from openforms.utils.admin import SubmitActions
 

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -113,6 +113,14 @@ class FormVersionFactory(factory.django.DjangoModelFactory):
         obj.save()
 
 
+class FormLogicFactory(factory.django.DjangoModelFactory):
+    json_logic_trigger = {"==": [{"var": "test-key"}, 1]}
+    actions = [{"action": {"type": "disable-next"}}]
+
+    class Meta:
+        model = "forms.FormLogic"
+
+
 class FormPriceLogicFactory(factory.django.DjangoModelFactory):
     form = factory.SubFactory(FormFactory)
     json_logic_trigger = {"==": [{"var": "test-key"}, 1]}

--- a/src/openforms/forms/tests/test_api_form_logic.py
+++ b/src/openforms/forms/tests/test_api_form_logic.py
@@ -13,9 +13,9 @@ from rest_framework import status
 from rest_framework.test import APITestCase, APITransactionTestCase
 
 from openforms.accounts.tests.factories import SuperUserFactory
-from openforms.forms.models import FormLogic
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
-from openforms.submissions.tests.form_logic.factories import FormLogicFactory
+
+from ..models import FormLogic
+from .factories import FormFactory, FormLogicFactory, FormStepFactory
 
 
 class FormLogicAPITests(APITestCase):

--- a/src/openforms/forms/tests/test_api_form_versions.py
+++ b/src/openforms/forms/tests/test_api_form_versions.py
@@ -8,11 +8,11 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
 
-from ...submissions.tests.form_logic.factories import FormLogicFactory
 from ..models import FormDefinition, FormLogic, FormStep, FormVersion
 from .factories import (
     FormDefinitionFactory,
     FormFactory,
+    FormLogicFactory,
     FormStepFactory,
     FormVersionFactory,
 )

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -7,13 +7,13 @@ from django.test import TestCase, override_settings
 
 from openforms.payments.contrib.ogone.tests.factories import OgoneMerchantFactory
 from openforms.products.tests.factories import ProductFactory
-from openforms.submissions.tests.form_logic.factories import FormLogicFactory
 
 from ..constants import FormVariableSources
 from ..models import Form, FormDefinition, FormLogic, FormStep
 from .factories import (
     FormDefinitionFactory,
     FormFactory,
+    FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )

--- a/src/openforms/submissions/tests/form_logic/factories.py
+++ b/src/openforms/submissions/tests/form_logic/factories.py
@@ -1,9 +1,0 @@
-import factory
-
-
-class FormLogicFactory(factory.django.DjangoModelFactory):
-    json_logic_trigger = {"==": [{"var": "test-key"}, 1]}
-    actions = [{"action": {"type": "disable-next"}, "component": "testComponent"}]
-
-    class Meta:
-        model = "forms.FormLogic"

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -2,12 +2,15 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+)
 from openforms.submissions.tests.mixins import VariablesTestMixin
 
 from ..factories import SubmissionFactory, SubmissionStepFactory
 from ..mixins import SubmissionsMixin
-from .factories import FormLogicFactory
 
 
 class CheckLogicEndpointTests(VariablesTestMixin, SubmissionsMixin, APITestCase):

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -6,12 +6,15 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from openforms.forms.constants import LogicActionTypes
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+)
 
 from ...form_logic import evaluate_form_logic
 from ..factories import SubmissionFactory, SubmissionStepFactory
 from ..mixins import SubmissionsMixin, VariablesTestMixin
-from .factories import FormLogicFactory
 
 
 class ComponentModificationTests(VariablesTestMixin, TestCase):

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,
+    FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
@@ -10,7 +11,6 @@ from openforms.forms.tests.factories import (
 from ...form_logic import evaluate_form_logic
 from ..factories import SubmissionFactory, SubmissionStepFactory
 from ..mixins import VariablesTestMixin
-from .factories import FormLogicFactory
 
 
 class VariableModificationTests(VariablesTestMixin, TestCase):

--- a/src/openforms/submissions/tests/form_logic/test_side_effects.py
+++ b/src/openforms/submissions/tests/form_logic/test_side_effects.py
@@ -3,11 +3,14 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from openforms.forms.constants import LogicActionTypes
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+)
 
 from ..factories import SubmissionFactory, SubmissionStepFactory
 from ..mixins import SubmissionsMixin, VariablesTestMixin
-from .factories import FormLogicFactory
 
 
 class SideEffectTests(VariablesTestMixin, SubmissionsMixin, APITestCase):

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -2,11 +2,14 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+)
 
 from ..factories import SubmissionFactory, SubmissionStepFactory
 from ..mixins import SubmissionsMixin, VariablesTestMixin
-from .factories import FormLogicFactory
 
 
 class CheckLogicSubmissionTest(VariablesTestMixin, SubmissionsMixin, APITestCase):

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -6,7 +6,11 @@ from rest_framework.reverse import reverse
 
 from openforms.config.models import GlobalConfiguration
 from openforms.forms.models import FormVariable
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+)
 
 from ...rendering import Renderer, RenderModes
 from ...rendering.nodes import FormNode, SubmissionStepNode
@@ -15,7 +19,6 @@ from ..factories import (
     SubmissionStepFactory,
     SubmissionValueVariableFactory,
 )
-from ..form_logic.factories import FormLogicFactory
 
 
 class FormNodeTests(TestCase):

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -24,6 +24,7 @@ from openforms.authentication.constants import FORM_AUTH_SESSION_KEY, AuthAttrib
 from openforms.forms.constants import SubmissionAllowedChoices
 from openforms.forms.tests.factories import (
     FormFactory,
+    FormLogicFactory,
     FormPriceLogicFactory,
     FormStepFactory,
     FormVariableFactory,
@@ -32,7 +33,6 @@ from openforms.forms.tests.factories import (
 from ..constants import SUBMISSIONS_SESSION_KEY
 from ..models import SubmissionStep
 from .factories import SubmissionFactory, SubmissionStepFactory
-from .form_logic.factories import FormLogicFactory
 from .mixins import SubmissionsMixin, VariablesTestMixin
 
 

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -1,13 +1,16 @@
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+)
 from openforms.submissions.form_logic import evaluate_form_logic
 from openforms.submissions.tests.factories import (
     SubmissionFactory,
     SubmissionStepFactory,
 )
-from openforms.submissions.tests.form_logic.factories import FormLogicFactory
 
 from ...models.submission_value_variable import (
     SubmissionValueVariable,

--- a/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
@@ -5,6 +5,7 @@ from rest_framework.test import APITestCase
 from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,
+    FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
@@ -12,7 +13,6 @@ from openforms.submissions.tests.mixins import VariablesTestMixin
 
 from ...models import SubmissionValueVariable
 from ..factories import SubmissionFactory, SubmissionStepFactory
-from ..form_logic.factories import FormLogicFactory
 from ..mixins import SubmissionsMixin
 
 


### PR DESCRIPTION
The model is defined in the forms app, so that's where the factory
model belongs too.