### PR TITLE
:rotating_light: Do not use deprected defusedxml.lxml anymore

### DIFF
--- a/docs/developers/backend/core/utils.rst
+++ b/docs/developers/backend/core/utils.rst
@@ -66,3 +66,9 @@ Model file fields
 
 .. automodule:: openforms.utils.files
    :members:
+
+XML
+---
+
+.. automodule:: openforms.utils.xml
+   :members:

--- a/src/openforms/prefill/contrib/stufbg/plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/plugin.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterable, List, Tuple
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from defusedxml.lxml import fromstring as df_fromstring
 from glom import T as Target, glom
 from lxml import etree
 from requests import HTTPError, RequestException
@@ -12,6 +11,7 @@ from requests import HTTPError, RequestException
 from openforms.authentication.constants import AuthAttribute
 from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.submissions.models import Submission
+from openforms.utils.xml import fromstring
 from stuf.stuf_bg.constants import FieldChoices
 from stuf.stuf_bg.models import StufBGConfig
 
@@ -180,7 +180,7 @@ class StufBgPrefill(BasePlugin):
             )
         else:
             try:
-                xml = df_fromstring(response.content)
+                xml = fromstring(response.content)
             except etree.XMLSyntaxError as e:
                 raise InvalidPluginConfiguration(
                     _("SyntaxError in response: {exception}").format(exception=e)

--- a/src/openforms/utils/xml.py
+++ b/src/openforms/utils/xml.py
@@ -1,0 +1,17 @@
+"""
+XML parsing with DTD/Entities blocking.
+
+Inspired by https://github.com/mvantellingen/python-zeep/pull/1179/ as their solution
+for the deprecated defusedxml.lxml module and the defaults applied in defusedxml.lxml.
+"""
+from lxml.etree import XMLParser, fromstring as _fromstring
+
+
+def fromstring(content: str):
+    """
+    Create an LXML etree from the string content without resolving entities.
+
+    Resolving entities is a security risk, which is why we disable it.
+    """
+    parser = XMLParser(resolve_entities=False)
+    return _fromstring(content, parser=parser)


### PR DESCRIPTION
This was just an example and has been deprecated for a while now.