### PR TITLE
[#1964] File upload broken

### DIFF
--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -205,7 +205,7 @@ class FormVariable(models.Model):
         return _("Form variable '{key}'").format(key=self.key)
 
     def get_initial_value(self):
-        return self.initial_value or None
+        return self.initial_value
 
     def derive_info_from_component(self):
         if self.source != FormVariableSources.component or not self.form_definition:
@@ -213,7 +213,7 @@ class FormVariable(models.Model):
 
         component = get_component(self.form_definition.configuration, self.key)
 
-        if not self.initial_value:
+        if self.initial_value is None:
             self.initial_value = get_component_default_value(component)
 
         self.data_type = get_component_datatype(component)

--- a/src/openforms/forms/tests/variables/test_model.py
+++ b/src/openforms/forms/tests/variables/test_model.py
@@ -93,3 +93,8 @@ class FormVariableModelTests(TestCase):
         self.assertEqual(FormVariableDataTypes.array, variable1.data_type)
         self.assertEqual(FormVariableDataTypes.array, variable2.data_type)
         self.assertEqual(FormVariableDataTypes.array, variable3.data_type)
+
+    def test_variable_with_array_default_value(self):
+        variable = FormVariableFactory.create(initial_value=[])
+
+        self.assertEqual([], variable.get_initial_value())


### PR DESCRIPTION
Part of #1964 

What was happening, is that file uploads with multiple value needs the initial value `[]`. This was correctly set when the form was built. But the function `get_initial_value` of the form variable was doing:

```
def get_initial_value(self):
        return self.initial_value or None
```

which for the empty array was returning None. 

This was then causing the submission endpoint to fail when dealing with the attachments:
```
TypeError: 'NoneType' object is not iterable
...
  File "openforms/submissions/attachments.py", line 279, in resolve_uploads_from_data
    for info in upload_info:
```