### PR TITLE
:zap: [#1922] -- Optimize the bulk form variables endpoints

### DIFF
--- a/src/openforms/api/fields.py
+++ b/src/openforms/api/fields.py
@@ -1,0 +1,31 @@
+from rest_framework import relations
+
+
+class RelatedFieldFromContext(relations.HyperlinkedRelatedField):
+    """
+    Look up the object in the serializer context.
+    """
+
+    def __init__(self, context_name="objects", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # key to use to look up the object in the context, which is a dict mapping
+        # of :arg`lookup_field` to the instance(s)
+        self.context_name = context_name
+
+    def get_object(self, view_name, view_args, view_kwargs):
+        # these view_args and view_kwargs come from processing the input URL,
+        # which lead to a valid resolver match.
+        input_url = self.reverse(view_name, args=view_args, kwargs=view_kwargs)
+
+        # grab the object from the context
+        obj_collection = self.parent.context[self.context_name]
+        lookup_value = view_kwargs[self.lookup_url_kwarg]
+        try:
+            obj = obj_collection[lookup_value]
+        except KeyError:
+            self.fail("does_not_exist")
+        context_obj_url = self.get_url(obj, view_name, None, None)
+
+        if input_url != context_obj_url:
+            self.fail("incorrect_match")
+        return obj

--- a/src/openforms/api/tests/test_fields.py
+++ b/src/openforms/api/tests/test_fields.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+
+from rest_framework import serializers
+from rest_framework.reverse import reverse
+
+from openforms.forms.models import Form
+from openforms.forms.tests.factories import FormFactory
+
+from ..fields import RelatedFieldFromContext
+
+
+class RelatedFieldFromContextSerializer(serializers.Serializer):
+    form = RelatedFieldFromContext(
+        queryset=Form.objects.all(),
+        view_name="api:form-detail",
+        lookup_field="uuid",
+        lookup_url_kwarg="uuid_or_slug",
+        context_name="forms",
+    )
+
+
+class RelatedFieldFromContextTests(TestCase):
+    def test_valid_lookup(self):
+        form = FormFactory.create()
+        serializer = RelatedFieldFromContextSerializer(
+            data={
+                "form": reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid}),
+            },
+            context={"forms": {str(form.uuid): form}},
+        )
+
+        self.assertTrue(serializer.is_valid())
+
+    def test_invalid_lookup(self):
+        form1 = FormFactory.create()
+        form2 = FormFactory.create()
+        serializer = RelatedFieldFromContextSerializer(
+            data={
+                "form": reverse("api:form-detail", kwargs={"uuid_or_slug": form1.uuid}),
+            },
+            context={"forms": {str(form2.uuid): form2}},
+        )
+
+        is_valid = serializer.is_valid()
+
+        self.assertFalse(is_valid)
+        self.assertEqual(serializer.errors["form"][0].code, "does_not_exist")
+
+    def test_wrong_object(self):
+        form1 = FormFactory.create()
+        form2 = FormFactory.create()
+        serializer = RelatedFieldFromContextSerializer(
+            data={
+                "form": reverse("api:form-detail", kwargs={"uuid_or_slug": form1.uuid}),
+            },
+            context={
+                "forms": {
+                    str(form1.uuid): form2,
+                    str(form2.uuid): form1,
+                }
+            },
+        )
+
+        is_valid = serializer.is_valid()
+
+        self.assertFalse(is_valid)
+        self.assertEqual(serializer.errors["form"][0].code, "incorrect_match")

--- a/src/openforms/forms/api/serializers/form_variable.py
+++ b/src/openforms/forms/api/serializers/form_variable.py
@@ -5,12 +5,13 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from openforms.api.fields import RelatedFieldFromContext
 from openforms.api.serializers import ListWithChildSerializer
 from openforms.formio.utils import get_component
 from openforms.variables.constants import FormVariableSources
 from openforms.variables.service import get_static_variables
 
-from ...models import FormVariable
+from ...models import Form, FormDefinition, FormVariable
 
 
 class FormVariableListSerializer(ListWithChildSerializer):
@@ -57,7 +58,43 @@ class FormVariableListSerializer(ListWithChildSerializer):
 
 
 # TODO transform in polymorphic serializer to validate on different types of initial values?
+
+# Performance notes: when doing stuff in bulk, every serializer is validated individually,
+# meaning it does a lookup for ``form`` and ``form_definition`` for EVERY variable.
+# This means that (out of the box) at least O(2*n) queries are performed, with ``n`` the
+# number of component # variables, and an additional O(m) queries with ``m`` the number
+# of user-defined variables.
+#
+# We can reduce this by not querying for the form and instead rely on the serializer
+# context (the form is looked up in the viewset). We can further optimize this by
+# prefetching the form definitions used in the form and put that in the serializer
+# context, making it easier to lookup the values without having to do DB queries to
+# validate them (and there will also be duplicate results).
+
+
 class FormVariableSerializer(serializers.HyperlinkedModelSerializer):
+    form = RelatedFieldFromContext(
+        queryset=Form.objects.all(),
+        view_name="api:form-detail",
+        lookup_field="uuid",
+        lookup_url_kwarg="uuid_or_slug",
+        label=FormVariable._meta.get_field("form").verbose_name,
+        help_text=FormVariable._meta.get_field("form").help_text,
+        required=True,
+        context_name="forms",
+    )
+    form_definition = RelatedFieldFromContext(
+        queryset=FormDefinition.objects.all(),
+        view_name="api:formdefinition-detail",
+        lookup_field="uuid",
+        lookup_url_kwarg="uuid",
+        label=FormVariable._meta.get_field("form_definition").verbose_name,
+        help_text=FormVariable._meta.get_field("form_definition").help_text,
+        required=False,
+        allow_null=True,
+        context_name="form_definitions",
+    )
+
     class Meta:
         model = FormVariable
         list_serializer_class = FormVariableListSerializer
@@ -74,18 +111,16 @@ class FormVariableSerializer(serializers.HyperlinkedModelSerializer):
             "is_sensitive_data",
             "initial_value",
         )
-        extra_kwargs = {
-            "form": {
-                "view_name": "api:form-detail",
-                "lookup_field": "uuid",
-                "lookup_url_kwarg": "uuid_or_slug",
-            },
-            "form_definition": {
-                "view_name": "api:formdefinition-detail",
-                "lookup_field": "uuid",
-                "lookup_url_kwarg": "uuid",
-            },
-        }
+        # note that DRF by default generates a UniqueTogetherValidator on (form, key).
+        # We removed this validator for performance reasons, as it's doing a query for
+        # every variable in the bulk update call, leading to O(n) queries with ``n``
+        # the amount of variables.
+        # The (bulk) API endpoint(s) and this ListSerializer are responsible for
+        # applying # this validation on the whole collection.
+        validators = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def validate(self, attrs):
         if (form_definition := attrs.get("form_definition")) and attrs.get(

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -13,7 +13,6 @@ from openforms.accounts.tests.factories import (
 )
 from openforms.forms.models import FormVariable
 from openforms.forms.tests.factories import (
-    FormDefinitionFactory,
     FormFactory,
     FormStepFactory,
     FormVariableFactory,
@@ -53,7 +52,8 @@ class FormVariableViewsetTest(APITestCase):
     def test_bulk_create_and_update(self):
         user = StaffUserFactory.create(user_permissions=["change_form"])
         form = FormFactory.create()
-        form_definition = FormDefinitionFactory.create()
+        form_step = FormStepFactory.create(form=form)
+        form_definition = form_step.form_definition
 
         form_path = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
         form_url = f"http://testserver.com{form_path}"
@@ -120,7 +120,8 @@ class FormVariableViewsetTest(APITestCase):
     def test_unique_together_key_form(self):
         user = SuperUserFactory.create()
         form = FormFactory.create()
-        form_definition = FormDefinitionFactory.create()
+        form_step = FormStepFactory.create(form=form)
+        form_definition = form_step.form_definition
 
         form_path = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
         form_url = f"http://testserver.com{form_path}"
@@ -278,7 +279,8 @@ class FormVariableViewsetTest(APITestCase):
     def test_dotted_variable_keys(self):
         user = SuperUserFactory.create()
         form = FormFactory.create()
-        form_definition = FormDefinitionFactory.create()
+        form_step = FormStepFactory.create(form=form)
+        form_definition = form_step.form_definition
 
         form_path = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
         form_url = f"http://testserver.com{form_path}"
@@ -369,7 +371,8 @@ class FormVariableViewsetTest(APITestCase):
     def test_key_clash_with_static_data(self):
         user = SuperUserFactory.create()
         form = FormFactory.create()
-        form_definition = FormDefinitionFactory.create()
+        form_step = FormStepFactory.create(form=form)
+        form_definition = form_step.form_definition
 
         form_path = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
         form_url = f"http://testserver.com{form_path}"


### PR DESCRIPTION
Related to #1922

Performance improvement variables bulk update, for a case with 30 component variables and 20 user defined variables:

* before: 84 queries
* after: 5 queries

**Variables list**

* Removed unnecessary prefetch/select_related from variables-list endpoint
* Added select_related on variables-list endpoint for variable form and form-definition
* Variables-list endpoint now has a fixed number of queries: 2 (+ session/middleware queries etc.)

**Variables bulk update**

Every form variable was being validated individually, meaning that a FK lookup was performed for the form and the (optional) form definition, giving a complexity somewhere between `O(n)` and `O(2*n)` with n the number of form variables.

The form validation/lookup is not needed in the first place, since the endpoint is scoped within a form detail endpoint. The form definition validation is a bit more complex, but again, multiple variables can belong to the same form-definition, so doing this query multiple times is wasted performance.

The performance patch collects the form and it's related form definitions upfront and passes them via the serializer context down to a custom field which replaces the DB lookups with context lookups. This results in a fixed number of queries: `O(5)`.