### PR TITLE
Renderer should check front end logic

### DIFF
--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -13,7 +13,7 @@ from openforms.emails.utils import strip_tags_plus  # TODO: put somewhere else
 from openforms.submissions.rendering.constants import RenderModes
 from openforms.utils.urls import build_absolute_uri
 
-from ..utils import iter_components
+from ..utils import is_visible_in_frontend, iter_components
 from .conf import RENDER_CONFIGURATION
 from .nodes import ComponentNode
 from .registry import register
@@ -29,7 +29,8 @@ class ContainerMixin:
         if self.mode == RenderModes.export:
             return True
 
-        if self.component.get("hidden") is True:
+        # We only pass the step data, since frontend logic only has access to the current step data.
+        if not is_visible_in_frontend(self.component, self.step.data):
             return False
 
         render_configuration = RENDER_CONFIGURATION[self.mode]

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -9,7 +9,7 @@ from openforms.submissions.rendering.constants import RenderModes
 
 from ..formatters.service import format_value
 from ..typing import Component
-from ..utils import is_layout_component, iter_components
+from ..utils import is_layout_component, is_visible_in_frontend, iter_components
 
 if TYPE_CHECKING:
     from openforms.submissions.rendering import Renderer
@@ -94,8 +94,9 @@ class ComponentNode(Node):
             return True
 
         # explicitly hidden components never show up. Note that this property can be set
-        # by form logic!
-        if self.component.get("hidden") is True:
+        # by logic rules or by frontend logic!
+        # We only pass the step data, since frontend logic only has access to the current step data.
+        if not is_visible_in_frontend(self.component, self.step.data):
             return False
 
         render_configuration = RENDER_CONFIGURATION[self.mode]

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -163,6 +163,30 @@ class FormNodeTests(TestCase):
                         }
                     ],
                 },
+                # hidden component, made visible by frontend logic, leaf node
+                {
+                    "key": "input14",
+                    "type": "textfield",
+                    "label": "Input 14",
+                    "hidden": True,
+                    "conditional": {
+                        "show": True,
+                        "when": "input1",
+                        "eq": "aaaaa",
+                    },
+                },
+                # visible component, made hidden by frontend logic, leaf node
+                {
+                    "key": "input15",
+                    "type": "textfield",
+                    "label": "Input 15",
+                    "hidden": False,
+                    "conditional": {
+                        "show": False,
+                        "when": "input1",
+                        "eq": "aaaaa",
+                    },
+                },
                 # TODO columns
             ]
         }
@@ -188,6 +212,8 @@ class FormNodeTests(TestCase):
                 {"input13": "ooooo"},
                 {"input13": "ppppp"},
             ],
+            "input14": "qqqqq",
+            "input15": "rrrrr",
         }
 
         submission = SubmissionFactory.from_components(
@@ -294,7 +320,7 @@ class FormNodeTests(TestCase):
             )
             nodelist += list(component_node)
 
-        self.assertEqual(len(nodelist), 16)
+        self.assertEqual(len(nodelist), 18)
         labels = [node.label for node in nodelist]
         # The fieldset/editgrid components have no labels
         self.assertEqual(
@@ -317,6 +343,8 @@ class FormNodeTests(TestCase):
                 "input12",
                 "input13",
                 "input13",
+                "input14",
+                "input15",
             ],
         )
 
@@ -335,7 +363,7 @@ class FormNodeTests(TestCase):
                 )
                 nodelist += list(component_node)
 
-        self.assertEqual(len(nodelist), 9)
+        self.assertEqual(len(nodelist), 10)
         labels = [node.label for node in nodelist]
         expected_labels = [
             "Input 1",
@@ -347,6 +375,7 @@ class FormNodeTests(TestCase):
             "Visible editgrid with visible children",
             "Input 11",
             "Visible editgrid with hidden children",
+            "Input 14",
         ]
         self.assertEqual(labels, expected_labels)
 


### PR DESCRIPTION
If a component is hidden/visible because of frontend logic, render appropriately.