### PR TITLE
[#2078] Make field label compulsory

### DIFF
--- a/src/openforms/js/components/form/coSign.js
+++ b/src/openforms/js/components/form/coSign.js
@@ -1,7 +1,7 @@
 import {Formio} from 'react-formio';
 
 import {getFullyQualifiedUrl} from 'utils/urls';
-import {DESCRIPTION, LABEL} from 'components/form/edit/options';
+import {DESCRIPTION, LABEL_REQUIRED} from 'components/form/edit/options';
 
 const FieldComponent = Formio.Components.components.field;
 
@@ -15,7 +15,7 @@ const EDIT_FORM_TABS = [
         key: 'basic',
         label: 'Basic',
         components: [
-          LABEL,
+          LABEL_REQUIRED,
           DESCRIPTION,
           {
             type: 'select',

--- a/src/openforms/js/components/form/edit/options.js
+++ b/src/openforms/js/components/form/edit/options.js
@@ -4,6 +4,15 @@ const LABEL = {
   label: 'Label',
 };
 
+const LABEL_REQUIRED = {
+  type: 'textfield',
+  key: 'label',
+  label: 'Label',
+  validate: {
+    required: true,
+  },
+};
+
 const KEY = {
   type: 'textfield',
   key: 'key',
@@ -119,6 +128,7 @@ const REQUIRED = {
 };
 
 export {
+  LABEL_REQUIRED,
   LABEL,
   KEY,
   DESCRIPTION,

--- a/src/openforms/js/components/form/edit/tabs.js
+++ b/src/openforms/js/components/form/edit/tabs.js
@@ -2,6 +2,7 @@ import {Utils} from 'formiojs';
 
 import {getFullyQualifiedUrl} from '../../../utils/urls';
 import {
+  LABEL_REQUIRED,
   LABEL,
   KEY,
   DESCRIPTION,
@@ -24,7 +25,7 @@ const BASIC = {
   key: 'basic',
   label: 'Basic',
   components: [
-    LABEL,
+    LABEL_REQUIRED,
     KEY,
     DESCRIPTION,
     PRESENTATION,

--- a/src/openforms/js/components/form/editGrid.js
+++ b/src/openforms/js/components/form/editGrid.js
@@ -5,7 +5,7 @@ import {
   HIDDEN,
   IS_SENSITIVE_DATA,
   KEY,
-  LABEL,
+  LABEL_REQUIRED,
   REQUIRED,
 } from './edit/options';
 
@@ -32,7 +32,7 @@ const EDIT_FORM_TABS = [
         key: 'basic',
         label: 'Basic',
         components: [
-          LABEL,
+          LABEL_REQUIRED,
           KEY,
           GROUP_LABEL,
           DESCRIPTION,


### PR DESCRIPTION
Fixes #2078 

Note: because #1391 fieldset component can have empty labels

So I also left that columns and content components can have empty labels.
