### PR TITLE
Improve performance form logic endpoints

### DIFF
--- a/src/openforms/forms/api/datastructures.py
+++ b/src/openforms/forms/api/datastructures.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from django.utils.functional import cached_property
+
+from ..models import Form, FormVariable
+
+
+@dataclass
+class FormVariableWrapper:
+    form: Form
+
+    @cached_property
+    def variables(self) -> Dict[str, FormVariable]:
+        return {variable.key: variable for variable in self.form.formvariable_set.all()}
+
+    def get(self, key: str, default=None) -> Optional[FormVariable]:
+        return self.variables.get(key, default)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.variables
+
+    def __getitem__(self, key: str) -> FormVariable:
+        return self.variables[key]

--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -58,6 +58,12 @@ class FormLogicBaseSerializer(serializers.HyperlinkedModelSerializer):
         self.fields["form"].label = related_field.verbose_name
 
 
+class FormLogicListSerializer(ListWithChildSerializer):
+    child_serializer_class = (
+        "openforms.forms.api.serializers.logic.form_logic.FormLogicSerializer"
+    )
+
+
 class FormLogicSerializer(FormLogicBaseSerializer, OrderedModelSerializer):
     trigger_from_step = NestedHyperlinkedRelatedField(
         required=False,
@@ -83,6 +89,7 @@ class FormLogicSerializer(FormLogicBaseSerializer, OrderedModelSerializer):
 
     class Meta(FormLogicBaseSerializer.Meta):
         model = FormLogic
+        list_serializer_class = FormLogicListSerializer
         fields = FormLogicBaseSerializer.Meta.fields + (
             "order",
             "trigger_from_step",
@@ -109,7 +116,3 @@ class FormLogicSerializer(FormLogicBaseSerializer, OrderedModelSerializer):
         validators = FormLogicBaseSerializer.Meta.validators + [
             FormLogicTriggerFromStepFormValidator()
         ]
-
-
-class FormLogicListSerializer(ListWithChildSerializer):
-    child_serializer_class = FormLogicSerializer

--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -4,9 +4,10 @@ from ordered_model.serializers import OrderedModelSerializer
 from rest_framework import serializers
 from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 
+from openforms.api.fields import RelatedFieldFromContext
 from openforms.api.serializers import ListWithChildSerializer
 
-from ....models import FormLogic, FormStep
+from ....models import Form, FormLogic, FormStep
 from ...validators import (
     FormLogicTriggerFromStepFormValidator,
     JsonLogicTriggerValidator,
@@ -16,6 +17,15 @@ from .action_serializers import LogicComponentActionSerializer
 
 
 class FormLogicBaseSerializer(serializers.HyperlinkedModelSerializer):
+    form = RelatedFieldFromContext(
+        queryset=Form.objects.all(),
+        view_name="api:form-detail",
+        lookup_field="uuid",
+        lookup_url_kwarg="uuid_or_slug",
+        required=True,
+        context_name="forms",
+    )
+
     class Meta:
         fields = (
             "uuid",
@@ -26,11 +36,6 @@ class FormLogicBaseSerializer(serializers.HyperlinkedModelSerializer):
         extra_kwargs = {
             "uuid": {
                 "read_only": True,
-            },
-            "form": {
-                "view_name": "api:form-detail",
-                "lookup_field": "uuid",
-                "lookup_url_kwarg": "uuid_or_slug",
             },
             "json_logic_trigger": {
                 "help_text": _(
@@ -44,6 +49,13 @@ class FormLogicBaseSerializer(serializers.HyperlinkedModelSerializer):
         validators = [
             JsonLogicTriggerValidator("json_logic_trigger"),
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        related_field = self.Meta.model._meta.get_field("form")
+        self.fields["form"].help_text = related_field.help_text
+        self.fields["form"].label = related_field.verbose_name
 
 
 class FormLogicSerializer(FormLogicBaseSerializer, OrderedModelSerializer):

--- a/src/openforms/forms/api/serializers/logic/form_logic_price.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic_price.py
@@ -3,9 +3,14 @@ from openforms.forms.api.serializers.logic.form_logic import FormLogicBaseSerial
 from openforms.forms.models import FormPriceLogic
 
 
+class FormPriceLogicListSerializer(ListWithChildSerializer):
+    child_serializer_class = "openforms.forms.api.serializers.logic.form_logic_price.FormPriceLogicSerializer"
+
+
 class FormPriceLogicSerializer(FormLogicBaseSerializer):
     class Meta(FormLogicBaseSerializer.Meta):
         model = FormPriceLogic
+        list_serializer_class = FormPriceLogicListSerializer
         fields = FormLogicBaseSerializer.Meta.fields + ("price",)
         extra_kwargs = {
             **FormLogicBaseSerializer.Meta.extra_kwargs,
@@ -15,7 +20,3 @@ class FormPriceLogicSerializer(FormLogicBaseSerializer):
                 "lookup_url_kwarg": "uuid_or_slug",
             },
         }
-
-
-class FormPriceLogicListSerializer(ListWithChildSerializer):
-    child_serializer_class = FormPriceLogicSerializer

--- a/src/openforms/forms/api/validators.py
+++ b/src/openforms/forms/api/validators.py
@@ -153,14 +153,12 @@ class JsonLogicTriggerValidator(JsonLogicValidator):
                 if needle_bits[0] == variable.key:
                     return
 
-            variable_related_to_form = form.formvariable_set.filter(key=needle)
-            if not variable_related_to_form:
-                # selectboxes case
-                variable_related_to_form = form.formvariable_set.filter(
-                    key=".".join(needle_bits[:-1])
-                )
+            form_variables = serializer.context["form_variables"]
+            if variable_related_to_form := form_variables.get(needle) is None:
+                alternative_needle = ".".join(needle_bits[:-1])
+                variable_related_to_form = form_variables.get(alternative_needle)
 
-            if not variable_related_to_form:
+            if variable_related_to_form is None:
                 raise serializers.ValidationError(
                     {
                         self.trigger_field: ErrorDetail(

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -25,6 +25,7 @@ from ..messages import add_success_message
 from ..models import Category, Form, FormDefinition, FormStep, FormVersion
 from ..tasks import recouple_submission_variables_to_form_variables
 from ..utils import export_form, import_form
+from .datastructures import FormVariableWrapper
 from .filters import FormVariableFilter
 from .parsers import (
     FormCamelCaseJSONParser,
@@ -281,9 +282,16 @@ class FormViewSet(viewsets.ModelViewSet):
             # So that the admin can display deleted forms, but the list endpoint doesn't return them
             queryset = queryset.filter(_is_deleted=False)
 
-        # ⚡️ - the prefetches are not required for the variables bulk (update/read)
+        # ⚡️ - the prefetches are not required for the variables/logic bulk (update/read)
         # endpoints, so we clear prefetches and select_related calls.
-        if self.action in ("variables_bulk_update", "variables_list"):
+        if self.action in (
+            "variables_bulk_update",
+            "variables_list",
+            "logic_rules_bulk_update",
+            "logic_rules_list",
+            "price_logic_rules_bulk_update",
+            "price_logic_rules_list",
+        ):
             queryset = queryset.select_related(None).prefetch_related(None)
 
         return queryset
@@ -519,6 +527,7 @@ class FormViewSet(viewsets.ModelViewSet):
                 "form": form,
                 # context for :class:`openforms.api.fields.RelatedFieldFromContext` lookups
                 "forms": {str(form.uuid): form},
+                "form_variables": FormVariableWrapper(form),
             },
         )
         serializer.is_valid(raise_exception=True)
@@ -573,6 +582,7 @@ class FormViewSet(viewsets.ModelViewSet):
                 "form": form,
                 # context for :class:`openforms.api.fields.RelatedFieldFromContext` lookups
                 "forms": {str(form.uuid): form},
+                "form_variables": FormVariableWrapper(form),
             },
         )
         serializer.is_valid(raise_exception=True)

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -512,7 +512,14 @@ class FormViewSet(viewsets.ModelViewSet):
         logic_rules.delete()
 
         serializer = FormLogicSerializer(
-            data=request.data, many=True, context={"request": request, "form": form}
+            data=request.data,
+            many=True,
+            context={
+                "request": request,
+                "form": form,
+                # context for :class:`openforms.api.fields.RelatedFieldFromContext` lookups
+                "forms": {str(form.uuid): form},
+            },
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
@@ -559,7 +566,14 @@ class FormViewSet(viewsets.ModelViewSet):
         price_logic_rules.delete()
 
         serializer = FormPriceLogicSerializer(
-            data=request.data, many=True, context={"request": request, "form": form}
+            data=request.data,
+            many=True,
+            context={
+                "request": request,
+                "form": form,
+                # context for :class:`openforms.api.fields.RelatedFieldFromContext` lookups
+                "forms": {str(form.uuid): form},
+            },
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/src/openforms/forms/tests/test_api_form_logic_bulk.py
+++ b/src/openforms/forms/tests/test_api_form_logic_bulk.py
@@ -1136,13 +1136,14 @@ class FormLogicAPITests(APITestCase):
             },
         ]
 
-        # 1. Start transaction
+        # 1. transaction SAVEPOINT
         # 2. Fetch the form (from UUID param in endpoint)
         # 3. Delete all the existing logic rules (to be replaced)
         # 4. Look up all the form variables for the form (once)
-        # 5-9. OrderedModelSerializer.create moves the rule to the specified order,
-        #    which triggers 2 queries per rule to be inserted.
-        with self.assertNumQueries(9):
+        # 5. Get max order within form (from ordered_model.models.OrderedModelQuerySet.bulk_create)
+        # 6. Bulk insert logic rules
+        # 7. transaction RELEASE SAVEPOINT
+        with self.assertNumQueries(7):
             response = self.client.put(url, data=form_logic_data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -192,7 +192,7 @@ def import_form_data(
             if resource == "forms" and existing_form_instance:
                 serializer_kwargs["instance"] = existing_form_instance
 
-            if resource == "formVariables":
+            if resource in ("formVariables", "formLogic"):
                 # by now, the form resource has been created (or it was an existing one)
                 _form = existing_form_instance or created_form
                 serializer_kwargs["context"].update(

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -17,6 +17,7 @@ from openforms.formio.utils import iter_components
 from openforms.typing import JSONObject
 from openforms.variables.constants import FormVariableSources
 
+from .api.datastructures import FormVariableWrapper
 from .api.serializers import (
     FormDefinitionSerializer,
     FormExportSerializer,
@@ -204,6 +205,15 @@ def import_form_data(
                                 formstep__form=_form
                             )
                         },
+                    }
+                )
+
+            if resource == "formLogic":
+                # by now, the form resource has been created (or it was an existing one)
+                _form = existing_form_instance or created_form
+                serializer_kwargs["context"].update(
+                    {
+                        "form_variables": FormVariableWrapper(_form),
                     }
                 )
 


### PR DESCRIPTION
Form logic endpoints had some terrible performance due to:

* validation of `form` FK (1 query per rule)
* validation of referenced variables in trigger (1-2 queries per variable per rule)
* insertion calculating + setting the rule for every rule (2 queries per rule)

So the number of queries was (worst case) `O(3n + 2m)` with `n` the number of rules and `m` the number of `{"var": "foo"}` references in the logic triggers.

This PR optimizes that to:

* no additional queries for `form` FK validation
* 1 query to prefetch all the form variables for trigger validation
* 2 queries for bulk insertion of the rules

This results in a fixed number of queries: `O(3)`