### PR TITLE
Refactored the public API for (static) variables 

### DIFF
--- a/src/openforms/authentication/tests/test_static_variables.py
+++ b/src/openforms/authentication/tests/test_static_variables.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from openforms.authentication.constants import AuthAttribute
 from openforms.authentication.tests.factories import AuthInfoFactory
-from openforms.forms.models import FormVariable
+from openforms.variables.service import get_static_variables
 
 
 class TestStaticVariables(TestCase):
@@ -16,7 +16,7 @@ class TestStaticVariables(TestCase):
 
         static_data = {
             variable.key: variable
-            for variable in FormVariable.get_static_data(auth_info.submission)
+            for variable in get_static_variables(submission=auth_info.submission)
         }
 
         expected = {
@@ -37,9 +37,7 @@ class TestStaticVariables(TestCase):
                 self.assertEqual(static_data[variable_key].initial_value, value)
 
     def test_auth_static_data_no_submission(self):
-        static_data = {
-            variable.key: variable for variable in FormVariable.get_static_data()
-        }
+        static_data = {variable.key: variable for variable in get_static_variables()}
 
         expected = {
             "auth_identifier": None,

--- a/src/openforms/forms/api/serializers/form_variable.py
+++ b/src/openforms/forms/api/serializers/form_variable.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 from openforms.api.serializers import ListWithChildSerializer
 from openforms.formio.utils import get_component
 from openforms.variables.constants import FormVariableSources
+from openforms.variables.service import get_static_variables
 
 from ...models import FormVariable
 
@@ -16,12 +17,12 @@ class FormVariableListSerializer(ListWithChildSerializer):
     def get_child_serializer_class(self):
         return FormVariableSerializer
 
-    def process_object(self, variable: "FormVariable"):
+    def process_object(self, variable: FormVariable):
         variable.derive_info_from_component()
         return variable
 
     def validate(self, attrs):
-        static_data_keys = [item.key for item in FormVariable.get_static_data()]
+        static_data_keys = [item.key for item in get_static_variables()]
 
         existing_form_key_combinations = []
         errors = defaultdict(list)

--- a/src/openforms/forms/api/validators.py
+++ b/src/openforms/forms/api/validators.py
@@ -10,8 +10,8 @@ from openforms.api.utils import get_from_serializer_data_or_instance
 from openforms.formio.utils import iter_components
 from openforms.typing import JSONObject
 from openforms.utils.json_logic import JsonLogicTest
+from openforms.variables.service import get_static_variables
 
-from ..models import FormVariable
 from ..validation.registry import register as formio_validators_registry
 
 
@@ -147,7 +147,7 @@ class JsonLogicTriggerValidator(JsonLogicValidator):
 
             # Check if the trigger references a static variable
             needle_bits = needle.split(".")
-            for variable in FormVariable.get_static_data():
+            for variable in get_static_variables():
                 if needle_bits[0] == variable.key:
                     return
 

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 
 from django.core.validators import RegexValidator
 from django.db import models, transaction
@@ -17,15 +17,10 @@ from openforms.formio.utils import (
     iter_components,
 )
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
-from openforms.variables.registry import (
-    register_static_variable as static_variables_register,
-)
 
 from .form_definition import FormDefinition
 
 if TYPE_CHECKING:  # pragma: nocover
-    from openforms.submissions.models import Submission
-
     from .form import Form
     from .form_step import FormStep
 
@@ -211,16 +206,6 @@ class FormVariable(models.Model):
 
     def get_initial_value(self):
         return self.initial_value or None
-
-    @staticmethod
-    def get_static_data(
-        submission: Optional["Submission"] = None,
-    ) -> List["FormVariable"]:
-
-        return [
-            registered_variable.get_static_variable(submission=submission)
-            for registered_variable in static_variables_register
-        ]
 
     def derive_info_from_component(self):
         if self.source != FormVariableSources.component or not self.form_definition:

--- a/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
+++ b/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
@@ -139,10 +139,7 @@ class VariablesInLogicAPITests(APITestCase):
         self.client.force_authenticate(user=user)
         url = reverse("api:form-logics-list")
 
-        with patch(
-            "openforms.forms.models.form_variable.static_variables_register",
-            new=register,
-        ):
+        with patch("openforms.variables.service.register", new=register):
             response = self.client.post(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
@@ -172,10 +169,7 @@ class VariablesInLogicAPITests(APITestCase):
         self.client.force_authenticate(user=user)
         url = reverse("api:form-logics-list")
 
-        with patch(
-            "openforms.forms.models.form_variable.static_variables_register",
-            new=register,
-        ):
+        with patch("openforms.variables.service.register", new=register):
             response = self.client.post(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
@@ -284,10 +278,7 @@ class VariablesInLogicBulkAPITests(APITestCase):
 
         self.client.force_authenticate(user=user)
         url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
-        with patch(
-            "openforms.forms.models.form_variable.static_variables_register",
-            new=register,
-        ):
+        with patch("openforms.variables.service.register", new=register):
             response = self.client.put(url, data=form_logic_data)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -394,7 +394,7 @@ class FormVariableViewsetTest(APITestCase):
         self.client.force_authenticate(user)
 
         with patch(
-            "openforms.forms.models.form_variable.FormVariable.get_static_data"
+            "openforms.forms.api.serializers.form_variable.get_static_variables"
         ) as m:
             m.return_value = [
                 FormVariable(

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from glom import Assign, PathAccessError, glom
 
 from openforms.forms.models.form_variable import FormVariable
+from openforms.variables.service import get_static_variables
 
 from ..constants import SubmissionValueVariableSources
 from .submission import Submission
@@ -131,7 +132,7 @@ class SubmissionValueVariablesState:
         if self._static_data is None:
             self._static_data = {
                 variable.key: variable.initial_value
-                for variable in FormVariable.get_static_data(self.submission)
+                for variable in get_static_variables(submission=self.submission)
             }
         return self._static_data
 

--- a/src/openforms/variables/service.py
+++ b/src/openforms/variables/service.py
@@ -1,0 +1,31 @@
+"""
+Public Python API to access (static) form variables.
+"""
+from typing import List, Optional
+
+from openforms.forms.models import FormVariable
+from openforms.submissions.models import Submission
+
+from .registry import register_static_variable as register
+
+__all__ = ["get_static_variables"]
+
+
+def get_static_variables(
+    *, submission: Optional[Submission] = None
+) -> List[FormVariable]:
+    """
+    Return the full collection of static variables registered by all apps.
+
+    :param submission: Optional, but recommended - the submission instance to get the
+      variables for. Many of the static variables require the submission for sufficient
+      context to be able to produce a value. Variables are static within that submission
+      context, i.e. they don't change because of filling out the form.
+
+    You should not rely on the order of returned variables, as they are registered in
+    the order the Django apps are loaded - and this may change without notice.
+    """
+    return [
+        registered_variable.get_static_variable(submission=submission)
+        for registered_variable in register
+    ]

--- a/src/openforms/variables/tests/test_views.py
+++ b/src/openforms/variables/tests/test_views.py
@@ -54,10 +54,7 @@ class GetStaticVariablesViewTest(APITestCase):
         register = Registry()
         register("now")(DemoNow)
 
-        with patch(
-            "openforms.forms.models.form_variable.static_variables_register",
-            new=register,
-        ):
+        with patch("openforms.variables.service.register", new=register):
             response = self.client.get(url)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/src/openforms/variables/views.py
+++ b/src/openforms/variables/views.py
@@ -6,8 +6,9 @@ from rest_framework.views import APIView
 
 from openforms.api.serializers import ExceptionSerializer
 from openforms.forms.api.serializers import FormVariableSerializer
-from openforms.forms.models import FormVariable
 from openforms.utils.api.views import ListMixin
+
+from .service import get_static_variables
 
 
 @extend_schema_view(
@@ -26,4 +27,4 @@ class StaticFormVariablesView(ListMixin, APIView):
     serializer_class = FormVariableSerializer
 
     def get_objects(self):
-        return FormVariable.get_static_data()
+        return get_static_variables()


### PR DESCRIPTION
Instead of `FormVariable.get_static_data` (and leaking `Submission` objects into the `forms` app), we can now use `openforms.variables.service.get_static_variables` for a better separation of concerns.