### PR TITLE
[#1798] Delete submissions forms from admin

### DIFF
--- a/src/openforms/logging/tests/test_admin.py
+++ b/src/openforms/logging/tests/test_admin.py
@@ -1,14 +1,17 @@
 from django.contrib.auth.models import Permission
-from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
-from openforms.accounts.tests.factories import StaffUserFactory
+from django_webtest import WebTest
+
+from openforms.accounts.tests.factories import StaffUserFactory, SuperUserFactory
 from openforms.logging import logevent
+from openforms.logging.models import TimelineLogProxy
 from openforms.logging.tests.factories import TimelineLogProxyFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 
 
-class AVGAuditLogListViewTests(TestCase):
+class AVGAuditLogListViewTests(WebTest):
     def test_view(self):
         url = reverse("admin:logging_avgtimelinelogproxy_changelist")
 
@@ -30,3 +33,30 @@ class AVGAuditLogListViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         # one log
         self.assertEqual(response.context_data["cl"].result_count, 1)
+
+    def test_superuser_cant_delete_logs_with_bulk_action(self):
+        submission = SubmissionFactory.create(completed_on=timezone.now())
+        user = SuperUserFactory.create()
+
+        logevent.submission_details_view_admin(submission, user)
+
+        url = reverse("admin:logging_timelinelogproxy_changelist")
+        changelist = self.app.get(url, user=user)
+
+        html_form = changelist.forms["changelist-form"]
+
+        # It is not possible to select the "delete_selected" option
+        self.assertIsNone(html_form.fields.get("action"))
+
+    def test_superuser_cant_delete_individual_logs(self):
+        submission = SubmissionFactory.create(completed_on=timezone.now())
+        user = SuperUserFactory.create()
+
+        logevent.submission_details_view_admin(submission, user)
+        log = TimelineLogProxy.objects.get(object_id=submission.id)
+
+        url = reverse(
+            "admin:logging_timelinelogproxy_delete", kwargs={"object_id": log.id}
+        )
+
+        self.app.get(url, user=user, expect_errors=403)

--- a/src/openforms/logging/tests/test_events.py
+++ b/src/openforms/logging/tests/test_events.py
@@ -69,7 +69,7 @@ class EventTests(VariablesTestMixin, TestCase):
             submission.data,
         )
 
-        log = submission.logs.get()
+        log = TimelineLogProxy.objects.get(object_id=submission.id)
         logged_rules = log.extra_data["evaluated_rules"]
 
         self.assertEqual(2, len(logged_rules))

--- a/src/openforms/submissions/admin_views.py
+++ b/src/openforms/submissions/admin_views.py
@@ -5,6 +5,7 @@ from django.views.generic import ListView
 
 from openforms.utils.mixins import UserIsStaffMixin
 
+from ..logging.models import TimelineLogProxy
 from .models import Submission
 
 
@@ -24,7 +25,9 @@ class LogsEvaluatedLogicView(UserIsStaffMixin, PermissionRequiredMixin, ListView
 
     def get_queryset(self):
         logic_log_template = "logging/events/submission_logic_evaluated.txt"
-        queryset = self.submission.logs.filter(template=logic_log_template)
+        queryset = TimelineLogProxy.objects.filter(
+            template=logic_log_template, object_id=self.submission.id
+        )
         return queryset.order_by("timestamp")
 
     def get_context_data(self):

--- a/src/openforms/submissions/admin_views.py
+++ b/src/openforms/submissions/admin_views.py
@@ -1,11 +1,12 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from django.views.generic import ListView
 
+from openforms.logging.models import TimelineLogProxy
 from openforms.utils.mixins import UserIsStaffMixin
 
-from ..logging.models import TimelineLogProxy
 from .models import Submission
 
 
@@ -26,7 +27,9 @@ class LogsEvaluatedLogicView(UserIsStaffMixin, PermissionRequiredMixin, ListView
     def get_queryset(self):
         logic_log_template = "logging/events/submission_logic_evaluated.txt"
         queryset = TimelineLogProxy.objects.filter(
-            template=logic_log_template, object_id=self.submission.id
+            template=logic_log_template,
+            object_id=self.submission.id,
+            content_type=ContentType.objects.get_for_model(Submission),
         )
         return queryset.order_by("timestamp")
 

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
 
 from django.contrib.auth.hashers import make_password as get_salted_hash
-from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models, transaction
 from django.db.models import Q
 from django.template import Context, Template
@@ -145,8 +144,6 @@ class Submission(models.Model):
 
     uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
     form = models.ForeignKey("forms.Form", on_delete=models.PROTECT)
-
-    logs = GenericRelation("logging.TimelineLogProxy")
 
     # meta information
     form_url = models.URLField(


### PR DESCRIPTION
Fixes #1798 

I ended up adding the possibility to remove logs from the admin for the users with the right permissions. 

The removal of the objects through the admin is logged in the `LogEntry` model ([here](https://github.com/django/django/blob/main/django/contrib/admin/options.py#L948) ) by default.