### PR TITLE
Variables in email registration

### DIFF
--- a/src/openforms/registrations/contrib/email/config.py
+++ b/src/openforms/registrations/contrib/email/config.py
@@ -40,9 +40,11 @@ class EmailOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     email_subject = serializers.CharField(
         label=_("Email subject"),
         help_text=_(
-            "Subject of the email sent to the registration backend. You can use the expressions "
-            "'{{ form_name }}' and '{{ submission_reference }}' to include the form name and the reference "
-            "number to the submission in the subject."
+            "Subject of the email sent to the registration backend. You can use "
+            "the expressions '{{ form_name }}' and '{{ submission_reference }}' "
+            "to include the form name and the reference number to the submission "
+            "in the subject. Additionally, all the form variables are available with "
+            "the 'vars' prefix, e.g.: '{{ vars.environment }}'."
         ),
         required=False,
         validators=[DjangoTemplateValidator()],

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext, ugettext_lazy as _
 
 from openforms.emails.utils import send_mail_html, strip_tags_plus
+from openforms.submissions.datastructures import DataContainer
 from openforms.submissions.exports import create_submission_export
 from openforms.submissions.models import Submission
 from openforms.submissions.rendering.constants import RenderModes
@@ -47,6 +48,9 @@ class EmailRegistration(BasePlugin):
         # explicitly get a reference before registering
         set_submission_reference(submission)
 
+        variables_state = submission.load_submission_value_variables_state()
+        data_container = DataContainer(variables_state)
+
         subject_template = options.get("email_subject") or ugettext(
             "[Open Forms] {{ form_name }} - submission {{ submission_reference }}"
         )
@@ -55,6 +59,7 @@ class EmailRegistration(BasePlugin):
             {
                 "form_name": submission.form.admin_name,
                 "submission_reference": submission.public_registration_reference,
+                "vars": data_container.data,
             },
         )
 

--- a/src/openforms/submissions/datastructures.py
+++ b/src/openforms/submissions/datastructures.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+from typing import Any, Tuple
+
+from glom import assign
+
+from openforms.typing import DataMapping
+
+from .models.submission_value_variable import SubmissionValueVariablesState
+
+
+@dataclass
+class DataContainer:
+    """
+    A data container to access the submission variable values as python objects.
+    """
+
+    state: SubmissionValueVariablesState
+
+    _initial_data: Tuple[Tuple[str, Any]] = field(init=False, default_factory=tuple)
+
+    def __post_init__(self):
+        # ensure the initial data is immutable
+        self._initial_data = tuple(self.data.items())  # record for logging purposes
+
+    @property
+    def initial_data(self) -> DataMapping:
+        return dict(self._initial_data)
+
+    @property
+    def data(self) -> DataMapping:
+        """
+        Collect the total picture of data/variable values.
+
+        The current view on the submission variable value state is augmented with
+        the static variables.
+
+        :return: A datamapping (key: variable key, value: variable value) ready for
+          (template context) evaluation.
+        """
+        dynamic_values = {
+            key: variable.to_python() for key, variable in self.state.variables.items()
+        }
+        static_values = self.state.static_data()
+        # this construct may have dots in the key names, so we need to expand that
+        # into nested objects
+        flattened_data = {**dynamic_values, **static_values}
+        nested_data = {}
+        for dotted_path, value in flattened_data.items():
+            assign(nested_data, dotted_path, value, missing=dict)
+        return nested_data
+
+    def update(self, updates: DataMapping) -> None:
+        """
+        Update the dynamic data state.
+        """
+        self.state.set_values(updates)

--- a/src/openforms/submissions/logic/datastructures.py
+++ b/src/openforms/submissions/logic/datastructures.py
@@ -1,60 +1,13 @@
-from dataclasses import dataclass, field
-from typing import Any, Tuple
-
-from glom import assign
-
 from openforms.typing import DataMapping
 
+from ..datastructures import DataContainer as _DataContainer
 from ..models import SubmissionStep
-from ..models.submission_value_variable import SubmissionValueVariablesState
 
 
-@dataclass
-class DataContainer:
+class DataContainer(_DataContainer):
     """
     A data container to manage the data/variables lifecycle during logic evaluation.
     """
-
-    state: SubmissionValueVariablesState
-
-    _initial_data: Tuple[Tuple[str, Any]] = field(init=False, default_factory=tuple)
-
-    def __post_init__(self):
-        # ensure the initial data is immutable
-        self._initial_data = tuple(self.data.items())  # record for logging purposes
-
-    @property
-    def initial_data(self) -> DataMapping:
-        return dict(self._initial_data)
-
-    @property
-    def data(self) -> DataMapping:
-        """
-        Collect the total picture of data/variable values.
-
-        The current view on the submission variable value state is augmented with
-        the static variables.
-
-        :return: A datamapping (key: variable key, value: variable value) ready for
-          (template context) evaluation.
-        """
-        dynamic_values = {
-            key: variable.to_python() for key, variable in self.state.variables.items()
-        }
-        static_values = self.state.static_data()
-        # this construct may have dots in the key names, so we need to expand that
-        # into nested objects
-        flattened_data = {**dynamic_values, **static_values}
-        nested_data = {}
-        for dotted_path, value in flattened_data.items():
-            assign(nested_data, dotted_path, value, missing=dict)
-        return nested_data
-
-    def update(self, updates: DataMapping) -> None:
-        """
-        Update the dynamic data state.
-        """
-        self.state.set_values(updates)
 
     def get_updated_step_data(self, step: SubmissionStep) -> DataMapping:
         relevant_variables = self.state.get_variables_in_submission_step(


### PR DESCRIPTION
#1579

* User-defined variables are already included via Silvia's earlier implementation
* Added support and help-text for variables in the e-mail subject.

Note that I chose the `vars` namespace for use in the template engine - `variables` is maybe better but a bit too long? Either way, let me know if you can think of a better namespace.