### PR TITLE
Tighten CSRF validation for anonymous users

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -48,6 +48,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CancelAppointmentInput'
         required: true
+      security:
+      - cookieAuth: []
       responses:
         '204':
           description: No response body
@@ -845,6 +847,8 @@ paths:
             schema:
               $ref: '#/components/schemas/TemporaryFileUpload'
         required: true
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:
@@ -3630,6 +3634,8 @@ paths:
         required: true
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '200':
           content:
@@ -3661,6 +3667,8 @@ paths:
         required: true
       tags:
       - submissions
+      security:
+      - cookieAuth: []
       responses:
         '204':
           description: No response body
@@ -3775,6 +3783,7 @@ paths:
               $ref: '#/components/schemas/ValidationInput'
         required: true
       security:
+      - cookieAuth: []
       - {}
       responses:
         '200':

--- a/src/openforms/api/authentication.py
+++ b/src/openforms/api/authentication.py
@@ -1,0 +1,19 @@
+from rest_framework import authentication
+
+
+class AnonCSRFSessionAuthentication(authentication.SessionAuthentication):
+    """
+    Enforce the CSRF checks even for non-authenticated users.
+
+    DRF by default only enforces CSRF checks for authenticated users, assuming the
+    attack vector targets logged-in sessions. However, non-authenticated user sessions
+    also need CSRF-protection. Only legitimate users who have received the CSRF-token
+    from an endpoint are allowed to consume the API using session cookies.
+    """
+
+    def authenticate(self, request):
+        result = super().authenticate(request)
+        # this is different from core DRF
+        if result is None:
+            self.enforce_csrf(request)
+        return result

--- a/src/openforms/api/drf_spectacular/__init__.py
+++ b/src/openforms/api/drf_spectacular/__init__.py
@@ -1,0 +1,1 @@
+from . import extensions  # noqa - imported to register extension

--- a/src/openforms/api/drf_spectacular/extensions.py
+++ b/src/openforms/api/drf_spectacular/extensions.py
@@ -1,0 +1,5 @@
+from drf_spectacular.authentication import SessionScheme
+
+
+class AnonCSRFSessionScheme(SessionScheme):
+    target_class = "openforms.api.authentication.AnonCSRFSessionAuthentication"

--- a/src/openforms/appointments/api/views.py
+++ b/src/openforms/appointments/api/views.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.views import APIView
 
+from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.serializers import ExceptionSerializer
 from openforms.logging import logevent
 from openforms.submissions.api.permissions import (
@@ -244,7 +245,7 @@ class CancelAppointmentView(GenericAPIView):
     lookup_field = "uuid"
     lookup_url_kwarg = "submission_uuid"
     queryset = Submission.objects.all()
-    authentication_classes = ()
+    authentication_classes = (AnonCSRFSessionAuthentication,)
     permission_classes = [ActiveSubmissionPermission]
 
     def post(self, request, *args, **kwargs):

--- a/src/openforms/formio/api/views.py
+++ b/src/openforms/formio/api/views.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
+from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.parsers import MaxFilesizeMultiPartParser
 from openforms.submissions.api.permissions import AnyActiveSubmissionPermission
 from openforms.submissions.api.renderers import PlainTextErrorRenderer
@@ -43,7 +44,7 @@ from .serializers import TemporaryFileUploadSerializer
 class TemporaryFileUploadView(GenericAPIView):
     parser_classes = [MaxFilesizeMultiPartParser]
     serializer_class = TemporaryFileUploadSerializer
-    authentication_classes = []
+    authentication_classes = (AnonCSRFSessionAuthentication,)
     permission_classes = [AnyActiveSubmissionPermission]
     renderer_classes = [CamelCaseJSONRenderer]
 

--- a/src/openforms/submissions/api/views.py
+++ b/src/openforms/submissions/api/views.py
@@ -7,6 +7,7 @@ from djangorestframework_camel_case.render import CamelCaseJSONRenderer
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.generics import DestroyAPIView, GenericAPIView
 
+from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.serializers import ExceptionSerializer
 
 from ..models import SubmissionReport, TemporaryFileUpload
@@ -85,7 +86,7 @@ class DownloadSubmissionReportView(GenericAPIView):
     ),
 )
 class TemporaryFileView(DestroyAPIView):
-    authentication_classes = []
+    authentication_classes = (AnonCSRFSessionAuthentication,)
     permission_classes = [OwnsTemporaryUploadPermission]
     renderer_classes = [FileRenderer, CamelCaseJSONRenderer]
 

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -19,6 +19,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 from openforms.api import pagination
+from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.filters import PermissionFilterMixin
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.forms.models import FormStep
@@ -120,7 +121,7 @@ class SubmissionViewSet(
         .order_by("created_on")
     )
     serializer_class = SubmissionSerializer
-    authentication_classes = (authentication.SessionAuthentication,)
+    authentication_classes = (AnonCSRFSessionAuthentication,)
     permission_classes = [ActiveSubmissionPermission]
     lookup_field = "uuid"
     pagination_class = pagination.PageNumberPagination
@@ -382,7 +383,7 @@ class SubmissionStepViewSet(
 
     queryset = SubmissionStep.objects.all()
     serializer_class = SubmissionStepSerializer
-    authentication_classes = (authentication.SessionAuthentication,)
+    authentication_classes = (AnonCSRFSessionAuthentication,)
     permission_classes = [
         ActiveSubmissionPermission,
         FormAuthenticationPermission,

--- a/src/openforms/submissions/tests/test_csrf.py
+++ b/src/openforms/submissions/tests/test_csrf.py
@@ -1,0 +1,89 @@
+from django.test import override_settings
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient, APITestCase
+
+from openforms.forms.tests.factories import FormFactory
+
+from .factories import SubmissionFactory
+from .mixins import SubmissionsMixin
+
+
+class CSRFAPIClient(APIClient):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("enforce_csrf_checks", True)
+        super().__init__(*args, **kwargs)
+
+
+@override_settings(ALLOWED_HOSTS=["testserver", "testserver.com"])
+class CSRFForAnonymousUsersTests(SubmissionsMixin, APITestCase):
+    client_class = CSRFAPIClient
+
+    def test_anonymous_user_submission_start_require_csrf_token(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__login_required=False,
+        )
+        form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+        form_response = self.client.get(form_url)
+
+        body = {
+            "form": f"http://testserver.com{form_url}",
+            "formUrl": "http://testserver.com/my-form",
+        }
+
+        with self.subTest("missing CSRF token"):
+            response = self.client.post(
+                reverse("api:submission-list"),
+                body,
+                HTTP_HOST="testserver.com",
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("CSRF token included"):
+            csrf_value = form_response.headers["X-CSRFToken"]
+
+            response = self.client.post(
+                reverse("api:submission-list"),
+                body,
+                HTTP_HOST="testserver.com",
+                HTTP_X_CSRFTOKEN=csrf_value,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_anonymous_user_put_step_data_require_csrf_token(self):
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__login_required=False,
+        )
+        submission_response = self.client.get(
+            reverse("api:submission-detail", kwargs={"uuid": submission.uuid})
+        )
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": submission.form.formstep_set.get().uuid,
+            },
+        )
+        body = {"data": {"component1": "henlo"}}
+
+        with self.subTest("missing CSRF token"):
+            response = self.client.put(endpoint, body)
+
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("CSRF token included"):
+            csrf_value = submission_response.headers["X-CSRFToken"]
+
+            response = self.client.put(
+                endpoint,
+                body,
+                HTTP_X_CSRFTOKEN=csrf_value,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/src/openforms/validations/api/views.py
+++ b/src/openforms/validations/api/views.py
@@ -6,6 +6,7 @@ from rest_framework import authentication, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.utils.api.views import ListMixin
 from openforms.validations.api.serializers import (
     ValidationInputSerializer,
@@ -36,7 +37,7 @@ class ValidationView(APIView):
     Validate a value using given validator
     """
 
-    authentication_classes = ()
+    authentication_classes = (AnonCSRFSessionAuthentication,)
 
     @extend_schema(
         operation_id="validation_run",


### PR DESCRIPTION
The CORS policy + CSRF_TRUSTED_ORIGINS does a great deal of protecting against CSRF attacks, and most of our endpoints use PUT/DELETE calls, but there are a number of POST calls that benefit from extra CSRF protection.