### PR TITLE
:bug: don't crash form import on non-existent categories

### DIFF
--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -171,6 +171,14 @@ def import_form_data(
                 old_uuid = entry["uuid"]
                 entry["uuid"] = str(uuid4())
 
+            if resource == "forms":
+                # we can only extract a category UUID from the URL here, but that requires
+                # an exact match and we currently don't provide import/export functionality
+                # for categories. Relying on ID/Name is not much better than guesswork either,
+                # so we always import forms with NO category at all to prevent import errors.
+                # See #1774 for one such example of an error.
+                entry["category"] = None
+
             if resource == "forms" and not existing_form_instance:
                 entry["active"] = False
 


### PR DESCRIPTION
Fixes #1774

Category information is discarded during import - end users are
responsible for assigning the form to the appropriate category after
import, just like they have to publish them explicitly.