### PR TITLE
Insert variables in formio config

### DIFF
--- a/docs/developers/backend/core/index.rst
+++ b/docs/developers/backend/core/index.rst
@@ -41,3 +41,4 @@ same thing twice.
    tokens
    testing-tools
    variables
+   templating

--- a/docs/developers/backend/core/templating.rst
+++ b/docs/developers/backend/core/templating.rst
@@ -1,0 +1,29 @@
+.. _developers_backend_core_templating:
+
+==========
+Templating
+==========
+
+Open Forms provides templating solutions for form-designers
+(see :ref:`manual_templates`), built on top of the Django Template Language.
+
+Templating functionality is gradually becoming public API for other apps/packages.
+
+Module: :mod:`openforms.template`
+
+Reference
+=========
+
+Module functionality
+--------------------
+
+.. automodule:: openforms.template
+   :members:
+
+.. autoattribute:: openforms.template.sandbox_backend
+
+Backends
+--------
+
+.. autoclass:: openforms.template.backends.sandboxed_django.SandboxedDjangoTemplates
+   :members:

--- a/docs/developers/backend/core/testing-tools.rst
+++ b/docs/developers/backend/core/testing-tools.rst
@@ -11,3 +11,7 @@ Testing tools
 
 .. automodule:: openforms.utils.tests.test_migrations
    :members:
+
+.. automodule:: openforms.formio.tests.assertions
+   :members:
+   :undoc-members:

--- a/docs/manual/templates.rst
+++ b/docs/manual/templates.rst
@@ -7,6 +7,9 @@ Sjablonen
 Open Forms ondersteunt sjablonen voor verschillende aspecten. Sjablonen zijn
 teksten die aangepaste kunnen worden op basis van het ingevulde formulier.
 
+.. note::
+    Voor de ontwikkelaardocumentatie, zie :ref:`developers_backend_core_templating`.
+
 Momenteel worden sjablonen gebruikt voor:
 
 * Bevestigingsmail

--- a/src/openforms/formio/tests/assertions.py
+++ b/src/openforms/formio/tests/assertions.py
@@ -1,0 +1,32 @@
+from typing import Dict
+
+from glom import GlomError, glom
+
+from openforms.typing import JSONObject, JSONValue
+
+from ..utils import get_component
+
+
+class FormioMixin:
+    def assertFormioComponent(
+        self, configuration: JSONObject, key: str, properties_map: Dict[str, JSONValue]
+    ) -> None:
+        """
+        Assert that the formio component with specified key has the expected properties.
+
+        :arg configuration: Formio form configuration
+        :arg key: the unique key of the component to check
+        :arg properties_map: a mapping of formio property name to expected property
+          value. Note that the dict keys can be dotted paths for nested properties.
+        """
+        component = get_component(configuration, key)
+        if component is None:
+            self.fail(f"Component with key '{key}' not found in configuration.")
+
+        for key, expected_value in properties_map.items():
+            with self.subTest(property=key, expected=expected_value):
+                try:
+                    value = glom(component, key)
+                except GlomError:
+                    self.fail(f"Could not find property with path '{key}' in component")
+                self.assertEqual(value, expected_value)

--- a/src/openforms/formio/tests/test_assertions.py
+++ b/src/openforms/formio/tests/test_assertions.py
@@ -1,0 +1,75 @@
+from unittest import TestCase
+
+from .assertions import FormioMixin
+
+FORMIO_CONFIGURATION = {
+    "components": [
+        {
+            "type": "textfield",
+            "key": "text1",
+            "defaultValue": "foo",
+            "nested": {
+                "property": "value",
+            },
+        }
+    ]
+}
+
+
+class FormioMixinAssertionsTests(FormioMixin, TestCase):
+    def test_correct_config_subset_properties(self):
+        try:
+            self.assertFormioComponent(
+                FORMIO_CONFIGURATION,
+                "text1",
+                {
+                    "type": "textfield",
+                    "defaultValue": "foo",
+                },
+            )
+        except AssertionError:
+            self.fail("Assertion should have passed.")
+
+    def test_nested_lookup(self):
+        try:
+            self.assertFormioComponent(
+                FORMIO_CONFIGURATION,
+                "text1",
+                {
+                    "nested.property": "value",
+                },
+            )
+        except AssertionError:
+            self.fail("Assertion should have passed.")
+
+    def test_invalid_component_key(self):
+        with self.assertRaises(AssertionError):
+            self.assertFormioComponent(FORMIO_CONFIGURATION, "bad-key", {})
+
+    def test_component_missing_property(self):
+        self._outcome.expectedFailure = True
+
+        try:
+            self.assertFormioComponent(
+                FORMIO_CONFIGURATION, "text1", {"missingProperty": "bar"}
+            )
+        except Exception:
+            pass
+
+        # internals because of the self.subTest usage
+        self.assertFalse(self._outcome.success)
+        self._outcome.errors = []
+
+    def test_component_unexpected_value(self):
+        self._outcome.expectedFailure = True
+
+        try:
+            self.assertFormioComponent(
+                FORMIO_CONFIGURATION, "text1", {"defaultValue": "bar"}
+            )
+        except Exception:
+            pass
+
+        # internals because of the self.subTest usage
+        self.assertFalse(self._outcome.success)
+        self._outcome.errors = []

--- a/src/openforms/formio/tests/test_variables_injection.py
+++ b/src/openforms/formio/tests/test_variables_injection.py
@@ -1,0 +1,134 @@
+from copy import deepcopy
+from datetime import date
+
+from django.test import SimpleTestCase, override_settings
+from django.utils import timezone
+
+from freezegun import freeze_time
+
+from ..variables import inject_variables
+
+VARIABLES = {
+    "html_variable": "<span>HTML injection!</span>",
+    "content_timestamp": date(2022, 8, 16),
+    # from json data - only use primitives!
+    "labels": {
+        "text1": "Label eerste textfield",
+    },
+    "placeholder_with_double_quotes": 'These should " be escaped',
+    "defaults": {
+        "text1": 123,
+        "text2": 123.45,
+        "number1": 0.1 + 0.1 + 0.1,
+    },
+    "now": timezone.now,
+    "checkboxChecked": True,
+}
+
+
+CONFIGURATION = {
+    "components": [
+        {
+            "type": "content",
+            "key": "content1",
+            "html": "<p>We expected a {{ html_variable }} to be escaped.</p>",
+            "label": 'Message at {{ content_timestamp|date:"Y-m-d" }}',
+        },
+        {
+            "type": "textfield",
+            "key": "text1",
+            "label": "{{ labels.text1 }}",
+            "placeholder": "{{ placeholder_with_double_quotes }}",
+            "defaultValue": "{{ defaults.text1 }}",
+        },
+        {
+            "type": "textfield",
+            "key": "text2",
+            "defaultValue": "{{ defaults.text2 }}",
+        },
+        {
+            "type": "textfield",
+            "key": "textfieldMulti",
+            "multiple": True,
+            "defaultValue": [
+                "{{ defaults.text1 }}",
+                "{{ defaults.text2|floatformat }}",
+            ],
+        },
+        {
+            "type": "date",
+            "key": "date1",
+            "label": """Het is vandaag {{ now|date:"l" }}""",
+            "defaultValue": "{{ now|date:'d-m-Y' }}",
+        },
+        {
+            "type": "number",
+            "key": "number1",
+            # works because formio attempts to parse it as a number, even though we
+            # pass a string
+            "defaultValue": "{{ defaults.number1|floatformat:2 }}",
+        },
+        {
+            "type": "checkbox",
+            "key": "checkbox1",
+            # this works because formio interprets 'false/true' strings as actual
+            # booleans. Note that we don't expose this in the form designer UI yet!
+            "defaultValue": "{{ checkboxChecked|yesno:'true,false,null' }}",
+        },
+    ]
+}
+
+
+@override_settings(LANGUAGE_CODE="nl")
+@freeze_time("2022-08-16T11:57:02+02:00")
+class VariableInjectionTests(SimpleTestCase):
+    def test_variable_interpolation(self):
+        configuration = deepcopy(CONFIGURATION)
+
+        inject_variables(configuration, VARIABLES)
+
+        lookup_table = {comp["key"]: comp for comp in configuration["components"]}
+
+        content1 = lookup_table["content1"]
+        text1 = lookup_table["text1"]
+        text2 = lookup_table["text2"]
+        textfield_multi = lookup_table["textfieldMulti"]
+        date1 = lookup_table["date1"]
+        number1 = lookup_table["number1"]
+        checkbox1 = lookup_table["checkbox1"]
+
+        with self.subTest("HTML content"):
+            self.assertEqual(
+                content1["html"],
+                "<p>We expected a &lt;span&gt;HTML injection!&lt;/span&gt; to be escaped.</p>",
+            )
+            self.assertEqual(content1["label"], "Message at 2022-08-16")
+
+        with self.subTest("Nested lookups"):
+            self.assertEqual(text1["label"], "Label eerste textfield")
+
+        with self.subTest("Double quotes in placeholder escaped"):
+            self.assertEqual(text1["placeholder"], "These should &quot; be escaped")
+
+        with self.subTest("Stringified default value"):
+            self.assertEqual(text1["defaultValue"], "123")
+
+        with self.subTest("Stringified default value (float)"):
+            self.assertEqual(text2["defaultValue"], "123.45")  # unlocalized!
+
+        with self.subTest("Default values with multiple=true"):
+            self.assertEqual(
+                textfield_multi["defaultValue"], ["123", "123.4"]
+            )  # unlocalized!
+
+        with self.subTest("Builtin template filters"):
+            self.assertEqual(date1["label"], "Het is vandaag dinsdag")
+            self.assertEqual(date1["defaultValue"], "16-08-2022")
+
+        # questionable but convenient formio behaviour - it parses the string as a number
+        with self.subTest("Number default floatformat, unlocalized"):
+            self.assertEqual(number1["defaultValue"], "0.30")  # unlocalized!
+
+        # questionable but convenient formio behaviour - it parses the string as a boolean
+        with self.subTest("Checkbox default value boolean-ish"):
+            self.assertEqual(checkbox1["defaultValue"], "true")

--- a/src/openforms/formio/tests/test_variables_injection.py
+++ b/src/openforms/formio/tests/test_variables_injection.py
@@ -132,3 +132,39 @@ class VariableInjectionTests(SimpleTestCase):
         # questionable but convenient formio behaviour - it parses the string as a boolean
         with self.subTest("Checkbox default value boolean-ish"):
             self.assertEqual(checkbox1["defaultValue"], "true")
+
+    def test_custom_libraries_not_available(self):
+        configuration = {
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "textfield1",
+                    "label": "{% load multidomain %}{% multidomain_switcher %}",
+                }
+            ]
+        }
+
+        inject_variables(configuration, {})
+
+        self.assertEqual(
+            configuration["components"][0]["label"],
+            "{% load multidomain %}{% multidomain_switcher %}",
+        )
+
+    def test_custom_builtins_not_available(self):
+        configuration = {
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "textfield1",
+                    "label": "{% privacy_policy %}",
+                }
+            ]
+        }
+
+        inject_variables(configuration, {})
+
+        self.assertEqual(
+            configuration["components"][0]["label"],
+            "{% privacy_policy %}",
+        )

--- a/src/openforms/formio/tests/test_variables_injection.py
+++ b/src/openforms/formio/tests/test_variables_injection.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from freezegun import freeze_time
 
-from ..variables import inject_variables
+from ..variables import inject_variables, render
 
 VARIABLES = {
     "html_variable": "<span>HTML injection!</span>",
@@ -171,4 +171,15 @@ class VariableInjectionTests(SimpleTestCase):
         self.assertEqual(
             configuration["components"][0]["label"],
             "{% privacy_policy %}",
+        )
+
+    def test_rendering_nested_structures(self):
+        structure = {"topLevel": {"nested": "{{ expression }}"}}
+        context = {"expression": "yepp"}
+
+        result = render(structure, context)
+
+        self.assertEqual(
+            result,
+            {"topLevel": {"nested": "yepp"}},
         )

--- a/src/openforms/formio/tests/test_variables_injection.py
+++ b/src/openforms/formio/tests/test_variables_injection.py
@@ -114,12 +114,12 @@ class VariableInjectionTests(SimpleTestCase):
             self.assertEqual(text1["defaultValue"], "123")
 
         with self.subTest("Stringified default value (float)"):
-            self.assertEqual(text2["defaultValue"], "123.45")  # unlocalized!
+            # localized! Formio seems to handle localized values correctly
+            self.assertEqual(text2["defaultValue"], "123,45")
 
         with self.subTest("Default values with multiple=true"):
-            self.assertEqual(
-                textfield_multi["defaultValue"], ["123", "123.4"]
-            )  # unlocalized!
+            # localized! Formio seems to handle localized values correctly
+            self.assertEqual(textfield_multi["defaultValue"], ["123", "123,5"])
 
         with self.subTest("Builtin template filters"):
             self.assertEqual(date1["label"], "Het is vandaag dinsdag")
@@ -127,7 +127,11 @@ class VariableInjectionTests(SimpleTestCase):
 
         # questionable but convenient formio behaviour - it parses the string as a number
         with self.subTest("Number default floatformat, unlocalized"):
-            self.assertEqual(number1["defaultValue"], "0.30")  # unlocalized!
+            # localized! Formio seems to handle localized values correctly.
+            # We can't combine `{% localize off %}` with the floatformat template filter,
+            # as the use_l10n parameter is not passed down inside of floatformat. This is fixed
+            # in newer django versions than 3.2. For now, we can accept localized values.
+            self.assertEqual(number1["defaultValue"], "0,30")
 
         # questionable but convenient formio behaviour - it parses the string as a boolean
         with self.subTest("Checkbox default value boolean-ish"):

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -33,7 +33,7 @@ def iter_components(
                 )
 
 
-def get_component(configuration: JSONObject, key: str) -> JSONObject:
+def get_component(configuration: JSONObject, key: str) -> Optional[Component]:
     for component in iter_components(configuration=configuration, recursive=True):
         if component["key"] == key:
             return component

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Union
 
 from django.template import TemplateSyntaxError
-from django.template.backends.django import DjangoTemplates
 
 from openforms.submissions.logic.datastructures import DataMapping
-from openforms.typing import JSONObject, JSONPrimitive, JSONValue
+from openforms.template import render_from_string
+from openforms.typing import JSONObject, JSONValue
 
 from .utils import iter_components
 
@@ -22,34 +21,6 @@ SUPPOORTED_TEMPLATE_PROPERTIES = (
 )
 
 
-# TODO: move to separate utility for sandboxed rendering!
-class SandboxedDjangoTemplates(DjangoTemplates):
-    def get_templatetag_libraries(self, custom_libraries):
-        return {}
-
-
-# statically configured engine without access to templates on the filesystem
-template_engine = SandboxedDjangoTemplates(
-    params={
-        "NAME": "django_sandboxed",
-        "DIRS": [],  # no file system paths to look up files (also blocks {% include %} etc)
-        "APP_DIRS": False,
-        "OPTIONS": {
-            "autoescape": True,
-            "libraries": [],  # no access to our custom template tags
-            "builtins": [
-                "django.templatetags.l10n",  # allow usage of localize/unlocalize
-            ],
-        },
-    }
-)
-
-
-def _render(source: str, context: dict) -> str:
-    template = template_engine.from_string(source)
-    return template.render(context)
-
-
 def render(formio_bit: JSONValue, context: dict) -> JSONValue:
     """
     Take a formio property value and evaluate the templates inside.
@@ -63,7 +34,7 @@ def render(formio_bit: JSONValue, context: dict) -> JSONValue:
     """
     # string primitive - we can throw it into the template engine
     if isinstance(formio_bit, str):
-        return _render(formio_bit, context)
+        return render_from_string(formio_bit, context)
 
     # collection - map every item recursively
     if isinstance(formio_bit, list):

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -10,7 +10,7 @@ from .utils import iter_components
 logger = logging.getLogger(__name__)
 
 
-SUPPOORTED_TEMPLATE_PROPERTIES = (
+SUPPORTED_TEMPLATE_PROPERTIES = (
     "label",
     "legend",
     "defaultValue",
@@ -61,14 +61,14 @@ def inject_variables(configuration: JSONObject, values: DataMapping) -> None:
 
     :arg configuration: A dictionary containing the static Formio configuration (from
       the form designer)
-    :arg values: A mapping of variable name to its value (Python native objects)
+    :arg values: A mapping of variable key to its value (Python native objects)
     :returns: None - this function mutates the datastructures in place
 
     .. todo:: Support getting non-string based configuration from variables, such as
        `validate.required` etc.
     """
     for component in iter_components(configuration=configuration, recursive=True):
-        for property_name in SUPPOORTED_TEMPLATE_PROPERTIES:
+        for property_name in SUPPORTED_TEMPLATE_PROPERTIES:
             property_value = component.get(property_name)
             if not property_value:
                 continue

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -2,9 +2,8 @@ import logging
 
 from django.template import TemplateSyntaxError
 
-from openforms.submissions.logic.datastructures import DataMapping
 from openforms.template import render_from_string
-from openforms.typing import JSONObject, JSONValue
+from openforms.typing import DataMapping, JSONObject, JSONValue
 
 from .utils import iter_components
 

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -36,6 +36,9 @@ template_engine = SandboxedDjangoTemplates(
         "OPTIONS": {
             "autoescape": True,
             "libraries": [],  # no access to our custom template tags
+            "builtins": [
+                "django.templatetags.l10n",  # allow usage of localize/unlocalize
+            ],
         },
     }
 )

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -1,0 +1,81 @@
+import logging
+
+from django.template import TemplateSyntaxError
+from django.template.backends.django import DjangoTemplates
+
+from openforms.submissions.logic.datastructures import DataMapping
+from openforms.typing import JSONObject
+
+from .utils import iter_components
+
+logger = logging.getLogger(__name__)
+
+
+SUPPOORTED_TEMPLATE_PROPERTIES = (
+    "label",
+    "legend",
+    "defaultValue",
+    "description",
+    "html",
+    "placeholder",
+)
+
+
+# TODO: move to separate utility for sandboxed rendering!
+class SandboxedDjangoTemplates(DjangoTemplates):
+    def get_templatetag_libraries(self, custom_libraries):
+        return {}
+
+
+# statically configured engine without access to templates on the filesystem
+template_engine = SandboxedDjangoTemplates(
+    params={
+        "NAME": "django_sandboxed",
+        "DIRS": [],  # no file system paths to look up files (also blocks {% include %} etc)
+        "APP_DIRS": False,
+        "OPTIONS": {
+            "autoescape": True,
+            "libraries": [],  # no access to our custom template tags
+        },
+    }
+)
+
+
+def render(source: str, context: dict) -> str:
+    template = template_engine.from_string(source)
+    return template.render(context)
+
+
+def inject_variables(configuration: JSONObject, values: DataMapping) -> None:
+    """
+    Inject the variable values into the Formio configuration.
+
+    Takes a Formio configuration and fully resolved variable state (mapping of variable
+    name to its value as a Python object). The configuration is iterated over and every
+    component is checked for properties that can be templated. Note that the
+    configuration is mutated in the process!
+
+    :arg configuration: A dictionary containing the static Formio configuration (from
+      the form designer)
+    :arg values: A mapping of variable name to its value (Python native objects)
+    :returns: None - this function mutates the datastructures in place
+
+    .. todo:: Support getting non-string based configuration from variables, such as
+       `validate.required` etc.
+    """
+    for component in iter_components(configuration=configuration, recursive=True):
+        for property_name in SUPPOORTED_TEMPLATE_PROPERTIES:
+            property_value = component.get(property_name)
+            if not property_value:
+                continue
+
+            try:
+                templated_value = render(property_value, values)
+            except TemplateSyntaxError as exc:
+                logger.debug(
+                    "Error during formio configuration 'template' rendering",
+                    exc_info=exc,
+                )
+                # return the original config instead
+                return property_value
+            component[property_name] = templated_value

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -156,6 +156,12 @@ class FormVariableFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = "forms.FormVariable"
 
+    class Params:
+        user_defined = factory.Trait(
+            source=FormVariableSources.user_defined,
+            form_definition=None,
+        )
+
 
 class CategoryFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: "Category %03d" % n)

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -209,6 +209,7 @@ def evaluate_form_logic(
 
 
 def check_submission_logic(submission, unsaved_data=None):
+    # TODO: https://github.com/open-formulieren/open-forms/issues/1913
     logic_rules = FormLogic.objects.filter(
         form=submission.form,
         actions__contains=[{"action": {"type": LogicActionTypes.step_not_applicable}}],
@@ -223,6 +224,9 @@ def check_submission_logic(submission, unsaved_data=None):
     for rule in logic_rules:
         if jsonLogic(rule.json_logic_trigger, merged_data):
             for action in rule.actions:
+                # TODO: this should not be necessary because of the query filter above?
+                # but perhaps we might want to re-use the logic rules cached on the
+                # submission instance?
                 if action["action"]["type"] != LogicActionTypes.step_not_applicable:
                     continue
 

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict
 import elasticapm
 from json_logic import jsonLogic
 
-from openforms.formio.service import get_dynamic_configuration
+from openforms.formio.service import get_dynamic_configuration, inject_variables
 from openforms.formio.utils import get_component, get_component_default_value
 from openforms.forms.constants import LogicActionTypes
 from openforms.forms.models import FormLogic
@@ -162,7 +162,7 @@ def evaluate_form_logic(
         mutation.apply(step, configuration)
 
     # 7.2 Interpolate the component configuration with the variables.
-    # TODO!
+    inject_variables(configuration, data_container.data)
 
     # 7.3 Handle custom formio types - TODO: this needs to be lifted out of
     # :func:`get_dynamic_configuration` so that it can use variables.

--- a/src/openforms/submissions/logic/datastructures.py
+++ b/src/openforms/submissions/logic/datastructures.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 from glom import assign
 
+from openforms.typing import DataMapping
+
 from ..models import SubmissionStep
 from ..models.submission_value_variable import SubmissionValueVariablesState
-
-DataMapping = Dict[str, Any]
 
 
 @dataclass

--- a/src/openforms/submissions/tests/renderer/test_formio_integration.py
+++ b/src/openforms/submissions/tests/renderer/test_formio_integration.py
@@ -97,3 +97,21 @@ class SubmissionRendererIntegrationTests(TestCase):
             "Input 4: fourth input",
         ]
         self.assertEqual(rendered, expected)
+
+    def test_variables_in_formio_config_are_templated_out(self):
+        """
+        Assert that the formio configuration has properly templated out variables.
+
+        This ensures the renderer-aspect from #1708.
+        """
+        fd = self.submission.steps[0].form_step.form_definition
+        fd.configuration["components"][3]["label"] = "Templated out value: {{ input1 }}"
+        fd.save()
+        renderer = Renderer(
+            submission=self.submission, mode=RenderModes.pdf, as_html=True
+        )
+
+        nodelist = list(renderer)
+
+        fieldset_node = nodelist[-2]
+        self.assertEqual(fieldset_node.render(), "Templated out value: first input")

--- a/src/openforms/submissions/tests/test_variables/test_variable_injection.py
+++ b/src/openforms/submissions/tests/test_variables/test_variable_injection.py
@@ -1,0 +1,223 @@
+"""
+Assert that (submission) variables are injected at key stages.
+
+The formio dynamic configuration must interpolate variables using the supported
+expressions. Most notably, this is relevant for the:
+
+* GET submission step detail endpoint
+* POST evaluate logic check endpoint
+"""
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.formio.tests.assertions import FormioMixin
+from openforms.forms.tests.factories import FormFactory, FormVariableFactory
+from openforms.variables.constants import FormVariableDataTypes
+
+from ..factories import SubmissionStepFactory
+from ..mixins import SubmissionsMixin
+
+CONFIGURATION = {
+    "components": [
+        {
+            "type": "fieldset",
+            "key": "group1",
+            "label": "{{ labels.group1 }}",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "text1",
+                    "label": "{{ labels.text1 }}",
+                    "description": "{{ helpTexts.text1 }}",
+                }
+            ],
+        },
+        {
+            "type": "checkbox",
+            "key": "checkbox1",
+            "label": "Enable {{ text1|default:'' }}?",
+            "defaultValue": False,
+            "hidden": True,
+        },
+        {
+            "type": "content",
+            "key": "content1",
+            "html": "<p>{{ text1|default:'' }} enabled: {{ checkbox1|yesno:'yes,no' }}</p>",
+        },
+    ]
+}
+
+
+class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration=CONFIGURATION,
+        )
+        form_step = form.formstep_set.get()
+        FormVariableFactory.create(
+            user_defined=True,
+            form=form,
+            key="labels",
+            data_type=FormVariableDataTypes.object,
+            initial_value={
+                "group1": "Group 1",
+                "text1": "Label 1",
+            },
+        )
+        FormVariableFactory.create(
+            user_defined=True,
+            form=form,
+            key="helpTexts",
+            data_type=FormVariableDataTypes.object,
+            initial_value={
+                "text1": "Help 1",
+            },
+        )
+        submission_step = SubmissionStepFactory.create(
+            submission__form=form, form_step=form_step, data={}
+        )
+
+        cls.submission_step = submission_step
+        cls.submission = submission_step.submission
+
+    def test_detail_endpoint_interpolates_variables(self):
+        self._add_submission_to_session(self.submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": self.submission.uuid,
+                "step_uuid": self.submission_step.form_step.uuid,
+            },
+        )
+
+        response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        configuration = response.json()["formStep"]["configuration"]
+
+        with self.subTest(component="group1"):
+            self.assertFormioComponent(
+                configuration,
+                "group1",
+                {"label": "Group 1"},
+            )
+        with self.subTest(component="text1"):
+            self.assertFormioComponent(
+                configuration,
+                "text1",
+                {
+                    "label": "Label 1",
+                    "description": "Help 1",
+                },
+            )
+        with self.subTest(component="checkbox1"):
+            self.assertFormioComponent(
+                configuration,
+                "checkbox1",
+                {
+                    "label": "Enable ?",  # empty variable -> empty string
+                },
+            )
+        with self.subTest(component="content1"):
+            self.assertFormioComponent(
+                configuration,
+                "content1",
+                {"html": "<p> enabled: no</p>"},
+            )
+
+    def test_detail_endpoint_interpolates_with_submission_data(self):
+        self._add_submission_to_session(self.submission)
+        self.submission_step.data = {"text1": 'First "textfield"', "checkbox1": True}
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": self.submission.uuid,
+                "step_uuid": self.submission_step.form_step.uuid,
+            },
+        )
+
+        response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        configuration = response.json()["formStep"]["configuration"]
+
+        with self.subTest(component="group1"):
+            self.assertFormioComponent(
+                configuration,
+                "group1",
+                {"label": "Group 1"},
+            )
+        with self.subTest(component="text1"):
+            self.assertFormioComponent(
+                configuration,
+                "text1",
+                {
+                    "label": "Label 1",
+                    "description": "Help 1",
+                },
+            )
+        with self.subTest(component="checkbox1"):
+            self.assertFormioComponent(
+                configuration,
+                "checkbox1",
+                {
+                    "label": "Enable First &quot;textfield&quot;?",
+                },
+            )
+        with self.subTest(component="content1"):
+            self.assertFormioComponent(
+                configuration,
+                "content1",
+                {"html": "<p>First &quot;textfield&quot; enabled: yes</p>"},
+            )
+
+    def test_logic_evalution_endpoint(self):
+        self._add_submission_to_session(self.submission)
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": self.submission.uuid,
+                "step_uuid": self.submission_step.form_step.uuid,
+            },
+        )
+
+        response = self.client.post(endpoint, {"data": {"text1": "some input"}})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        configuration = response.json()["step"]["formStep"]["configuration"]
+
+        with self.subTest(component="group1"):
+            self.assertFormioComponent(
+                configuration,
+                "group1",
+                {"label": "Group 1"},
+            )
+        with self.subTest(component="text1"):
+            self.assertFormioComponent(
+                configuration,
+                "text1",
+                {
+                    "label": "Label 1",
+                    "description": "Help 1",
+                },
+            )
+        with self.subTest(component="checkbox1"):
+            self.assertFormioComponent(
+                configuration,
+                "checkbox1",
+                {
+                    "label": "Enable some input?",
+                },
+            )
+        with self.subTest(component="content1"):
+            self.assertFormioComponent(
+                configuration,
+                "content1",
+                {"html": "<p>some input enabled: no</p>"},
+            )

--- a/src/openforms/template/__init__.py
+++ b/src/openforms/template/__init__.py
@@ -1,0 +1,32 @@
+"""
+Expose template functionality as public API.
+
+The ``template`` package provides generic template rendering constructs. Features are:
+
+* Option to sandbox templates to only allow safe-ish public API
+* Utilities to evaluate templates from string (user-contributed content and inherently
+  unsafe).
+
+Possible future features:
+
+* Caching for string-based templates
+* ...
+"""
+from .backends.sandboxed_django import backend as sandbox_backend
+
+__all__ = ["render_from_string", "sandbox_backend"]
+
+
+def render_from_string(source: str, context: dict, backend=sandbox_backend) -> str:
+    """
+    Render a template source string using the provided context.
+
+    :arg source: The template source to render
+    :arg context: The context data for the template to render
+    :arg backend: An optional alternative Django template backend instance to use.
+      Defaults to the sandboxed backend.
+    :raises: :class:`django.template.TemplateSyntaxError` if the template source is
+      invalid
+    """
+    template = backend.from_string(source)
+    return template.render(context)

--- a/src/openforms/template/backends/sandboxed_django.py
+++ b/src/openforms/template/backends/sandboxed_django.py
@@ -2,6 +2,15 @@ from django.template.backends.django import DjangoTemplates
 
 
 class SandboxedDjangoTemplates(DjangoTemplates):
+    """
+    A 'sandboxed' Django templates backend.
+
+    The sandboxed backend (by default) does not allow:
+
+    * looking up template files from file-system
+    * loading or using non-builtin templatetag libraries (except for the ``l10n`` library)
+    """
+
     def __init__(self, params):
         params = params.copy()
         params.setdefault("NAME", "django_sandboxed")
@@ -24,7 +33,7 @@ class SandboxedDjangoTemplates(DjangoTemplates):
         )
         super().__init__(params)
 
-    def get_templatetag_libraries(self, custom_libraries):
+    def get_templatetag_libraries(self, custom_libraries: dict) -> dict:
         """
         Do not automatically discover template tag libraries.
 
@@ -37,9 +46,4 @@ class SandboxedDjangoTemplates(DjangoTemplates):
 backend = SandboxedDjangoTemplates({})
 """
 An instance of the 'sandboxed' Django templates backend.
-
-The sandboxed backend (by default) does not allow:
-
-* looking up template files from file-system
-* loading or using non-builtin templatetag libraries (except for the ``l10n`` library)
 """

--- a/src/openforms/template/backends/sandboxed_django.py
+++ b/src/openforms/template/backends/sandboxed_django.py
@@ -1,0 +1,45 @@
+from django.template.backends.django import DjangoTemplates
+
+
+class SandboxedDjangoTemplates(DjangoTemplates):
+    def __init__(self, params):
+        params = params.copy()
+        params.setdefault("NAME", "django_sandboxed")
+        # no file system paths to look up files (also blocks {% include %} etc)
+        params.setdefault("DIRS", [])
+        params.setdefault("APP_DIRS", False)
+
+        params.setdefault("OPTIONS", {})
+        params["OPTIONS"].setdefault(
+            "autoescape", True
+        )  # assume HTML context and auto-escape
+        params["OPTIONS"].setdefault(
+            "libraries", {}
+        )  # no access to our custom template tags by default
+        params["OPTIONS"].setdefault(
+            "builtins",
+            [
+                "django.templatetags.l10n",  # allow usage of localize/unlocalize
+            ],
+        )
+        super().__init__(params)
+
+    def get_templatetag_libraries(self, custom_libraries):
+        """
+        Do not automatically discover template tag libraries.
+
+        This prevents user-content from loading and using the libraries that are
+        private API to Open Forms.
+        """
+        return {}
+
+
+backend = SandboxedDjangoTemplates({})
+"""
+An instance of the 'sandboxed' Django templates backend.
+
+The sandboxed backend (by default) does not allow:
+
+* looking up template files from file-system
+* loading or using non-builtin templatetag libraries (except for the ``l10n`` library)
+"""

--- a/src/openforms/typing.py
+++ b/src/openforms/typing.py
@@ -1,7 +1,9 @@
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 JSONPrimitive = Union[str, int, None, float]
 
 JSONValue = Union[JSONPrimitive, "JSONObject", List["JSONValue"]]
 
 JSONObject = Dict[str, JSONValue]
+
+DataMapping = Dict[str, Any]  # key: value pair


### PR DESCRIPTION
Related to #1708 

**Changes**

* Added isolated django template backend instance for user-input rendering
* Added formio test utils/assertions to verify component properties
* Added service function to inject variables values into formio configuration (using the django template engine)
* Hooked up variable injection into the form logic evaluation function