### PR TITLE
Surpress warning output in tests

### DIFF
--- a/src/csp_post_processor/tests/test_schema_generation.py
+++ b/src/csp_post_processor/tests/test_schema_generation.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib import admin
 from django.test import override_settings
 from django.urls import path
@@ -71,7 +73,10 @@ urlpatterns = [
 @override_settings(ROOT_URLCONF=__name__, CSP_REPORT_URI="/blah")
 class SchemaGenerationExtensionTests(APITestCase):
     def test_expected_schema_generation(self):
-        response = self.client.get("")
+        # can't use override_settings because drf-spectacular doesn't seem to
+        # listen to settings_changed to clear internal caches
+        with patch("drf_spectacular.drainage.GENERATOR_STATS.silent", new=True):
+            response = self.client.get("")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         schema = response.json()

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eherkenning_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eherkenning_auth.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from base64 import b64decode
 from typing import Optional
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from lxml import etree
 from openforms.forms.tests.factories import FormFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
+from openforms.tests.utils import surpress_output
 
 from ....constants import CO_SIGN_PARAMETER, FORM_AUTH_SESSION_KEY, AuthAttribute
 from ....contrib.tests.saml_utils import (
@@ -230,7 +232,8 @@ class AuthenticationStep5Tests(TestCase):
             }
         )
 
-        response = self.client.get(url, follow=True)
+        with surpress_output(sys.stderr, os.devnull):
+            response = self.client.get(url, follow=True)
 
         self.assertRedirects(
             response, f"https://testserver{form_path}", status_code=302
@@ -380,7 +383,9 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, TestCase):
             }
         )
 
-        response = self.client.get(url)
+        with surpress_output(sys.stderr, os.devnull):
+            response = self.client.get(url)
+
         self.assertRedirects(
             response, str(auth_return_url), fetch_redirect_response=False
         )

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from base64 import b64decode
 from typing import Optional
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from lxml import etree
 from openforms.forms.tests.factories import FormFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
+from openforms.tests.utils import surpress_output
 
 from ....constants import CO_SIGN_PARAMETER, FORM_AUTH_SESSION_KEY, AuthAttribute
 from ....contrib.tests.saml_utils import (
@@ -230,7 +232,8 @@ class AuthenticationStep5Tests(TestCase):
             }
         )
 
-        response = self.client.get(url, follow=True)
+        with surpress_output(sys.stderr, os.devnull):
+            response = self.client.get(url, follow=True)
 
         self.assertRedirects(
             response, f"https://testserver{form_path}", status_code=302
@@ -383,7 +386,9 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, TestCase):
             }
         )
 
-        response = self.client.get(url)
+        with surpress_output(sys.stderr, os.devnull):
+            response = self.client.get(url)
+
         self.assertRedirects(
             response, str(auth_return_url), fetch_redirect_response=False
         )

--- a/src/openforms/tests/utils.py
+++ b/src/openforms/tests/utils.py
@@ -1,3 +1,5 @@
+import contextlib
+import os
 import socket
 
 from django.conf import settings
@@ -22,3 +24,28 @@ def can_connect(hostname: str):
         return True
     except Exception:
         return False
+
+
+@contextlib.contextmanager
+def surpress_output(stdchannel, dest_filename):
+    """
+    A context manager to temporarily redirect stdout or stderr
+
+    e.g.:
+
+
+    with surpress_output(sys.stderr, os.devnull):
+        if compiler.has_function('clock_gettime', libraries=['rt']):
+            libraries.append('rt')
+
+    Taken from https://stackoverflow.com/a/17753573
+    """
+
+    oldstdchannel = os.dup(stdchannel.fileno())
+    dest_file = open(dest_filename, "w")
+    os.dup2(dest_file.fileno(), stdchannel.fileno())
+    try:
+        yield
+    finally:
+        os.dup2(oldstdchannel, stdchannel.fileno())
+        dest_file.close()


### PR DESCRIPTION
This has been bothering me for a a long time - there's some useless output in tests that we can safely ignore.