### PR TITLE
:zap: [#1922] -- move logic evaluation logging to celery

### DIFF
--- a/src/openforms/analytics_tools/models.py
+++ b/src/openforms/analytics_tools/models.py
@@ -7,8 +7,6 @@ from django.utils.translation import gettext_lazy as _
 
 from solo.models import SingletonModel
 
-from openforms.logging import logevent
-
 from .constants import AnalyticsTools
 from .utils import (
     get_cookies,
@@ -288,6 +286,7 @@ class AnalyticsToolsConfiguration(SingletonModel):
         is_activated: bool,
         string_replacements_list: List[tuple],
     ):
+        from openforms.logging import logevent
 
         if is_activated:
             logevent.enabling_analytics_tool(self, analytics_tool)

--- a/src/openforms/logging/logic.py
+++ b/src/openforms/logging/logic.py
@@ -1,0 +1,93 @@
+"""
+Process the logic evaluation logging information.
+
+This relies on the datastructures used in :module:`openforms.submissions.form_logic`.
+"""
+from typing import List
+
+from openforms.submissions.logic.log_utils import get_targeted_components
+from openforms.submissions.logic.rules import EvaluatedRule
+from openforms.submissions.models import Submission
+from openforms.typing import JSONObject
+from openforms.utils.json_logic import ComponentMeta, introspect_json_logic
+
+from .logevent import _create_log
+
+
+def log_logic_evaluation(
+    submission: Submission,
+    evaluated_rules: List["EvaluatedRule"],
+    initial_data: JSONObject,
+    resolved_data: JSONObject,
+):
+    if not evaluated_rules:
+        return
+    evaluated_rules_list = []
+
+    submission_state = submission.load_execution_state()
+    form_steps = submission_state.form_steps
+
+    # Keep a mapping for each component's key for each component in the entire form.
+    # The key of the mapping is the component key, the value is a dataclass composed of
+    # form_step and component definition
+    components_map = {}
+    for form_step in form_steps:
+        for component in form_step.form_definition.iter_components():
+            components_map[component["key"]] = ComponentMeta(form_step, component)
+
+    input_data = []
+    all_variables = submission.form.formvariable_set.distinct("key").in_bulk(
+        field_name="key"
+    )
+    for evaluated_rule in evaluated_rules:
+        rule = evaluated_rule.rule
+
+        trigger = rule.json_logic_trigger
+        if not isinstance(trigger, (dict, list)):
+            # The trigger was a primitive, no need to introspect
+            evaluated_rule_data = {
+                "raw_logic_expression": trigger,
+                "readable_rule": str(trigger),
+                "targeted_components": get_targeted_components(
+                    rule,
+                    components_map,
+                    all_variables,
+                    initial_data,
+                ),
+                "trigger": evaluated_rule.triggered,
+            }
+
+            evaluated_rules_list.append(evaluated_rule_data)
+            continue
+
+        rule_introspection = introspect_json_logic(
+            trigger, components_map, initial_data
+        )
+
+        # Gathering all the input component of each evaluated rule
+        input_data.extend(rule_introspection.get_input_components())
+
+        targeted_components = get_targeted_components(
+            rule, components_map, all_variables, initial_data
+        )
+        evaluated_rule_data = {
+            "raw_logic_expression": rule_introspection.expression,
+            "readable_rule": rule_introspection.as_string(),
+            "targeted_components": targeted_components,
+            "trigger": evaluated_rule.triggered,
+        }
+
+        evaluated_rules_list.append(evaluated_rule_data)
+
+    # de-duplication of input data
+    deduplicated_input_data = {node["key"]: node for node in input_data}
+
+    return _create_log(
+        submission,
+        "submission_logic_evaluated",
+        extra_data={
+            "evaluated_rules": evaluated_rules_list,
+            "input_data": deduplicated_input_data,
+            "resolved_data": resolved_data,
+        },
+    )

--- a/src/openforms/logging/tasks.py
+++ b/src/openforms/logging/tasks.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from typing import List, TypedDict
+
+from openforms.celery import app
+from openforms.forms.models import FormLogic
+from openforms.typing import JSONObject
+
+
+class EvaluatedRuleDict(TypedDict):
+    rule_id: int
+    triggered: bool
+
+
+@app.task(ignore_result=True)
+def log_logic_evaluation(
+    *,
+    submission_id: int,
+    timestamp: str,  # ISO-8601 timestamp
+    evaluated_rules: List[EvaluatedRuleDict],
+    initial_data: JSONObject,
+    resolved_data: JSONObject,
+):
+    from openforms.submissions.logic.rules import EvaluatedRule
+    from openforms.submissions.models import Submission
+
+    from .logic import log_logic_evaluation as _log_logic_evaluation
+    from .models import TimelineLogProxy
+
+    # de-serialize the data bank into native python objects
+    submission = Submission.objects.get(id=submission_id)
+    rule_ids = [item["rule_id"] for item in evaluated_rules]
+    rules = {
+        rule.id: rule
+        for rule in FormLogic.objects.filter(
+            form_id=submission.form_id, id__in=rule_ids
+        )
+    }
+    _evaluated_rules = [
+        EvaluatedRule(rule=rules[item["rule_id"]], triggered=item["triggered"])
+        for item in evaluated_rules
+    ]
+
+    log_entry = _log_logic_evaluation(
+        submission, _evaluated_rules, initial_data, resolved_data
+    )
+
+    # overwrite the timestamp, since celery tasks run later than 'now'. This makes the
+    # timestamp more accurate & matching with server time that ran the evaluation.
+    _timestamp = datetime.fromisoformat(timestamp)
+    TimelineLogProxy.objects.filter(pk=log_entry.pk).update(timestamp=_timestamp)

--- a/src/openforms/logging/tests/test_events.py
+++ b/src/openforms/logging/tests/test_events.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 
 from openforms.forms.models import FormLogic
 from openforms.forms.tests.factories import FormLogicFactory
-from openforms.logging import logevent
+from openforms.logging import logevent, logic
 from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.logic.rules import EvaluatedRule
 from openforms.submissions.tests.factories import SubmissionFactory
@@ -70,7 +70,7 @@ class EventTests(TestCase):
         )
         rule_2 = cast(FormLogic, rule_2)
 
-        logevent.submission_logic_evaluated(
+        logic.log_logic_evaluation(
             submission,
             [
                 EvaluatedRule(rule=rule, triggered=True),

--- a/src/openforms/prefill/__init__.py
+++ b/src/openforms/prefill/__init__.py
@@ -38,7 +38,6 @@ from glom import Path, PathAccessError, glom
 from zgw_consumers.concurrent import parallel
 
 from openforms.formio.utils import format_date_value, iter_components
-from openforms.logging import logevent
 from openforms.plugins.exceptions import PluginNotEnabled
 from openforms.typing import JSONObject
 
@@ -52,6 +51,10 @@ logger = logging.getLogger(__name__)
 def _fetch_prefill_values(
     grouped_fields: Dict[str, list], submission: "Submission", register
 ) -> Dict[str, Dict[str, Any]]:
+    from openforms.logging import (  # local import to prevent AppRegistryNotReady
+        logevent,
+    )
+
     @elasticapm.capture_span(span_type="app.prefill")
     def invoke_plugin(item: Tuple[str, List[str]]) -> Tuple[str, Dict[str, Any]]:
         plugin_id, fields = item

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1,4 +1,4 @@
-from django.test import tag
+from django.test import override_settings, tag
 
 from freezegun import freeze_time
 from rest_framework import status
@@ -595,6 +595,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             )
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
     def test_evaluate_logic_with_default_values(self):
         form = FormFactory.create(

--- a/src/openforms/submissions/tests/test_admin.py
+++ b/src/openforms/submissions/tests/test_admin.py
@@ -16,7 +16,7 @@ from openforms.accounts.tests.factories import (
 )
 from openforms.forms.models import FormLogic, FormVariable
 from openforms.forms.tests.factories import FormLogicFactory
-from openforms.logging import logevent
+from openforms.logging import logevent, logic
 from openforms.logging.logevent import submission_start
 from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.logic.rules import EvaluatedRule
@@ -280,7 +280,7 @@ class LogicLogsAdminTests(WebTest):
         )
         merged_data = self.submission.get_merged_data()
 
-        logevent.submission_logic_evaluated(
+        logic.log_logic_evaluation(
             self.submission,
             [EvaluatedRule(rule=cast(FormLogic, rule), triggered=False)],
             merged_data,


### PR DESCRIPTION
The processing and queries are now done in the celery tasks, making the logic check endpoint a bit faster.