### PR TITLE
Making different logic checks/evaluations consistent

### DIFF
--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:  # pragma: nocover
     from openforms.appointments.models import AppointmentInfo
     from openforms.forms.models import Form
     from openforms.plugins.plugin import AbstractBasePlugin
+    from openforms.submissions.logic.rules import EvaluatedRule
     from openforms.submissions.models import (
         Submission,
         SubmissionPayment,
@@ -466,7 +467,7 @@ def submission_export_list(form: "Form", user: "User"):
 
 def submission_logic_evaluated(
     submission: "Submission",
-    evaluated_rules,
+    evaluated_rules: List["EvaluatedRule"],
     initial_data: dict,
     resolved_data: dict,
 ):
@@ -496,7 +497,7 @@ def submission_logic_evaluated(
     }
     for evaluated_rule in evaluated_rules:
 
-        rule = evaluated_rule["rule"]
+        rule = evaluated_rule.rule
         rule_introspection = introspect_json_logic(
             rule.json_logic_trigger, components_map, initial_data
         )
@@ -557,7 +558,7 @@ def submission_logic_evaluated(
             "raw_logic_expression": rule_introspection.expression,
             "readable_rule": rule_introspection.as_string(),
             "targeted_components": targeted_components,
-            "trigger": evaluated_rule["trigger"],
+            "trigger": evaluated_rule.triggered,
         }
 
         evaluated_rules_list.append(evaluated_rule_data)

--- a/src/openforms/logging/tests/test_events.py
+++ b/src/openforms/logging/tests/test_events.py
@@ -1,9 +1,13 @@
+from typing import cast
+
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
+from openforms.forms.models import FormLogic
 from openforms.forms.tests.factories import FormLogicFactory
 from openforms.logging import logevent
 from openforms.logging.models import TimelineLogProxy
+from openforms.submissions.logic.rules import EvaluatedRule
 from openforms.submissions.tests.factories import SubmissionFactory
 
 
@@ -58,15 +62,20 @@ class EventTests(TestCase):
             json_logic_trigger=json_logic_trigger,
             actions=[],
         )
+        rule = cast(FormLogic, rule)
         rule_2 = FormLogicFactory(
             form=submission.form,
             json_logic_trigger=json_logic_trigger_2,
             actions=[],
         )
+        rule_2 = cast(FormLogic, rule_2)
 
         logevent.submission_logic_evaluated(
             submission,
-            [{"rule": rule, "trigger": True}, {"rule": rule_2, "trigger": False}],
+            [
+                EvaluatedRule(rule=rule, triggered=True),
+                EvaluatedRule(rule=rule_2, triggered=False),
+            ],
             submission.data,
             submission.data,
         )

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -1,0 +1,100 @@
+from typing import Iterable, List, Optional
+
+from openforms.forms.models import FormLogic, FormStep
+
+from ..models import Submission, SubmissionStep
+
+
+def _include_rule(form_steps: List[FormStep], rule: FormLogic, step_index: int) -> bool:
+    # rules that always apply
+    if not rule.trigger_from_step:
+        return True
+
+    trigger_from_index = form_steps.index(rule.trigger_from_step)
+    # if the current step is before the trigger-from step, do not include the rule
+    if step_index < trigger_from_index:
+        return False
+
+    return True
+
+
+def get_rules_to_evaluate(
+    submission: Submission, current_step: Optional[SubmissionStep] = None
+) -> Iterable[FormLogic]:
+    """
+    Given a submission, return the logic rules ready for evaluation.
+
+    As a side-effect, the form logic query results are cached on ``submission.form``.
+
+    :arg submission: A submission instance to retrieve the rules for
+    :arg current_step: The (optional) step at which the rules need to be evaluated. If
+      not provided, the step following the last completed step is used, or the first
+      step in the form if there are no completed steps.
+    :returns: An iterable of :class`openforms.forms.models.FormLogic` instances. This
+      may be a queryset, but could also be a list. Typically cached on the form instance
+      for performance reasons.
+    """
+    # some callers evaluate logic for all steps at once, so we can avoid repeated queries
+    # by caching the rules on the form instance.
+    # Note that form.formlogic_set.all() is never cached by django, so we can't rely
+    # on that.
+    rules = getattr(submission.form, "_cached_logic_rules", None)
+    if rules is None:
+        rules = FormLogic.objects.select_related("trigger_from_step").filter(
+            form=submission.form
+        )
+        submission.form._cached_logic_rules = rules
+
+    submission_state = submission.load_execution_state()
+    # if there are no form steps, there is no usable form -> there are no logic rules
+    # to evaluate
+    if not submission_state.form_steps:
+        return []
+
+    # filter down the rules that are only applicable in the current step context
+    current_step = current_step or get_current_step(submission)
+    step_index = (
+        submission_state.form_steps.index(current_step.form_step)
+        if current_step
+        else -1
+    )
+
+    return [
+        rule
+        for rule in rules
+        if _include_rule(submission_state.form_steps, rule, step_index)
+    ]
+
+
+def get_current_step(submission: Submission) -> Optional[SubmissionStep]:
+    """
+    Obtain what the 'current step' of a submission is.
+
+    The current step is defined as the step following the last completed step. Note
+    that this does not evaluate any logic, so if this step happens to be made
+    not-applicable dynamically, it will still be returned.
+
+    If the last completed step is the last step in the form, then this step is returned.
+
+    :arg submission: The submission instance to get the current step for.
+    :returns: None if there are no steps in the form, otherwise the first submission
+      step that isn't completed.
+    """
+    submission_state = submission.load_execution_state()
+    if not submission_state.form_steps:
+        return
+
+    last_completed_step = submission_state.get_last_completed_step()
+    # no steps completed -> current index is first step: 0
+    if last_completed_step is None:
+        current_index = 0
+    else:
+        last_completed_step_index = submission_state.form_steps.index(
+            last_completed_step.form_step
+        )
+        current_index = min(
+            last_completed_step_index + 1, len(submission_state.form_steps) - 1
+        )
+
+    step = submission_state.submission_steps[current_index]
+    return step

--- a/src/openforms/submissions/tests/test_admin.py
+++ b/src/openforms/submissions/tests/test_admin.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import patch
 
 from django.urls import reverse
@@ -13,11 +14,12 @@ from openforms.accounts.tests.factories import (
     SuperUserFactory,
     UserFactory,
 )
-from openforms.forms.models import FormVariable
+from openforms.forms.models import FormLogic, FormVariable
 from openforms.forms.tests.factories import FormLogicFactory
 from openforms.logging import logevent
 from openforms.logging.logevent import submission_start
 from openforms.logging.models import TimelineLogProxy
+from openforms.submissions.logic.rules import EvaluatedRule
 from openforms.tests.utils import disable_2fa
 
 from ..constants import RegistrationStatuses
@@ -244,7 +246,7 @@ class LogicLogsAdminTests(WebTest):
 
         logevent.submission_logic_evaluated(
             self.submission,
-            [{"rule": rule, "trigger": True}],
+            [EvaluatedRule(rule=cast(FormLogic, rule), triggered=False)],
             merged_data,
             merged_data,
         )


### PR DESCRIPTION
Fixes #1913

We have two variants of logic checks:

1. Running explicitly in the context of a form step
2. Running on the submission as a whole

The second one did not take into account recent features such as:

* variables (static, user defined)
* logic actions changing values of variables that are used in other rules' trigger
* disabling of step-submission

**TODO**

Refactor the code to avoid the repetition and properly abstract this away:

- handle logging the evaluation
- handle skipping certain logic actions (formio configuration is not relevant for flavour 2)