### PR TITLE
Implement stable SDK URLs

### DIFF
--- a/src/openforms/urls.py
+++ b/src/openforms/urls.py
@@ -16,7 +16,7 @@ from mozilla_django_oidc_db.views import AdminLoginFailure
 from openforms.emails.admin import EmailTestAdminView
 from openforms.emails.views import EmailWrapperTestView
 from openforms.submissions.dev_views import SubmissionPDFTestView
-from openforms.utils.views import ErrorDetailView
+from openforms.utils.views import ErrorDetailView, SDKRedirectView
 
 handler500 = "openforms.utils.views.server_error"
 admin.site.site_header = "openforms admin"
@@ -104,6 +104,11 @@ urlpatterns = [
     path("eherkenning/", include("openforms.authentication.contrib.eherkenning.urls")),
     path("digid/idp/", include("digid_eherkenning.mock.idp.digid_urls")),
     path("fouten/<exception_class>/", ErrorDetailView.as_view(), name="error-detail"),
+    # stable SDK urls
+    path(
+        f"{settings.STATIC_URL.lstrip('/')}sdk/open-forms-sdk.<ext>",
+        SDKRedirectView.as_view(),
+    ),
 ]
 
 # NOTE: The staticfiles_urlpatterns also discovers static files (ie. no need to run collectstatic). Both the static

--- a/src/openforms/utils/tests/test_sdk_urls.py
+++ b/src/openforms/utils/tests/test_sdk_urls.py
@@ -1,0 +1,41 @@
+from django.test import TestCase, override_settings
+
+
+class StableSDKUrlTests(TestCase):
+    """
+    Ensure that stable SDK URLs can be used, independent of which version is deployed.
+
+    uwsgi --static-map serves the file IF it's available in the path, so when using
+    sdk version latest, the /static/sdk/open-forms-sdk.(js|css) URLs will resolve and
+    be served by uwsgi. If there's no match, then the request is handled by the app,
+    which emits a 302 redirect to the correct asset location.
+    """
+
+    @override_settings(SDK_RELEASE="1.2.3")
+    def test_sdk_latest(self):
+        base = "/static/sdk/"
+
+        js_url = f"{base}open-forms-sdk.js"
+        with self.subTest(js_url=js_url):
+            js_response = self.client.get(js_url)
+
+            self.assertRedirects(
+                js_response,
+                f"{base}1.2.3/open-forms-sdk.js",
+                fetch_redirect_response=False,
+            )
+
+        css_url = f"{base}open-forms-sdk.css"
+        with self.subTest(css_url=css_url):
+            css_response = self.client.get(css_url)
+
+            self.assertRedirects(
+                css_response,
+                f"{base}1.2.3/open-forms-sdk.css",
+                fetch_redirect_response=False,
+            )
+
+    def test_invalid_extension(self):
+        response = self.client.get("/static/sdk/open-forms-sdk.svg")
+
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
Fixes #2141 

This relies on uwsgi passing the URL down to the application if the file is not found in the `--static-map` endpoint (see https://uwsgi-docs.readthedocs.io/en/latest/StaticFiles.html#mode-3-using-static-file-mount-points)

The generic URLs in the shape of `/static/sdk/open-forms-sdk.js` work now, independently of which SDK version is actually deployed. No changes are needed for existing clients.