### PR TITLE
[#1661] Set auth static data

### DIFF
--- a/docs/developers/backend/core/variables.rst
+++ b/docs/developers/backend/core/variables.rst
@@ -35,3 +35,43 @@ The flow of how static variables are used in the backend is:
 
 #. When the step is persisted to the database:
    All the data corresponding to variables of type component / user defined is saved in a ``SubmissionValueVariable``.
+
+
+Adding new static FormVariables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Static variables can be defined by each app with the same mechanism used for plugins (see :ref:`adding_your_plugin`
+for more details).
+
+The steps to add a static variable to an app are:
+
+#. Within the app, create a python package ``static_variables``.
+#. Add an ``apps.py`` file with an ``AppConfig``. The static variables need to be imported in the ``ready`` method to be
+   added to the register:
+
+   .. code-block:: python
+
+        from django.apps import AppConfig
+
+        class StaticVariables(AppConfig):
+            name = "openforms.<app_name>.static_variables"
+            label = "<app_name>_static_variables"
+            verbose_name = "<App name> static variables"
+
+            def ready(self):
+                from . import static_variables  # noqa
+
+#. Add ``openforms.<app_name>.static_variable.apps.StaticVariables`` to the ``settings.INSTALLED_APPS``.
+#. Create a ``static_apps.py`` in the ``static_variables`` package of the app which you just created.
+#. Define any new static variable here using the ``BaseStaticVariable`` base class and the ``static_variables_register``
+   decorator (which adds the variable to the register).
+
+   .. code-block:: python
+
+        @static_variables_register("<variable key>")
+        class NewStaticVariable(BaseStaticVariable):
+            name = _("<variable name>")
+            data_type = "<variable type>"
+
+            def get_initial_value(self, *args, **kwargs):
+                ...

--- a/docs/developers/plugins/index.rst
+++ b/docs/developers/plugins/index.rst
@@ -4,7 +4,7 @@
 Plugins
 =======
 
-Open Forms has a plugin system for the several modules. Each module has a 
+Open Forms has a plugin system for the several modules. Each module has a
 specific goal and is invoked in different stages of the form process. Typically,
 a plugin uses some backend to communicate with an external system to perform
 some task.
@@ -12,17 +12,19 @@ some task.
 Developing plugins
 ==================
 
-Plugins for each component are developed in roughly the same way but uses a 
+Plugins for each component are developed in roughly the same way but uses a
 different base class that belongs to that particular component.
 
-Registering a plugin within a component makes it available for form editors to 
+Registering a plugin within a component makes it available for form editors to
 use in their forms.
+
+.. _adding_your_plugin:
 
 Adding your plugin
 ------------------
 
 Plugins are implemented as Django apps (which are essentially Python packages).
-Typically you can look at a demo plugin for each component in 
+Typically you can look at a demo plugin for each component in
 ``openforms.<component>.contrib.demo`` which acts as an example.
 
 1. Create the python package in ``openforms.<component>.contrib.<vendor>``
@@ -39,10 +41,10 @@ Typically you can look at a demo plugin for each component in
            def ready(self):
                from . import plugin  # noqa
 
-   It's important to import the plugin as part of the ``ready`` hook of the 
+   It's important to import the plugin as part of the ``ready`` hook of the
    ``AppConfig``, as this ensures that the plugin is added to the registry.
 
-3. Add the application to ``settings.INSTALLED_APPS``, this will cause the 
+3. Add the application to ``settings.INSTALLED_APPS``, this will cause the
    ``AppConfig`` to be loaded.
 
 .. _AppConfig: https://docs.djangoproject.com/en/2.2/ref/applications/

--- a/src/openforms/authentication/static_variables/apps.py
+++ b/src/openforms/authentication/static_variables/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class AuthStaticVariables(AppConfig):
+    name = "openforms.authentication.static_variables"
+    label = "authentication_static_variables"
+    verbose_name = "Authentication static variables"
+
+    def ready(self):
+        from . import static_variables  # noqa

--- a/src/openforms/authentication/static_variables/static_variables.py
+++ b/src/openforms/authentication/static_variables/static_variables.py
@@ -1,0 +1,73 @@
+from typing import TYPE_CHECKING, Optional
+
+from django.utils.translation import gettext_lazy as _
+
+from openforms.authentication.constants import AuthAttribute
+from openforms.forms.constants import FormVariableDataTypes
+from openforms.variables.base import BaseStaticVariable
+from openforms.variables.registry import static_variables_register
+
+if TYPE_CHECKING:  # pragma: nocover
+    from openforms.authentication.utils import FormAuth
+    from openforms.submissions.models import Submission
+
+
+@static_variables_register("auth_identifier")
+class AuthIdentifier(BaseStaticVariable):
+    name = _("Authentication identifier")
+    data_type = FormVariableDataTypes.object
+
+    def get_initial_value(
+        self, submission: Optional["Submission"]
+    ) -> Optional["FormAuth"]:
+        if not submission or not hasattr(submission, "auth_info"):
+            return None
+
+        from openforms.authentication.utils import FormAuth
+
+        auth_data = FormAuth(
+            plugin=submission.auth_info.plugin,
+            attribute=submission.auth_info.attribute,
+            value=submission.auth_info.value,
+            # TODO what is the structure of the data in the machtigen field?
+            machtigen=submission.auth_info.machtigen,
+        )
+
+        return auth_data
+
+
+def get_auth_value(submission: Optional["Submission"], attribute: str) -> str:
+    if not submission or not hasattr(submission, "auth_info"):
+        return ""
+
+    if submission.auth_info.attribute == attribute:
+        return submission.auth_info.value
+
+    return ""
+
+
+@static_variables_register("auth_bsn")
+class AuthBSN(BaseStaticVariable):
+    name = _("Authentication BSN")
+    data_type = FormVariableDataTypes.string
+
+    def get_initial_value(self, submission: Optional["Submission"]) -> str:
+        return get_auth_value(submission, AuthAttribute.bsn)
+
+
+@static_variables_register("auth_kvk")
+class AuthKvK(BaseStaticVariable):
+    name = _("Authentication KvK")
+    data_type = FormVariableDataTypes.string
+
+    def get_initial_value(self, submission: Optional["Submission"]) -> str:
+        return get_auth_value(submission, AuthAttribute.kvk)
+
+
+@static_variables_register("auth_pseudo")
+class AuthPseudo(BaseStaticVariable):
+    name = _("Authentication pseudo")
+    data_type = FormVariableDataTypes.string
+
+    def get_initial_value(self, submission: Optional["Submission"]) -> str:
+        return get_auth_value(submission, AuthAttribute.pseudo)

--- a/src/openforms/authentication/static_variables/static_variables.py
+++ b/src/openforms/authentication/static_variables/static_variables.py
@@ -2,17 +2,19 @@ from typing import TYPE_CHECKING, Optional
 
 from django.utils.translation import gettext_lazy as _
 
-from openforms.authentication.constants import AuthAttribute
-from openforms.forms.constants import FormVariableDataTypes
 from openforms.variables.base import BaseStaticVariable
-from openforms.variables.registry import static_variables_register
+from openforms.variables.constants import FormVariableDataTypes
+from openforms.variables.registry import register_static_variable
+
+from ..constants import AuthAttribute
 
 if TYPE_CHECKING:  # pragma: nocover
-    from openforms.authentication.utils import FormAuth
     from openforms.submissions.models import Submission
 
+    from ..utils import FormAuth
 
-@static_variables_register("auth_identifier")
+
+@register_static_variable("auth_identifier")
 class AuthIdentifier(BaseStaticVariable):
     name = _("Authentication identifier")
     data_type = FormVariableDataTypes.object
@@ -20,10 +22,10 @@ class AuthIdentifier(BaseStaticVariable):
     def get_initial_value(
         self, submission: Optional["Submission"]
     ) -> Optional["FormAuth"]:
-        if not submission or not hasattr(submission, "auth_info"):
+        if not submission or not submission.is_authenticated:
             return None
 
-        from openforms.authentication.utils import FormAuth
+        from ..utils import FormAuth
 
         auth_data = FormAuth(
             plugin=submission.auth_info.plugin,
@@ -37,7 +39,7 @@ class AuthIdentifier(BaseStaticVariable):
 
 
 def get_auth_value(submission: Optional["Submission"], attribute: str) -> str:
-    if not submission or not hasattr(submission, "auth_info"):
+    if not submission or not submission.is_authenticated:
         return ""
 
     if submission.auth_info.attribute == attribute:
@@ -46,28 +48,31 @@ def get_auth_value(submission: Optional["Submission"], attribute: str) -> str:
     return ""
 
 
-@static_variables_register("auth_bsn")
+@register_static_variable("auth_bsn")
 class AuthBSN(BaseStaticVariable):
     name = _("Authentication BSN")
     data_type = FormVariableDataTypes.string
 
-    def get_initial_value(self, submission: Optional["Submission"]) -> str:
+    @staticmethod
+    def get_initial_value(submission: Optional["Submission"]) -> str:
         return get_auth_value(submission, AuthAttribute.bsn)
 
 
-@static_variables_register("auth_kvk")
+@register_static_variable("auth_kvk")
 class AuthKvK(BaseStaticVariable):
     name = _("Authentication KvK")
     data_type = FormVariableDataTypes.string
 
-    def get_initial_value(self, submission: Optional["Submission"]) -> str:
+    @staticmethod
+    def get_initial_value(submission: Optional["Submission"]) -> str:
         return get_auth_value(submission, AuthAttribute.kvk)
 
 
-@static_variables_register("auth_pseudo")
+@register_static_variable("auth_pseudo")
 class AuthPseudo(BaseStaticVariable):
     name = _("Authentication pseudo")
     data_type = FormVariableDataTypes.string
 
-    def get_initial_value(self, submission: Optional["Submission"]) -> str:
+    @staticmethod
+    def get_initial_value(submission: Optional["Submission"]) -> str:
         return get_auth_value(submission, AuthAttribute.pseudo)

--- a/src/openforms/authentication/tests/test_static_variables.py
+++ b/src/openforms/authentication/tests/test_static_variables.py
@@ -17,6 +17,13 @@ class TestStaticVariables(TestCase):
         static_data = FormVariable.get_static_data(auth_info.submission)
 
         self.assertEqual(5, len(static_data))
+        (
+            form_auth_var,
+            auth_identifier_var,
+            auth_bsn_var,
+            auth_kvk_var,
+            auth_pseudo_var,
+        ) = static_data
         self.assertEqual(
             {
                 "plugin": "test-plugin",
@@ -24,7 +31,7 @@ class TestStaticVariables(TestCase):
                 "value": "111222333",
                 "machtigen": {AuthAttribute.bsn: "123456789"},
             },
-            static_data[1].initial_value,
+            auth_identifier_var.initial_value,
         )
 
         self.assertEqual(

--- a/src/openforms/authentication/tests/test_static_variables.py
+++ b/src/openforms/authentication/tests/test_static_variables.py
@@ -1,0 +1,84 @@
+from django.test import TestCase
+
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.tests.factories import AuthInfoFactory
+from openforms.forms.models import FormVariable
+
+
+class TestStaticVariables(TestCase):
+    def test_auth_static_data(self):
+        auth_info = AuthInfoFactory.create(
+            plugin="test-plugin",
+            attribute=AuthAttribute.bsn,
+            value="111222333",
+            machtigen={AuthAttribute.bsn: "123456789"},
+        )
+
+        static_data = FormVariable.get_static_data(auth_info.submission)
+
+        self.assertEqual(5, len(static_data))
+        self.assertEqual(
+            {
+                "plugin": "test-plugin",
+                "attribute": AuthAttribute.bsn,
+                "value": "111222333",
+                "machtigen": {AuthAttribute.bsn: "123456789"},
+            },
+            static_data[1].initial_value,
+        )
+
+        self.assertEqual(
+            "auth_bsn",
+            static_data[2].key,
+        )
+        self.assertEqual(
+            "111222333",
+            static_data[2].initial_value,
+        )
+        self.assertEqual(
+            "auth_kvk",
+            static_data[3].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[3].initial_value,
+        )
+        self.assertEqual(
+            "auth_pseudo",
+            static_data[4].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[4].initial_value,
+        )
+
+    def test_auth_static_data_no_submission(self):
+        static_data = FormVariable.get_static_data()
+
+        self.assertEqual(5, len(static_data))
+        self.assertIsNone(static_data[1].initial_value)
+
+        self.assertEqual(
+            "auth_bsn",
+            static_data[2].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[2].initial_value,
+        )
+        self.assertEqual(
+            "auth_kvk",
+            static_data[3].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[3].initial_value,
+        )
+        self.assertEqual(
+            "auth_pseudo",
+            static_data[4].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[4].initial_value,
+        )

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -220,6 +220,9 @@ INSTALLED_APPS = [
     "openforms.utils",
     "openforms.plugins",
     "openforms.custom_field_types",
+    # Apps registering static variables
+    "openforms.variables.static_variables.apps.StaticVariables",
+    "openforms.authentication.static_variables.apps.AuthStaticVariables",
 ]
 
 MIDDLEWARE = [

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -26,21 +26,17 @@ def get_dynamic_configuration(
     configuration = handle_custom_types(
         configuration, request=request, submission=submission
     )
-    configuration = insert_variables(
-        configuration, submission=submission, request=request
-    )
+    configuration = insert_variables(configuration, submission=submission)
     return configuration
 
 
-def insert_variables(
-    configuration: dict, submission: Submission, request: "Request"
-) -> dict:
+def insert_variables(configuration: dict, submission: Submission) -> dict:
     # TODO: refactor when interpolating configuration properties with variables
     inject_prefill(configuration, submission)
 
     value_variables_state = submission.load_submission_value_variables_state()
     data = value_variables_state.get_data()
-    static_data = value_variables_state.static_data(request)
+    static_data = value_variables_state.static_data()
 
     for component in iter_components(configuration):
         if "html" in component:

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -2,7 +2,7 @@ import logging
 from datetime import date, datetime
 from typing import Any, Iterator, List, Optional
 
-from openforms.forms.constants import FormVariableDataTypes
+from openforms.variables.constants import FormVariableDataTypes
 
 from ..typing import JSONObject
 from .constants import COMPONENT_DATATYPES

--- a/src/openforms/forms/api/serializers/form_variable.py
+++ b/src/openforms/forms/api/serializers/form_variable.py
@@ -7,8 +7,8 @@ from rest_framework.exceptions import ValidationError
 
 from openforms.api.serializers import ListWithChildSerializer
 from openforms.formio.utils import get_component
+from openforms.variables.constants import FormVariableSources
 
-from ...constants import FormVariableSources
 from ...models import FormVariable
 
 

--- a/src/openforms/forms/api/validators.py
+++ b/src/openforms/forms/api/validators.py
@@ -146,13 +146,14 @@ class JsonLogicTriggerValidator(JsonLogicValidator):
                 )
 
             # Check if the trigger references a static variable
-            if needle in [variable.key for variable in FormVariable.get_static_data()]:
-                return
+            needle_bits = needle.split(".")
+            for variable in FormVariable.get_static_data():
+                if needle_bits[0] == variable.key:
+                    return
 
             variable_related_to_form = form.formvariable_set.filter(key=needle)
             if not variable_related_to_form:
                 # selectboxes case
-                needle_bits = needle.split(".")
                 variable_related_to_form = form.formvariable_set.filter(
                     key=".".join(needle_bits[:-1])
                 )

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -56,3 +56,6 @@ class FormVariableDataTypes(DjangoChoices):
 class FormVariableStaticInitialValues(DjangoChoices):
     now = ChoiceItem("now", _("Now"))
     auth_identifier = ChoiceItem("auth_identifier", "Authentication identifier")
+    auth_bsn = ChoiceItem("auth_bsn", "Authentication BSN")
+    auth_kvk = ChoiceItem("auth_kvk", "Authentication KvK")
+    auth_pseudo = ChoiceItem("auth_pseudo", "Authentication pseudo")

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -55,3 +55,4 @@ class FormVariableDataTypes(DjangoChoices):
 
 class FormVariableStaticInitialValues(DjangoChoices):
     now = ChoiceItem("now", _("Now"))
+    auth_identifier = ChoiceItem("auth_identifier", "Authentication identifier")

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -35,27 +35,3 @@ class SubmissionAllowedChoices(DjangoChoices):
     no_without_overview = ChoiceItem(
         "no_without_overview", _("No (without overview page)")
     )
-
-
-class FormVariableSources(DjangoChoices):
-    component = ChoiceItem("component", _("Component"))
-    user_defined = ChoiceItem("user_defined", _("User defined"))
-
-
-class FormVariableDataTypes(DjangoChoices):
-    string = ChoiceItem("string", _("String"))
-    boolean = ChoiceItem("boolean", _("Boolean"))
-    object = ChoiceItem("object", _("Object"))
-    array = ChoiceItem("array", _("Array"))
-    int = ChoiceItem("int", _("Integer"))
-    float = ChoiceItem("float", _("Float"))
-    datetime = ChoiceItem("datetime", _("Datetime"))
-    time = ChoiceItem("time", _("Time"))
-
-
-class FormVariableStaticInitialValues(DjangoChoices):
-    now = ChoiceItem("now", _("Now"))
-    auth_identifier = ChoiceItem("auth_identifier", "Authentication identifier")
-    auth_bsn = ChoiceItem("auth_bsn", "Authentication BSN")
-    auth_kvk = ChoiceItem("auth_kvk", "Authentication KvK")
-    auth_pseudo = ChoiceItem("auth_pseudo", "Authentication pseudo")

--- a/src/openforms/forms/migrations/0037_remove_invalid_component_vars.py
+++ b/src/openforms/forms/migrations/0037_remove_invalid_component_vars.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-from openforms.forms.constants import FormVariableSources
+from openforms.variables.constants import FormVariableSources
 
 
 def remove_component_variables_without_definition(apps, schema_editor):

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -25,12 +25,9 @@ from openforms.registrations.fields import RegistrationBackendChoiceField
 from openforms.registrations.registry import register as registration_register
 from openforms.utils.files import DeleteFileFieldFilesMixin, DeleteFilesQuerySetMixin
 from openforms.utils.validators import DjangoTemplateValidator
+from openforms.variables.constants import FormVariableSources
 
-from ..constants import (
-    ConfirmationEmailOptions,
-    FormVariableSources,
-    SubmissionAllowedChoices,
-)
+from ..constants import ConfirmationEmailOptions, SubmissionAllowedChoices
 from .utils import literal_getter
 
 User = get_user_model()

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -16,9 +16,11 @@ from openforms.formio.utils import (
     is_layout_component,
     iter_components,
 )
-from openforms.variables.registry import static_variables_register
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+from openforms.variables.registry import (
+    register_static_variable as static_variables_register,
+)
 
-from ..constants import FormVariableDataTypes, FormVariableSources
 from .form_definition import FormDefinition
 
 if TYPE_CHECKING:  # pragma: nocover
@@ -216,7 +218,7 @@ class FormVariable(models.Model):
     ) -> List["FormVariable"]:
 
         return [
-            registered_variable.get_static_variable(submission)
+            registered_variable.get_static_variable(submission=submission)
             for registered_variable in static_variables_register
         ]
 

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -1,8 +1,8 @@
 import factory
 
 from openforms.products.tests.factories import ProductFactory
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
-from ..constants import FormVariableDataTypes, FormVariableSources
 from ..models import FormStep, FormVariable
 from ..utils import form_to_json
 

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -12,9 +12,10 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import TokenFactory, UserFactory
+from openforms.variables.constants import FormVariableSources
 
 from ...emails.tests.factories import ConfirmationEmailTemplateFactory
-from ..constants import EXPORT_META_KEY, ConfirmationEmailOptions, FormVariableSources
+from ..constants import EXPORT_META_KEY, ConfirmationEmailOptions
 from ..models import Form, FormDefinition, FormStep
 from .factories import (
     FormDefinitionFactory,

--- a/src/openforms/forms/tests/test_copy.py
+++ b/src/openforms/forms/tests/test_copy.py
@@ -11,8 +11,8 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import SuperUserFactory, TokenFactory
 from openforms.tests.utils import NOOP_CACHES
+from openforms.variables.constants import FormVariableSources
 
-from ..constants import FormVariableSources
 from ..models import Form, FormDefinition, FormStep, FormVariable
 from .factories import (
     FormDefinitionFactory,

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -7,8 +7,9 @@ from django.test import TestCase, override_settings
 
 from openforms.payments.contrib.ogone.tests.factories import OgoneMerchantFactory
 from openforms.products.tests.factories import ProductFactory
+from openforms.variables.constants import FormVariableSources
 
-from ..constants import EXPORT_META_KEY, FormVariableSources
+from ..constants import EXPORT_META_KEY
 from ..models import Form, FormDefinition, FormLogic, FormStep
 from .factories import (
     CategoryFactory,

--- a/src/openforms/forms/tests/test_restore_version.py
+++ b/src/openforms/forms/tests/test_restore_version.py
@@ -1,15 +1,15 @@
 import copy
 import datetime
 import json
-from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
 from freezegun import freeze_time
 
-from ..constants import FormVariableDataTypes, FormVariableSources
-from ..models import FormDefinition, FormStep, FormVariable, FormVersion
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+
+from ..models import FormDefinition, FormStep, FormVersion
 from .factories import (
     FormDefinitionFactory,
     FormFactory,
@@ -351,17 +351,6 @@ FORM_VARIABLES = [
 ]
 
 
-@patch(
-    "openforms.forms.models.FormVariable.get_static_data",
-    return_value=[
-        FormVariable(
-            name="Now",
-            key="now",
-            data_type=FormVariableDataTypes.datetime,
-            initial_value="2021-07-16T21:15:00+00:00",
-        )
-    ],
-)
 class RestoreVersionsWithVariablesTest(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -376,7 +365,7 @@ class RestoreVersionsWithVariablesTest(TestCase):
             "formLogic": json.dumps([]),
         }
 
-    def test_restore_form_with_more_component_variables(self, m):
+    def test_restore_form_with_more_component_variables(self):
         form_definition = FormDefinitionFactory.create(
             name="Icecream questionnaire",
             internal_name="Icecream questionnaire",
@@ -398,7 +387,7 @@ class RestoreVersionsWithVariablesTest(TestCase):
 
         self.assertEqual(1, form.formvariable_set.count())
 
-    def test_restore_form_with_fewer_component_variables(self, m):
+    def test_restore_form_with_fewer_component_variables(self):
         form_definition = FormDefinitionFactory.create(
             name="Icecream questionnaire",
             internal_name="Icecream questionnaire",
@@ -429,7 +418,7 @@ class RestoreVersionsWithVariablesTest(TestCase):
 
         self.assertEqual(1, form.formvariable_set.count())
 
-    def test_restore_form_with_user_defined_variables(self, m):
+    def test_restore_form_with_user_defined_variables(self):
         form_definition = FormDefinitionFactory.create(
             name="Icecream questionnaire",
             internal_name="Icecream questionnaire",

--- a/src/openforms/forms/tests/test_restore_version.py
+++ b/src/openforms/forms/tests/test_restore_version.py
@@ -355,8 +355,8 @@ FORM_VARIABLES = [
     "openforms.forms.models.FormVariable.get_static_data",
     return_value=[
         FormVariable(
-            key="now",
             name="Now",
+            key="now",
             data_type=FormVariableDataTypes.datetime,
             initial_value="2021-07-16T21:15:00+00:00",
         )

--- a/src/openforms/forms/tests/variables/test_model.py
+++ b/src/openforms/forms/tests/variables/test_model.py
@@ -1,7 +1,8 @@
 from django.db import IntegrityError
 from django.test import TestCase
 
-from ...constants import FormVariableDataTypes, FormVariableSources
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+
 from ..factories import FormFactory, FormVariableFactory
 
 

--- a/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
+++ b/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
@@ -274,4 +274,3 @@ class VariablesInLogicBulkAPITests(APITestCase):
         response = self.client.put(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-

--- a/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
+++ b/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
@@ -8,10 +8,36 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import SuperUserFactory
 from openforms.authentication.constants import AuthAttribute
+from openforms.variables.base import BaseStaticVariable
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+from openforms.variables.registry import Registry
 
-from ...constants import FormVariableDataTypes, FormVariableSources
-from ...models import FormVariable
 from ..factories import FormFactory, FormVariableFactory
+
+
+class DemoNow(BaseStaticVariable):
+    name = "Now"
+    data_type = FormVariableDataTypes.datetime
+
+    def get_initial_value(self, *args, **kwargs):
+        return "2021-07-16T21:15:00+00:00"
+
+
+class DemoAuthIdentifier(BaseStaticVariable):
+    name = "Authentication identifier"
+    data_type = FormVariableDataTypes.object
+
+    def get_initial_value(self, *args, **kwargs):
+        return {
+            "plugin": "digid",
+            "attribute": AuthAttribute.bsn,
+            "value": "123456782",
+        }
+
+
+register = Registry()
+register("now")(DemoNow)
+register("auth_identifier")(DemoAuthIdentifier)
 
 
 # TODO Remove once the FormLogicViewSet endpoint is removed
@@ -88,11 +114,7 @@ class VariablesInLogicAPITests(APITestCase):
             error["invalidParams"][0]["reason"],
         )
 
-    @patch(
-        "openforms.forms.models.FormVariable.get_static_data",
-        return_value=[FormVariable(key="now")],
-    )
-    def test_static_variable_in_trigger(self, m_get_static_data):
+    def test_static_variable_in_trigger(self):
         user = SuperUserFactory.create()
         form = FormFactory.create()
 
@@ -116,26 +138,16 @@ class VariablesInLogicAPITests(APITestCase):
 
         self.client.force_authenticate(user=user)
         url = reverse("api:form-logics-list")
-        response = self.client.post(url, data=form_logic_data)
+
+        with patch(
+            "openforms.forms.models.form_variable.static_variables_register",
+            new=register,
+        ):
+            response = self.client.post(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
 
-    @patch(
-        "openforms.forms.models.FormVariable.get_static_data",
-        return_value=[
-            FormVariable(
-                name="Authentication identifier",
-                key="auth_identifier",
-                data_type=FormVariableDataTypes.object,
-                initial_value={
-                    "plugin": "digid",
-                    "attribute": AuthAttribute.bsn,
-                    "value": "123456782",
-                },
-            )
-        ],
-    )
-    def test_auth_static_variable_in_trigger(self, m_get_static_data):
+    def test_auth_static_variable_in_trigger(self):
         user = SuperUserFactory.create()
         form = FormFactory.create()
 
@@ -159,7 +171,12 @@ class VariablesInLogicAPITests(APITestCase):
 
         self.client.force_authenticate(user=user)
         url = reverse("api:form-logics-list")
-        response = self.client.post(url, data=form_logic_data)
+
+        with patch(
+            "openforms.forms.models.form_variable.static_variables_register",
+            new=register,
+        ):
+            response = self.client.post(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
 
@@ -241,11 +258,7 @@ class VariablesInLogicBulkAPITests(APITestCase):
             error["invalidParams"][0]["reason"],
         )
 
-    @patch(
-        "openforms.forms.models.FormVariable.get_static_data",
-        return_value=[FormVariable(key="now")],
-    )
-    def test_static_variable_in_trigger(self, m_get_static_data):
+    def test_static_variable_in_trigger(self):
         user = SuperUserFactory.create()
         form = FormFactory.create()
 
@@ -271,6 +284,10 @@ class VariablesInLogicBulkAPITests(APITestCase):
 
         self.client.force_authenticate(user=user)
         url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
-        response = self.client.put(url, data=form_logic_data)
+        with patch(
+            "openforms.forms.models.form_variable.static_variables_register",
+            new=register,
+        ):
+            response = self.client.put(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -324,7 +324,7 @@ class FormVariableViewsetTest(APITestCase):
         self.client.force_authenticate(user)
 
         with patch(
-            "openforms.forms.api.serializers.form_variable.FormVariableSerializer"
+            "openforms.forms.models.form_variable.FormVariable.get_static_data"
         ) as m:
             m.return_value = [
                 FormVariable(

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -11,13 +11,13 @@ from openforms.accounts.tests.factories import (
     SuperUserFactory,
     UserFactory,
 )
-from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.models import FormVariable
 from openforms.forms.tests.factories import (
     FormDefinitionFactory,
     FormFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 
 @override_settings(LANGUAGE_CODE="en")

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -13,6 +13,8 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
 
+from openforms.variables.constants import FormVariableSources
+
 from .api.serializers import (
     FormDefinitionSerializer,
     FormExportSerializer,
@@ -21,7 +23,7 @@ from .api.serializers import (
     FormStepSerializer,
     FormVariableSerializer,
 )
-from .constants import EXPORT_META_KEY, FormVariableSources
+from .constants import EXPORT_META_KEY
 from .models import Form, FormDefinition, FormLogic, FormStep, FormVariable
 
 IMPORT_ORDER = {

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -26,7 +26,7 @@ const ActionProperty = ({action, errors, onChange}) => {
   const castValueTypeToString = action => {
     const valueType = action.action.property.type;
     const value = action.action.state;
-    return value ? TYPE_TO_STRING[valueType](value) : value;
+    return TYPE_TO_STRING[valueType](value);
   };
 
   const castValueStringToType = value => {

--- a/src/openforms/js/components/admin/form_design/variables/StaticData.js
+++ b/src/openforms/js/components/admin/form_design/variables/StaticData.js
@@ -25,14 +25,6 @@ const StaticData = () => {
           />
         }
       />
-      <HeadColumn
-        content={
-          <FormattedMessage
-            defaultMessage="Example initial"
-            description="Variable table initial value title"
-          />
-        }
-      />
     </>
   );
 
@@ -46,7 +38,6 @@ const StaticData = () => {
               <td>{item.name}</td>
               <td>{item.key}</td>
               <td>{item.dataType}</td>
-              <td>{JSON.stringify(item.initialValue)}</td>
             </tr>
           );
         })}

--- a/src/openforms/payments/tasks.py
+++ b/src/openforms/payments/tasks.py
@@ -22,7 +22,7 @@ def update_submission_payment_status(submission_id: int):
     logger.info(
         "Updating payment information for submission %d (if needed!)", submission_id
     )
-    submission = Submission.objects.get(id=submission_id)
+    submission = Submission.objects.select_related("auth_info").get(id=submission_id)
     is_retrying = submission.needs_on_completion_retry
     try:
         update_submission_payment_registration(submission)

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -132,7 +132,9 @@ class EmailRegistration(BasePlugin):
             mime_type = types_map[f".{attachment_format}"]
             if attachment_format in [AttachmentFormat.csv, AttachmentFormat.xlsx]:
                 export_data = create_submission_export(
-                    Submission.objects.filter(pk=submission.pk)
+                    Submission.objects.filter(pk=submission.pk).select_related(
+                        "auth_info"
+                    )
                 ).export(attachment_format)
 
                 attachment = (

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -126,7 +126,7 @@ class ObjectsAPIRegistration(BasePlugin):
                 },
             )
             submission_csv = create_submission_export(
-                Submission.objects.filter(pk=submission.pk)
+                Submission.objects.filter(pk=submission.pk).select_related("auth_info")
             ).export("csv")
 
             submission_csv_document = create_csv_document(

--- a/src/openforms/registrations/tasks.py
+++ b/src/openforms/registrations/tasks.py
@@ -39,7 +39,7 @@ def register_submission(submission_id: int) -> None:
     Submission registration is only executed for "completed" forms, and is delegated
     to the underlying registration backend (if set).
     """
-    submission = Submission.objects.get(id=submission_id)
+    submission = Submission.objects.select_related("auth_info").get(id=submission_id)
     is_retrying = submission.needs_on_completion_retry
 
     logger.debug("Register submission '%s'", submission)

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -358,7 +358,7 @@ class SubmissionStepViewSet(
         qs = SubmissionStep.objects.filter(
             submission__uuid=submission_uuid,
             form_step__uuid=self.kwargs["step_uuid"],
-        ).select_related("submission", "submission__form")
+        ).select_related("submission", "submission__form", "submission__auth_info")
         try:
             submission_step = qs.get()
         except SubmissionStep.DoesNotExist:

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -95,9 +95,7 @@ def evaluate_form_logic(
 
     step_index = submission_state.form_steps.index(step.form_step)
 
-    data_container = DataContainer(
-        state=submission_variables_state, request=context.get("request")
-    )
+    data_container = DataContainer(state=submission_variables_state)
 
     # 5. Evaluate the logic rules in order
     mutation_operations = []

--- a/src/openforms/submissions/logic/datastructures.py
+++ b/src/openforms/submissions/logic/datastructures.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Tuple
 
 from glom import assign
-from rest_framework.request import Request
 
 from ..models import SubmissionStep
 from ..models.submission_value_variable import SubmissionValueVariablesState
@@ -13,11 +12,10 @@ DataMapping = Dict[str, Any]
 @dataclass
 class DataContainer:
     """
-    A data container to manage the data/variables lifecyle during logic evaluation.
+    A data container to manage the data/variables lifecycle during logic evaluation.
     """
 
     state: SubmissionValueVariablesState
-    request: Request  # TODO: to replace with submission instance for context
 
     _initial_data: Tuple[Tuple[str, Any]] = field(init=False, default_factory=tuple)
 
@@ -43,7 +41,7 @@ class DataContainer:
         dynamic_values = {
             key: variable.value for key, variable in self.state.variables.items()
         }
-        static_values = self.state.static_data(self.request)
+        static_values = self.state.static_data()
         # this construct may have dots in the key names, so we need to expand that
         # into nested objects
         flattened_data = {**dynamic_values, **static_values}

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -67,9 +67,11 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        submissions = Submission.objects.filter(
-            id__in=options["submission_id"]
-        ).order_by("id")
+        submissions = (
+            Submission.objects.filter(id__in=options["submission_id"])
+            .select_related("auth_info")
+            .order_by("id")
+        )
         for submission in submissions:
             self.render_submission(
                 submission,

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -136,13 +136,11 @@ class SubmissionValueVariablesState:
             if key in self._variables:
                 del self._variables[key]
 
-    # TODO: Argument request present for when we will use the data in the session to put
-    #  data returned from DigiD/eHerkenning into static vars
     def static_data(self, request: "Request") -> dict:
         if self._static_data is None:
             self._static_data = {
                 variable.key: variable.initial_value
-                for variable in FormVariable.get_static_data()
+                for variable in FormVariable.get_static_data(request)
             }
         return self._static_data
 

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -13,8 +13,6 @@ from ..constants import SubmissionValueVariableSources
 from .submission import Submission
 
 if TYPE_CHECKING:  # pragma: nocover
-    from rest_framework.request import Request
-
     from .submission_step import SubmissionStep
 
 
@@ -136,11 +134,11 @@ class SubmissionValueVariablesState:
             if key in self._variables:
                 del self._variables[key]
 
-    def static_data(self, request: "Request") -> dict:
+    def static_data(self) -> dict:
         if self._static_data is None:
             self._static_data = {
                 variable.key: variable.initial_value
-                for variable in FormVariable.get_static_data(request)
+                for variable in FormVariable.get_static_data(self.submission)
             }
         return self._static_data
 

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -85,13 +85,6 @@ class SubmissionValueVariablesState:
             and variable.form_variable.form_definition == form_definition
         }
 
-    def get_variables_unrelated_to_a_step(self) -> Dict[str, "SubmissionValueVariable"]:
-        return {
-            variable_key: variable
-            for variable_key, variable in self.variables.items()
-            if not variable.form_variable.form_definition
-        }
-
     def collect_variables(
         self, submission: "Submission"
     ) -> Dict[str, "SubmissionValueVariable"]:

--- a/src/openforms/submissions/tasks/cleanup.py
+++ b/src/openforms/submissions/tasks/cleanup.py
@@ -81,7 +81,7 @@ def finalize_completion_retry(submission_id: int):
 
 
 @app.task(ignore_result=True)
-def maybe_hash_identifying_attributes(submission_id: int):
+def maybe_hash_identifying_attributes(submission_id: int) -> None:
     """
     If the registration was successful or not relevant, hash the identifying attributes.
 
@@ -96,7 +96,8 @@ def maybe_hash_identifying_attributes(submission_id: int):
     if submission.registration_status != RegistrationStatuses.success:
         return
 
-    if submission.auth_info.attribute_hashed:
+    if not submission.is_authenticated:
         return
 
-    submission.auth_info.hash_identifying_attributes()
+    if not submission.auth_info.attribute_hashed:
+        submission.auth_info.hash_identifying_attributes()

--- a/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
+++ b/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
@@ -1,12 +1,12 @@
 from django.test import TestCase
 
-from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 from ...form_logic import evaluate_form_logic
 from ..factories import SubmissionFactory, SubmissionStepFactory

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -1,12 +1,12 @@
 from django.test import TestCase
 
-from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 from ...form_logic import evaluate_form_logic
 from ..factories import SubmissionFactory, SubmissionStepFactory

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -116,6 +116,12 @@ class FormNodeTests(TestCase):
             submission=self.submission, mode=RenderModes.pdf, as_html=True
         )
 
+        import logging
+
+        logger = logging.getLogger("django.db.backends")
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(logging.StreamHandler())
+
         # Expected queries:
         # 1. Retrieve all the variables defined for the submission form
         # 2. Retrieve all the submission variable values
@@ -123,6 +129,7 @@ class FormNodeTests(TestCase):
         # 4. Get the step-specific data from submission variable values (TODO: this can probably be optimized away?)
         # 5. Load submission state: get form steps
         # 6. Load submission state: get submission steps
-        # 7. Query the form logic rules for the submission form (and this is cached)
-        with self.assertNumQueries(7):
+        # 7. Retrieve the submission auth info
+        # 8. Query the form logic rules for the submission form (and this is cached)
+        with self.assertNumQueries(8):
             list(renderer)

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -112,6 +112,7 @@ class FormNodeTests(TestCase):
         """
         Assert that the number of queries stays low while rendering a submission.
         """
+        self.submission.is_authenticated  # Load the auth info (otherwise an extra query is needed)
         renderer = Renderer(
             submission=self.submission, mode=RenderModes.pdf, as_html=True
         )
@@ -123,7 +124,6 @@ class FormNodeTests(TestCase):
         # 4. Get the step-specific data from submission variable values (TODO: this can probably be optimized away?)
         # 5. Load submission state: get form steps
         # 6. Load submission state: get submission steps
-        # 7. Retrieve the submission auth info
-        # 8. Query the form logic rules for the submission form (and this is cached)
-        with self.assertNumQueries(8):
+        # 7. Query the form logic rules for the submission form (and this is cached)
+        with self.assertNumQueries(7):
             list(renderer)

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -116,12 +116,6 @@ class FormNodeTests(TestCase):
             submission=self.submission, mode=RenderModes.pdf, as_html=True
         )
 
-        import logging
-
-        logger = logging.getLogger("django.db.backends")
-        logger.setLevel(logging.DEBUG)
-        logger.addHandler(logging.StreamHandler())
-
         # Expected queries:
         # 1. Retrieve all the variables defined for the submission form
         # 2. Retrieve all the submission variable values

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -43,6 +43,7 @@ class SubmissionVariablesPerformanceTests(APITestCase):
 
         # ensure there is a submission
         submission = SubmissionFactory.create(form=form)
+        submission.is_authenticated  # Load the auth info (otherwise an extra query is needed)
         SubmissionStepFactory.create(
             submission=submission,
             form_step=form_step1,
@@ -57,10 +58,9 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 1. get_dynamic_configuration: injects variables in configuration and *currently* does 1 query to retrieve
         #    variables with prefill data, so the defaultValue on the components can be set.
         # 2. Retrieve all logic rules related to a form
-        # 3. Retrieve auth info for the submission
-        # 4. Load submission state: Retrieve formsteps,
-        # 5. Load submission state: Retrieve submission steps
-        with self.assertNumQueries(5):
+        # 3. Load submission state: Retrieve formsteps,
+        # 4. Load submission state: Retrieve submission steps
+        with self.assertNumQueries(4):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_evaluate_form_logic_with_rules(self):
@@ -91,6 +91,7 @@ class SubmissionVariablesPerformanceTests(APITestCase):
 
         # ensure there is a submission
         submission = SubmissionFactory.create(form=form)
+        submission.is_authenticated  # Load the auth info (otherwise an extra query is needed)
         SubmissionStepFactory.create(
             submission=submission,
             form_step=form_step1,
@@ -119,18 +120,17 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 1.  get_dynamic_configuration: injects variables in configuration and *currently* does 1 query to retrieve
         #     variables with prefill data, so the defaultValue on the components can be set.
         # 2.  Retrieve all logic rules related to a form
-        # 3.  Retrieve auth info for the submission
-        # 4.  Load submission state: Retrieve formsteps,
-        # 5.  Load submission state: Retrieve submission steps
-        # 6.  Retrieve the submission variables to be deleted
-        # 7.  Retrieve the submission attachment files to be deleted
-        # 8.  SAVEPOINT
-        # 9.  Delete submission attachment files
-        # 10. RELEASE SAVEPOINT
-        # 11. Delete submission values
-        # 12. Retrieve all form_variables
-        # 13. Creation of timelinelog
-        with self.assertNumQueries(13):
+        # 3.  Load submission state: Retrieve formsteps,
+        # 4.  Load submission state: Retrieve submission steps
+        # 5.  Retrieve the submission variables to be deleted
+        # 6.  Retrieve the submission attachment files to be deleted
+        # 7.  SAVEPOINT
+        # 8.  Delete submission attachment files
+        # 9.  RELEASE SAVEPOINT
+        # 10. Delete submission values
+        # 11. Retrieve all form_variables
+        # 12. Creation of timelinelog
+        with self.assertNumQueries(12):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_update_step_data(self):
@@ -374,6 +374,7 @@ class SubmissionVariablesPerformanceTests(APITestCase):
 
         # ensure there is a submission
         submission = SubmissionFactory.create(form=form)
+        submission.is_authenticated  # Load the auth info (otherwise an extra query is needed)
         SubmissionStepFactory.create(
             submission=submission,
             form_step=form_step1,
@@ -391,10 +392,9 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 3. renderer get_children: get submission steps
         # 4. Retrieve prefill data
         # 5. Retrieve logic rules
-        # 6. Retrieve auth info for the submission
-        # 7. Load submission state: Retrieve formsteps,
-        # 8. Load submission state: Retrieve submission steps
-        with self.assertNumQueries(8):
+        # 6. Load submission state: Retrieve formsteps,
+        # 7. Load submission state: Retrieve submission steps
+        with self.assertNumQueries(7):
             nodes = [node for node in renderer]
 
         with self.assertNumQueries(0):

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -57,9 +57,10 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 1. get_dynamic_configuration: injects variables in configuration and *currently* does 1 query to retrieve
         #    variables with prefill data, so the defaultValue on the components can be set.
         # 2. Retrieve all logic rules related to a form
-        # 3. Load submission state: Retrieve formsteps,
-        # 4. Load submission state: Retrieve submission steps
-        with self.assertNumQueries(4):
+        # 3. Retrieve auth info for the submission
+        # 4. Load submission state: Retrieve formsteps,
+        # 5. Load submission state: Retrieve submission steps
+        with self.assertNumQueries(5):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_evaluate_form_logic_with_rules(self):
@@ -118,17 +119,18 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 1.  get_dynamic_configuration: injects variables in configuration and *currently* does 1 query to retrieve
         #     variables with prefill data, so the defaultValue on the components can be set.
         # 2.  Retrieve all logic rules related to a form
-        # 3.  Load submission state: Retrieve formsteps,
-        # 4.  Load submission state: Retrieve submission steps
-        # 5.  Retrieve the submission variables to be deleted
-        # 6.  Retrieve the submission attachment files to be deleted
-        # 7.  SAVEPOINT
-        # 8.  Delete submission attachment files
-        # 9.  RELEASE SAVEPOINT
-        # 10. Delete submission values
-        # 11. Retrieve all form_variables
-        # 12. Creation of timelinelog
-        with self.assertNumQueries(12):
+        # 3.  Retrieve auth info for the submission
+        # 4.  Load submission state: Retrieve formsteps,
+        # 5.  Load submission state: Retrieve submission steps
+        # 6.  Retrieve the submission variables to be deleted
+        # 7.  Retrieve the submission attachment files to be deleted
+        # 8.  SAVEPOINT
+        # 9.  Delete submission attachment files
+        # 10. RELEASE SAVEPOINT
+        # 11. Delete submission values
+        # 12. Retrieve all form_variables
+        # 13. Creation of timelinelog
+        with self.assertNumQueries(13):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_update_step_data(self):
@@ -389,9 +391,10 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 3. renderer get_children: get submission steps
         # 4. Retrieve prefill data
         # 5. Retrieve logic rules
-        # 6. Load submission state: Retrieve formsteps,
-        # 7. Load submission state: Retrieve submission steps
-        with self.assertNumQueries(7):
+        # 6. Retrieve auth info for the submission
+        # 7. Load submission state: Retrieve formsteps,
+        # 8. Load submission state: Retrieve submission steps
+        with self.assertNumQueries(8):
             nodes = [node for node in renderer]
 
         with self.assertNumQueries(0):

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -5,10 +5,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.authentication.constants import AuthAttribute
-from openforms.authentication.tests.factories import AuthInfoFactory
 from openforms.forms.constants import FormVariableSources
-from openforms.forms.models import FormVariable
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -162,80 +159,3 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(1, submission.submissionvaluevariable_set.count())
         self.assertEqual("name", submission.submissionvaluevariable_set.get().key)
-
-    def test_auth_static_data(self):
-        auth_info = AuthInfoFactory.create(
-            plugin="test-plugin",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            machtigen={AuthAttribute.bsn: "123456789"},
-        )
-
-        static_data = FormVariable.get_static_data(auth_info.submission)
-
-        self.assertEqual(5, len(static_data))
-        self.assertEqual(
-            {
-                "plugin": "test-plugin",
-                "attribute": AuthAttribute.bsn,
-                "value": "111222333",
-                "machtigen": {AuthAttribute.bsn: "123456789"},
-            },
-            static_data[1].initial_value,
-        )
-
-        self.assertEqual(
-            "auth_bsn",
-            static_data[2].key,
-        )
-        self.assertEqual(
-            "111222333",
-            static_data[2].initial_value,
-        )
-        self.assertEqual(
-            "auth_kvk",
-            static_data[3].key,
-        )
-        self.assertEqual(
-            "",
-            static_data[3].initial_value,
-        )
-        self.assertEqual(
-            "auth_pseudo",
-            static_data[4].key,
-        )
-        self.assertEqual(
-            "",
-            static_data[4].initial_value,
-        )
-
-    def test_auth_static_data_no_submission(self):
-        static_data = FormVariable.get_static_data()
-
-        self.assertEqual(5, len(static_data))
-        self.assertIsNone(static_data[1].initial_value)
-
-        self.assertEqual(
-            "auth_bsn",
-            static_data[2].key,
-        )
-        self.assertEqual(
-            "",
-            static_data[2].initial_value,
-        )
-        self.assertEqual(
-            "auth_kvk",
-            static_data[3].key,
-        )
-        self.assertEqual(
-            "",
-            static_data[3].initial_value,
-        )
-        self.assertEqual(
-            "auth_pseudo",
-            static_data[4].key,
-        )
-        self.assertEqual(
-            "",
-            static_data[4].initial_value,
-        )

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -5,13 +5,13 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.forms.constants import FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableSources
 
 from ...models import Submission
 from ..factories import SubmissionFactory
@@ -28,7 +28,7 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "content",
-                        "html": "<p>The raw time now is: {{ now }}</p>",
+                        "html": "<p>The raw time now is: {{ now.isoformat }}</p>",
                         "type": "content",
                         "label": "Content",
                     },

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -3,10 +3,10 @@ from django.test import override_settings
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
-from rest_framework.test import APIRequestFactory, APITestCase
+from rest_framework.test import APITestCase
 
-from openforms.accounts.tests.factories import StaffUserFactory
-from openforms.authentication.constants import FORM_AUTH_SESSION_KEY, AuthAttribute
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.tests.factories import AuthInfoFactory
 from openforms.forms.constants import FormVariableSources
 from openforms.forms.models import FormVariable
 from openforms.forms.tests.factories import (
@@ -164,21 +164,25 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
         self.assertEqual("name", submission.submissionvaluevariable_set.get().key)
 
     def test_auth_static_data(self):
-        factory = APIRequestFactory()
-        request = factory.get("/foo")
-        request.user = StaffUserFactory.build()
-        auth_data = {
-            "plugin": "test-plugin",
-            "attribute": AuthAttribute.bsn,
-            "value": "111222333",
-            "machtigen": {AuthAttribute.bsn: "123456789"},
-        }
-        request.session = {FORM_AUTH_SESSION_KEY: auth_data}
+        auth_info = AuthInfoFactory.create(
+            plugin="test-plugin",
+            attribute=AuthAttribute.bsn,
+            value="111222333",
+            machtigen={AuthAttribute.bsn: "123456789"},
+        )
 
-        static_data = FormVariable.get_static_data(request)
+        static_data = FormVariable.get_static_data(auth_info.submission)
 
         self.assertEqual(2, len(static_data))
-        self.assertEqual(auth_data, static_data[1].initial_value)
+        self.assertEqual(
+            {
+                "plugin": "test-plugin",
+                "attribute": AuthAttribute.bsn,
+                "value": "111222333",
+                "machtigen": {AuthAttribute.bsn: "123456789"},
+            },
+            static_data[1].initial_value,
+        )
 
     def test_auth_static_data_no_request(self):
         static_data = FormVariable.get_static_data()

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -173,7 +173,7 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
 
         static_data = FormVariable.get_static_data(auth_info.submission)
 
-        self.assertEqual(2, len(static_data))
+        self.assertEqual(5, len(static_data))
         self.assertEqual(
             {
                 "plugin": "test-plugin",
@@ -184,8 +184,58 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
             static_data[1].initial_value,
         )
 
-    def test_auth_static_data_no_request(self):
+        self.assertEqual(
+            "auth_bsn",
+            static_data[2].key,
+        )
+        self.assertEqual(
+            "111222333",
+            static_data[2].initial_value,
+        )
+        self.assertEqual(
+            "auth_kvk",
+            static_data[3].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[3].initial_value,
+        )
+        self.assertEqual(
+            "auth_pseudo",
+            static_data[4].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[4].initial_value,
+        )
+
+    def test_auth_static_data_no_submission(self):
         static_data = FormVariable.get_static_data()
 
-        self.assertEqual(2, len(static_data))
+        self.assertEqual(5, len(static_data))
         self.assertIsNone(static_data[1].initial_value)
+
+        self.assertEqual(
+            "auth_bsn",
+            static_data[2].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[2].initial_value,
+        )
+        self.assertEqual(
+            "auth_kvk",
+            static_data[3].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[3].initial_value,
+        )
+        self.assertEqual(
+            "auth_pseudo",
+            static_data[4].key,
+        )
+        self.assertEqual(
+            "",
+            static_data[4].initial_value,
+        )

--- a/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
@@ -2,13 +2,13 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.forms.constants import FormVariableDataTypes, FormVariableSources
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 from ...models import SubmissionValueVariable
 from ..factories import SubmissionFactory, SubmissionStepFactory

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -15,9 +15,9 @@ from openforms.emails.utils import (
     send_mail_html,
     strip_tags_plus,
 )
-from openforms.forms.constants import FormVariableSources
 from openforms.forms.models import FormVariable
 from openforms.logging import logevent
+from openforms.variables.constants import FormVariableSources
 
 from .constants import SUBMISSIONS_SESSION_KEY, UPLOADS_SESSION_KEY
 from .models import Submission, SubmissionValueVariable, TemporaryFileUpload

--- a/src/openforms/variables/base.py
+++ b/src/openforms/variables/base.py
@@ -1,14 +1,18 @@
-from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 
 from openforms.forms.models import FormVariable
 
 
 @dataclass
-class BaseStaticVariable:
+class BaseStaticVariable(ABC):
     identifier: str
+    name: str = field(init=False)
+    data_type: str = field(init=False)
 
+    @abstractmethod
     def get_initial_value(self, *args, **kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: nocover
 
     def get_static_variable(self, *args, **kwargs):
         return FormVariable(

--- a/src/openforms/variables/base.py
+++ b/src/openforms/variables/base.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from openforms.forms.models import FormVariable
+
+
+@dataclass
+class BaseStaticVariable:
+    identifier: str
+
+    def get_initial_value(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def get_static_variable(self, *args, **kwargs):
+        return FormVariable(
+            name=self.name,
+            key=self.identifier,
+            data_type=self.data_type,
+            initial_value=self.get_initial_value(*args, **kwargs),
+        )

--- a/src/openforms/variables/constants.py
+++ b/src/openforms/variables/constants.py
@@ -1,0 +1,19 @@
+from django.utils.translation import gettext_lazy as _
+
+from djchoices import ChoiceItem, DjangoChoices
+
+
+class FormVariableSources(DjangoChoices):
+    component = ChoiceItem("component", _("Component"))
+    user_defined = ChoiceItem("user_defined", _("User defined"))
+
+
+class FormVariableDataTypes(DjangoChoices):
+    string = ChoiceItem("string", _("String"))
+    boolean = ChoiceItem("boolean", _("Boolean"))
+    object = ChoiceItem("object", _("Object"))
+    array = ChoiceItem("array", _("Array"))
+    int = ChoiceItem("int", _("Integer"))
+    float = ChoiceItem("float", _("Float"))
+    datetime = ChoiceItem("datetime", _("Datetime"))
+    time = ChoiceItem("time", _("Time"))

--- a/src/openforms/variables/registry.py
+++ b/src/openforms/variables/registry.py
@@ -11,4 +11,4 @@ class Registry(BaseRegistry):
 
 # Sentinel to provide the default registry. You can easily instantiate another
 # :class:`Registry` object to use as dependency injection in tests.
-static_variables_register = Registry()
+register_static_variable = Registry()

--- a/src/openforms/variables/registry.py
+++ b/src/openforms/variables/registry.py
@@ -1,0 +1,14 @@
+from openforms.plugins.registry import BaseRegistry
+
+
+class Registry(BaseRegistry):
+    """
+    A registry for static variables.
+    """
+
+    module = "variables"
+
+
+# Sentinel to provide the default registry. You can easily instantiate another
+# :class:`Registry` object to use as dependency injection in tests.
+static_variables_register = Registry()

--- a/src/openforms/variables/static_variables/apps.py
+++ b/src/openforms/variables/static_variables/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class StaticVariables(AppConfig):
+    name = "openforms.variables.static_variables"
+    verbose_name = "Static variables"
+
+    def ready(self):
+        from . import static_variables  # noqa

--- a/src/openforms/variables/static_variables/static_variables.py
+++ b/src/openforms/variables/static_variables/static_variables.py
@@ -1,16 +1,16 @@
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from openforms.forms.constants import FormVariableDataTypes
+from openforms.variables.constants import FormVariableDataTypes
 
 from ..base import BaseStaticVariable
-from ..registry import static_variables_register
+from ..registry import register_static_variable
 
 
-@static_variables_register("now")
+@register_static_variable("now")
 class Now(BaseStaticVariable):
     name = _("Now")
     data_type = FormVariableDataTypes.datetime
 
     def get_initial_value(self, *args, **kwargs):
-        return timezone.now().isoformat()
+        return timezone.now()

--- a/src/openforms/variables/static_variables/static_variables.py
+++ b/src/openforms/variables/static_variables/static_variables.py
@@ -1,0 +1,16 @@
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+from openforms.forms.constants import FormVariableDataTypes
+
+from ..base import BaseStaticVariable
+from ..registry import static_variables_register
+
+
+@static_variables_register("now")
+class Now(BaseStaticVariable):
+    name = _("Now")
+    data_type = FormVariableDataTypes.datetime
+
+    def get_initial_value(self, *args, **kwargs):
+        return timezone.now().isoformat()

--- a/src/openforms/variables/tests/test_registry.py
+++ b/src/openforms/variables/tests/test_registry.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
-from openforms.forms.constants import FormVariableDataTypes
-from openforms.forms.models import FormVariable
+from openforms.variables.constants import FormVariableDataTypes
 
 from ..base import BaseStaticVariable
 from ..registry import Registry
@@ -13,13 +12,11 @@ class RegistryTests(TestCase):
 
         @test_static_variables_register("demo")
         class DemoVariable(BaseStaticVariable):
-            def get_static_variable(self, *args, **kwargs):
-                return FormVariable(
-                    name="Demo",
-                    key="demo",
-                    data_type=FormVariableDataTypes.string,
-                    initial_value="Test!",
-                )
+            name = "Test"
+            data_type = FormVariableDataTypes.string
+
+            def get_initial_value(self, *args, **kwargs):
+                return "Test!"
 
         static_vars = list(test_static_variables_register)
 

--- a/src/openforms/variables/tests/test_registry.py
+++ b/src/openforms/variables/tests/test_registry.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from openforms.forms.constants import FormVariableDataTypes
+from openforms.forms.models import FormVariable
+
+from ..base import BaseStaticVariable
+from ..registry import Registry
+
+
+class RegistryTests(TestCase):
+    def test_get_registry(self):
+        test_static_variables_register = Registry()
+
+        @test_static_variables_register("demo")
+        class DemoVariable(BaseStaticVariable):
+            def get_static_variable(self, *args, **kwargs):
+                return FormVariable(
+                    name="Demo",
+                    key="demo",
+                    data_type=FormVariableDataTypes.string,
+                    initial_value="Test!",
+                )
+
+        static_vars = list(test_static_variables_register)
+
+        self.assertEqual(1, len(static_vars))
+
+        demo_variable = test_static_variables_register["demo"].get_static_variable()
+
+        self.assertEqual("Test!", demo_variable.initial_value)

--- a/src/openforms/variables/tests/test_views.py
+++ b/src/openforms/variables/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -5,6 +7,7 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
 from openforms.forms.constants import FormVariableDataTypes
+from openforms.forms.models import FormVariable
 
 
 class GetStaticVariablesViewTest(APITestCase):
@@ -39,7 +42,19 @@ class GetStaticVariablesViewTest(APITestCase):
         )
 
         self.client.force_authenticate(user=user)
-        response = self.client.get(url)
+
+        with patch(
+            "openforms.forms.models.form_variable.FormVariable.get_static_data"
+        ) as m:
+            m.return_value = [
+                FormVariable(
+                    name="Now",
+                    key="now",
+                    data_type=FormVariableDataTypes.datetime,
+                    initial_value="2021-07-16T21:15:00+00:00",
+                )
+            ]
+            response = self.client.get(url)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 

--- a/src/openforms/variables/tests/test_views.py
+++ b/src/openforms/variables/tests/test_views.py
@@ -6,8 +6,8 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
-from openforms.forms.constants import FormVariableDataTypes
 from openforms.forms.models import FormVariable
+from openforms.variables.constants import FormVariableDataTypes
 
 
 class GetStaticVariablesViewTest(APITestCase):


### PR DESCRIPTION
Fixes #1661 

**Changes**: 
We now have an `auth_identifier` static variable, which contains all information:
```
{ "plugin": "digid", "attribute": "bsn", "value": "111222333", "machtigen": {}}
```
And then there are 3 more static vars (`auth_bsn`, `auth_kvk` and `auth_pseudo`) which only contain the value of the  `auth_identifier` and are `""` if no value is present for that particular attribute.

Every app can define their static variables through the register.
 