### PR TITLE
Add datatype for repeating group component

### DIFF
--- a/src/openforms/formio/constants.py
+++ b/src/openforms/formio/constants.py
@@ -8,4 +8,5 @@ COMPONENT_DATATYPES = {
     "selectboxes": "object",
     "npFamilyMembers": "object",
     "map": "array",
+    "editgrid": "array",
 }

--- a/src/openforms/js/components/admin/form_design/variables/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/constants.js
@@ -10,6 +10,7 @@ const COMPONENT_DATATYPES = {
   selectboxes: 'object',
   npFamilyMembers: 'object',
   map: 'array',
+  editgrid: 'array',
 };
 
 const DATATYPES_CHOICES = [


### PR DESCRIPTION
Noticed that the repeating groups had data type 'string' while they are arrays