### PR TITLE
Fix cookie tests running with --keepdb option

### DIFF
--- a/src/openforms/analytics_tools/tests/mixin.py
+++ b/src/openforms/analytics_tools/tests/mixin.py
@@ -7,8 +7,9 @@ class AnalyticsMixin:
     def setUp(self):
         super().setUp()
         self.config = AnalyticsToolsConfiguration.get_solo()
-        self.config.analytics_cookie_consent_group = CookieGroup.objects.get(
-            varname="analytical"
-        )
+        (
+            self.config.analytics_cookie_consent_group,
+            _,
+        ) = CookieGroup.objects.get_or_create(varname="analytical")
 
         self.addCleanup(lambda: AnalyticsToolsConfiguration.get_solo().delete())


### PR DESCRIPTION
Not sure of the reason but it seems that with --keepdb, the CookieGroup is deleted at one point while we run all project's tests