### PR TITLE
Explicit handling of deactivated/maintenance forms

### DIFF
--- a/src/openforms/api/exceptions.py
+++ b/src/openforms/api/exceptions.py
@@ -26,3 +26,15 @@ class RequestEntityTooLarge(APIException):
     status_code = 413  # does not exist in rest_framework.status
     default_detail = _("Request entity too large")
     default_code = "request_entity_too_large"
+
+
+class UnprocessableEntity(APIException):
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    default_detail = _("Request understood and validated, but cannot be processed.")
+    default_code = "unprocessable_entity"
+
+
+class ServiceUnavailable(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = _("Service is not available.")
+    default_code = "service_unavailable"

--- a/src/openforms/authentication/tasks.py
+++ b/src/openforms/authentication/tasks.py
@@ -1,0 +1,9 @@
+from openforms.celery import app
+
+
+@app.task(ignore_result=True)
+def hash_identifying_attributes(auth_info_id: int):
+    from .models import AuthInfo
+
+    auth_info = AuthInfo.objects.get(id=auth_info_id)
+    auth_info.hash_identifying_attributes()

--- a/src/openforms/authentication/tests/test_tasks.py
+++ b/src/openforms/authentication/tests/test_tasks.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from ..tasks import hash_identifying_attributes
+from .factories import AuthInfoFactory
+
+
+class HashIdentifyingAttributesTaskTests(TestCase):
+    @patch("openforms.authentication.models.hash_identifying_attributes_task")
+    def test_model_method_sync(self, mock_hash_task):
+        auth_info = AuthInfoFactory.create()
+
+        auth_info.hash_identifying_attributes()
+
+        mock_hash_task.delay.assert_not_called()
+        self.assertTrue(auth_info.attribute_hashed)
+
+    @patch("openforms.authentication.models.hash_identifying_attributes_task")
+    def test_model_method_async(self, mock_hash_task):
+        auth_info = AuthInfoFactory.create()
+
+        auth_info.hash_identifying_attributes(delay=True)
+
+        mock_hash_task.delay.assert_called_once_with(auth_info.id)
+        self.assertFalse(auth_info.attribute_hashed)
+
+    def test_task_function(self):
+        auth_info = AuthInfoFactory.create()
+
+        hash_identifying_attributes(auth_info.id)
+
+        auth_info.refresh_from_db()
+        self.assertTrue(auth_info.attribute_hashed)

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -273,6 +273,15 @@ class Form(models.Model):
         else:
             return self.admin_name
 
+    @property
+    def is_available(self) -> bool:
+        """
+        Soft deleted, deactivated or forms in maintenance mode are not available.
+        """
+        if any((self._is_deleted, not self.active, self.maintenance_mode)):
+            return False
+        return True
+
     def get_absolute_url(self):
         return reverse("forms:form-detail", kwargs={"slug": self.slug})
 

--- a/src/openforms/forms/validators.py
+++ b/src/openforms/forms/validators.py
@@ -38,14 +38,6 @@ def validate_formio_js_schema(value: dict):
         )
 
 
-def validate_not_maintainance_mode(form):
-    if form.maintenance_mode:
-        raise ValidationError(
-            _("Form is in maintenance mode."),
-            code="invalid",
-        )
-
-
 def validate_not_deleted(form):
     if form._is_deleted:
         raise ValidationError(

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -19,10 +19,7 @@ from openforms.emails.utils import render_email_template, send_mail_html
 from openforms.forms.api.serializers import FormDefinitionSerializer
 from openforms.forms.constants import SubmissionAllowedChoices
 from openforms.forms.models import FormStep
-from openforms.forms.validators import (
-    validate_not_deleted,
-    validate_not_maintainance_mode,
-)
+from openforms.forms.validators import validate_not_deleted
 
 from ...utils.urls import build_absolute_uri
 from ..attachments import validate_uploads
@@ -31,7 +28,7 @@ from ..form_logic import check_submission_logic, evaluate_form_logic
 from ..models import Submission, SubmissionStep, TemporaryFileUpload
 from ..tokens import submission_resume_token_generator
 from .fields import NestedRelatedField
-from .validators import ValidatePrefillData
+from .validators import FormMaintenanceModeValidator, ValidatePrefillData
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +185,7 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
                 "lookup_field": "uuid",
                 "lookup_url_kwarg": "uuid_or_slug",
                 "validators": [
-                    validate_not_maintainance_mode,
+                    FormMaintenanceModeValidator(),
                     validate_not_deleted,
                 ],
             },

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -120,7 +120,10 @@ class SubmissionViewSet(
                 check_form_status(self.request, submission.form)
             except FormDeactivated:
                 remove_submission_from_session(submission, self.request.session)
-                # TODO: hash auth attributes of submission?
+                if submission.is_authenticated:
+                    # do this async, as the transaction is rolled back because of the raised
+                    # exception.
+                    submission.auth_info.hash_identifying_attributes(delay=True)
                 raise
 
             self._get_object_cache = submission
@@ -428,7 +431,10 @@ class SubmissionStepViewSet(
             check_form_status(self.request, submission.form)
         except FormDeactivated:
             remove_submission_from_session(submission, self.request.session)
-            # TODO: hash auth attributes of submission?
+            if submission.is_authenticated:
+                # do this async, as the transaction is rolled back because of the raised
+                # exception.
+                submission.auth_info.hash_identifying_attributes(delay=True)
             raise
 
         return submission_step

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 from typing import Tuple
 
@@ -10,6 +11,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema
 from rest_framework import authentication, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
@@ -60,6 +62,19 @@ from .serializers import (
 from .validation import CompletionValidationSerializer, validate_submission_completion
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def cleanup_deactivated_form_session(request: Request, submission: Submission):
+    try:
+        yield
+    except FormDeactivated:
+        remove_submission_from_session(submission, request.session)
+        if submission.is_authenticated:
+            # do this async, as the transaction is rolled back because of the raised
+            # exception.
+            submission.auth_info.hash_identifying_attributes(delay=True)
+        raise
 
 
 @extend_schema_view(
@@ -116,15 +131,8 @@ class SubmissionViewSet(
         if not hasattr(self, "_get_object_cache"):
             submission = super().get_object()
 
-            try:
+            with cleanup_deactivated_form_session(self.request, submission):
                 check_form_status(self.request, submission.form)
-            except FormDeactivated:
-                remove_submission_from_session(submission, self.request.session)
-                if submission.is_authenticated:
-                    # do this async, as the transaction is rolled back because of the raised
-                    # exception.
-                    submission.auth_info.hash_identifying_attributes(delay=True)
-                raise
 
             self._get_object_cache = submission
             # on the fly, calculate the price if it's not set yet (required for overview screen)
@@ -427,15 +435,8 @@ class SubmissionStepViewSet(
         self.check_object_permissions(self.request, submission_step)
 
         submission = submission_step.submission
-        try:
+        with cleanup_deactivated_form_session(self.request, submission):
             check_form_status(self.request, submission.form)
-        except FormDeactivated:
-            remove_submission_from_session(submission, self.request.session)
-            if submission.is_authenticated:
-                # do this async, as the transaction is rolled back because of the raised
-                # exception.
-                submission.auth_info.hash_identifying_attributes(delay=True)
-            raise
 
         return submission_step
 

--- a/src/openforms/submissions/exceptions.py
+++ b/src/openforms/submissions/exceptions.py
@@ -9,4 +9,5 @@ class FormDeactivated(UnprocessableEntity):
 
 
 class FormMaintenance(ServiceUnavailable):
-    pass
+    default_detail = _("The form is currently disabled for maintenance.")
+    default_code = "form-maintenance"

--- a/src/openforms/submissions/exceptions.py
+++ b/src/openforms/submissions/exceptions.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from openforms.api.exceptions import ServiceUnavailable, UnprocessableEntity
+
+
+class FormDeactivated(UnprocessableEntity):
+    default_detail = _("The form is deactivated.")
+    default_code = "form-inactive"
+
+
+class FormMaintenance(ServiceUnavailable):
+    pass

--- a/src/openforms/submissions/templates/submissions/resume_form_error.html
+++ b/src/openforms/submissions/templates/submissions/resume_form_error.html
@@ -1,6 +1,29 @@
 {% extends "core/views/form/form_detail.html" %}
+{% load i18n %}
 
 {% block card %}
-    {# TODO: style #}
-    HTTP {{ error.status_code }} - {{ error.detail }} ({{ error.detail.code }})
+<div class="card">
+    <header class="card__header">
+        <h1 class="title">
+            {% if error.detail.code == 'form-inactive' %}
+                {% trans "Sorry - this form is no longer available" %}
+            {% elif error.detail.code == 'form-maintenance' %}
+                {% trans "Form temporarily unavailable" %}
+            {% endif %}
+        </h1>
+    </header>
+
+    <div class="card__body">
+        {% if error.detail.code == 'form-inactive' %}
+            {% blocktrans trimmed %}
+                Unfortunately, this form is no longer in use. We apologise for any
+                inconveniences.
+            {% endblocktrans %}
+        {% elif error.detail.code == 'form-maintenance' %}
+            {% blocktrans trimmed %}
+                This form is currently undergoing maintenance. Please try again later.
+            {% endblocktrans %}
+        {% endif %}
+    </div>
+</div>
 {% endblock %}

--- a/src/openforms/submissions/templates/submissions/resume_form_error.html
+++ b/src/openforms/submissions/templates/submissions/resume_form_error.html
@@ -1,0 +1,6 @@
+{% extends "core/views/form/form_detail.html" %}
+
+{% block card %}
+    {# TODO: style #}
+    HTTP {{ error.status_code }} - {{ error.detail }} ({{ error.detail.code }})
+{% endblock %}

--- a/src/openforms/submissions/tests/test_disabled_forms.py
+++ b/src/openforms/submissions/tests/test_disabled_forms.py
@@ -101,7 +101,7 @@ class InactiveFormTests(SubmissionsMixin, APITestCase):
         step = self.form.formstep_set.get()
         self._add_submission_to_session(submission)
         endpoint = reverse(
-            "api:submission-steps-validate",
+            "api:submission-steps-logic-check",
             kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
         )
         body = {"data": {}}
@@ -220,7 +220,315 @@ class InactiveFormStaffUserTests(InactiveFormTests):
     ALLOWED_HOSTS=["*"],
     CORS_ALLOWED_ORIGINS=["http://testserver.com"],
 )
-class MaintenanceFormTests(SubmissionsMixin, APITestCase):
+class MaintenanceFormAnonUserTests(SubmissionsMixin, APITestCase):
     """
     Tests for forms in maintenance mode.
     """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.form = FormFactory.create(
+            generate_minimal_setup=True, active=True, maintenance_mode=True
+        )
+        cls.form_url = reverse(
+            "api:form-detail", kwargs={"uuid_or_slug": cls.form.uuid}
+        )
+
+    def test_retrieve_form_detail(self):
+        form_detail = self.client.get(self.form_url)
+
+        self.assertEqual(form_detail.status_code, status.HTTP_200_OK)
+
+    def test_cannot_start_submission(self):
+        submissions_url = reverse("api:submission-list")
+        body = {
+            "form": f"http://testserver.com{self.form_url}",
+            "formUrl": "http://testserver.com/my-form",
+        }
+
+        response = self.client.post(submissions_url, body)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = response.json()["invalidParams"][0]
+        self.assertEqual(error["name"], "form")
+        self.assertEqual(error["code"], "form-maintenance")
+
+    def test_cannot_validate_step_data(self):
+        """
+        Assert that step data validation returns HTTP 422 for deactivated forms.
+
+        This shortcuts and improves user experience - if the step data is invalid,
+        there's no point in providing that feedback and having the user correct the
+        mistakes if the next action (submit) just leads to another error that the form
+        is no longer available.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.post(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        error = response.json()
+        self.assertEqual(error["code"], "form-maintenance")
+
+    def test_cannot_logic_check_step_data(self):
+        """
+        Assert that step data logic check returns HTTP 422 for deactivated forms.
+
+        This shortcuts and improves user experience - if the step data is invalid,
+        there's no point in providing that feedback and having the user correct the
+        mistakes if the next action (submit) just leads to another error that the form
+        is no longer available.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.post(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        error = response.json()
+        self.assertEqual(error["code"], "form-maintenance")
+
+    def test_cannot_submit_step_data(self):
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.put(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        error = response.json()
+        self.assertEqual(error["code"], "form-maintenance")
+
+    def test_cannot_complete_submission(self):
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        SubmissionStepFactory.create(submission=submission, form_step=step, data={})
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        error = response.json()
+        self.assertEqual(error["code"], "form-maintenance")
+
+    def test_cannot_suspend_submission(self):
+        submission = SubmissionFactory.create(form=self.form)
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-suspend", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint, {"email": "foo@bar.com"})
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        error = response.json()
+        self.assertEqual(error["code"], "form-maintenance")
+
+    def test_resume_submission(self):
+        """
+        Test that resuming a form that has been deactivated is not possible.
+
+        It's possible a submission is suspended while the form is still active,
+        but time passes and by the time the submission is resumed, the form has been
+        deactivated.
+
+        The resume page should then display an error instead of redirecting to the
+        UI/frontend.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        endpoint = reverse(
+            "submissions:resume",
+            kwargs={
+                "token": submission_resume_token_generator.make_token(submission),
+                "submission_uuid": submission.uuid,
+            },
+        )
+
+        response = self.client.get(endpoint)
+
+        # _not_ 301/302/30x redirect
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertTemplateUsed(response, "submissions/resume_form_error.html")
+
+
+class MaintenanceFormAuthenticatedUserTests(MaintenanceFormAnonUserTests):
+    """
+    Authenticated but non-staff users get the same behaviour as anonymous users.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = UserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_authenticate(user=self.user)
+
+    def test_resume_submission(self):
+        self.client.force_login(user=self.user)
+        super().test_resume_submission()
+
+
+@tag("gh-1967")
+@override_settings(
+    CORS_ALLOW_ALL_ORIGINS=False,
+    ALLOWED_HOSTS=["*"],
+    CORS_ALLOWED_ORIGINS=["http://testserver.com"],
+)
+class MaintenanceFormStaffUserTests(SubmissionsMixin, APITestCase):
+    """
+    Tests for forms in maintenance mode.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = StaffUserFactory.create()
+        cls.form = FormFactory.create(
+            generate_minimal_setup=True, active=True, maintenance_mode=True
+        )
+        cls.form_url = reverse(
+            "api:form-detail", kwargs={"uuid_or_slug": cls.form.uuid}
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_authenticate(user=self.user)
+
+    def test_retrieve_form_detail(self):
+        form_detail = self.client.get(self.form_url)
+
+        self.assertEqual(form_detail.status_code, status.HTTP_200_OK)
+
+    def test_can_start_submission(self):
+        submissions_url = reverse("api:submission-list")
+        body = {
+            "form": f"http://testserver.com{self.form_url}",
+            "formUrl": "http://testserver.com/my-form",
+        }
+
+        response = self.client.post(submissions_url, body)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_can_validate_step_data(self):
+        """
+        Assert that step data validation returns HTTP 422 for deactivated forms.
+
+        This shortcuts and improves user experience - if the step data is invalid,
+        there's no point in providing that feedback and having the user correct the
+        mistakes if the next action (submit) just leads to another error that the form
+        is no longer available.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.post(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_can_logic_check_step_data(self):
+        """
+        Assert that step data logic check returns HTTP 422 for deactivated forms.
+
+        This shortcuts and improves user experience - if the step data is invalid,
+        there's no point in providing that feedback and having the user correct the
+        mistakes if the next action (submit) just leads to another error that the form
+        is no longer available.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.post(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_can_submit_step_data(self):
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.put(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_can_complete_submission(self):
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        SubmissionStepFactory.create(submission=submission, form_step=step, data={})
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_can_suspend_submission(self):
+        submission = SubmissionFactory.create(form=self.form)
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-suspend", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint, {"email": "foo@bar.com"})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_resume_submission(self):
+        """
+        Test that resuming a form that has been deactivated is not possible.
+
+        It's possible a submission is suspended while the form is still active,
+        but time passes and by the time the submission is resumed, the form has been
+        deactivated.
+
+        The resume page should then display an error instead of redirecting to the
+        UI/frontend.
+        """
+        self.client.force_login(user=self.user)
+        submission = SubmissionFactory.create(form=self.form)
+        endpoint = reverse(
+            "submissions:resume",
+            kwargs={
+                "token": submission_resume_token_generator.make_token(submission),
+                "submission_uuid": submission.uuid,
+            },
+        )
+
+        response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)

--- a/src/openforms/submissions/tests/test_disabled_forms.py
+++ b/src/openforms/submissions/tests/test_disabled_forms.py
@@ -1,0 +1,226 @@
+"""
+Forms can be disabled in one of two ways:
+
+* active=False -> the form is disabled for everyone, including admin users
+* maintenance=True -> the form is disabled for regular users, but admin users can still
+  use the form
+
+Maintenance mode is communicated using HTTP 503 - it's temporarily unavailable.
+
+De-activated is communicated using HTTP 422 (Unprocessable Entity) - the client did not
+expect the form to be deactivated. See also https://stackoverflow.com/a/62450708
+Other contenders are HTTP 409 (conflict) and HTTP 410 (Gone), but the client cannot
+resolve the 409, and it's not the submission/step resource itself that's gone, but
+the form it belongs to.
+"""
+from django.test import override_settings, tag
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
+from openforms.forms.tests.factories import FormFactory
+
+from ..tokens import submission_resume_token_generator
+from .factories import SubmissionFactory, SubmissionStepFactory
+from .mixins import SubmissionsMixin
+
+
+@tag("gh-1967")
+@override_settings(
+    CORS_ALLOW_ALL_ORIGINS=False,
+    ALLOWED_HOSTS=["*"],
+    CORS_ALLOWED_ORIGINS=["http://testserver.com"],
+)
+class InactiveFormTests(SubmissionsMixin, APITestCase):
+    """
+    Tests for forms that are not active.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.form = FormFactory.create(generate_minimal_setup=True, active=False)
+        cls.form_url = reverse(
+            "api:form-detail", kwargs={"uuid_or_slug": cls.form.uuid}
+        )
+
+    def test_retrieve_form_detail(self):
+        form_detail = self.client.get(self.form_url)
+
+        self.assertEqual(form_detail.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cannot_start_submission(self):
+        submissions_url = reverse("api:submission-list")
+        body = {
+            "form": f"http://testserver.com{self.form_url}",
+            "formUrl": "http://testserver.com/my-form",
+        }
+
+        response = self.client.post(submissions_url, body)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        error = response.json()
+        self.assertEqual(error["code"], "form-inactive")
+
+    def test_cannot_validate_step_data(self):
+        """
+        Assert that step data validation returns HTTP 422 for deactivated forms.
+
+        This shortcuts and improves user experience - if the step data is invalid,
+        there's no point in providing that feedback and having the user correct the
+        mistakes if the next action (submit) just leads to another error that the form
+        is no longer available.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.post(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        error = response.json()
+        self.assertEqual(error["code"], "form-inactive")
+
+    def test_cannot_logic_check_step_data(self):
+        """
+        Assert that step data logic check returns HTTP 422 for deactivated forms.
+
+        This shortcuts and improves user experience - if the step data is invalid,
+        there's no point in providing that feedback and having the user correct the
+        mistakes if the next action (submit) just leads to another error that the form
+        is no longer available.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.post(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        error = response.json()
+        self.assertEqual(error["code"], "form-inactive")
+
+    def test_cannot_submit_step_data(self):
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        body = {"data": {}}
+
+        response = self.client.put(endpoint, body)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        error = response.json()
+        self.assertEqual(error["code"], "form-inactive")
+
+    def test_cannot_complete_submission(self):
+        submission = SubmissionFactory.create(form=self.form)
+        step = self.form.formstep_set.get()
+        SubmissionStepFactory.create(submission=submission, form_step=step, data={})
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        error = response.json()
+        self.assertEqual(error["code"], "form-inactive")
+
+    def test_cannot_suspend_submission(self):
+        submission = SubmissionFactory.create(form=self.form)
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-suspend", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint, {"email": "foo@bar.com"})
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        error = response.json()
+        self.assertEqual(error["code"], "form-inactive")
+
+    def test_resume_submission(self):
+        """
+        Test that resuming a form that has been deactivated is not possible.
+
+        It's possible a submission is suspended while the form is still active,
+        but time passes and by the time the submission is resumed, the form has been
+        deactivated.
+
+        The resume page should then display an error instead of redirecting to the
+        UI/frontend.
+        """
+        submission = SubmissionFactory.create(form=self.form)
+        endpoint = reverse(
+            "submissions:resume",
+            kwargs={
+                "token": submission_resume_token_generator.make_token(submission),
+                "submission_uuid": submission.uuid,
+            },
+        )
+
+        response = self.client.get(endpoint)
+
+        # _not_ 301/302/30x redirect
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTemplateUsed(response, "submissions/resume_form_error.html")
+
+
+class InactiveFormAuthenticatedUserTests(InactiveFormTests):
+    """
+    Identical tests, but with an authenticated non-staff user.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = UserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_authenticate(user=self.user)
+
+
+class InactiveFormStaffUserTests(InactiveFormTests):
+    """
+    Identical tests, but with an authenticated non-staff user.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.user = StaffUserFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_authenticate(user=self.user)
+
+    def test_retrieve_form_detail(self):
+        form_detail = self.client.get(self.form_url)
+
+        self.assertEqual(form_detail.status_code, status.HTTP_200_OK)
+
+
+@tag("gh-1967")
+@override_settings(
+    CORS_ALLOW_ALL_ORIGINS=False,
+    ALLOWED_HOSTS=["*"],
+    CORS_ALLOWED_ORIGINS=["http://testserver.com"],
+)
+class MaintenanceFormTests(SubmissionsMixin, APITestCase):
+    """
+    Tests for forms in maintenance mode.
+    """

--- a/src/openforms/submissions/tests/test_start_submission.py
+++ b/src/openforms/submissions/tests/test_start_submission.py
@@ -8,7 +8,10 @@ Functional requirements are:
 
 * multiple submissions for the same flow must be able to exist at the same time
 * data of different submissions should not affect each other
-* "login" makes no sense, as we are usually dealing with anonymous users
+* "login" usually is not releavnt, as we mostly deal with anonymous users. However,
+  some plugins/functionality is limited to staff users.
+
+See ``test_disabled_forms.py`` for more extensive tests around maintenance mode.
 """
 from django.test import override_settings
 
@@ -129,20 +132,6 @@ class SubmissionStartTests(APITestCase):
         submission = Submission.objects.get()
         self.assertEqual(submission.auth_info.value, "123456782")
         self.assertEqual(submission.auth_info.plugin, "digid")
-
-    def test_start_submission_in_maintenance_mode(self):
-        form = FormFactory.create(maintenance_mode=True)
-        FormStepFactory.create(form=form)
-
-        form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
-        body = {
-            "form": f"http://testserver.com{form_url}",
-            "formUrl": "http://testserver.com/my-form",
-        }
-
-        response = self.client.post(self.endpoint, body)
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_start_submission_on_deleted_form(self):
         form = FormFactory.create(deleted_=True)

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -108,29 +108,6 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
         self.assertNotIn(str(submission.uuid), submissions_in_session)
         self.assertEqual(submissions_in_session, [])
 
-    @freeze_time("2020-12-11T10:53:19+01:00")
-    def test_complete_submission_in_maintenance_mode(self):
-        form = FormFactory.create(maintenance_mode=True)
-        step1 = FormStepFactory.create(form=form, optional=False)
-        step2 = FormStepFactory.create(form=form, optional=False)
-        submission = SubmissionFactory.create(form=form)
-        SubmissionStepFactory.create(
-            submission=submission, form_step=step1, data={"foo": "bar"}
-        )
-        SubmissionStepFactory.create(
-            submission=submission, form_step=step2, data={"foo": "bar"}
-        )
-        self._add_submission_to_session(submission)
-        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
-
-        response = self.client.post(endpoint)
-
-        # TODO: in the near future this will become HTTP_200_OK again, see
-        # :meth:`test_complete_submission`
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        submission.refresh_from_db()
-        self.assertEqual(submission.completed_on, timezone.now())
-
     def test_submit_form_with_not_applicable_step(self):
         form = FormFactory.create()
         step1 = FormStepFactory.create(

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -224,8 +224,6 @@ def check_form_status(
         return
 
     if not form.active:
-        # TODO: clear submission from session!
-        # TODO: hash auth attributes of submission?
         raise FormDeactivated()
 
     # do not clear the submission from the session, as maintenance mode is supposed

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -4,7 +4,6 @@ from typing import Any, Union
 from django.conf import settings
 from django.contrib.sessions.backends.base import SessionBase
 from django.http import HttpRequest
-from django.utils.translation import gettext as _
 
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
@@ -226,4 +225,10 @@ def check_form_status(
 
     if not form.active:
         # TODO: clear submission from session!
+        # TODO: hash auth attributes of submission?
         raise FormDeactivated()
+
+    # do not clear the submission from the session, as maintenance mode is supposed
+    # to pass after a while
+    if form.maintenance_mode and not request.user.is_staff:
+        raise FormMaintenance()

--- a/src/openforms/submissions/views.py
+++ b/src/openforms/submissions/views.py
@@ -140,11 +140,14 @@ class ResumeSubmissionView(ResumeFormMixin, RedirectView):
 
     def get_form_resume_url(self, submission: Submission) -> str:
         form_resume_url = furl(submission.form_url)
+
+        state = submission.load_execution_state()
+        last_completed_step = state.get_last_completed_step()
+        target_step = last_completed_step or state.submission_steps[0]
+
         # furl adds paths with the /= operator
         form_resume_url /= "stap"
-        form_resume_url /= (
-            submission.get_last_completed_step().form_step.form_definition.slug
-        )
+        form_resume_url /= target_step.form_step.form_definition.slug
         # Add the submission uuid to the query param
         form_resume_url.add({"submission_uuid": submission.uuid})
         return form_resume_url.url

--- a/src/openforms/variables/rendering/nodes.py
+++ b/src/openforms/variables/rendering/nodes.py
@@ -31,9 +31,13 @@ class VariablesNode(Node):
     @property
     def variables(self):
         if not self._variables:
-            self._variables = self.submission.submissionvaluevariable_set.filter(
-                form_variable__source=FormVariableSources.user_defined
-            ).select_related("form_variable")
+            self._variables = (
+                self.submission.submissionvaluevariable_set.filter(
+                    form_variable__source=FormVariableSources.user_defined
+                )
+                .select_related("form_variable")
+                .order_by("pk")
+            )
         return self._variables
 
     def render(self) -> str:


### PR DESCRIPTION
Contributes to #1967

This PR implements the API behaviour that can be detected by the SDK to display appropriate error messages.

**Progress**

- [x] Tests for deactivated forms
    - [x] Anonymous users
    - [x] Authenticated (but not staff) users
    - [x] Authenticated staff users
- [x] Implement HTTP 422 for deactivated forms
- [x] Implement resume-submission error page for deactivated forms
- [x] Remove existing submission from session for deactivated forms
- [x] Hash auth attributes for deactived form submissions
- [x] Tests for maintenance mode forms
    - [x] Anonymous users
    - [x] Authenticated (but not staff) users
    - [x] Authenticated staff users
- [x] Implement HTTP 503 for maintenance forms
- [x] Implement resume-submission HTTP 503 error page for maintenance forms