### PR TITLE
Sort formdefinition choices

### DIFF
--- a/src/openforms/js/components/admin/form_design/NewStepFormDefinitionPicker.js
+++ b/src/openforms/js/components/admin/form_design/NewStepFormDefinitionPicker.js
@@ -22,7 +22,8 @@ const NewStepFormDefinitionPicker = ({onReplace}) => {
 
   const formDefinitionChoices = formDefinitions
     .filter(fd => fd.isReusable)
-    .map(fd => [fd.url, fd.internalName || fd.name]);
+    .map(fd => [fd.url, fd.internalName || fd.name])
+    .sort((a, b) => a[1].localeCompare(b[1]));
 
   const closeModal = () => {
     setIsModalOpen(false);


### PR DESCRIPTION
Requested by @joeribekker 

Description:
> can you make the list of FormDefinitions that is shown when creating a form in the admin, and you want to add a form step, alphabetical?
> ![image](https://user-images.githubusercontent.com/58147939/190440012-d2117a45-98d5-4fa2-8a6e-8490d0f9e05c.png)
