### PR TITLE
[#1964] Don't log a success message if no prefill data is retrieved

### DIFF
--- a/src/openforms/prefill/__init__.py
+++ b/src/openforms/prefill/__init__.py
@@ -67,7 +67,8 @@ def _fetch_prefill_values(
             logevent.prefill_retrieve_failure(submission, plugin, e)
             return plugin_id, {}
         else:
-            logevent.prefill_retrieve_success(submission, plugin, fields)
+            if values:
+                logevent.prefill_retrieve_success(submission, plugin, fields)
             return plugin_id, values
 
     with parallel() as executor:


### PR DESCRIPTION
Part of #1964

This is really a bandaid: to fix this properly this https://github.com/open-formulieren/open-forms/issues/1891 needs to be tackled, so the _fetch_prefill_values can properly log successes/failures