### PR TITLE
[#1697] Deal with duplicate keys in variables and form components

### DIFF
--- a/src/openforms/forms/api/serializers/form_variable.py
+++ b/src/openforms/forms/api/serializers/form_variable.py
@@ -21,23 +21,24 @@ class FormVariableListSerializer(serializers.ListSerializer):
         static_data_keys = [item.key for item in FormVariable.get_static_data()]
 
         existing_form_key_combinations = []
-        for item in attrs:
+        errors = {}
+        for index, item in enumerate(attrs):
             key_form_combination = (item["key"], item["form"].slug)
             if key_form_combination in existing_form_key_combinations:
-                raise ValidationError(
-                    _("The form and key attributes must be unique together"),
-                    code="unique",
-                )
+                errors[f"{index}.key"] = _("Key not unique within form")
+                continue
 
             if item["key"] in static_data_keys:
-                raise ValidationError(
-                    _(
-                        "The variable key cannot be equal to any of the following values: {static_data}."
-                    ).format(static_data=", ".join(static_data_keys)),
-                    code="unique",
-                )
+                errors[f"{index}.key"] = _(
+                    "The variable key cannot be equal to any of the following values: {static_data}."
+                ).format(static_data=", ".join(static_data_keys))
+                continue
 
             existing_form_key_combinations.append(key_form_combination)
+
+        if errors:
+            raise ValidationError(errors, code="unique")
+
         return attrs
 
 

--- a/src/openforms/forms/api/serializers/form_variable.py
+++ b/src/openforms/forms/api/serializers/form_variable.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -21,23 +23,33 @@ class FormVariableListSerializer(serializers.ListSerializer):
         static_data_keys = [item.key for item in FormVariable.get_static_data()]
 
         existing_form_key_combinations = []
-        errors = {}
+        errors = defaultdict(list)
         for index, item in enumerate(attrs):
             key_form_combination = (item["key"], item["form"].slug)
             if key_form_combination in existing_form_key_combinations:
-                errors[f"{index}.key"] = _("Key not unique within form")
+                errors[f"{index}.key"].append(
+                    serializers.ErrorDetail(
+                        _("The variable key must be unique within a form"),
+                        code="unique",
+                    )
+                )
                 continue
 
             if item["key"] in static_data_keys:
-                errors[f"{index}.key"] = _(
-                    "The variable key cannot be equal to any of the following values: {static_data}."
-                ).format(static_data=", ".join(static_data_keys))
+                errors[f"{index}.key"].append(
+                    serializers.ErrorDetail(
+                        _(
+                            "The variable key cannot be equal to any of the following values: {static_data}."
+                        ).format(static_data=", ".join(static_data_keys)),
+                        code="unique",
+                    )
+                )
                 continue
 
             existing_form_key_combinations.append(key_form_combination)
 
         if errors:
-            raise ValidationError(errors, code="unique")
+            raise ValidationError(errors)
 
         return attrs
 

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -163,7 +163,7 @@ class FormVariableViewsetTest(APITestCase):
         self.assertEqual(1, len(error["invalidParams"]))
         self.assertEqual(
             error["invalidParams"][0]["reason"],
-            "Key not unique within form",
+            "The variable key must be unique within a form",
         )
         self.assertEqual(
             error["invalidParams"][0]["code"],

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -160,13 +160,18 @@ class FormVariableViewsetTest(APITestCase):
         error = response.json()
 
         self.assertEqual(error["code"], "invalid")
+        self.assertEqual(1, len(error["invalidParams"]))
         self.assertEqual(
             error["invalidParams"][0]["reason"],
-            "The form and key attributes must be unique together",
+            "Key not unique within form",
         )
         self.assertEqual(
             error["invalidParams"][0]["code"],
             "unique",
+        )
+        self.assertEqual(
+            error["invalidParams"][0]["name"],
+            "1.key",
         )
 
     def test_list_form_variables(self):

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -1367,6 +1367,12 @@
       "value": "Are you sure you want to delete this?"
     }
   ],
+  "ZB6mnn": [
+    {
+      "type": 0,
+      "value": "The variable key must be unique within a form"
+    }
+  ],
   "ZICfus": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -1371,6 +1371,12 @@
       "value": "Weet u zeker dat u dit wilt verwijderen?"
     }
   ],
+  "ZB6mnn": [
+    {
+      "type": 0,
+      "value": "The variable key must be unique within a form"
+    }
+  ],
   "ZICfus": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -54,7 +54,12 @@ import {
   getFormStep,
   parseValidationErrors,
 } from './utils';
-import {checkForDuplicateKeys, getFormVariables, updateFormVariables} from './variables/utils';
+import {
+  checkForDuplicateKeys,
+  getFormVariables,
+  updateFormVariables,
+  variableHasErrors,
+} from './variables/utils';
 import VariablesEditor from './variables/VariablesEditor';
 import {EMPTY_VARIABLE} from './variables/constants';
 import Tab from './Tab';
@@ -1115,11 +1120,7 @@ const FormCreationForm = ({csrftoken, formUuid, formUrl, formHistoryUrl}) => {
               />
             </Tab>
             {featureFlags.enable_form_variables && (
-              <Tab
-                hasErrors={state.formVariables.some(
-                  variable => Object.entries(variable.errors || {}).length
-                )}
-              >
+              <Tab hasErrors={state.formVariables.some(variable => variableHasErrors(variable))}>
                 <FormattedMessage defaultMessage="Variables" description="Variables tab title" />
               </Tab>
             )}

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -54,7 +54,7 @@ import {
   getFormStep,
   parseValidationErrors,
 } from './utils';
-import {getFormVariables, updateFormVariables} from './variables/utils';
+import {checkForDuplicateKeys, getFormVariables, updateFormVariables} from './variables/utils';
 import VariablesEditor from './variables/VariablesEditor';
 import {EMPTY_VARIABLE} from './variables/constants';
 import Tab from './Tab';
@@ -387,6 +387,9 @@ function reducer(draft, action) {
         originalComp,
         draft.formVariables,
         step.configuration
+      );
+      draft.validationErrors = draft.validationErrors.concat(
+        checkForDuplicateKeys(draft.formVariables)
       );
 
       // check if we need updates to the backendRegistrationOptions

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -389,7 +389,7 @@ function reducer(draft, action) {
         step.configuration
       );
       draft.validationErrors = draft.validationErrors.concat(
-        checkForDuplicateKeys(draft.formVariables)
+        checkForDuplicateKeys(draft.formVariables, draft.staticVariables)
       );
 
       // check if we need updates to the backendRegistrationOptions
@@ -627,7 +627,9 @@ function reducer(draft, action) {
       // Check that after the update there are no duplicate keys.
       // If it is the case, update the key that was last updated
       if (propertyName === 'key') {
-        const existingKeysAfterUpdate = draft.formVariables.map(variable => variable.key);
+        const existingKeysAfterUpdate = draft.staticVariables
+          .concat(draft.formVariables)
+          .map(variable => variable.key);
         const uniqueKeysAfterUpdate = new Set(existingKeysAfterUpdate);
 
         if (existingKeysAfterUpdate.length !== uniqueKeysAfterUpdate.size) {

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -338,13 +338,16 @@ function reducer(draft, action) {
       const {mutationType, schema, args, formDefinition} = action.payload;
 
       let originalComp;
+      let isNew;
       switch (mutationType) {
         case 'changed': {
-          [originalComp] = args;
+          originalComp = args[0];
+          isNew = args[4];
           break;
         }
         case 'removed': {
           originalComp = null;
+          isNew = false;
           break;
         }
         default:
@@ -379,6 +382,7 @@ function reducer(draft, action) {
       draft.formVariables = updateFormVariables(
         formDefinition,
         mutationType,
+        isNew,
         schema,
         originalComp,
         draft.formVariables,

--- a/src/openforms/js/components/admin/form_design/variables/StaticData.js
+++ b/src/openforms/js/components/admin/form_design/variables/StaticData.js
@@ -41,7 +41,7 @@ const StaticData = () => {
       <ChangelistTableWrapper headColumns={headColumns} extraModifiers={['fixed']}>
         {staticData.map((item, index) => {
           return (
-            <tr className={`row${(index % 2) + 1}`} key={index}>
+            <tr className={`row${(index % 2) + 1}`} key={item.key}>
               <td />
               <td>{item.name}</td>
               <td>{item.key}</td>

--- a/src/openforms/js/components/admin/form_design/variables/StaticData.js
+++ b/src/openforms/js/components/admin/form_design/variables/StaticData.js
@@ -41,7 +41,7 @@ const StaticData = () => {
       <ChangelistTableWrapper headColumns={headColumns} extraModifiers={['fixed']}>
         {staticData.map((item, index) => {
           return (
-            <tr className={`row${(index % 2) + 1}`}>
+            <tr className={`row${(index % 2) + 1}`} key={index}>
               <td />
               <td>{item.name}</td>
               <td>{item.key}</td>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
@@ -15,6 +15,10 @@ const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
     variable => variable.source === VARIABLE_SOURCES.userDefined
   );
 
+  const componentVariables = variables.filter(
+    variable => variable.source === VARIABLE_SOURCES.component
+  );
+
   return (
     <Fieldset
       title={
@@ -28,7 +32,11 @@ const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
       <div className="variables-editor__tabs">
         <Tabs>
           <TabList>
-            <Tab>
+            <Tab
+              hasErrors={componentVariables.some(
+                variable => Object.entries(variable.errors || {}).length
+              )}
+            >
               <FormattedMessage
                 defaultMessage="Component"
                 description="Component variables tab title"
@@ -50,17 +58,11 @@ const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
           </TabList>
 
           <TabPanel>
-            <VariablesTable
-              variables={variables.filter(
-                variable => variable.source === VARIABLE_SOURCES.component
-              )}
-            />
+            <VariablesTable variables={componentVariables} />
           </TabPanel>
           <TabPanel>
             <UserDefinedVariables
-              variables={variables.filter(
-                variable => variable.source === VARIABLE_SOURCES.userDefined
-              )}
+              variables={userDefinedVariables}
               onAdd={onAdd}
               onDelete={onDelete}
               onChange={onChange}

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
@@ -9,6 +9,7 @@ import {VARIABLE_SOURCES} from './constants';
 import UserDefinedVariables from './UserDefinedVariables';
 import VariablesTable from './VariablesTable';
 import StaticData from './StaticData';
+import {variableHasErrors} from './utils';
 
 const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
   const userDefinedVariables = variables.filter(
@@ -32,21 +33,13 @@ const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
       <div className="variables-editor__tabs">
         <Tabs>
           <TabList>
-            <Tab
-              hasErrors={componentVariables.some(
-                variable => Object.entries(variable.errors || {}).length
-              )}
-            >
+            <Tab hasErrors={componentVariables.some(variable => variableHasErrors(variable))}>
               <FormattedMessage
                 defaultMessage="Component"
                 description="Component variables tab title"
               />
             </Tab>
-            <Tab
-              hasErrors={userDefinedVariables.some(
-                variable => Object.entries(variable.errors || {}).length
-              )}
-            >
+            <Tab hasErrors={userDefinedVariables.some(variable => variableHasErrors(variable))}>
               <FormattedMessage
                 defaultMessage="User defined"
                 description="User defined variables tab title"

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -32,6 +32,19 @@ const SensitiveData = ({isSensitive}) => {
   );
 };
 
+const Td = ({variable, fieldName}) => {
+  const field = variable[fieldName];
+  const fieldErrors = variable.errors ? variable.errors[fieldName] : [];
+
+  return (
+    <td>
+      <Field name={fieldName} errors={fieldErrors}>
+        <div>{field}</div>
+      </Field>
+    </td>
+  );
+};
+
 const VariableRow = ({index, variable}) => {
   const formContext = useContext(FormContext);
   const formSteps = formContext.formSteps;
@@ -44,11 +57,16 @@ const VariableRow = ({index, variable}) => {
     return '';
   };
 
+  const hasErrors = !!Object.entries(variable.errors || {}).length;
+  const rowClassnames = classNames(`row${(index % 2) + 1}`, 'variables-table__row', {
+    'variables-table__row--errors': hasErrors,
+  });
+
   return (
-    <tr className={`row${(index % 2) + 1}`}>
+    <tr className={rowClassnames}>
       <td />
       <td>{variable.name}</td>
-      <td>{variable.key}</td>
+      <Td variable={variable} fieldName="key" />
       <td>{getFormDefinitionName(variable.formDefinition)}</td>
       <td>{variable.prefillAttribute}</td>
       <td>{variable.prefillPlugin}</td>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -11,8 +11,9 @@ import {ChangelistTableWrapper, HeadColumn} from 'components/admin/tables';
 import {FormContext} from 'components/admin/form_design/Context';
 import {get} from 'utils/fetch';
 import Field from 'components/admin/forms/Field';
+import {getUniqueRandomString} from 'utils/random';
 
-import {DATATYPES_CHOICES} from './constants';
+import {DATATYPES_CHOICES, VARIABLES_ERROR_MESSAGES} from './constants';
 
 const SensitiveData = ({isSensitive}) => {
   const intl = useIntl();
@@ -33,8 +34,19 @@ const SensitiveData = ({isSensitive}) => {
 };
 
 const Td = ({variable, fieldName}) => {
+  const intl = useIntl();
+
   const field = variable[fieldName];
-  const fieldErrors = variable.errors ? variable.errors[fieldName] : [];
+  let fieldErrors = variable.errors ? variable.errors[fieldName] : [];
+
+  if (!Array.isArray(fieldErrors)) fieldErrors = [fieldErrors];
+
+  fieldErrors = fieldErrors.map(error => {
+    if (VARIABLES_ERROR_MESSAGES[error]) {
+      return intl.formatMessage(VARIABLES_ERROR_MESSAGES[error]);
+    }
+    return error;
+  });
 
   return (
     <td>
@@ -156,7 +168,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
           <Select
             name="formDefinition"
             choices={formStepsChoices}
-            value={variable.formDefinition}
+            value={variable.formDefinition || ''}
             onChange={onValueChanged}
             allowBlank
           />
@@ -167,7 +179,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
           <Select
             name="prefillPlugin"
             choices={prefillPluginChoices}
-            value={variable.prefillPlugin}
+            value={variable.prefillPlugin || ''}
             onChange={onValueChanged}
             allowBlank
           />
@@ -178,7 +190,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
           <Select
             name="prefillAttribute"
             choices={prefillAttributeChoices}
-            value={variable.prefillAttribute}
+            value={variable.prefillAttribute || ''}
             onChange={onValueChanged}
             disabled={loading || !variable.prefillPlugin}
           />
@@ -190,7 +202,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
             name="dataType"
             choices={DATATYPES_CHOICES}
             translateChoices
-            value={variable.dataType}
+            value={variable.dataType || ''}
             onChange={onValueChanged}
           />
         </Field>
@@ -306,14 +318,14 @@ const VariablesTable = ({variables, editable, onChange, onDelete}) => {
         {variables.map((variable, index) =>
           editable ? (
             <EditableVariableRow
-              key={variable.key}
+              key={`${variable.key}-${index}`}
               index={index}
               variable={variable}
               onChange={onChange}
               onDelete={onDelete}
             />
           ) : (
-            <VariableRow key={variable.key} index={index} variable={variable} />
+            <VariableRow key={`${variable.key}-${index}`} index={index} variable={variable} />
           )
         )}
       </ChangelistTableWrapper>

--- a/src/openforms/js/components/admin/form_design/variables/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/constants.js
@@ -89,4 +89,9 @@ const EMPTY_VARIABLE = {
   initial_value: '',
 };
 
-export {COMPONENT_DATATYPES, VARIABLE_SOURCES, DATATYPES_CHOICES, EMPTY_VARIABLE};
+const UNIQUE_KEY_ERROR = defineMessage({
+  description: 'Unique key error message',
+  defaultMessage: 'Key not unique within form',
+});
+
+export {COMPONENT_DATATYPES, VARIABLE_SOURCES, DATATYPES_CHOICES, EMPTY_VARIABLE, UNIQUE_KEY_ERROR};

--- a/src/openforms/js/components/admin/form_design/variables/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/constants.js
@@ -89,9 +89,17 @@ const EMPTY_VARIABLE = {
   initial_value: '',
 };
 
-const UNIQUE_KEY_ERROR = defineMessage({
-  description: 'Unique key error message',
-  defaultMessage: 'Key not unique within form',
-});
+const VARIABLES_ERROR_MESSAGES = {
+  unique: defineMessage({
+    description: 'Unique key error message',
+    defaultMessage: 'Key not unique within form',
+  }),
+};
 
-export {COMPONENT_DATATYPES, VARIABLE_SOURCES, DATATYPES_CHOICES, EMPTY_VARIABLE, UNIQUE_KEY_ERROR};
+export {
+  COMPONENT_DATATYPES,
+  VARIABLE_SOURCES,
+  DATATYPES_CHOICES,
+  EMPTY_VARIABLE,
+  VARIABLES_ERROR_MESSAGES,
+};

--- a/src/openforms/js/components/admin/form_design/variables/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/constants.js
@@ -89,17 +89,4 @@ const EMPTY_VARIABLE = {
   initial_value: '',
 };
 
-const VARIABLES_ERROR_MESSAGES = {
-  unique: defineMessage({
-    description: 'Unique key error message',
-    defaultMessage: 'Key not unique within form',
-  }),
-};
-
-export {
-  COMPONENT_DATATYPES,
-  VARIABLE_SOURCES,
-  DATATYPES_CHOICES,
-  EMPTY_VARIABLE,
-  VARIABLES_ERROR_MESSAGES,
-};
+export {COMPONENT_DATATYPES, VARIABLE_SOURCES, DATATYPES_CHOICES, EMPTY_VARIABLE};

--- a/src/openforms/js/components/admin/form_design/variables/types.js
+++ b/src/openforms/js/components/admin/form_design/variables/types.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+
+const Variable = PropTypes.shape({
+  form: PropTypes.string,
+  formDefinition: PropTypes.string,
+  name: PropTypes.string,
+  key: PropTypes.string.isRequired,
+  source: PropTypes.string,
+  prefillPlugin: PropTypes.string,
+  prefillAttribute: PropTypes.string,
+  dataType: PropTypes.string,
+  dataFormat: PropTypes.string,
+  isSensitiveData: PropTypes.bool,
+  initialValue: PropTypes.string,
+  errors: PropTypes.object,
+});
+
+export default Variable;

--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {Utils as FormioUtils} from 'formiojs';
 
-import {COMPONENT_DATATYPES, VARIABLE_SOURCES} from './constants';
+import {COMPONENT_DATATYPES, UNIQUE_KEY_ERROR, VARIABLE_SOURCES} from './constants';
 
 const getComponentDatatype = component => {
   if (component.multiple) {
@@ -154,6 +154,24 @@ const updateFormVariables = (
   return updatedFormVariables;
 };
 
+const checkForDuplicateKeys = formVariables => {
+  let validationErrors = [];
+  let existingKeys = [];
+  formVariables.map((variable, index) => {
+    if (existingKeys.includes(variable.key)) {
+      validationErrors.push([`variables.${index}.key`, UNIQUE_KEY_ERROR]);
+
+      if (!variable.errors) variable.errors = {};
+      variable.errors['key'] = UNIQUE_KEY_ERROR;
+      return;
+    }
+
+    existingKeys.push(variable.key);
+  });
+
+  return validationErrors;
+};
+
 const getDefaultValue = component => {
   if (component.hasOwnProperty('defaultValue') && component.defaultValue !== null)
     return component.defaultValue;
@@ -161,4 +179,4 @@ const getDefaultValue = component => {
   return null;
 };
 
-export {updateFormVariables, getFormVariables};
+export {updateFormVariables, getFormVariables, checkForDuplicateKeys};

--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -131,6 +131,7 @@ const updateFormVariables = (
       return variable;
     });
   } else if (mutationType === 'removed') {
+    // When a component is removed, oldComponent is null
     let keysToRemove = [newComponent.key];
 
     // Case where a layout component is being removed,
@@ -141,10 +142,13 @@ const updateFormVariables = (
       });
     }
 
-    // When a component is removed, oldComponent is null
-    updatedFormVariables = updatedFormVariables.filter(
-      variable => !keysToRemove.includes(variable.key)
-    );
+    updatedFormVariables = updatedFormVariables.filter(variable => {
+      const matchKeyToRemove = keysToRemove.includes(variable.key);
+
+      // In the case that there are duplicate keys, we need to figure out which of the variables with duplicate keys
+      // should be removed. Since in a step there can't be duplicate keys, check that the formDefinition matches
+      return !matchKeyToRemove || variable.formDefinition !== formDefinition;
+    });
   }
 
   return updatedFormVariables;

--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {Utils as FormioUtils} from 'formiojs';
 
-import {COMPONENT_DATATYPES, UNIQUE_KEY_ERROR, VARIABLE_SOURCES} from './constants';
+import {COMPONENT_DATATYPES, VARIABLE_SOURCES} from './constants';
 
 const getComponentDatatype = component => {
   if (component.multiple) {
@@ -154,15 +154,16 @@ const updateFormVariables = (
   return updatedFormVariables;
 };
 
-const checkForDuplicateKeys = formVariables => {
+const checkForDuplicateKeys = (formVariables, staticVariables) => {
   let validationErrors = [];
   let existingKeys = [];
-  formVariables.map((variable, index) => {
+
+  staticVariables.concat(formVariables).map((variable, index) => {
     if (existingKeys.includes(variable.key)) {
-      validationErrors.push([`variables.${index}.key`, UNIQUE_KEY_ERROR]);
+      validationErrors.push([`variables.${index}.key`, 'unique']);
 
       if (!variable.errors) variable.errors = {};
-      variable.errors['key'] = UNIQUE_KEY_ERROR;
+      variable.errors['key'] = 'unique';
       return;
     }
 

--- a/src/openforms/js/components/admin/forms/Field.js
+++ b/src/openforms/js/components/admin/forms/Field.js
@@ -4,14 +4,17 @@ import classNames from 'classnames';
 
 import {PrefixContext} from './Context';
 import ErrorList from './ErrorList';
+import {useIntl} from 'react-intl';
 
-export const normalizeErrors = (errors = []) => {
-  if (typeof errors === 'string') {
+export const normalizeErrors = (errors = [], intl) => {
+  if (!Array.isArray(errors)) {
     errors = [errors];
   }
   const hasErrors = Boolean(errors && errors.length);
   const formattedErrors = errors.map(error => {
     if (typeof error === 'string') return error;
+
+    if (error.defaultMessage) return intl.formatMessage(error);
 
     const [key, msg] = error;
     return msg;
@@ -31,6 +34,7 @@ const Field = ({
   children,
   fieldBox = false,
 }) => {
+  const intl = useIntl();
   const originalName = name;
   const prefix = useContext(PrefixContext);
   name = prefix ? `${prefix}-${name}` : name;
@@ -38,7 +42,7 @@ const Field = ({
   const htmlFor = `id_${name}`;
 
   const modifiedChildren = React.cloneElement(children, {id: htmlFor, name: originalName});
-  const [hasErrors, formattedErrors] = normalizeErrors(errors);
+  const [hasErrors, formattedErrors] = normalizeErrors(errors, intl);
   const className = classNames({fieldBox: fieldBox}, {errors: hasErrors});
 
   return (

--- a/src/openforms/js/components/admin/forms/Select.js
+++ b/src/openforms/js/components/admin/forms/Select.js
@@ -29,6 +29,8 @@ const Select = ({
   name = prefix ? `${prefix}-${name}` : name;
   const options = allowBlank ? [BLANK_OPTION].concat(choices) : choices;
 
+  extraProps.value = extraProps.value || '';
+
   return (
     <select name={name} {...extraProps}>
       {options.map(([value, label]) => (

--- a/src/openforms/js/components/admin/forms/ValidationErrors.js
+++ b/src/openforms/js/components/admin/forms/ValidationErrors.js
@@ -10,8 +10,19 @@ const ValidationErrorsProvider = ({children, errors = []}) => {
   );
 };
 
+const errorArray = props => {
+  const errorMsg = 'Invalid error passed to ValidationErrorsProvider.';
+
+  if (props.length !== 2) return new Error(`${errorMsg} It should have length 2`);
+
+  if (typeof props[0] !== 'string')
+    return new Error(`${errorMsg} The error key should be a string.`);
+  if (!(typeof props[1] === 'string' || props[1].defaultMessage))
+    return new Error(`${errorMsg} The error msg should be a string or and intl object.`);
+};
+
 ValidationErrorsProvider.propTypes = {
-  errors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+  errors: PropTypes.arrayOf(PropTypes.arrayOf(errorArray)),
 };
 
 export {ValidationErrorsProvider, ValidationErrorContext};

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -954,6 +954,11 @@
     "description": "Default delete confirmation message",
     "originalDefault": "Are you sure you want to delete this?"
   },
+  "ZB6mnn": {
+    "defaultMessage": "The variable key must be unique within a form",
+    "description": "Unique key error message",
+    "originalDefault": "The variable key must be unique within a form"
+  },
   "ZICfus": {
     "defaultMessage": "Previous text",
     "description": "Form step previous text label",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -954,6 +954,11 @@
     "description": "Default delete confirmation message",
     "originalDefault": "Are you sure you want to delete this?"
   },
+  "ZB6mnn": {
+    "defaultMessage": "The variable key must be unique within a form",
+    "description": "Unique key error message",
+    "originalDefault": "The variable key must be unique within a form"
+  },
   "ZICfus": {
     "defaultMessage": "'Vorige' tekst",
     "description": "Form step previous text label",


### PR DESCRIPTION
Fixes #1697 

The cases that I tested are:
- Create 2 form components with same keys
- Create a user defined var and then a component with the same key
- Create a form component with key 'now' (clash with static variable)
- Create a user defined var with key 'now' (clash with static variable)