### PR TITLE
Move frontend code quality checks to separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext
 
-      - name: Read .nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
-      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+      - uses: actions/setup-node@v3
+          with:
+            node-version-file: '.nvmrc'
 
       - name: Start CI docker services
         run: |
@@ -229,9 +225,9 @@ jobs:
         with:
           name: open-forms-oas
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version-file: '.nvmrc'
       - name: Install spectral
         run: npm install -g @stoplight/spectral@5.9.2
       - name: Run OAS linter
@@ -247,9 +243,9 @@ jobs:
         with:
           name: open-forms-oas
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm install -g openapi-to-postmanv2
       - name: Create tests folder
@@ -267,9 +263,9 @@ jobs:
         with:
           name: open-forms-oas
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm install -g @openapitools/openapi-generator-cli@2.4.2
       - name: Validate schema

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: isort/isort-action@v0.1.0
         with:
           requirementsFiles: requirements/ci.txt
-          sortPaths: "src docs"
+          sortPaths: 'src docs'
           configuration: '--check-only --diff'
 
   black:
@@ -94,24 +94,6 @@ jobs:
           echo '| :--- | ---- | ------ | :---- |' >> $GITHUB_STEP_SUMMARY
           python ./bin/flake8_summary.py "${{ steps.flake8.outputs.flake8_output }}" >> $GITHUB_STEP_SUMMARY
 
-  prettier:
-    name: Check frontend code formatting with prettier
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
-        with:
-          node-version: '16'
-
-      - name: Install prettier
-        run: |
-          npm ci --legacy-peer-deps
-
-      - name: Run prettier
-        run: |
-          npm run checkformat
-
   migrations:
     name: Check for model changes not present in the migrations or default_admin_index fixture
     runs-on: ubuntu-latest
@@ -124,7 +106,8 @@ jobs:
         ports:
           - 5432:5432
         # Needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options:
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/fe-code-quality.yml
+++ b/.github/workflows/fe-code-quality.yml
@@ -1,0 +1,38 @@
+name: Frontend code quality checks
+
+# Run this workflow every time a new commit pushed to your repository
+on:
+  push:
+    branches:
+      - master
+      - stable/*
+    tags:
+    paths:
+      - '**.scss'
+      - '**.js'
+      - '**.yaml'
+  pull_request:
+    paths:
+      - '**.scss'
+      - '**.js'
+      - '**.yaml'
+  workflow_dispatch:
+
+jobs:
+  prettier:
+    name: Check frontend code formatting with prettier
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '16'
+
+      - name: Install prettier
+        run: |
+          npm ci --legacy-peer-deps
+
+      - name: Run prettier
+        run: |
+          npm run checkformat

--- a/.github/workflows/fe-code-quality.yml
+++ b/.github/workflows/fe-code-quality.yml
@@ -25,9 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
 
       - name: Install prettier
         run: |

--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -165,7 +165,7 @@ $djai-border-width: 8px;
   .glyphicon {
     display: block;
     font-weight: 900;
-    font-family: "Font Awesome 6 Free";
+    font-family: 'Font Awesome 6 Free';
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     font-style: normal;


### PR DESCRIPTION
The backend code quality is only triggered on backend-related files, which is why a code style violation managed to slip through the cracks.

This sets up js/scss checks with prettier in a separate workflow. Additionally, the node-version stuff is handled properly with the github action `node-version-file` option.