### PR TITLE
Fix StUF-GB onvolledige datum crash

### DIFF
--- a/src/openforms/prefill/contrib/stufbg/plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/plugin.py
@@ -108,6 +108,13 @@ class StufBgPrefill(BasePlugin):
         response_dict = {}
         for attribute in attributes:
             value = glom(data, ATTRIBUTES_TO_STUF_BG_MAPPING[attribute], default=None)
+            # if the XML element has attributes, we don't get a return value of the content,
+            # but rather an OrderedDict from xmltodict with the #text key for the content
+            # and @<attribute> keys for the attributes.
+            # E.g. <ns:geboortedatum StUF:indOnvolledigeDatum="M">19600701</ns:geboortedatum>,
+            # see #1617 for such a regression.
+            if isinstance(value, dict) and "#text" in value:
+                value = value["#text"]
 
             if value and "@noValue" not in value:
                 response_dict[attribute] = value

--- a/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from requests import RequestException
 
@@ -159,6 +159,20 @@ class StufBgPrefillTests(TestCase):
 
             self.assertEqual(values, {})
             self.assertEqual(logs.records[0].fault, {})
+
+    @tag("gh-1617")
+    def test_onvolledige_datum(self):
+        """
+        Regression test for StUF-onvolledigeDatum responses.
+
+        See issue #1617 on Github.
+        """
+        client_patcher = mock_stufbg_client("StufBgResponseOnvolledigeDatum.xml")
+        self.addCleanup(client_patcher.stop)
+
+        values = self.plugin.get_prefill_values(self.submission, ["geboortedatum"])
+
+        self.assertEqual(values["geboortedatum"], "19600701")
 
 
 class StufBgCheckTests(TestCase):

--- a/src/stuf/stuf_bg/templates/stuf_bg/tests/responses/StufBgResponseOnvolledigeDatum.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/tests/responses/StufBgResponseOnvolledigeDatum.xml
@@ -1,0 +1,57 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
+                  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
+    <soapenv:Header/>
+    <soapenv:Body>
+        <ns:npsLa01>
+            <ns:stuurgegevens>
+                <StUF:berichtcode>La01</StUF:berichtcode>
+                <StUF:zender>
+                    <StUF:organisatie>{{ ontvanger_organisatie }}</StUF:organisatie>
+                    <StUF:applicatie>{{ ontvanger_applicatie }}</StUF:applicatie>
+                    <StUF:administratie>{{ ontvanger_administratie }}</StUF:administratie>
+                    <StUF:gebruiker>{{ ontvanger_gebruiker }}</StUF:gebruiker>
+                </StUF:zender>
+                <StUF:ontvanger>
+                    <StUF:organisatie>{{ zender_organisatie }}</StUF:organisatie>
+                    <StUF:applicatie>{{ zender_applicatie }}</StUF:applicatie>
+                    <StUF:administratie>{{ zender_administratie }}</StUF:administratie>
+                    <StUF:gebruiker>{{ zender_gebruiker }}</StUF:gebruiker>
+                </StUF:ontvanger>
+                <StUF:referentienummer>{{ referentienummer }}</StUF:referentienummer>
+                <StUF:tijdstipBericht>{{ tijdstip_bericht }}</StUF:tijdstipBericht>
+            </ns:stuurgegevens>
+            <ns:parameters>
+                <StUF:indicatorAfnemerIndicatie>false</StUF:indicatorAfnemerIndicatie>
+            </ns:parameters>
+            <ns:antwoord>
+                <ns:object StUF:entiteittype="NPS">
+                    <ns:inp.bsn>999992314</ns:inp.bsn>
+                    <ns:geslachtsnaam>Maykin</ns:geslachtsnaam>
+                    <ns:voorvoegselGeslachtsnaam>van</ns:voorvoegselGeslachtsnaam>
+                    <ns:voornamen>Media</ns:voornamen>
+                    <ns:geslachtsaanduiding>M</ns:geslachtsaanduiding>
+                    <ns:geboortedatum StUF:indOnvolledigeDatum="M">19600701</ns:geboortedatum>
+                    <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
+                    <ns:inp.geboorteLand>6030</ns:inp.geboorteLand>
+                    <ns:overlijdensdatum>19800915</ns:overlijdensdatum>
+                    <ns:verblijfsadres>
+                        <ns:wpl.woonplaatsNaam>Amsterdam</ns:wpl.woonplaatsNaam>
+                        <ns:gor.straatnaam>Keizersgracht</ns:gor.straatnaam>
+                        <ns:aoa.postcode>1015 CJ</ns:aoa.postcode>
+                        <ns:aoa.huisnummer>117</ns:aoa.huisnummer>
+                        <ns:aoa.huisletter>A</ns:aoa.huisletter>
+                        <ns:aoa.huisnummertoevoeging>B</ns:aoa.huisnummertoevoeging>
+                    </ns:verblijfsadres>
+                    <ns:sub.verblijfBuitenland>
+                      <ns:lnd.landnaam>Paris</ns:lnd.landnaam>
+                      <ns:sub.adresBuitenland1>Buitenland regel 1</ns:sub.adresBuitenland1>
+                      <ns:sub.adresBuitenland2>Buitenland regel 2</ns:sub.adresBuitenland2>
+                      <ns:sub.adresBuitenland3>Buitenland regel 3</ns:sub.adresBuitenland3>
+                   </ns:sub.verblijfBuitenland>
+                    <ns:inp.datumInschrijving>20051216</ns:inp.datumInschrijving>
+                </ns:object>
+            </ns:antwoord>
+        </ns:npsLa01>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Fixes #1617

Crash is caused by different return value in xmltodict when the XML element has attributes:

```
<foo>bar</foo> -> {"foo": "bar"}
```
while

```
<foo attribute="baz">bar</foo> -> {"foo": {"#text": "bar", "@attribute": "baz"}}
```

We get both complete/incomplete dates, so we need to be able to handle both of them.