### PR TITLE
 Help text in repeating groups is too long

### DIFF
--- a/src/openforms/js/components/form/editGrid.js
+++ b/src/openforms/js/components/form/editGrid.js
@@ -19,7 +19,7 @@ const GROUP_LABEL = {
     'The label that will be shown above each repeating group in the ' +
     'summary page, the submission report and the confirmation email. ' +
     'The index of the item will be added next to it, i.e. if you enter ' +
-    '"Item" it will be displayed as "Item 1", "Item 2" ...',
+    "'Item' it will be displayed as 'Item 1', 'Item 2', ...",
   defaultValue: 'Item',
 };
 


### PR DESCRIPTION
Fixes #1839 

The text wasn't too long, but for some reason, double quotes inside single quote were closing the string. So the tooltip were displaying the string until the double quotes.