### PR TITLE
[#1896] Primitives and arrays are valid jsonLogic

### DIFF
--- a/src/openforms/js/components/admin/forms/JsonWidget.js
+++ b/src/openforms/js/components/admin/forms/JsonWidget.js
@@ -12,6 +12,28 @@ const jsonFormat = value => {
   return JSON.stringify(value, null, 2);
 };
 
+const isJsonLogic = jsonExpression => {
+  // jsonLogic accepts primitives
+  if (
+    jsonExpression == null || // typeof null -> 'object'
+    typeof jsonExpression === 'string' ||
+    typeof jsonExpression === 'boolean' ||
+    typeof jsonExpression === 'number'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(jsonExpression)) {
+    for (const item of jsonExpression) {
+      const isValid = isJsonLogic(item);
+      if (!isValid) return false;
+    }
+    return true;
+  }
+
+  return jsonLogic.is_logic(jsonExpression);
+};
+
 const JsonWidget = ({name, logic, onChange}) => {
   const intl = useIntl();
   const [jsonError, setJsonError] = useState('');
@@ -48,7 +70,7 @@ const JsonWidget = ({name, logic, onChange}) => {
       }
     }
 
-    if (!jsonLogic.is_logic(updatedJson)) {
+    if (!isJsonLogic(updatedJson)) {
       setJsonError(invalidLogicMessage);
       return;
     }


### PR DESCRIPTION
Fixes #1896 

The json-logic-js function `is_logic` only accepts objects: https://github.com/jwadhams/json-logic-js/blob/master/logic.js#L176 (while if we enter primitive values/arrays in the [play-with-it page](https://jsonlogic.com/play.html) these are accepted).