### PR TITLE
:zap: Optimizing API endpoints

### DIFF
--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -92,7 +92,7 @@ CACHES.update(
 # Library settings
 #
 
-ELASTIC_APM["DEBUG"] = True
+ELASTIC_APM["DEBUG"] = config("DISABLE_APM_IN_DEV", default=True)
 
 # Django debug toolbar
 INSTALLED_APPS += ["debug_toolbar", "ddt_api_calls"]

--- a/src/openforms/formio/dynamic_config/date.py
+++ b/src/openforms/formio/dynamic_config/date.py
@@ -1,6 +1,6 @@
 import operator
 from datetime import datetime, time
-from typing import Literal, Optional, TypedDict, cast
+from typing import Literal, Optional, TypedDict, Union, cast
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -113,12 +113,15 @@ class DateComponent(BasePlugin):
         assert config["mode"] == "relativeToVariable"
 
         base_value = cast(
-            Optional[datetime],
+            Optional[Union[datetime, str]],
             glom(data, config["variable"], default=None),
         )
-        # can't do calculations on values that don't exist
-        if base_value is None:
+        # can't do calculations on values that don't exist or are empty
+        if not base_value:
             return None
+
+        # if it's not empty-ish, it's a datetime
+        base_value = cast(datetime, base_value)
 
         assert (
             base_value.tzinfo is not None

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -328,6 +328,8 @@ class Form(models.Model):
 
     @property
     def login_required(self) -> bool:
+        # TODO: check if we have a prefetch cache, otherwise fall back to a simpler
+        # query with .exists()
         return any(
             [
                 form_step.form_definition.login_required

--- a/src/openforms/registrations/contrib/microsoft_graph/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/tests/test_backend.py
@@ -45,18 +45,29 @@ class MSGraphRegistrationBackendTests(TestCase):
     def test_submission(self, upload_mock):
         data = {"foo": "bar", "some_list": ["value1", "value2"]}
 
-        submission = SubmissionFactory.create(
+        components = [
+            {
+                "key": "foo",
+                "type": "textfield",
+            },
+            {
+                "key": "some_list",
+                "type": "textfield",
+                "multiple": True,
+            },
+        ]
+        submission = SubmissionFactory.from_components(
+            components,
+            data,
             completed=True,
+            with_report=True,
             form__name="MyName",
             form__internal_name="MyInternalName: with (extra)",
             form__registration_backend="microsoft-graph",
             form__product__price=Decimal("11.35"),
             form__payment_backend="demo",
         )
-        submission_step = SubmissionStepFactory.create(submission=submission, data=data)
-        submission.save()
-
-        SubmissionReportFactory.create(submission=submission)
+        submission_step = submission.steps[0]
         SubmissionFileAttachmentFactory.create(
             submission_step=submission_step,
             file_name="my-foo.bin",

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
@@ -964,13 +964,15 @@ class ObjectsAPIBackendTests(TestCase):
                 "tussenvoegsel": "de",
                 "geboortedatum": "2000-12-31",
             },
+            completed=True,
         )
+        submission_step = submission.steps[0]
 
         SubmissionFileAttachmentFactory.create(
-            submission_step__submission=submission, file_name="attachment1.jpg"
+            submission_step=submission_step, file_name="attachment1.jpg"
         )
         SubmissionFileAttachmentFactory.create(
-            submission_step__submission=submission, file_name="attachment2.jpg"
+            submission_step=submission_step, file_name="attachment2.jpg"
         )
 
         mock_service_oas_get(m, "https://objecten.nl/api/v1/", "objecten")

--- a/src/openforms/submissions/api/permissions.py
+++ b/src/openforms/submissions/api/permissions.py
@@ -50,7 +50,8 @@ class FormAuthenticationPermission(permissions.BasePermission):
     def has_object_permission(
         self, request: Request, view: APIView, step: SubmissionStep
     ) -> bool:
-        login_required = step.submission.form.login_required
+        # ⚡️ form_login_required leverages the optimized viewset query
+        login_required = step.submission.form_login_required
         if not login_required:
             return True
         return step.submission.is_authenticated

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -49,10 +49,8 @@ class Renderer:
         """
         Return the submission steps in the correct order.
         """
-        steps_qs = self.submission.submissionstep_set.select_related(
-            "form_step", "form_step__form_definition"
-        ).order_by("form_step__order")
-        return steps_qs
+        execution_state = self.submission.load_execution_state()
+        return [step for step in execution_state.submission_steps if step.pk]
 
     @property
     def has_children(self) -> bool:

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -161,6 +161,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
 
         # When the submission was initially created, the method calculate_price has already
         # loaded the submission_value_variables_state, but no submission variables existed at that point.
+        submission.load_execution_state(refresh=True)
         submission.load_submission_value_variables_state(refresh=True)
         return submission
 
@@ -292,8 +293,9 @@ class SubmissionValueVariableFactory(factory.django.DjangoModelFactory):
     form_variable = factory.SubFactory(
         FormVariableFactory,
         form=factory.SelfAttribute("..submission.form"),
+        key=factory.SelfAttribute("..key"),
     )
-    key = factory.SelfAttribute("form_variable.key")
+    key = factory.Faker("word")
     source = SubmissionValueVariableSources.user_input
 
     class Meta:

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -136,14 +136,13 @@ class FormNodeTests(TestCase):
             submission=self.submission, mode=RenderModes.pdf, as_html=True
         )
 
+        # preload the execution state - this usually happens only once and is then
+        # cached.
+        self.submission.load_execution_state()
+
         # Expected queries:
-        # 1. Retrieve all the variables defined for the submission form
-        # 2. Retrieve all the submission variable values
-        # 3. Getting the submission steps for the given submission
-        # 4. Get the step-specific data from submission variable values (TODO: this can probably be optimized away?)
-        # 5. Load submission state: get form steps
-        # 6. Load submission state: get submission steps
-        # 7. Query the form logic rules for the submission form (and this is cached)
-        # 8. Query if there are user defined variables
-        with self.assertNumQueries(8):
+        # 1. Retrieve all the form variables
+        # 2. Retrieve all the submission variables
+        # 3. Query the form logic rules for the submission form (and this is cached)
+        with self.assertNumQueries(3):
             list(renderer)

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -393,7 +393,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
         )
         SubmissionValueVariableFactory.create(
             submission=submission,
-            form_variable__key="userDefinedDate",
+            key="userDefinedDate",
             form_variable__user_defined=True,
             form_variable__data_type=FormVariableDataTypes.datetime,
             value="2022-12-31",

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -645,3 +645,32 @@ class SubmissionTests(TestCase):
             },
             submission.data,
         )
+
+    def test_form_login_required(self):
+        with self.subTest("form login not required"):
+            submission = SubmissionFactory.create(
+                form__generate_minimal_setup=True,
+                form__formstep__form_definition__login_required=False,
+            )
+
+            self.assertFalse(submission.form_login_required)
+
+        with self.subTest("form login required"):
+            submission = SubmissionFactory.create(
+                form__generate_minimal_setup=True,
+                form__formstep__form_definition__login_required=True,
+            )
+
+            self.assertTrue(submission.form_login_required)
+
+        with self.subTest("via annotate property, False"):
+            submission = SubmissionFactory.build()
+            submission._form_login_required = False
+
+            self.assertFalse(submission.form_login_required)
+
+        with self.subTest("via annotate property, True"):
+            submission = SubmissionFactory.build()
+            submission._form_login_required = True
+
+            self.assertTrue(submission.form_login_required)

--- a/src/openforms/submissions/tests/test_resume_form_view.py
+++ b/src/openforms/submissions/tests/test_resume_form_view.py
@@ -37,6 +37,7 @@ class SubmissionResumeViewTests(TestCase):
             form_step__optional=False,
             data={"foo": "bar"},
         )
+        submission.load_execution_state(refresh=True)
 
         endpoint = reverse(
             "submissions:resume",

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -57,12 +57,14 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         submission_step2._unsaved_data = {"var3": "test3", "var4": "test4"}
         data = submission.data
 
-        # 1. get_dynamic_configuration: injects variables in configuration and *currently* does 1 query to retrieve
-        #    variables with prefill data, so the defaultValue on the components can be set.
-        # 2. Retrieve all logic rules related to a form
-        # 3. Load submission state: Retrieve formsteps,
-        # 4. Load submission state: Retrieve submission steps
-        with self.assertNumQueries(4):
+        # preload the execution state, this normally happens in the viewset/calling code
+        submission.load_execution_state()
+        del submission._variables_state  # force re-fetching this to count queries
+
+        # 1. Loading the variables state - fetch all the form variables
+        # 2. Loading the variables state - fetch all the submission variables
+        # 3. Retrieve all logic rules related to a form
+        with self.assertNumQueries(3):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_evaluate_form_logic_with_rules(self):
@@ -119,20 +121,23 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         )
         data = submission.data
 
-        # 1.  get_dynamic_configuration: injects variables in configuration and *currently* does 1 query to retrieve
-        #     variables with prefill data, so the defaultValue on the components can be set.
-        # 2.  Retrieve all logic rules related to a form
-        # 3.  Load submission state: Retrieve formsteps,
-        # 4.  Load submission state: Retrieve submission steps
-        # 5.  Retrieve the submission variables to be deleted
-        # 6.  Retrieve the submission attachment files to be deleted
-        # 7.  SAVEPOINT
-        # 8.  Delete submission attachment files
-        # 9.  RELEASE SAVEPOINT
-        # 10. Delete submission values
-        # 11. Retrieve all form_variables
-        # 12. Creation of timelinelog
-        with self.assertNumQueries(12):
+        # preload the execution state, this normally happens in the viewset/calling code
+        submission.load_execution_state()
+        del submission._variables_state  # force re-fetching this to count queries
+
+        # 1.  Loading the variables state - fetch all the form variables
+        # 2.  Loading the variables state - fetch all the submission variables
+        # 3.  Retrieve all logic rules related to a form
+        # 4.  Retrieve the submission variables to be deleted - deletion of data happens
+        #     because the step is marked N/A
+        # 5.  Retrieve the submission attachment files to be deleted
+        # 6.  SAVEPOINT
+        # 7.  Delete submission attachment files
+        # 8.  RELEASE SAVEPOINT
+        # 9.  Delete submission values
+        # 10. Retrieve all form_variables
+        # 11. Creation of timelinelog
+        with self.assertNumQueries(11):
             evaluate_form_logic(submission, submission_step2, data)
 
     def test_update_step_data(self):
@@ -157,8 +162,11 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             data={"var1": "test1", "var2": "test2"},
         )
 
-        # 1. load_submission_state: retrieve form variables
-        # 2. load_submission_state: retrieve submission value variables
+        # typically done in the viewset before the data is accessed
+        submission.load_execution_state()
+
+        # 1. load_variables_state: retrieve form variables
+        # 2. load_variables_state: retrieve submission value variables
         # 3. bulk_create var3 and var4 submission value variables
         # 4. bulk_update var1 and var2 submission value variables
         with self.assertNumQueries(4):
@@ -191,8 +199,11 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             data={"var1": "test1", "var2": "test2"},
         )
 
-        # 1. load_submission_state: retrieve form variables
-        # 2. load_submission_state: retrieve submission value variables
+        # typically done in the viewset before the data is accessed
+        submission.load_execution_state()
+
+        # 1. load_variables_state: retrieve form variables
+        # 2. load_variables_state: retrieve submission value variables
         with self.assertNumQueries(2):
             submission_step.data
 
@@ -222,8 +233,11 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # ensure there is a submission
         submission = SubmissionFactory.create(form=form)
 
-        # 1. Get the submission variables that are already in the database
-        # 2. Get the form variables for which there is no corresponding submission variable in the database
+        # typically done in the viewset before the data is accessed
+        submission.load_execution_state()
+
+        # 1. Get the form variables
+        # 2. Get the submission variables
         with self.assertNumQueries(2):
             SubmissionValueVariablesState(submission).variables
 
@@ -259,11 +273,13 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             submission=submission, form_step=form_step2
         )
         submission_step2._unsaved_data = {"var3": "test3", "var4": "test4"}
+        # typically done in the viewset before the data is accessed
+        submission.load_execution_state()
 
         self.assertEqual(2, submission.submissionvaluevariable_set.count())
 
-        # 1. Get the submission variables that are already in the database
-        # 2. Get the form variables for which there is no corresponding submission variable in the database
+        # 1. Get the form variables
+        # 2. Get the submission variables
         with self.assertNumQueries(2):
             SubmissionValueVariablesState(submission).variables
 
@@ -300,11 +316,13 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             form_step=form_step2,
             data={"var3": "test3", "var4": "test4"},
         )
+        # typically done in the viewset before the data is accessed
+        submission.load_execution_state()
 
         self.assertEqual(4, submission.submissionvaluevariable_set.count())
 
-        # 1. Get the submission variables that are already in the database
-        # 2. Get the form variables for which there is no corresponding submission variable in the database
+        # 1. Get the form variables
+        # 2. Get the submission variables
         with self.assertNumQueries(2):
             SubmissionValueVariablesState(submission).variables
 
@@ -404,14 +422,13 @@ class SubmissionVariablesPerformanceTests(APITestCase):
 
         renderer = Renderer(submission=submission, mode=RenderModes.pdf, as_html=True)
 
-        # 1-2. renderer get_children: get submission data (get form variables and submission value variables)
-        # 3. renderer get_children: get submission steps
-        # 4. Retrieve prefill data
-        # 5. Retrieve logic rules
-        # 6. Load submission state: Retrieve formsteps,
-        # 7. Load submission state: Retrieve submission steps
-        # 8. Query if there are user defined variables
-        with self.assertNumQueries(8):
+        # typically done in the viewset/management command before the data is accessed
+        submission.load_execution_state()
+
+        # 1. Retrieve form variables
+        # 2. Retrieve submission variables
+        # 3. Retrieve logic rules
+        with self.assertNumQueries(3):
             nodes = [node for node in renderer]
 
         with self.assertNumQueries(0):

--- a/src/openforms/variables/rendering/nodes.py
+++ b/src/openforms/variables/rendering/nodes.py
@@ -14,8 +14,8 @@ class VariablesNode(Node):
     """
     Render node for the user defined variables related to a form.
 
-    This node is only 'visible' for certain render modes (cli and registration), but it is not rendered if there are
-    user defined variables related to the form.
+    This node is only 'visible' for certain render modes (cli and registration), but it
+    is not rendered if there are user defined variables related to the form.
     """
 
     submission: Submission
@@ -31,13 +31,14 @@ class VariablesNode(Node):
     @property
     def variables(self):
         if not self._variables:
-            self._variables = (
-                self.submission.submissionvaluevariable_set.filter(
-                    form_variable__source=FormVariableSources.user_defined
-                )
-                .select_related("form_variable")
-                .order_by("pk")
-            )
+            variables_state = self.submission.load_submission_value_variables_state()
+            relevant_vars = [
+                variable
+                for variable in variables_state.variables.values()
+                if variable.pk
+                and variable.form_variable.source == FormVariableSources.user_defined
+            ]
+            self._variables = sorted(relevant_vars, key=lambda variable: variable.pk)
         return self._variables
 
     def render(self) -> str:


### PR DESCRIPTION
A combination of analysis using Elastic APM and django-silk to figure out the origin of excessive queries, followed by some workarounds to remove the queries that are not absolutely needed.

* Logic check endpoint with test case used for profiling: 18 -> 11 queries
* Renderer with variables node: 8 -> 3 queries

Let's get this merged and tested on our test environment, so we can check again with APM what the new situation is (and run the profiling benchmark again).