### PR TITLE
Issue/1611 use temporary step ids step select

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormLogic.js
+++ b/src/openforms/js/components/admin/form_design/FormLogic.js
@@ -114,7 +114,7 @@ const Rule = ({
   _logicType,
   order,
   jsonLogicTrigger,
-  triggerFromStep: triggerFromStepUrl,
+  triggerFromStep: triggerFromStepIdentifier,
   actions,
   isAdvanced,
   onChange,
@@ -123,7 +123,7 @@ const Rule = ({
 }) => {
   const intl = useIntl();
   const [displayAdvancedOptions, setDisplayAdvancedOptions] = useState(false);
-  const triggerFromStep = useFormStep(triggerFromStepUrl);
+  const triggerFromStep = useFormStep(triggerFromStepIdentifier);
 
   const deleteConfirmMessage = intl.formatMessage({
     description: 'Logic rule deletion confirm message',
@@ -212,10 +212,10 @@ const Rule = ({
               <DSLEditorNode errors={null}>
                 <StepSelection
                   name="triggerFromStep"
-                  value={triggerFromStepUrl || ''}
+                  value={triggerFromStepIdentifier || ''}
                   onChange={onChange}
                 />
-                {!triggerFromStepUrl && (
+                {!triggerFromStepIdentifier && (
                   <>
                     &nbsp;
                     <FormattedMessage

--- a/src/openforms/js/components/admin/form_design/StepSelection.js
+++ b/src/openforms/js/components/admin/form_design/StepSelection.js
@@ -9,7 +9,11 @@ const getStepDisplayName = step => step.internalName || step.name;
 const StepSelection = ({name, value, onChange}) => {
   const formContext = useContext(FormContext);
   const formSteps = formContext.formSteps;
-  const formStepChoices = formSteps.map((step, index) => [step.url, getStepDisplayName(step)]);
+  const formStepChoices = formSteps.map((step, index) => {
+    const display = getStepDisplayName(step);
+    const identifier = step.url || step._generatedId;
+    return [identifier, display];
+  });
 
   return (
     <Select name={name} choices={formStepChoices} allowBlank onChange={onChange} value={value} />
@@ -22,13 +26,23 @@ StepSelection.propTypes = {
   onChange: PropTypes.func,
 };
 
-const useFormStep = (formStepUrl = '') => {
+/**
+ * Look up the form step in the form context by identifier.
+ *
+ * @param  {String} identifier  The URL for persisted steps or generated ID for non-persisted steps.
+ * @return {Object|null}        Object with the step instance from the context, or null if no identifier was provided.
+ */
+const useFormStep = (identifier = '') => {
   const formContext = useContext(FormContext);
   const formSteps = formContext.formSteps;
-  if (!formStepUrl) return null;
+  if (!identifier) return null;
 
   // look up the step from the array of steps in the context
-  const step = formSteps.find(element => element.url == formStepUrl);
+  const step = formSteps.find(element => {
+    const urlMatch = element.url && element.url === identifier;
+    const generatedIdMatch = element._generatedId === identifier;
+    return urlMatch || generatedIdMatch;
+  });
   return {
     step,
     stepName: getStepDisplayName(step),

--- a/src/openforms/js/components/admin/form_design/data/complete-form.js
+++ b/src/openforms/js/components/admin/form_design/data/complete-form.js
@@ -8,6 +8,38 @@ import {updateOrCreateFormSteps} from './steps';
 import {createOrUpdateFormVariables} from './variables';
 import {createFormVersion} from './versions';
 
+const getStepsByGeneratedId = formSteps => {
+  const stepsWithGeneratedId = formSteps.filter(step => !!step._generatedId);
+  return Object.fromEntries(stepsWithGeneratedId.map(step => [step._generatedId, step]));
+};
+
+/**
+ * Resolve temporary step IDs to actual URLs.
+ *
+ * This requires the stepsByGeneratedId being up-to-date with server-side UUID/URLs,
+ * so typically you can only call this after all the form steps are committed to the
+ * backend.
+ *
+ * This relies on the client-side _generatedId still being around while the URL has been
+ * set. If the passed in stepIdentifier is a URL, it is left untouched. If not, it is
+ * assumed to be a generated ID and the step is looked up in the `stepsByGeneratedId`
+ * mapping.
+ *
+ * The return value is the URL reference (if applicable).
+ */
+const getStepReference = (stepsByGeneratedId, stepIdentifier, stepAttribute = 'url') => {
+  // empty-ish value -> leave untouched
+  if (!stepIdentifier) return stepIdentifier;
+  try {
+    new URL(stepIdentifier);
+    // if it's a URL, return it - this was already set by the backend.
+    return stepIdentifier;
+  } catch {
+    const step = stepsByGeneratedId[stepIdentifier];
+    return step[stepAttribute];
+  }
+};
+
 /**
  * Save the form itself without any related objects.
  */
@@ -162,27 +194,15 @@ const saveVariables = async (state, csrftoken) => {
     form: {url: formUrl},
   } = state;
 
-  // resolve the variable.formDefinition URLs from the updated state after form steps
-  // and form definitions have been saved. This relies on the _generatedId for temporary
-  // steps/definitions.
-  const stepsByGeneratedId = Object.fromEntries(
-    state.formSteps.filter(step => !!step._generatedId).map(step => [step._generatedId, step])
-  );
+  const stepsByGeneratedId = getStepsByGeneratedId(state.formSteps);
   let newState = produce(state, draft => {
     for (const variable of draft.formVariables) {
       variable.form = formUrl;
-      // static/user defined variables do not relate to any form definition - this may be
-      // null or an empty string
-      if (!variable.formDefinition) continue;
-      // if the variable.formDefinition is not a URL, we have to resolve it against the
-      // temporary client-side ID. This also allows us to update the state with the
-      // actual resolved resource URLs.
-      try {
-        new URL(variable.formDefinition);
-      } catch {
-        const formStep = stepsByGeneratedId[variable.formDefinition];
-        variable.formDefinition = formStep.formDefinition;
-      }
+      variable.formDefinition = getStepReference(
+        stepsByGeneratedId,
+        variable.formDefinition,
+        'formDefinition'
+      );
     }
   });
 


### PR DESCRIPTION
Fixes #1611

Instead of the empty URL, we now use the step._generatedId as a unique
reference for steps that only live in browser memory (so far). After saving the
steps to the backend, these steps are updated with their UUID and URL references,
making it possible to grab the actual URL from the temporary ID during the
saving phase.
