### PR TITLE
Refactor logic evaluation implementation

### DIFF
--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import date, datetime
-from typing import Any, Dict, Iterator, List
+from typing import Any, Iterator, List, Optional
 
 from openforms.forms.constants import FormVariableDataTypes
 
@@ -37,19 +37,6 @@ def get_component(configuration: JSONObject, key: str) -> JSONObject:
     for component in iter_components(configuration=configuration, recursive=True):
         if component["key"] == key:
             return component
-
-
-def get_default_values(configuration: dict) -> Dict[str, Any]:
-    defaults = {}
-
-    for component in iter_components(configuration, recursive=True):
-        if "key" not in component:
-            continue
-        if "defaultValue" not in component:
-            continue
-        defaults[component["key"]] = component["defaultValue"]
-
-    return defaults
 
 
 def is_layout_component(component):
@@ -108,7 +95,7 @@ def get_component_datatype(component):
     return COMPONENT_DATATYPES.get(component_type, FormVariableDataTypes.string)
 
 
-def get_component_default_value(component):
+def get_component_default_value(component) -> Optional[Any]:
     # Formio has a getter for the:
     # - emptyValue: https://github.com/formio/formio.js/blob/4.13.x/src/components/textfield/TextField.js#L58
     # - defaultValue:

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -67,6 +67,7 @@ class FormVariableManager(models.Manager):
         ):
             if (
                 (is_layout_component(component) and not component["type"] == "editgrid")
+                or component["type"] == "content"
                 or component["key"] in existing_form_variables_keys
                 or component_in_editgrid(form_definition_configuration, component)
             ):

--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -465,7 +465,10 @@ def submission_export_list(form: "Form", user: "User"):
 
 
 def submission_logic_evaluated(
-    submission: "Submission", evaluated_rules, resulting_data
+    submission: "Submission",
+    evaluated_rules,
+    initial_data: dict,
+    resolved_data: dict,
 ):
     if not evaluated_rules:
         return
@@ -495,7 +498,7 @@ def submission_logic_evaluated(
 
         rule = evaluated_rule["rule"]
         rule_introspection = introspect_json_logic(
-            rule.json_logic_trigger, components_map, resulting_data
+            rule.json_logic_trigger, components_map, initial_data
         )
 
         # Gathering all the input component of each evaluated rule
@@ -545,7 +548,7 @@ def submission_logic_evaluated(
                     action_log_data["value"] = value_expression
                 else:
                     action_logic_introspection = introspect_json_logic(
-                        action_details["value"], components_map, resulting_data
+                        action_details["value"], components_map, initial_data
                     )
                     action_log_data["value"] = action_logic_introspection.as_string()
             targeted_components.append(action_log_data)
@@ -568,6 +571,7 @@ def submission_logic_evaluated(
         extra_data={
             "evaluated_rules": evaluated_rules_list,
             "input_data": deduplicated_input_data,
+            "resolved_data": resolved_data,
         },
     )
 

--- a/src/openforms/logging/tests/test_events.py
+++ b/src/openforms/logging/tests/test_events.py
@@ -66,6 +66,7 @@ class EventTests(TestCase):
             submission,
             [{"rule": rule, "trigger": True}, {"rule": rule_2, "trigger": False}],
             submission.data,
+            submission.data,
         )
 
         log = TimelineLogProxy.objects.get(object_id=submission.id)

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from typing import Any, TypedDict
+
+from openforms.formio.utils import get_component
+from openforms.forms.constants import LogicActionTypes
+from openforms.typing import JSONObject
+
+from ..models import SubmissionStep
+from ..models.submission_step import DirtyData
+
+
+class ActionDetails(TypedDict):
+    type: str
+    property: dict
+    state: Any
+    value: Any
+
+
+class ActionDict(TypedDict):
+    component: str
+    variable: str
+    form_step: str
+    action: ActionDetails
+
+
+def compile_action_operation(action: ActionDict):
+    return ActionOperation.from_action(action)
+
+
+class ActionOperation:
+    @staticmethod
+    def from_action(action: ActionDict) -> "ActionOperation":
+        action_type = action["action"]["type"]
+        cls = ACTION_TYPE_MAPPING[action_type]
+        return cls.from_action(action)
+
+    def apply(self, step: SubmissionStep, configuration: JSONObject) -> None:
+        """
+        Implements the side effects of the action operation.
+        """
+        pass
+
+
+@dataclass
+class PropertyAction(ActionOperation):
+    component: str
+    property: str
+    value: Any
+
+    @classmethod
+    def from_action(cls, action: ActionDict) -> "PropertyAction":
+        return cls(
+            component=action["component"],
+            property=action["action"]["property"]["value"],
+            value=action["action"]["state"],
+        )
+
+    def apply(self, step: SubmissionStep, configuration: JSONObject) -> None:
+        component = get_component(configuration, key=self.component)
+        component[self.property] = self.value
+
+
+class DisableNextAction(ActionOperation):
+    @classmethod
+    def from_action(cls, action: ActionDict) -> "DisableNextAction":
+        return cls()
+
+    def apply(self, step: SubmissionStep, configuration: JSONObject) -> None:
+        step._can_submit = False
+
+
+@dataclass
+class StepNotApplicableAction(ActionOperation):
+    form_step_identifier: str
+
+    @classmethod
+    def from_action(cls, action: ActionDict) -> "StepNotApplicableAction":
+        return cls(
+            form_step_identifier=action["form_step"],
+        )
+
+    def apply(self, step: SubmissionStep, configuration: JSONObject) -> None:
+        execution_state = (
+            step.submission.load_execution_state()
+        )  # typically cached already
+        submission_step_to_modify = execution_state.resolve_step(
+            self.form_step_identifier
+        )
+        submission_step_to_modify._is_applicable = False
+
+        # This clears data in the database to make sure that saved steps which later become
+        # not-applicable don't have old data
+        submission_step_to_modify.data = {}
+        if submission_step_to_modify == step:
+            step._is_applicable = False
+            step.data = DirtyData({})
+
+
+ACTION_TYPE_MAPPING = {
+    LogicActionTypes.property: PropertyAction,
+    LogicActionTypes.disable_next: DisableNextAction,
+    LogicActionTypes.step_not_applicable: StepNotApplicableAction,
+}

--- a/src/openforms/submissions/logic/datastructures.py
+++ b/src/openforms/submissions/logic/datastructures.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
+
+from glom import assign
+from rest_framework.request import Request
+
+from ..models import SubmissionStep
+from ..models.submission_value_variable import SubmissionValueVariablesState
+
+DataMapping = Dict[str, Any]
+
+
+@dataclass
+class DataContainer:
+    """
+    A data container to manage the data/variables lifecyle during logic evaluation.
+    """
+
+    state: SubmissionValueVariablesState
+    request: Request  # TODO: to replace with submission instance for context
+
+    _initial_data: Tuple[Tuple[str, Any]] = field(init=False, default_factory=tuple)
+
+    def __post_init__(self):
+        # ensure the initial data is immutable
+        self._initial_data = tuple(self.data.items())  # record for logging purposes
+
+    @property
+    def initial_data(self) -> DataMapping:
+        return dict(self._initial_data)
+
+    @property
+    def data(self) -> DataMapping:
+        """
+        Collect the total picture of data/variable values.
+
+        The current view on the submission variable value state is augmented with
+        the static variables.
+
+        :return: A datamapping (key: variable key, value: variable value) ready for
+          (template context) evaluation.
+        """
+        dynamic_values = {
+            key: variable.value for key, variable in self.state.variables.items()
+        }
+        static_values = self.state.static_data(self.request)
+        # this construct may have dots in the key names, so we need to expand that
+        # into nested objects
+        flattened_data = {**dynamic_values, **static_values}
+        nested_data = {}
+        for dotted_path, value in flattened_data.items():
+            assign(nested_data, dotted_path, value, missing=dict)
+        return nested_data
+
+    def update(self, updates: DataMapping) -> None:
+        """
+        Update the dynamic data state.
+        """
+        self.state.set_values(updates)
+
+    def get_updated_step_data(self, step: SubmissionStep) -> DataMapping:
+        relevant_variables = self.state.get_variables_in_submission_step(
+            step, include_unsaved=True
+        )
+        return {
+            key: variable.value
+            for key, variable in relevant_variables.items()
+            if variable.value and variable.value != variable.form_variable.initial_value
+        }

--- a/src/openforms/submissions/logic/datastructures.py
+++ b/src/openforms/submissions/logic/datastructures.py
@@ -65,5 +65,5 @@ class DataContainer:
         return {
             key: variable.value
             for key, variable in relevant_variables.items()
-            if variable.value and variable.value != variable.form_variable.initial_value
+            if variable.value != variable.form_variable.initial_value
         }

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -166,6 +166,26 @@ class SubmissionValueVariablesState:
 
         SubmissionValueVariable.objects.bulk_create(variables_to_prefill)
 
+    def set_values(self, data: Dict[str, Any]) -> None:
+        """
+        Apply the values from ``data`` to the current state of the variables.
+
+        This does NOT persist the values, it only mutates the value instances in place.
+        The ``data`` structure maps variable key and (new) values to set on the
+        variables in the state.
+
+        :arg data: mapping of variable key to value.
+
+        .. todo:: apply variable.datatype/format to obtain python objects? This also
+           needs to properly serialize back to JSON though!
+        """
+        for key, variable in self.variables.items():
+            try:
+                new_value = glom(data, key)
+            except PathAccessError:
+                continue
+            variable.value = new_value
+
 
 class SubmissionValueVariableManager(models.Manager):
     def bulk_create_or_update_from_data(

--- a/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
+++ b/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
@@ -61,7 +61,9 @@ class DeterministicEvaluationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step, {"a": 3})
 
-        self.assertEqual(submission_step.data["a"], 8)  # ( 3 x 2 ) + 2
+        state = submission.load_submission_value_variables_state()
+        variable = state.variables["a"]
+        self.assertEqual(variable.value, 8)  # ( 3 x 2 ) + 2
 
     def test_evaluate_rules_when_trigger_step_reached(self):
         """
@@ -134,7 +136,11 @@ class DeterministicEvaluationTests(TestCase):
         with self.subTest("Evaluation skipped on step 1"):
             evaluate_form_logic(submission, ss1, submission.data)
 
-            self.assertEqual(ss1.data, {"a": 2, "b": 4})
+            state = submission.load_submission_value_variables_state()
+            var_a = state.variables["a"]
+            var_b = state.variables["b"]
+            self.assertEqual(var_a.value, 2)
+            self.assertEqual(var_b.value, 4)
 
         with self.subTest("Evaluation not skipped on step 2"):
             ss2 = SubmissionStepFactory.create(
@@ -143,7 +149,11 @@ class DeterministicEvaluationTests(TestCase):
 
             evaluate_form_logic(submission, ss2, submission.data)
 
-            self.assertEqual(ss2.data, {"c": 2, "d": 6})
+            state = submission.load_submission_value_variables_state()
+            var_c = state.variables["c"]
+            var_d = state.variables["d"]
+            self.assertEqual(var_c.value, 2)
+            self.assertEqual(var_d.value, 6)
 
         with self.subTest("Evaluation not skipped on step 3"):
             ss3 = SubmissionStepFactory.create(
@@ -152,4 +162,5 @@ class DeterministicEvaluationTests(TestCase):
 
             evaluate_form_logic(submission, ss3, submission.data)
 
+            state = submission.load_submission_value_variables_state()
             self.assertEqual(ss3.data, {"d": 6})

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1034,7 +1034,7 @@ class StepModificationTests(TestCase):
             "changingKey": "original",
         }
 
-        evaluate_form_logic(submission, submission_step, dirty_data)
+        evaluate_form_logic(submission, submission_step, dirty_data, dirty=True)
 
         self.assertEqual(
             submission_step.data,

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -88,9 +88,9 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step2, submission.data)
 
-        updated_variable_value = submission_step2._unsaved_data.get("nTotalBoxes")
-
-        self.assertEqual(7, updated_variable_value)
+        variables_state = submission.load_submission_value_variables_state()
+        variable = variables_state.variables["nTotalBoxes"]
+        self.assertEqual(7, variable.value)
 
     def test_modify_variable_related_to_another_step_than_the_one_being_edited(self):
         form = FormFactory.create()
@@ -167,7 +167,9 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step2, submission.data)
 
-        self.assertEqual(7, submission_step2.data["nTotalBoxes"])
+        variables_state = submission.load_submission_value_variables_state()
+        variable = variables_state.variables["nTotalBoxes"]
+        self.assertEqual(7, variable.value)
 
     def test_modify_variable_not_related_to_a_step(self):
         form = FormFactory.create()
@@ -244,4 +246,6 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step2, submission.data)
 
-        self.assertEqual(7, submission_step2.data["nTotalBoxes"])
+        variables_state = submission.load_submission_value_variables_state()
+        variable = variables_state.variables["nTotalBoxes"]
+        self.assertEqual(7, variable.value)

--- a/src/openforms/submissions/tests/test_admin.py
+++ b/src/openforms/submissions/tests/test_admin.py
@@ -223,7 +223,10 @@ class LogicLogsAdminTests(WebTest):
         merged_data = self.submission.get_merged_data()
 
         logevent.submission_logic_evaluated(
-            self.submission, [{"rule": rule, "trigger": True}], merged_data
+            self.submission,
+            [{"rule": rule, "trigger": True}],
+            merged_data,
+            merged_data,
         )
 
         response = self.app.get(

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -123,9 +123,8 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(
-            {
-                "isJohn": True
-            },  # Only changed data is returned and static variables are not present in the data
+            # Only changed data is returned and static variables are not present in the data
+            {},
             response.data["step"]["data"],
         )
 


### PR DESCRIPTION
Related to #1708

Refactored the logic evaluation algorithm so that now we first work towards resolving the variable state (logic actions can change variable values), and then we apply the dynamic formio configuration using this resolved state/values.

The logic actions have been split up in a new interface so that we can clean up the code and side-effects applied from logic actions. This also all makes it a bit more logging friendly to get insight on what is happening when.