### PR TITLE
Handle stuf bg prefill error on empty antwoord

### DIFF
--- a/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
@@ -113,9 +113,9 @@ class StufBgPrefillTests(TestCase):
         attributes = FieldChoices.attributes.keys()
 
         with self.assertLogs() as logs:
-            values = self.plugin.get_prefill_values(self.submission, attributes)
+            with self.assertRaises(ValueError):
+                self.plugin.get_prefill_values(self.submission, attributes)
 
-            self.assertEqual(values, {})
             self.assertEqual(logs.records[0].fault["faultcode"], "soapenv:Server")
             self.assertEqual(logs.records[0].fault["faultstring"], "Policy Falsified")
             self.assertEqual(
@@ -130,11 +130,13 @@ class StufBgPrefillTests(TestCase):
         self.addCleanup(client_patcher.stop)
         attributes = FieldChoices.attributes.keys()
 
-        with self.assertLogs() as logs:
+        try:
             values = self.plugin.get_prefill_values(self.submission, attributes)
+        except ValueError:
+            # empty responses should be handled graciously
+            self.fail("No fault/error expected.")
 
-            self.assertEqual(values, {})
-            self.assertEqual(logs.records[0].fault, {})
+        self.assertEqual(values, {})
 
     def test_get_available_attributes_when_object_not_found_reponse_is_returned(self):
         client_patcher = mock_stufbg_client("StufBgNotFoundResponse.xml")
@@ -142,9 +144,9 @@ class StufBgPrefillTests(TestCase):
         attributes = FieldChoices.attributes.keys()
 
         with self.assertLogs() as logs:
-            values = self.plugin.get_prefill_values(self.submission, attributes)
+            with self.assertRaises(ValueError):
+                self.plugin.get_prefill_values(self.submission, attributes)
 
-            self.assertEqual(values, {})
             self.assertEqual(
                 logs.records[0].fault, {"faultstring": "Object niet gevonden"}
             )
@@ -154,11 +156,13 @@ class StufBgPrefillTests(TestCase):
         self.addCleanup(client_patcher.stop)
         attributes = FieldChoices.attributes.keys()
 
-        with self.assertLogs() as logs:
+        try:
             values = self.plugin.get_prefill_values(self.submission, attributes)
+        except ValueError:
+            # empty responses should be handled graciously
+            self.fail("No fault/error expected.")
 
-            self.assertEqual(values, {})
-            self.assertEqual(logs.records[0].fault, {})
+        self.assertEqual(values, {})
 
     @tag("gh-1617")
     def test_onvolledige_datum(self):

--- a/src/stuf/stuf_bg/client.py
+++ b/src/stuf/stuf_bg/client.py
@@ -103,12 +103,13 @@ class StufBGClient:
             try:
                 # Get the fault information if there
                 fault = dict_response["Envelope"]["Body"]["Fault"]
-            except KeyError:
+            except Exception:
                 fault = {}
-            finally:
-                logger.error(
-                    "Response data has an unexpected shape",
-                    extra={"response": dict_response, "fault": fault},
-                    exc_info=exc,
-                )
-                return {}
+
+            # ensure it gets logged to Sentry before re-raising
+            logger.error(
+                "Response data has an unexpected shape",
+                extra={"response": dict_response, "fault": fault},
+                exc_info=exc,
+            )
+            raise

--- a/src/stuf/stuf_bg/tests/test_client.py
+++ b/src/stuf/stuf_bg/tests/test_client.py
@@ -178,26 +178,7 @@ class StufBGConfigTests(TestCase):
         :func:`openforms.prefill._fetch_prefill_values`).
         """
         with requests_mock.Mocker() as m:
-            m.post(
-                self.service.soap_service.url,
-                content=bytes(
-                    loader.render_to_string(
-                        "stuf_bg/tests/responses/StufBgNoAnswerResponse.xml",
-                        context={
-                            "referentienummer": "38151851-0fe9-4463-ba39-416042b8f406",
-                            "tijdstip_bericht": timezone.now(),
-                            "zender_organisatie": self.service.ontvanger_organisatie,
-                            "zender_applicatie": self.service.ontvanger_applicatie,
-                            "zender_administratie": self.service.ontvanger_administratie,
-                            "zender_gebruiker": self.service.ontvanger_gebruiker,
-                            "ontvanger_organisatie": self.service.zender_organisatie,
-                            "ontvanger_applicatie": self.service.zender_applicatie,
-                            "ontvanger_administratie": self.service.zender_administratie,
-                            "ontvanger_gebruiker": self.service.zender_gebruiker,
-                        },
-                    ),
-                    encoding="utf-8",
-                ),
-            )
-            with self.assertRaises(TypeError):
+            m.post(self.service.soap_service.url, content=b"I am not valid XML")
+
+            with self.assertRaises(Exception):
                 self.client.get_values("999992314", list(FieldChoices.values.keys()))


### PR DESCRIPTION
Fixes #1842 - closes #1852

This patch is two-fold:

* ensure that StUF-BG errors bubble up so that `openforms.prefill._fetch_prefill_values` can handle them (which logs it using `logevent.prefill_retrieve_failure` in case of unexpected errors)
* handle missing keys/data graciously, so we keep noise out of Sentry (we only want to catch programming errors, not logical errors because there just isn't any data to prefill)
