### PR TITLE
[#1899] Normalisation step when checking prefill data

### DIFF
--- a/src/openforms/formio/normalization.py
+++ b/src/openforms/formio/normalization.py
@@ -6,7 +6,7 @@ from openforms.plugins.plugin import AbstractBasePlugin
 from openforms.plugins.registry import BaseRegistry
 
 from .typing import Component
-from .utils import conform_to_mask
+from .utils import conform_to_mask, format_date_value
 
 __all__ = ["normalize_value_for_component", "register", "Normalizer"]
 
@@ -63,3 +63,9 @@ class PostalCodeNormalizer(Normalizer):
                 "Could not conform value '%s' to input mask '%s', returning original value."
             )
             return value
+
+
+@register("date")
+class DateNormalizer(Normalizer):
+    def normalize(self, component: Component, value: str) -> str:
+        return format_date_value(value)

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -13,14 +13,13 @@ from openforms.typing import DataMapping, JSONObject
 from .dynamic_config.service import apply_dynamic_configuration
 from .normalization import normalize_value_for_component
 from .typing import Component
-from .utils import format_date_value, iter_components, mimetype_allowed
+from .utils import iter_components, mimetype_allowed
 from .variables import inject_variables
 
 __all__ = [
     "get_dynamic_configuration",
     "update_configuration_for_request",
     "normalize_value_for_component",
-    "format_date_value",
     "iter_components",
     "mimetype_allowed",
     "inject_variables",

--- a/src/openforms/prefill/__init__.py
+++ b/src/openforms/prefill/__init__.py
@@ -37,7 +37,7 @@ import elasticapm
 from glom import Path, PathAccessError, glom
 from zgw_consumers.concurrent import parallel
 
-from openforms.formio.utils import format_date_value, iter_components
+from openforms.formio.utils import iter_components
 from openforms.plugins.exceptions import PluginNotEnabled
 from openforms.typing import JSONObject
 
@@ -125,8 +125,6 @@ def _set_default_values(
             )
 
         component["defaultValue"] = prefill_value
-        if component["type"] == "date":
-            component["defaultValue"] = format_date_value(prefill_value)
 
 
 def inject_prefill(configuration: dict, submission: "Submission") -> None:

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 from glom import Assign, PathAccessError, glom
 
-from openforms.formio.utils import get_all_component_keys
+from openforms.formio.utils import format_date_value, get_all_component_keys
 from openforms.forms.models.form_variable import FormVariable
 from openforms.variables.constants import FormVariableDataTypes
 from openforms.variables.service import get_static_variables
@@ -340,7 +340,8 @@ class SubmissionValueVariable(models.Model):
             return self.value
 
         if self.value and data_type == FormVariableDataTypes.datetime:
-            naive_date = parse_date(self.value)
+            date = format_date_value(self.value)
+            naive_date = parse_date(date)
             if naive_date is not None:
                 aware_date = timezone.make_aware(datetime.combine(naive_date, time.min))
                 return aware_date


### PR DESCRIPTION
Fixes #1899 for 2.0

The flow is a bit different from 1.1.x:
- On create submission, variables are prefilled (no normalisation, because no component)
- On logic check, default values are injected in the configuration by get_dynamic_configuration (which takes the values from the filled variables). Here there is normalisation.
- On saving a submission step, the prefill data is validated. This takes the values of the prefilled variables (not normalised) and compares it to the incoming data (normalised).
- The variables are updated with the normalised value.

**Changes**
In the validation step, the prefill values are normalised before comparing them to the incoming data