### PR TITLE
Columns options in form builder

### DIFF
--- a/src/openforms/js/components/form/columns.js
+++ b/src/openforms/js/components/form/columns.js
@@ -49,6 +49,22 @@ const COLUM_EDIT_TABS = {
               {label: '9/12 (75%)', value: '9'},
               {label: '10/12 (83.33%)', value: '10'},
               {label: '11/12 (91.67%)', value: '11'},
+              {label: '12/12 (100%)', value: '12'},
+            ],
+          },
+        },
+        {
+          type: 'select',
+          key: 'sizeMobile',
+          label: 'Size (mobile)',
+          tooltip: 'Width of the column on mobile viewports',
+          defaultValue: '4',
+          data: {
+            values: [
+              {label: '1/4 (25%)', value: '1'},
+              {label: '2/4 (50%)', value: '2'},
+              {label: '3/4 (75%)', value: '3'},
+              {label: '4/4 (100%)', value: '4'},
             ],
           },
         },

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -40,6 +40,8 @@
   "Year": "Jaar",
   "File Name": "Bestandsnaam",
   "Size": "Grootte",
+  "Size (mobile)": "Grootte (mobiel)",
+  "Width of the column on mobile viewports": "Grootte van de kolom in mobiele weergave",
   "Type": "Type",
   "Press to open ": "Klik om te openen ",
   "or": "of",

--- a/src/openforms/scss/components/admin/_edit-panel.scss
+++ b/src/openforms/scss/components/admin/_edit-panel.scss
@@ -29,7 +29,9 @@
   }
 
   &__edit-area {
-    width: 100%;
+    flex-grow: 1;
+    min-width: 0;
+    width: 75%;
 
     // override default django styles
     h2 {

--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -102,6 +102,14 @@ div.flatpickr-calendar.open {
   top: 100px;
 }
 
+.formio.builder,
+.component-preview {
+  .col-form-label {
+    @include ellipsis;
+    max-width: 100%;
+  }
+}
+
 // bootstrap competing with django admin form styling...
 .react-form-create {
   :not([ref='editForm']) {

--- a/src/openforms/scss/components/builder/_columns.scss
+++ b/src/openforms/scss/components/builder/_columns.scss
@@ -38,7 +38,7 @@ $bootstrap-ratio-desktop: math.div(12, $grid-columns-desktop);
   }
 
   .column {
-    $col-sizes: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11;
+    $col-sizes: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12;
 
     @each $col-size in $col-sizes {
       &--span-#{$col-size} {

--- a/src/openforms/scss/components/builder/_columns.scss
+++ b/src/openforms/scss/components/builder/_columns.scss
@@ -24,6 +24,10 @@ $bootstrap-ratio-desktop: math.div(12, $grid-columns-desktop);
   display: flex;
   width: 100%;
 
+  margin-left: -3px;
+  margin-right: -3px;
+  margin-bottom: 6px;
+
   .alert-info {
     text-indent: -9999px; // basically push the text off the screen
     line-height: 0; // collapse the lines to not take up vertical space
@@ -38,8 +42,17 @@ $bootstrap-ratio-desktop: math.div(12, $grid-columns-desktop);
   }
 
   .column {
-    $col-sizes: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12;
+    display: flex;
+    flex-direction: column;
 
+    padding-left: 3px;
+    padding-right: 3px;
+
+    & > * {
+      flex-grow: 1;
+    }
+
+    $col-sizes: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12;
     @each $col-size in $col-sizes {
       &--span-#{$col-size} {
         @include bootstrap-span(width, $col-size);
@@ -48,7 +61,8 @@ $bootstrap-ratio-desktop: math.div(12, $grid-columns-desktop);
   }
 }
 
-[ref='editForm'] {
+[ref='editForm'],
+[ref='preview'] {
   .formio-component-columns.row {
     margin-left: -7.5px;
     margin-right: -7.5px;


### PR DESCRIPTION
Fixes #2113 

* The (nested) boxes for columns now stretch to look more like a grid
* The labels of components are now limited to a single line (only in the builder!) and truncated with an ellipsis

![image](https://user-images.githubusercontent.com/5518550/194339344-9b27ae9a-7ea2-48aa-9247-24242d804674.png)

![image](https://user-images.githubusercontent.com/5518550/194339419-bc51c44a-e742-43d0-a769-0d050884d406.png)
