### PR TITLE
[#2058] Summary page data from backend

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3584,6 +3584,38 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+  /api/v1/submissions/{uuid}/summary:
+    get:
+      operationId: submissions_summary_list
+      description: Retrieve the data to display in the submission summary page.
+      summary: Summary page data
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - submissions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SubmissionStepSummarySerialzier'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
   /api/v1/submissions/files/{uuid}:
     get:
       operationId: submissions_files_retrieve
@@ -6216,6 +6248,24 @@ components:
             one day.
       required:
       - statusUrl
+    SubmissionComponentSummary:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Display name of the component.
+        value:
+          type: object
+          additionalProperties: {}
+          description: Raw value of the component.
+        component:
+          type: object
+          additionalProperties: {}
+          description: Configuration of the component.
+      required:
+      - component
+      - name
+      - value
     SubmissionProcessingStatus:
       type: object
       properties:
@@ -6315,6 +6365,24 @@ components:
       - formStep
       - id
       - isApplicable
+      - slug
+    SubmissionStepSummarySerialzier:
+      type: object
+      properties:
+        slug:
+          type: string
+          description: Slug of the form definition used in the form step.
+          pattern: ^[-a-zA-Z0-9_]+$
+        name:
+          type: string
+          description: Name of the form definition used in the form step.
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubmissionComponentSummary'
+      required:
+      - data
+      - name
       - slug
     SubmissionSuspension:
       type: object

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -166,6 +166,14 @@ class EditGridNode(ContainerMixin, ComponentNode):
     layout_modifier: str = "editgrid"
     display_value: str = ""
 
+    @property
+    def value(self):
+        return None
+
+    @property
+    def _value(self):
+        return super().value
+
     def get_children(self) -> Iterator["ComponentNode"]:
         """
         Return children as many times as they are repeated in the data
@@ -198,7 +206,7 @@ class EditGridNode(ContainerMixin, ComponentNode):
         So we need to repeat the child nodes of the configuration and associate them with the data
         provided by the user.
         """
-        repeats = len(self.value) if self.value else 0
+        repeats = len(self._value) if self._value else 0
 
         for node_index in range(repeats):
             path = Path(self.component["key"])

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -451,3 +451,30 @@ class SubmissionCoSignStatusSerializer(serializers.ModelSerializer):
 
     def get_representation(self, submission: Submission) -> str:
         return submission.co_sign_data.get("representation", "")
+
+
+class SubmissionComponentSummarySerializer(serializers.Serializer):
+    name = serializers.CharField(
+        help_text=_("Display name of the component."),
+        required=True,
+    )
+    value = serializers.JSONField(
+        help_text=_("Raw value of the component."),
+        required=True,
+    )
+    component = serializers.JSONField(
+        help_text=_("Configuration of the component."),
+        required=True,
+    )
+
+
+class SubmissionStepSummarySerialzier(serializers.Serializer):
+    slug = serializers.SlugField(
+        help_text=_("Slug of the form definition used in the form step."),
+        required=True,
+    )
+    name = serializers.CharField(
+        help_text=_("Name of the form definition used in the form step."),
+        required=True,
+    )
+    data = SubmissionComponentSummarySerializer(many=True)

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -359,6 +359,19 @@ class SubmissionViewSet(
         logevent.submission_details_view_api(self.get_object(), request.user)
         return super().retrieve(request, *args, **kwargs)
 
+    @extend_schema(
+        summary=_("Summary page data"),
+        description=_("Get the data to display in the summary page"),
+        responses={
+            200: SubmissionSuspensionSerializer,
+        },
+    )
+    @action(detail=True, methods=["get"], url_name="summary")
+    def summary(self, request, *args, **kwargs):
+        submission = self.get_object()
+        summary_data = submission.render_summary_page()
+        return Response(summary_data)
+
 
 @extend_schema(
     parameters=[

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -61,6 +61,7 @@ from .serializers import (
     SubmissionStateLogic,
     SubmissionStateLogicSerializer,
     SubmissionStepSerializer,
+    SubmissionStepSummarySerialzier,
     SubmissionSuspensionSerializer,
 )
 from .validation import CompletionValidationSerializer, validate_submission_completion
@@ -361,12 +362,12 @@ class SubmissionViewSet(
 
     @extend_schema(
         summary=_("Summary page data"),
-        description=_("Get the data to display in the summary page"),
+        description=_("Retrieve the data to display in the submission summary page."),
         responses={
-            200: SubmissionSuspensionSerializer,
+            200: SubmissionStepSummarySerialzier(many=True),
         },
     )
-    @action(detail=True, methods=["get"], url_name="summary")
+    @action(detail=True, methods=["get"], url_name="summary", pagination_class=None)
     def summary(self, request, *args, **kwargs):
         submission = self.get_object()
         summary_data = submission.render_summary_page()

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -1,0 +1,189 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from openforms.forms.tests.factories import FormFactory, FormStepFactory
+from openforms.submissions.tests.factories import (
+    SubmissionFactory,
+    SubmissionStepFactory,
+)
+from openforms.submissions.tests.mixins import SubmissionsMixin
+
+COMPONENTS_1 = [
+    # visible component, leaf node
+    {
+        "type": "textfield",
+        "key": "input1",
+        "label": "Input 1",
+        "hidden": False,
+    },
+    # hidden component, leaf node
+    {
+        "type": "textfield",
+        "key": "input2",
+        "label": "Input 2",
+        "hidden": True,
+    },
+]
+
+
+COMPONENTS_2 = [  # container: visible fieldset with visible children
+    {
+        "type": "fieldset",
+        "key": "fieldsetVisibleChildren",
+        "label": "A container with visible children",
+        "hidden": False,
+        "components": [
+            {
+                "type": "textfield",
+                "key": "input3",
+                "label": "Input 3",
+                "hidden": True,
+            },
+            {
+                "type": "textfield",
+                "key": "input4",
+                "label": "Input 4",
+                "hidden": False,
+            },
+        ],
+    },
+    # container: hidden fieldset with visible children
+    {
+        "type": "fieldset",
+        "key": "hiddenFieldsetVisibleChildren",
+        "label": "A hidden container with visible children",
+        "hidden": True,
+        "components": [
+            {
+                "type": "textfield",
+                "key": "input5",
+                "label": "Input 5",
+                "hidden": True,
+            },
+            {
+                "type": "textfield",
+                "key": "input6",
+                "label": "Input 6",
+                "hidden": False,
+            },
+        ],
+    },
+]
+
+
+class SubmissionSummaryRendererTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        form = FormFactory.create()
+        form_step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={"components": COMPONENTS_1},
+            form_definition__slug="fd-0",
+            form_definition__name="Form Definition 0",
+        )
+        form_step2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={"components": COMPONENTS_2},
+            form_definition__slug="fd-1",
+            form_definition__name="Form Definition 1",
+        )
+
+        submission = SubmissionFactory.create(form=form)
+
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step1,
+            data={
+                "input1": "first input",
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step2,
+            data={
+                "input2": "second input",
+                "input4": "fourth input",
+            },
+        )
+
+        cls.submission = submission
+
+    def test_get_data_summary_page(self):
+        data = self.submission.render_summary_page()
+
+        self.assertEqual(2, len(data))
+
+        step1, step2 = data
+
+        self.assertEqual("fd-0", step1["slug"])
+        self.assertEqual("Form Definition 0", step1["name"])
+        self.assertEqual(1, len(step1["data"]))  # input1
+        self.assertIn("name", step1["data"][0])
+        self.assertIn("value", step1["data"][0])
+        self.assertIn("component", step1["data"][0])
+
+        self.assertEqual("fd-1", step2["slug"])
+        self.assertEqual("Form Definition 1", step2["name"])
+        self.assertEqual(2, len(step2["data"]))  # fieldsetVisibleChildren and input3
+        self.assertIn("name", step2["data"][0])
+        self.assertIn("value", step2["data"][0])
+        self.assertIn("component", step2["data"][0])
+
+    def test_check_summary_renderer_queries(self):
+        """Make sure we are not making a query to retrieve the form definition for each step"""
+
+        # 1. Get form steps
+        # 2. Get submission steps
+        # 3. Get form variables
+        # 4. Get submission variables
+        # 5. Get form logic
+        # 6. Get auth info
+        with self.assertNumQueries(6):
+            self.submission.render_summary_page()
+
+
+class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
+    def test_summary_page_endpoint(self):
+        form = FormFactory.create()
+        form_step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={"components": COMPONENTS_1},
+        )
+        form_step2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={"components": COMPONENTS_2},
+        )
+
+        submission = SubmissionFactory.create(form=form)
+
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step1,
+            data={
+                "input1": "first input",
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step2,
+            data={
+                "input2": "second input",
+                "input4": "fourth input",
+            },
+        )
+
+        self._add_submission_to_session(submission)
+
+        url = reverse("api:submission-summary", kwargs={"uuid": submission.uuid})
+        response = self.client.get(url)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        data = response.json()
+
+        self.assertEqual(2, len(data))


### PR DESCRIPTION
Part of #2058 

To do backend:
- [x] Document endpoint drf-spectacular (structure of response)
- [x] Generate OAS
- [x] Raw Value of EditGrid should be empty for summary

To do frontend https://github.com/open-formulieren/open-forms-sdk/pull/238
- [x] Finish cleaning up new summary page
- [x] Write tests
- [x] Fix CSS for summary
