### PR TITLE
Implement a thread-local request-scoped proxy cache

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -108,6 +108,10 @@ CACHES = {
             "IGNORE_EXCEPTIONS": False,
         },
     },
+    "solo": {
+        "BACKEND": "openforms.utils.cache.RequestProxyCache",
+        "LOCATION": "default",
+    },
 }
 
 #
@@ -849,7 +853,7 @@ ZGW_CONSUMERS_TEST_SCHEMA_DIRS = [
 #
 # Django Solo
 #
-SOLO_CACHE = "default"
+SOLO_CACHE = "solo"
 SOLO_CACHE_TIMEOUT = 60 * 5  # 5 minutes
 
 #

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -96,9 +96,7 @@ ELASTIC_APM["DEBUG"] = config("DISABLE_APM_IN_DEV", default=True)
 
 # Django debug toolbar
 INSTALLED_APPS += ["debug_toolbar", "ddt_api_calls"]
-MIDDLEWARE += [
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
-]
+MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 INTERNAL_IPS = ("127.0.0.1",)
 DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}
 DEBUG_TOOLBAR_PANELS = [

--- a/src/openforms/utils/apps.py
+++ b/src/openforms/utils/apps.py
@@ -10,6 +10,7 @@ class UtilsConfig(AppConfig):
     name = "openforms.utils"
 
     def ready(self):
+        from . import cache  # noqa
         from . import checks  # noqa
 
         # register custom converters

--- a/src/openforms/utils/cache.py
+++ b/src/openforms/utils/cache.py
@@ -1,0 +1,104 @@
+import threading
+
+from django.core import signals
+from django.core.cache import DEFAULT_CACHE_ALIAS, caches
+from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
+
+
+class RequestProxyCache(BaseCache):
+    """
+    Store and proxy cache items on a per-request basis.
+
+    This cache only operates during a request-response cycle.
+
+    When a cache key is not found, it is looked up in the configured upstream cache.
+    All operations like setting/deleting/clearing this cache are proxied to the
+    upstream cache.
+
+    Values cached in memory do not honor the timeouts, as the cache only exists for the
+    scope of a single request.
+    """
+
+    _storage = threading.local()
+
+    def __init__(self, upstream: str, params):
+        super().__init__(params)
+        upstream = upstream or DEFAULT_CACHE_ALIAS
+        self.upstream_cache = caches[upstream]
+        self._reset()
+
+    def _reset(self):
+        self._storage.__dict__.clear()
+        self._storage.in_request_response_cycle = False
+
+    @property
+    def active(self):
+        return self._storage.in_request_response_cycle
+
+    @property
+    def _cache(self):
+        return self._storage.__dict__
+
+    def mark_request_started(self):
+        self._storage.in_request_response_cycle = True
+
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        added = self.upstream_cache.add(key, value, timeout=timeout, version=version)
+        if added:
+            _key = self.make_key(key, version=version)
+            self._set(_key, value)
+        return added
+
+    def get(self, key, default=None, version=None):
+        _key = self.make_key(key, version=version)
+        local_value = self._cache.get(_key, self._missing_key)
+        if self.active and local_value is not self._missing_key:
+            return local_value
+
+        value = self.upstream_cache.get(key, default=default, version=version)
+        if self.active and value != default:
+            _key = self.make_key(key, version=version)
+            self._set(_key, value)
+        return value
+
+    def _set(self, key, value):
+        if not self.active:
+            return
+        self._cache[key] = value
+
+    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        self.upstream_cache.set(key, value, timeout=timeout, version=version)
+        _key = self.make_key(key, version=version)
+        self._set(_key, value)
+
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
+        return self.upstream_cache.touch(key, timeout=timeout, version=version)
+
+    def delete(self, key, version=None):
+        deleted = self.upstream_cache.delete(key, version=version)
+        if deleted:
+            _key = self.make_key(key, version=version)
+            if _key in self._cache:
+                del self._cache[_key]
+        return deleted
+
+    def clear(self):
+        self._reset()
+        return self.upstream_cache.clear()
+
+    def close(self):
+        self.upstream_cache.close()
+        self._reset()
+
+
+def mark_request_proxy_caches(**kwargs):
+    for cache in caches.all():
+        if not isinstance(cache, RequestProxyCache):
+            continue
+        cache.mark_request_started()
+
+
+signals.request_started.connect(
+    mark_request_proxy_caches,
+    dispatch_uid="openforms.cache.mark_request_start",
+)

--- a/src/openforms/utils/tests/test_cache.py
+++ b/src/openforms/utils/tests/test_cache.py
@@ -1,0 +1,231 @@
+import contextlib
+import time
+from unittest.mock import patch
+
+from django.core.cache import caches
+from django.http import HttpResponse
+from django.test import Client, TestCase, override_settings
+from django.urls import path
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "default",
+        },
+        "extra": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "extra",
+        },
+        "proxy1": {"BACKEND": "openforms.utils.cache.RequestProxyCache"},
+        "proxy2": {
+            "BACKEND": "openforms.utils.cache.RequestProxyCache",
+            "LOCATION": "extra",
+        },
+    }
+)
+class NoRequestProxyCacheTests(TestCase):
+    """
+    Tests for cache usage outside of the request-response cycle.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        def clear_caches():
+            for cache in caches.all():
+                cache.clear()
+
+        self.addCleanup(clear_caches)
+
+    def test_cache_state(self):
+        cache = caches["proxy1"]
+
+        self.assertFalse(cache.active)
+
+    def test_upstream_configuration(self):
+        caches["default"].set("a-key", 1)
+        caches["extra"].set("a-key", 2)
+
+        with self.subTest("proxy 1"):
+            value = caches["proxy1"].get("a-key")
+
+            self.assertEqual(value, 1)
+
+        with self.subTest("proxy 2"):
+            value = caches["proxy2"].get("a-key")
+
+            self.assertEqual(value, 2)
+
+    def test_cache_read(self):
+        cache = caches["proxy1"]
+
+        with self.subTest("upstream cache miss"):
+            value = cache.get("some-missing-key", default=None)
+
+            self.assertIsNone(value)
+
+        with self.subTest("upstream cache hit"):
+            upstream = caches["default"]
+            upstream.set("upstream-key", value="ok")
+
+            value = cache.get("upstream-key")
+
+            self.assertEqual(value, "ok")
+            # check that the value is not stored
+            self.assertTrue("upstream-key" in cache)
+            local_key = cache.make_key("upstream-key")
+            self.assertNotIn(local_key, cache._cache)
+
+    def test_cache_add(self):
+        with self.subTest("added to upstream"):
+            added = caches["proxy1"].add("some-key", 123)
+
+            self.assertTrue(added)
+
+        with self.subTest("already present in upstream"):
+            caches["extra"].add("some-key", 123)
+            added = caches["proxy2"].add("some-key", 123)
+
+            self.assertFalse(added)
+
+    def test_cache_set(self):
+        cache = caches["proxy1"]
+        upstream = caches["default"]
+
+        cache.set("set-a-key", 123)
+
+        value = upstream.get("set-a-key")
+        self.assertEqual(value, 123)
+        local_key = cache.make_key("upstream-key")
+        self.assertNotIn(local_key, cache._cache)
+
+    def test_cache_touch(self):
+        cache = caches["proxy1"]
+        upstream = caches["default"]
+        upstream.set("touch-key", 42, timeout=0.5)
+        time.sleep(0.25)
+        cache.touch("touch-key", timeout=1)
+        time.sleep(0.75)
+
+        value = upstream.get("touch-key")
+
+        self.assertEqual(value, 42)
+
+    def test_cache_delete(self):
+        cache = caches["proxy1"]
+        upstream = caches["default"]
+
+        with self.subTest("delete in upstream"):
+            upstream.set("delete-key", 42)
+
+            cache.delete("delete-key")
+
+            value = upstream.get("delete-key", None)
+            self.assertIsNone(value)
+
+        with self.subTest("does not exist"):
+            result = cache.delete("bad-key")
+
+            self.assertFalse(result)
+
+
+urlpatterns = []
+
+
+@contextlib.contextmanager
+def test_view(view):
+    with override_settings(ROOT_URLCONF=__name__):
+        with patch(f"{__name__}.urlpatterns", new=[path("", view)]):
+            yield
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "default",
+        },
+        "proxy": {"BACKEND": "openforms.utils.cache.RequestProxyCache"},
+    },
+    MIDDLEWARE=[],
+)
+class WithinRequestProxyCacheTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        def clear_caches():
+            for cache in caches.all():
+                cache.clear()
+
+        self.addCleanup(clear_caches)
+
+    def test_cache_active_in_request(self):
+        client = Client()
+        upstream = caches["default"]
+        upstream.set("foo", "bar")
+
+        def testview(request):
+            cache = caches["proxy"]
+            self.assertTrue(cache.active)
+            value = cache.get("foo")
+
+            self.assertEqual(value, "bar")
+            key = cache.make_key("foo")
+            self.assertIn(key, cache._cache)
+
+            # delete from upstream cache, repeated access is fetched from local cache
+            upstream.delete("foo")
+            local_value = cache.get("foo")
+            self.assertEqual(local_value, "bar")
+
+            return HttpResponse("ok")
+
+        with test_view(testview):
+            try:
+                client.get("/")
+            except Exception:
+                self.fail("Assertions in test view failed")
+
+    def test_cache_active_in_request_cache_miss(self):
+        client = Client()
+
+        def testview(request):
+            cache = caches["proxy"]
+            value = cache.get("some-missing-key", None)
+
+            self.assertIsNone(value)
+            key = cache.make_key("some-missing-key")
+            self.assertNotIn(key, cache._cache)
+
+            return HttpResponse("ok")
+
+        with test_view(testview):
+            try:
+                client.get("/")
+            except Exception:
+                self.fail("Assertions in test view failed")
+
+    def test_cache_delete_deletes_local_copy(self):
+        client = Client()
+        upstream = caches["default"]
+        cache = caches["proxy"]
+        cache.set("key-to-delete", 123)
+
+        def testview(request):
+            value = cache.get("key-to-delete")
+            self.assertEqual(value, 123)
+
+            cache.delete("key-to-delete")
+
+            self.assertIsNone(upstream.get("key-to-delete", default=None))
+            self.assertIsNone(cache.get("key-to-delete", default=None))
+
+            return HttpResponse("ok")
+
+        with test_view(testview):
+            try:
+                client.get("/")
+            except Exception:
+                self.fail("Assertions in test view failed")


### PR DESCRIPTION
Relates to #2042

From APM we can see that we have a lot (tens to hundreds) calls to `GlobalConfiguration.get_solo()` (or other solo models) within a single request-response cycle. The places where this applies is (non-exhaustive list):

* form-step list endpoint to get the next/previous/save literals, falling back to the global configuration
* form/submission detail, which uses the same serializers as above
* plugin registries to check if (demo) plugins are enabled/should be included
* middleware to limit the session TTL (admin vs. anon user)

These calls rack up and actually bombard APM, making it impossible to see what other stuff is happening in the request that is slowing things down.

This patch introduces a cache backend that fetches its data from another cache, and stores it in a thread local for the duration of a single HTTP request. This means that:

* the local python state is scoped to the request being handled by uwsgi and no locking/synchronization within the same process is needed
* this works with celery tasks, because there is no request/response cycle and the cache backend will just call the upstream cache
* this completely eliminates additional calls/network IO once the object has been retrieved from redis for the duration of the request
* because the cache is cleared/reset when a request is finished, we don't have to worry about configuration changes made in another thread/process - those result in the redis cache being updated, and the next request will hit redis again (once)