### PR TITLE
Ensure that logic variable references are updated

### DIFF
--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -47,7 +47,7 @@ import {
   getFormComponents,
   findComponent,
   checkKeyChange,
-  replaceComponentKeyInLogic,
+  updateKeyReferencesInLogic,
   getUniqueKey,
   getFormStep,
   parseValidationErrors,
@@ -357,7 +357,7 @@ function reducer(draft, action) {
       // Check if a key has been changed and if the logic rules need updating
       const hasKeyChanged = checkKeyChange(mutationType, schema, originalComp);
       if (mutationType === 'changed' && hasKeyChanged) {
-        draft.logicRules = replaceComponentKeyInLogic(
+        draft.logicRules = updateKeyReferencesInLogic(
           draft.logicRules,
           originalComp.key,
           schema.key
@@ -637,6 +637,9 @@ function reducer(draft, action) {
             Array.from(uniqueKeysAfterUpdate)
           );
         }
+
+        // upate logic rules with updated keys
+        draft.logicRules = updateKeyReferencesInLogic(draft.logicRules, key, propertyValue);
       }
       break;
     }

--- a/src/openforms/js/components/admin/form_design/utils.js
+++ b/src/openforms/js/components/admin/form_design/utils.js
@@ -54,7 +54,7 @@ const checkKeyChange = (mutationType, newComponent, oldComponent) => {
   return newComponent.key !== oldComponent.key;
 };
 
-const replaceComponentKeyInLogic = (existingLogicRules, originalKey, newKey) => {
+const updateKeyReferencesInLogic = (existingLogicRules, originalKey, newKey) => {
   return existingLogicRules.map((rule, index) => {
     if (!JSON.stringify(rule).includes(originalKey)) {
       return rule;
@@ -69,14 +69,15 @@ const replaceComponentKeyInLogic = (existingLogicRules, originalKey, newKey) => 
     );
     // Replace the key in the actions
     newRule.actions = newRule.actions.map((action, index) => {
-      if (action.component !== originalKey) {
-        return action;
+      // component references
+      if (action.component && action.component === originalKey) {
+        return {...action, component: newKey};
       }
-
-      return {
-        ...action,
-        component: newKey,
-      };
+      // variable references
+      if (action.variable && action.variable === originalKey) {
+        return {...action, variable: newKey};
+      }
+      return action;
     });
 
     return newRule;
@@ -126,7 +127,7 @@ export {
   getFormComponents,
   findComponent,
   checkKeyChange,
-  replaceComponentKeyInLogic,
+  updateKeyReferencesInLogic,
   getUniqueKey,
   getFormStep,
   parseValidationErrors,


### PR DESCRIPTION
Fixes #1806

Component key references were correctly updated already when a Formio
component key changes, however, the variable references in logic
actions weren't yet.

This patch ensures that the variable references are also updated, and applies the same logic when (user-defined) variable keys change.