### PR TITLE
Feature/1751 display logic rules ncely

### DIFF
--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -159,7 +159,6 @@ warnings.filterwarnings(
     r"django\.db\.models\.fields",
 )
 
-
 # Override settings with local settings.
 try:
     from .local import *  # noqa

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -30,13 +30,6 @@ def iter_components(
                 )
 
 
-def flatten(configuration: dict) -> Dict[str, Any]:
-    return {
-        component["key"]: component
-        for component in iter_components(configuration, recursive=True)
-    }
-
-
 def get_default_values(configuration: dict) -> Dict[str, Any]:
     defaults = {}
 

--- a/src/openforms/logging/tests/test_events.py
+++ b/src/openforms/logging/tests/test_events.py
@@ -70,21 +70,23 @@ class EventTests(VariablesTestMixin, TestCase):
         )
 
         log = submission.logs.get()
-        logged_rules = log.extra_data["log_evaluated_rules"]
+        logged_rules = log.extra_data["evaluated_rules"]
 
         self.assertEqual(2, len(logged_rules))
         self.assertEqual(
             {
+                "raw_logic_expression": json_logic_trigger,
                 "trigger": True,
-                "source_components": json_logic_trigger,
+                "readable_rule": "birthdate > 2022-06-20",
                 "targeted_components": rule.actions,
             },
             logged_rules[0],
         )
         self.assertEqual(
             {
+                "raw_logic_expression": json_logic_trigger_2,
                 "trigger": False,
-                "source_components": json_logic_trigger_2,
+                "readable_rule": "firstname == bar",
                 "targeted_components": rule_2.actions,
             },
             logged_rules[1],

--- a/src/openforms/scss/components/admin/_logic-evaluated-table.scss
+++ b/src/openforms/scss/components/admin/_logic-evaluated-table.scss
@@ -1,19 +1,22 @@
-.logic-rules-tables {
+.logic-logs {
   width: 100%;
-}
 
-.property-name-width {
-  width: 70%;
-}
+  &--variables {
+    .logic-logs__col-header {
+      &--name {
+        width: 70%;
+      }
+    }
+  }
 
-.rule-width {
-  width: 60%;
-}
-
-.trigger-width {
-  width: 10%;
-}
-
-.rule-list {
-  list-style: none;
+  &--rules {
+    .logic-logs__col-header {
+      &--rule {
+        width: 60%;
+      }
+      &--trigger {
+        width: 10%;
+      }
+    }
+  }
 }

--- a/src/openforms/setup.py
+++ b/src/openforms/setup.py
@@ -43,6 +43,7 @@ def setup_env():
     load_self_signed_certs()
     monkeypatch_requests()
     monkeypatch_mozilla_django_oidc_get_from_settings()
+    monkeypatch_json_logic()
 
 
 def load_self_signed_certs() -> None:
@@ -140,3 +141,13 @@ def mute_deprecation_warnings():
     """
     if not sys.warnoptions:
         warnings.simplefilter("ignore", DeprecationWarning, append=False)
+
+
+# TODO Apply this fix to the fork of json-logic.py
+def monkeypatch_json_logic():
+
+    from json_logic import operations
+
+    operations["in"] = (
+        lambda a, b: a in b if "__contains__" in dir(b) and a is not None else False
+    )

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -154,9 +154,7 @@ def evaluate_form_logic(
     step.data = DirtyData(updated_step_data)
 
     # Logging the rules
-    logevent.submission_logic_evaluated(
-        submission, evaluated_rules, updated_submission_data
-    )
+    logevent.submission_logic_evaluated(submission, evaluated_rules, data)
 
     if dirty:
         # only keep the changes in the data, so that old values do not overwrite otherwise

--- a/src/openforms/submissions/templates/admin/submissions/submission/logs.html
+++ b/src/openforms/submissions/templates/admin/submissions/submission/logs.html
@@ -17,14 +17,12 @@
 {% endblock %}
 
 {% block content %}
-    <h1>{% trans  "Logic logs" %}</h1>
     {% block field_sets %}
         {% if not logs_activity %}
             {% trans "No logic rules for that submission" %}
         
         {% else %}
             {% for log in logs_activity  %}
-                <span class="timestamp-log"></span>
                 <fieldset class="module aligned collapse collapsed fieldset-log">
                     <h2>
                         <time datetime="{{ log.timestamp.isoformat }}" title="{{ log.timestamp|date:'Y-m-d H:i:s' }}">
@@ -32,22 +30,48 @@
                         </time>
                         - {% trans 'Logic' %} -
                     </h2>
-                    <h4> {% trans "Logic rules" %} </h4>
-                    <table class="logic-rules-tables">
+                    <h4> {% trans "Variables" %} </h4>
+                    <table class="logic-logs logic-logs--variables">
                         <thead>
-                            <th class="rule-width"> {% trans "Rule" %} </th>
-                            <th class="trigger-width"> {% trans "Triggered" %} </th>
+                            <th class="logic-logs__col-header logic-logs__col-header--name"> {% trans "Property name" %} </th>
+                            <th class="logic-logs__col-header logic-logs__col-header--value"> {% trans "Value" %} </th>
+                        </thead>
+                        <tbody>
+                            {% for key, value in log.extra_data.input_data.items  %}
+                            <tr>
+                                <td>{{ value.step_name }}: <code>{{ key }}</code> &#40;{{ value.label }}&#41;</td>
+                                <td>{{ value.actual_value }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    <h4> {% trans "Logic rules" %} </h4>
+                    <table class="logic-logs logic-logs--rules">
+                        <thead>
+                            <th class="logic-logs__col-header logic-logs__col-header--rule"> {% trans "Rule" %} </th>
+                            <th class="logic-logs__col-header logic-logs__col-header--trigger"> {% trans "Triggered" %} </th>
                             <th> {% trans "Action" %} </th>
                         </thead>
                         <tbody>
-                            {% for rule in log.extra_data.log_evaluated_rules %}
+                            {% for rule in log.extra_data.evaluated_rules %}
                                     <tr>
                                         <td>
-                                            {{ rule.source_components }}
+                                            {{ rule.readable_rule }}
                                         </td>
                                         <td>{{ rule.trigger|yesno|capfirst }} </td>
                                         <td>
-                                            {{ rule.targeted_components }}
+                                        {% for action in rule.targeted_components %}
+                                            {% if action.key %}
+                                                <b>{{ action.type_display }}</b>: {{ action.step_name }}: <code>{{ action.key }}</code> ({{ action.label }}):
+                                                    {% if not 'state' in action %}
+                                                        <i>{{ action.value }}</i>
+                                                    {% else %}
+                                                        <i>{{ action.value }} = {{ action.state|yesno|capfirst }}</i>
+                                                    {% endif %}
+                                            {% else %}
+                                                <b>{{ action.type_display }}</b>
+                                            {% endif %}
+                                        {% endfor %}
                                         </td>
                                     </tr>
                             {% endfor %}

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1543,7 +1543,7 @@ class EvaluateLogicSubmissionTest(VariablesTestMixin, SubmissionsMixin, APITestC
         logs = TimelineLogProxy.objects.all()
         self.assertEqual(1, logs.count())
         log = logs[0]
-        self.assertTrue(log.extra_data["log_evaluated_rules"][0]["trigger"])
+        self.assertTrue(log.extra_data["evaluated_rules"][0]["trigger"])
 
     def test_evaluate_logic_log_event_not_triggered(self):
         form = FormFactory.create()
@@ -1599,4 +1599,4 @@ class EvaluateLogicSubmissionTest(VariablesTestMixin, SubmissionsMixin, APITestC
         logs = TimelineLogProxy.objects.all()
         self.assertEqual(1, logs.count())
         log = logs[0]
-        self.assertFalse(log.extra_data["log_evaluated_rules"][0]["trigger"])
+        self.assertFalse(log.extra_data["evaluated_rules"][0]["trigger"])

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -127,8 +127,9 @@ class SubmissionVariablesPerformanceTests(VariablesTestMixin, APITestCase):
         # 8. Delete submission attachment files
         # 9. RELEASE SAVEPOINT
         # 10. Delete submission values
-        # 11. Create log for rules
-        with self.assertNumQueries(11):
+        # 11. Retrieve all form_variables
+        # 12. Creation of timelinelog
+        with self.assertNumQueries(12):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_update_step_data(self):

--- a/src/openforms/utils/json_logic.py
+++ b/src/openforms/utils/json_logic.py
@@ -1,14 +1,20 @@
 """
 Utilities to parse/process jsonLogic expressions.
 """
-from dataclasses import dataclass, field
-from typing import List, Union
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from json_logic import jsonLogic
+
+if TYPE_CHECKING:
+    from openforms.formio.typing import Component
+    from openforms.forms.models import FormStep
 
 __all__ = ["JsonLogicTest"]
 
 JSONLogicValue = Union[str, int, "JsonLogicTest"]
+JsonLogicExpression = Dict[str, Any]
+JsonLogicNode = Union["JsonLogicLeaf", "JsonLogicOperation"]
 
 
 @dataclass
@@ -49,3 +55,158 @@ def normalize_value(value: Union[dict, list, tuple, int, str]) -> JSONLogicValue
         return JsonLogicTest.from_expression(value)
 
     raise NotImplementedError(f"Unknown value type: {type(value)}")
+
+
+@dataclass
+class ComponentMeta:
+    form_step: "FormStep"
+    component: "Component"
+
+
+@dataclass
+class IntrospectionResult:
+
+    expression: dict
+    rule_tree: "JsonLogicOperation"
+
+    def as_string(self) -> str:
+        return stringify_json_tree(self.rule_tree)
+
+    def get_input_components(self) -> List[JsonLogicExpression]:
+        return get_leaves(self.rule_tree)
+
+
+@dataclass
+class JsonLogicLeaf:
+    key: str
+    actual_value: str
+    step_name: str
+    label: str
+
+
+@dataclass
+class JsonLogicOperation:
+    operator: str
+    children: List[JsonLogicNode]
+    value: str
+
+
+def introspect_json_logic(
+    expression: JsonLogicExpression,
+    components_map: Dict[str, ComponentMeta],
+    input_data: JsonLogicExpression,
+) -> IntrospectionResult:
+    logic_expression = JsonLogicTest.from_expression(expression)
+    rule_tree = convert_json_logic_in_json_tree(
+        logic_expression, components_map, input_data
+    )
+    return IntrospectionResult(expression=expression, rule_tree=rule_tree)
+
+
+def find_json_logic_test_value(value: JsonLogicTest) -> str:
+    """returns the value inside a JsonLogicTest"""
+    if isinstance(value, JsonLogicTest) and value.operator in ["date", "var"]:
+        return find_json_logic_test_value(value.values[0])
+    else:
+        return value
+
+
+def convert_json_logic_in_json_tree(
+    logics, component_map, resulting_data
+) -> JsonLogicOperation:
+    """returns a tree of JsonLogicNode's type nodes
+
+    This function transforms a logic_rule into a tree with informations related to the
+    components involved in the rule such as its `value`, `label`, `step name`...
+
+    :param logics:  :class:`JsonLogicTest` the logic rule
+    :param keys_mapped_to_component: dict of component with component key as key
+    :param keys_mapped_to_form: dict of form with component key as key
+    :param resulting_data: actual data from the submission form
+
+
+    :rtype: JsonLogicOperation
+    :return: rule with additional informations related to the involved component
+
+
+    """
+    # array of rules
+    if not isinstance(logics, JsonLogicTest):
+        return [
+            convert_json_logic_in_json_tree(logic, component_map, resulting_data)
+            for logic in logics
+        ]
+    json_logic_operation = JsonLogicOperation(
+        operator=logics.operator, children=[], value=""
+    )
+    for index, value in enumerate(logics.values):
+
+        # There is an operation
+        if isinstance(value, JsonLogicTest):
+            if value.operator in ["var", "date"]:
+                key = find_json_logic_test_value(logics.values[index])
+                # leaf not related to component --> just a value compared
+                if not component_map.get(key):
+                    json_logic_operation.value = key
+
+                # Leaf is a field
+                else:
+                    json_logic_value = JsonLogicLeaf(
+                        key=key,
+                        actual_value=resulting_data.get(key, ""),
+                        step_name=component_map[key].form_step.form_definition.name,
+                        label=component_map[key].component.get("label", ""),
+                    )
+                    json_logic_operation.children.append(json_logic_value)
+            elif value.operator == "rdelta":
+                json_logic_operation.value = value.values
+
+            # No relevant information with this operator
+            elif value.operator == "today":
+                pass
+            else:
+                json_logic_operation.children.append(
+                    convert_json_logic_in_json_tree(
+                        value,
+                        component_map,
+                        resulting_data,
+                    )
+                )
+
+        # No operation, it's a basic value
+        else:
+            json_logic_operation.value = value
+
+    # return logic_dict
+    return json_logic_operation
+
+
+def stringify_json_tree(node: JsonLogicNode) -> str:
+    """transform the json_tree in a string of rules"""
+
+    # Unary operation
+    if not node.children:
+        return f"{node.operator} {node.value}"
+
+    output = ""
+    children_number = len(node.children)
+    for index, child in enumerate(node.children):
+        last_child = index == children_number - 1
+        if isinstance(child, JsonLogicLeaf):
+            output += child.key
+        else:
+            output += f"({stringify_json_tree(child)})"
+        if node.value != "":
+            output += f" {node.operator} {node.value}"
+        else:
+            output += f" {node.operator} " if not last_child else ""
+
+    return output
+
+
+def get_leaves(node: JsonLogicNode) -> List[JsonLogicExpression]:
+
+    if isinstance(node, JsonLogicLeaf):
+        return [asdict(node)]
+
+    return sum((get_leaves(child) for child in node.children), [])


### PR DESCRIPTION
This feature introduces a nice display for logic rules instead of the untreated json_logic_trigger and actions related. This feature takes into account advanced rules, unary operators.

Also, the logic display is now realized in python directly instead of templates, which allows more flexibilty (That is why some templates files have been deleted)

I just adapted the previous tests from the #1682 feature but maybe adding some tests to test the new utils functions might be relevant.