### PR TITLE
Reduce the amount of (unnecessary) iter_components calls

### DIFF
--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, Optional
+
+from openforms.typing import JSONObject
+
+from .typing import Component
+from .utils import iter_components
+
+# TODO: mechanism to wrap/mark root components?
+
+
+@dataclass
+class FormioConfigurationWrapper:
+    """
+    Wrap around the Formio configuration dictionary for further processing.
+
+    This datastructure caches the internal datastructure to optimize mutations of the
+    formio configuration.
+    """
+
+    configuration: JSONObject
+    # depth-first ordered of all components in the formio configuration tree
+    _cached_component_map: Optional[Dict[str, Component]] = field(
+        init=False, default=None
+    )
+
+    @property
+    def component_map(self) -> Dict[str, Component]:
+        if self._cached_component_map is None:
+            self._cached_component_map = {
+                component["key"]: component
+                for component in iter_components(self.configuration, recursive=True)
+            }
+        return self._cached_component_map
+
+    def __iter__(self) -> Iterator[Component]:
+        for component in self.component_map.values():
+            yield component
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.component_map
+
+    def __getitem__(self, key: str) -> Component:
+        return self.component_map[key]

--- a/src/openforms/formio/dynamic_config/service.py
+++ b/src/openforms/formio/dynamic_config/service.py
@@ -3,22 +3,22 @@ Public API for dynamic configuration.
 """
 from typing import Optional
 
-from openforms.typing import DataMapping, JSONObject
+from openforms.typing import DataMapping
 
+from ..datastructures import FormioConfigurationWrapper
 from .registry import register
 
 __all__ = ["apply_dynamic_configuration"]
 
 
 def apply_dynamic_configuration(
-    configuration: JSONObject, data: Optional[DataMapping] = None
-) -> JSONObject:
+    configuration_wrapper: FormioConfigurationWrapper,
+    data: Optional[DataMapping] = None,
+) -> FormioConfigurationWrapper:
     """
     Loop over the formio configuration and mutate components in place.
     """
-    from ..service import iter_components
-
     data = data or {}  # normalize
-    for component in iter_components(configuration, recursive=True):
+    for component in configuration_wrapper:
         register.update_config(component, data=data)
-    return configuration
+    return configuration_wrapper

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -12,7 +12,7 @@ from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.variables.service import get_static_variables
 
 from ...dynamic_config.date import FormioDateComponent
-from ...service import get_dynamic_configuration
+from ...service import FormioConfigurationWrapper, get_dynamic_configuration
 from ...typing import Component
 
 request_factory = APIRequestFactory()
@@ -23,14 +23,15 @@ class DynamicDateConfigurationTests(SimpleTestCase):
     def _get_dynamic_config(
         component: Component, variables: Dict[str, Any]
     ) -> FormioDateComponent:
-        configuration = {"components": [component]}
+        config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")
         submission = SubmissionFactory.build()
         static_vars = get_static_variables(submission=None)  # don't do queries
         variables.update({var.key: var.initial_value for var in static_vars})
-        new_configuration = get_dynamic_configuration(
-            configuration, request=request, submission=submission, data=variables
+        config_wrapper = get_dynamic_configuration(
+            config_wrapper, request=request, submission=submission, data=variables
         )
+        new_configuration = config_wrapper.configuration
         return new_configuration["components"][0]
 
     def test_legacy_configuration_still_works(self):

--- a/src/openforms/formio/normalization.py
+++ b/src/openforms/formio/normalization.py
@@ -4,9 +4,10 @@ from typing import Any
 
 from openforms.plugins.plugin import AbstractBasePlugin
 from openforms.plugins.registry import BaseRegistry
+from openforms.utils.date import format_date_value
 
 from .typing import Component
-from .utils import conform_to_mask, format_date_value
+from .utils import conform_to_mask
 
 __all__ = ["normalize_value_for_component", "register", "Normalizer"]
 

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -8,8 +8,9 @@ from rest_framework.request import Request
 from openforms.forms.custom_field_types import handle_custom_types
 from openforms.prefill import inject_prefill
 from openforms.submissions.models import Submission
-from openforms.typing import DataMapping, JSONObject
+from openforms.typing import DataMapping
 
+from .datastructures import FormioConfigurationWrapper
 from .dynamic_config.service import apply_dynamic_configuration
 from .normalization import normalize_value_for_component
 from .typing import Component
@@ -32,28 +33,31 @@ from ..config.models import GlobalConfiguration
 # the context of the same request
 @elasticapm.capture_span(span_type="app.formio")
 def get_dynamic_configuration(
-    configuration: dict,
+    config_wrapper: FormioConfigurationWrapper,
     request: Request,
     submission: Submission,
     data: Optional[DataMapping] = None,
-) -> JSONObject:
+) -> FormioConfigurationWrapper:
     """
     Given a static Formio configuration, apply the hooks to dynamically transform this.
 
     The configuration is modified in the context of the provided :arg:`submission`.
     """
-    configuration = handle_custom_types(
-        configuration, request=request, submission=submission
+    # TODO: see if we can make the config wrapper smart enough to deal with this
+    config_wrapper.configuration = handle_custom_types(
+        config_wrapper.configuration, request=request, submission=submission
     )
-    apply_dynamic_configuration(configuration, data=data)
+    assert config_wrapper._cached_component_map is None
+
+    apply_dynamic_configuration(config_wrapper, data=data)
     # prefill is still 'special' even though it uses variables, as we specifically
     # set the `defaultValue` key to the resulting variable.
     # This *could* be refactored in the future by assigning a template expression to
     # the default value key and then pass it through :func:`inject_variables`. However,
     # this is still complicated in the form designer for non-text input defaults such
     # as checkboxes/dropdowns/radios/...
-    inject_prefill(configuration, submission)
-    return configuration
+    inject_prefill(config_wrapper, submission)
+    return config_wrapper
 
 
 def update_configuration_for_request(configuration: dict, request: Request) -> None:

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -60,7 +60,9 @@ def get_dynamic_configuration(
     return config_wrapper
 
 
-def update_configuration_for_request(configuration: dict, request: Request) -> None:
+def update_configuration_for_request(
+    config_wrapper: FormioConfigurationWrapper, request: Request
+) -> None:
     """
     Given a static Formio configuration, apply dynamic changes we always must do, like setting absolute urls.
 
@@ -70,7 +72,7 @@ def update_configuration_for_request(configuration: dict, request: Request) -> N
         update_urls_in_place,
         update_default_file_types,
     )
-    for component in iter_components(configuration):
+    for component in config_wrapper:
         for function in pipeline:
             function(component, request=request)
 

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -47,7 +47,6 @@ def get_dynamic_configuration(
     config_wrapper.configuration = handle_custom_types(
         config_wrapper.configuration, request=request, submission=submission
     )
-    assert config_wrapper._cached_component_map is None
 
     apply_dynamic_configuration(config_wrapper, data=data)
     # prefill is still 'special' even though it uses variables, as we specifically

--- a/src/openforms/formio/tests/test_service.py
+++ b/src/openforms/formio/tests/test_service.py
@@ -1,7 +1,10 @@
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
-from openforms.formio.service import update_configuration_for_request
+from openforms.formio.service import (
+    FormioConfigurationWrapper,
+    update_configuration_for_request,
+)
 
 
 class ServiceTestCase(TestCase):
@@ -19,7 +22,9 @@ class ServiceTestCase(TestCase):
                 },
             ],
         }
-        update_configuration_for_request(configuration, request)
+        update_configuration_for_request(
+            FormioConfigurationWrapper(configuration), request
+        )
 
         url = request.build_absolute_uri(reverse("api:formio:temporary-file-upload"))
         self.assertEqual(configuration["components"][0]["url"], url)

--- a/src/openforms/formio/tests/test_variables_injection.py
+++ b/src/openforms/formio/tests/test_variables_injection.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from freezegun import freeze_time
 
+from ..datastructures import FormioConfigurationWrapper
 from ..variables import inject_variables, render
 
 VARIABLES = {
@@ -85,7 +86,7 @@ class VariableInjectionTests(SimpleTestCase):
     def test_variable_interpolation(self):
         configuration = deepcopy(CONFIGURATION)
 
-        inject_variables(configuration, VARIABLES)
+        inject_variables(FormioConfigurationWrapper(configuration), VARIABLES)
 
         lookup_table = {comp["key"]: comp for comp in configuration["components"]}
 
@@ -148,7 +149,7 @@ class VariableInjectionTests(SimpleTestCase):
             ]
         }
 
-        inject_variables(configuration, {})
+        inject_variables(FormioConfigurationWrapper(configuration), {})
 
         self.assertEqual(
             configuration["components"][0]["label"],
@@ -166,7 +167,7 @@ class VariableInjectionTests(SimpleTestCase):
             ]
         }
 
-        inject_variables(configuration, {})
+        inject_variables(FormioConfigurationWrapper(configuration), {})
 
         self.assertEqual(
             configuration["components"][0]["label"],

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import date, datetime
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import elasticapm
@@ -108,22 +107,6 @@ def component_in_editgrid(configuration: dict, component: dict) -> bool:
                 return True
 
     return False
-
-
-def format_date_value(date_value: str) -> str:
-    try:
-        parsed_date = date.fromisoformat(date_value)
-    except ValueError:
-        try:
-            parsed_date = datetime.strptime(date_value, "%Y%m%d").date()
-        except ValueError:
-            logger.info(
-                "Invalid date %s for prefill of date field. Using empty value.",
-                date_value,
-            )
-            return ""
-
-    return parsed_date.isoformat()
 
 
 def get_component_datatype(component):

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -285,7 +285,3 @@ def is_visible_in_frontend(component: JSONObject, data: DataMapping) -> bool:
         if trigger_component_value == compare_value
         else not conditional_show
     )
-
-
-def get_all_component_keys(configuration: JSONObject) -> List[str]:
-    return [component["key"] for component in iter_components(configuration)]

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import elasticapm
@@ -38,6 +39,11 @@ def iter_components(
 
 @elasticapm.capture_span(span_type="app.formio.configuration")
 def get_component(configuration: JSONObject, key: str) -> Optional[Component]:
+    warnings.warn(
+        "`openforms.formio.utils.get_component` is not efficient, use "
+        "`openforms.formio.utils.FormioConfigurationWrapper` instead.",
+        DeprecationWarning,
+    )
     for component in iter_components(configuration=configuration, recursive=True):
         if component["key"] == key:
             return component

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -6,8 +6,9 @@ from django.template import TemplateSyntaxError
 from openforms.template import parse, render_from_string
 from openforms.typing import DataMapping, JSONObject, JSONValue
 
+from .datastructures import FormioConfigurationWrapper
 from .typing import Component
-from .utils import flatten_by_path, iter_components
+from .utils import flatten_by_path
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,9 @@ def validate_configuration(configuration: JSONObject) -> Dict[str, str]:
     return errored_components
 
 
-def inject_variables(configuration: JSONObject, values: DataMapping) -> None:
+def inject_variables(
+    configuration: FormioConfigurationWrapper, values: DataMapping
+) -> None:
     """
     Inject the variable values into the Formio configuration.
 
@@ -107,7 +110,7 @@ def inject_variables(configuration: JSONObject, values: DataMapping) -> None:
     .. todo:: Support getting non-string based configuration from variables, such as
        `validate.required` etc.
     """
-    for component in iter_components(configuration=configuration, recursive=True):
+    for component in configuration:
         for property_name, property_value in iter_template_properties(component):
             if not property_value:
                 continue

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -50,12 +50,12 @@ class UsedInFormSerializer(serializers.HyperlinkedModelSerializer):
 class FormDefinitionSerializer(serializers.HyperlinkedModelSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance=instance)
-        configuration = representation["configuration"]
-
         # set upload urls etc
         # TODO: move this to openforms.formio.dynamic_config
-        update_configuration_for_request(configuration, request=self.context["request"])
-
+        update_configuration_for_request(
+            instance.configuration_wrapper, request=self.context["request"]
+        )
+        representation["configuration"] = instance.configuration_wrapper.configuration
         return representation
 
     class Meta:

--- a/src/openforms/forms/models/form_definition.py
+++ b/src/openforms/forms/models/form_definition.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from copy import deepcopy
 from functools import partial
-from typing import List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -19,6 +19,9 @@ from openforms.formio.utils import iter_components
 from ..models import Form
 from ..tasks import detect_formiojs_configuration_snake_case
 from ..validators import validate_template_expressions
+
+if TYPE_CHECKING:
+    from openforms.formio.service import FormioConfigurationWrapper
 
 
 def _get_number_of_components(form_definition: "FormDefinition") -> int:
@@ -139,6 +142,12 @@ class FormDefinition(models.Model):
             )
 
         return super().delete(using=using, keep_parents=keep_parents)
+
+    @cached_property
+    def configuration_wrapper(self) -> "FormioConfigurationWrapper":
+        from openforms.formio.service import FormioConfigurationWrapper
+
+        return FormioConfigurationWrapper(self.configuration)
 
     def iter_components(self, configuration=None, recursive=True, **kwargs):
         if configuration is None:

--- a/src/openforms/forms/tests/test_api_formdefinition.py
+++ b/src/openforms/forms/tests/test_api_formdefinition.py
@@ -130,7 +130,9 @@ class FormDefinitionsAPITests(APITestCase):
             login_required=False,
             configuration={
                 "display": "form",
-                "components": [{"label": "Existing field"}],
+                "components": [
+                    {"key": "somekey", "type": "textfield", "label": "Existing field"}
+                ],
             },
         )
 
@@ -142,7 +144,14 @@ class FormDefinitionsAPITests(APITestCase):
                 "slug": "updated-slug",
                 "configuration": {
                     "display": "form",
-                    "components": [{"label": "Existing field"}, {"label": "New field"}],
+                    "components": [
+                        {
+                            "key": "somekey",
+                            "type": "textfield",
+                            "label": "Existing field",
+                        },
+                        {"key": "somekey2", "type": "textfield", "label": "New field"},
+                    ],
                 },
                 "login_required": True,
             },
@@ -155,7 +164,10 @@ class FormDefinitionsAPITests(APITestCase):
         self.assertEqual("Updated name", definition.name)
         self.assertEqual("updated-slug", definition.slug)
         self.assertEqual(True, definition.login_required)
-        self.assertIn({"label": "New field"}, definition.configuration["components"])
+        self.assertIn(
+            {"key": "somekey2", "type": "textfield", "label": "New field"},
+            definition.configuration["components"],
+        )
 
     def test_update_is_reusable_unsuccessful_with_multiple_forms(self):
         user = SuperUserFactory.create()
@@ -195,7 +207,13 @@ class FormDefinitionsAPITests(APITestCase):
                 "slug": "a-slug",
                 "configuration": {
                     "display": "form",
-                    "components": [{"label": "New field"}],
+                    "components": [
+                        {
+                            "label": "New field",
+                            "key": "newField",
+                            "type": "textfield",
+                        }
+                    ],
                 },
             },
         )
@@ -207,7 +225,14 @@ class FormDefinitionsAPITests(APITestCase):
         self.assertEqual("Name", definition.name)
         self.assertEqual("a-slug", definition.slug)
         self.assertEqual(
-            [{"label": "New field"}], definition.configuration["components"]
+            [
+                {
+                    "label": "New field",
+                    "key": "newField",
+                    "type": "textfield",
+                }
+            ],
+            definition.configuration["components"],
         )
 
     def test_create_no_camelcase_snakecase_conversion(self):
@@ -222,6 +247,8 @@ class FormDefinitionsAPITests(APITestCase):
                 "slug": "a-slug",
                 "configuration": {
                     "someCamelCase": "field",
+                    "key": "somekey",
+                    "type": "textfield",
                 },
             },
         )
@@ -240,7 +267,13 @@ class FormDefinitionsAPITests(APITestCase):
             slug="test-form-definition",
             configuration={
                 "display": "form",
-                "components": [{"widget": {"time_24hr": True}}],
+                "components": [
+                    {
+                        "key": "somekey",
+                        "type": "textfield",
+                        "widget": {"time_24hr": True},
+                    }
+                ],
             },
         )
 
@@ -340,6 +373,7 @@ class FormDefinitionsAPITests(APITestCase):
                             },
                             {
                                 "type": "content",
+                                "key": "content",
                                 "html": "<p>{{ missingVariable }} hello</p>",
                                 # syntax errors in non-supported properties should be accepted
                                 "unvalidated": "{{ foo ",
@@ -421,6 +455,7 @@ class FormioCoSignComponentValidationTests(APITestCase):
             "components": [
                 {
                     "type": "coSign",
+                    "key": "coSign",
                     "label": "Co-sign test",
                 }
             ]
@@ -447,6 +482,7 @@ class FormioCoSignComponentValidationTests(APITestCase):
             "components": [
                 {
                     "type": "coSign",
+                    "key": "coSign",
                     "label": "Co-sign test",
                     "authPlugin": "digid",
                 }
@@ -479,6 +515,7 @@ class FormioCoSignComponentValidationTests(APITestCase):
             "components": [
                 {
                     "type": "coSign",
+                    "key": "coSign",
                     "label": "Co-sign test",
                     "authPlugin": "digid",
                 }

--- a/src/openforms/prefill/tests/test_prefill_hook.py
+++ b/src/openforms/prefill/tests/test_prefill_hook.py
@@ -6,6 +6,7 @@ from django.test import TransactionTestCase
 from django.utils.crypto import get_random_string
 
 from openforms.config.models import GlobalConfiguration
+from openforms.formio.datastructures import FormioConfigurationWrapper
 from openforms.forms.tests.factories import FormStepFactory
 from openforms.plugins.exceptions import PluginNotEnabled
 from openforms.submissions.models import Submission
@@ -107,7 +108,7 @@ def apply_prefill(configuration: dict, submission: "Submission", register=None) 
     configuration = deepcopy(configuration)
     _submission = Submission.objects.get(pk=submission.pk)
     prefill_variables(_submission, register=register)
-    inject_prefill(configuration, _submission)
+    inject_prefill(FormioConfigurationWrapper(configuration), _submission)
     return configuration
 
 

--- a/src/openforms/prefill/tests/test_prefill_variables.py
+++ b/src/openforms/prefill/tests/test_prefill_variables.py
@@ -5,7 +5,10 @@ from django.test import RequestFactory, TestCase
 import requests_mock
 
 from openforms.authentication.constants import AuthAttribute
-from openforms.formio.service import get_dynamic_configuration
+from openforms.formio.service import (
+    FormioConfigurationWrapper,
+    get_dynamic_configuration,
+)
 from openforms.forms.tests.factories import FormStepFactory
 from openforms.logging.models import TimelineLogProxy
 from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
@@ -107,13 +110,16 @@ class PrefillVariablesTests(TestCase):
         prefill_variables(submission=submission_step.submission)
 
         request = RequestFactory().get("/foo")
-        configuration = get_dynamic_configuration(
-            submission_step.form_step.form_definition.configuration,
+        config_wrapper = FormioConfigurationWrapper(
+            submission_step.form_step.form_definition.configuration
+        )
+        config_wrapper = get_dynamic_configuration(
+            config_wrapper,
             request=request,
             submission=submission_step.submission,
         )
 
-        component = configuration["components"][0]
+        component = config_wrapper.configuration["components"][0]
         self.assertEqual(component["type"], "postcode")
         self.assertEqual(component["defaultValue"], "1015 CJ")
 

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -1,15 +1,10 @@
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from django.utils.functional import empty
 
 import elasticapm
 
-from openforms.formio.service import (
-    FormioConfigurationWrapper,
-    get_dynamic_configuration,
-    inject_variables,
-)
+from openforms.formio.service import get_dynamic_configuration, inject_variables
 from openforms.formio.utils import get_component_empty_value, is_visible_in_frontend
 from openforms.logging import logevent
 
@@ -68,7 +63,7 @@ def evaluate_form_logic(
 
     """
     # grab the configuration that will be mutated
-    configuration = step.form_step.form_definition.configuration
+    config_wrapper = step.form_step.form_definition.configuration_wrapper
 
     # 1. we have `submission` and `step` available and ...
     # 2. the prefilled variables are already recorded in the variables state
@@ -82,7 +77,7 @@ def evaluate_form_logic(
     # ensure this function is idempotent
     _evaluated = getattr(step, "_form_logic_evaluated", False)
     if _evaluated:
-        return configuration
+        return config_wrapper.configuration
 
     # 3. Load the (variables) state
     submission_variables_state = submission.load_submission_value_variables_state()
@@ -120,7 +115,6 @@ def evaluate_form_logic(
     # we need to apply the context-specific configurations before we can apply
     # mutations based on logic, which is then in turn passed to the serializer(s)
     # TODO: refactor this to rely on variables state
-    config_wrapper = FormioConfigurationWrapper(deepcopy(configuration))
     config_wrapper = get_dynamic_configuration(
         config_wrapper,
         # context is expected to contain request, as is the default behaviour with DRF

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -9,8 +9,8 @@ from django.utils.translation import gettext_lazy as _
 
 from glom import Assign, PathAccessError, glom
 
-from openforms.formio.utils import format_date_value, get_all_component_keys
 from openforms.forms.models.form_variable import FormVariable
+from openforms.utils.date import format_date_value
 from openforms.variables.constants import FormVariableDataTypes
 from openforms.variables.service import get_static_variables
 

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -24,11 +24,10 @@ if TYPE_CHECKING:  # pragma: nocover
 @dataclass
 class SubmissionValueVariablesState:
     submission: "Submission"
-    _variables: Optional[Dict[str, "SubmissionValueVariable"]] = None
-    _static_data: Optional[Dict[str, Any]] = None
-
-    def __init__(self, submission: "Submission"):
-        self.submission = submission
+    _variables: Optional[Dict[str, "SubmissionValueVariable"]] = field(
+        init=False, default=None
+    )
+    _static_data: Optional[Dict[str, Any]] = field(init=False, default=None)
 
     @property
     def variables(self) -> Dict[str, "SubmissionValueVariable"]:

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -28,6 +28,9 @@ class SubmissionValueVariablesState:
         init=False, default=None
     )
     _static_data: Optional[Dict[str, Any]] = field(init=False, default=None)
+    _configuration_wrapper_cache: Dict[int, FormioConfigurationWrapper] = field(
+        init=False, default_factory=dict
+    )
 
     @property
     def variables(self) -> Dict[str, "SubmissionValueVariable"]:
@@ -45,6 +48,19 @@ class SubmissionValueVariablesState:
 
     def get_variable(self, key: str) -> "SubmissionValueVariable":
         return self.variables[key]
+
+    def _get_step_configuration_wrapper(
+        self, step: "SubmissionStep"
+    ) -> FormioConfigurationWrapper:
+        # TODO: check if we can cache this on the SubmissionStep instance even to further
+        # optimize calls
+        form_definition = step.form_step.form_definition
+        cache_key = form_definition.id
+        if cache_key not in self._configuration_wrapper_cache:
+            self._configuration_wrapper_cache[cache_key] = FormioConfigurationWrapper(
+                form_definition.configuration
+            )
+        return self._configuration_wrapper_cache[cache_key]
 
     def get_data(
         self,
@@ -76,8 +92,8 @@ class SubmissionValueVariablesState:
         submission_step: "SubmissionStep",
         include_unsaved=True,
     ) -> Dict[str, "SubmissionValueVariable"]:
-        configuration = submission_step.form_step.form_definition.configuration
-        keys_in_step = get_all_component_keys(configuration)
+        configuration_wrapper = self._get_step_configuration_wrapper(submission_step)
+        keys_in_step = list(configuration_wrapper.component_map.keys())
 
         variables = self.variables
         if not include_unsaved:

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -28,9 +28,6 @@ class SubmissionValueVariablesState:
         init=False, default=None
     )
     _static_data: Optional[Dict[str, Any]] = field(init=False, default=None)
-    _configuration_wrapper_cache: Dict[int, FormioConfigurationWrapper] = field(
-        init=False, default_factory=dict
-    )
 
     @property
     def variables(self) -> Dict[str, "SubmissionValueVariable"]:
@@ -48,19 +45,6 @@ class SubmissionValueVariablesState:
 
     def get_variable(self, key: str) -> "SubmissionValueVariable":
         return self.variables[key]
-
-    def _get_step_configuration_wrapper(
-        self, step: "SubmissionStep"
-    ) -> FormioConfigurationWrapper:
-        # TODO: check if we can cache this on the SubmissionStep instance even to further
-        # optimize calls
-        form_definition = step.form_step.form_definition
-        cache_key = form_definition.id
-        if cache_key not in self._configuration_wrapper_cache:
-            self._configuration_wrapper_cache[cache_key] = FormioConfigurationWrapper(
-                form_definition.configuration
-            )
-        return self._configuration_wrapper_cache[cache_key]
 
     def get_data(
         self,
@@ -92,7 +76,9 @@ class SubmissionValueVariablesState:
         submission_step: "SubmissionStep",
         include_unsaved=True,
     ) -> Dict[str, "SubmissionValueVariable"]:
-        configuration_wrapper = self._get_step_configuration_wrapper(submission_step)
+        configuration_wrapper = (
+            submission_step.form_step.form_definition.configuration_wrapper
+        )
         keys_in_step = list(configuration_wrapper.component_map.keys())
 
         variables = self.variables

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -1,0 +1,17 @@
+import logging
+from datetime import date, datetime
+
+logger = logging.getLogger(__name__)
+
+
+def format_date_value(date_value: str) -> str:
+    try:
+        parsed_date = date.fromisoformat(date_value)
+    except ValueError:
+        try:
+            parsed_date = datetime.strptime(date_value, "%Y%m%d").date()
+        except ValueError:
+            logger.info("Can't parse date %s, using empty value.", date_value)
+            return ""
+
+    return parsed_date.isoformat()


### PR DESCRIPTION
Related to #2042

Performance test run results on a simple form. A more complex form had hundreds of `iter_components` calls

| **Metric**              | Before | After |
|-------------------------|--------|-------|
| Avg latency (ms)        | 479    | 278   |
| 90 percentile (ms)      | 886    | 420   |
| # iter_components calls | 45     | 6     |

Note that I attribute the speedup mostly to the reduced APM overhead (implicit result by removing `iter_components` calls)