### PR TITLE
[#2221] Remove code for warning double keys

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -15,7 +15,7 @@ from openforms.utils.expressions import FirstNotBlank
 
 from ..models import Category, Form, FormDefinition, FormStep
 from ..models.form import FormsExport
-from ..utils import export_form, get_duplicates_keys_for_form
+from ..utils import export_form
 from .mixins import FormioConfigMixin
 from .views import (
     DownloadExportedFormsView,
@@ -221,27 +221,6 @@ class FormAdmin(
         return obj.admin_name
 
     def get_form(self, request, *args, **kwargs):
-        if kwargs.get("change"):
-            # Display a warning if duplicate keys are used in form definitions
-            duplicate_keys = get_duplicates_keys_for_form(args[0])
-
-            if duplicate_keys:
-                error_message = _("{} occurs in both {}")
-                error_messages = "; ".join(
-                    [
-                        error_message.format(key, ", ".join(form_definitions))
-                        for key, form_definitions in duplicate_keys.items()
-                    ]
-                )
-                self.message_user(
-                    request,
-                    _(
-                        "The following form definitions contain fields with duplicate keys: %s"
-                    )
-                    % (error_messages),
-                    level=messages.WARNING,
-                )
-
         # no actual changes to the fields are triggered, we're only ending up here
         # because of the copy/export actions.
         kwargs["fields"] = ()

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -1,6 +1,5 @@
 import json
 from io import BytesIO
-from unittest import skip
 from unittest.mock import patch
 from zipfile import ZipFile
 
@@ -820,95 +819,6 @@ class FormChangeTests(WebTest):
         )
         patcher.start()
         self.addCleanup(patcher.stop)
-
-    @skip("With form variables, it is not possible to have duplicate keys")
-    def test_form_change_duplicate_keys_warning_message(self):
-        """
-        Assert that a warning message is displayed when a form has duplicate
-        keys in multiple form definitions
-        """
-        formdef1 = FormDefinitionFactory.create(
-            configuration={
-                "display": "form",
-                "components": [
-                    {
-                        "key": "duplicate-field1",
-                        "label": "Location",
-                        "type": "textfield",
-                    },
-                    {
-                        "key": "non-duplicate-field1",
-                        "label": "Product",
-                        "type": "textfield",
-                    },
-                ],
-            }
-        )
-        formdef2 = FormDefinitionFactory.create(
-            configuration={
-                "display": "form",
-                "components": [
-                    {
-                        "key": "duplicate-field1",
-                        "label": "Location",
-                        "type": "textfield",
-                    },
-                    {
-                        "key": "duplicate-field2",
-                        "label": "Foo",
-                        "type": "textfield",
-                    },
-                ],
-            }
-        )
-        formdef3 = FormDefinitionFactory.create(
-            configuration={
-                "display": "form",
-                "components": [
-                    {
-                        "key": "duplicate-field2",
-                        "label": "Foo",
-                        "type": "textfield",
-                    },
-                    {
-                        "key": "non-duplicate-field2",
-                        "label": "Bar",
-                        "type": "textfield",
-                    },
-                ],
-            }
-        )
-        FormStepFactory.create(form=self.form, form_definition=formdef1)
-        FormStepFactory.create(form=self.form, form_definition=formdef2)
-        FormStepFactory.create(form=self.form, form_definition=formdef3)
-        response = self.app.get(
-            reverse("admin:forms_form_change", args=(self.form.pk,)),
-            user=self.admin_user,
-        )
-
-        self.assertEqual(response.status_code, 200)
-
-        messagelist = response.pyquery(".messagelist")
-        warning_message = messagelist.find(".warning").text()
-
-        self.assertEqual(
-            warning_message,
-            _("The following form definitions contain fields with duplicate keys: %s")
-            % (
-                "; ".join(
-                    [
-                        _("{} occurs in both {}").format(
-                            "duplicate-field1",
-                            ", ".join([formdef1.name, formdef2.name]),
-                        ),
-                        _("{} occurs in both {}").format(
-                            "duplicate-field2",
-                            ", ".join([formdef2.name, formdef3.name]),
-                        ),
-                    ]
-                )
-            ),
-        )
 
 
 @disable_2fa

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -2,8 +2,7 @@ import json
 import random
 import string
 import zipfile
-from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import List, Optional
 from uuid import uuid4
 
 from django.conf import settings
@@ -301,18 +300,6 @@ def remove_key_from_dict(dictionary, key):
             for value in dictionary[dict_key]:
                 if isinstance(value, dict):
                     remove_key_from_dict(value, key)
-
-
-def get_duplicates_keys_for_form(form: Form) -> Dict[str, List]:
-    seen = defaultdict(list)
-    for formstep in form.formstep_set.select_related("form_definition").order_by("pk"):
-        for key in formstep.form_definition.get_all_keys():
-            seen[key].append(formstep.form_definition.name)
-
-    duplicate_keys = {
-        key: formdefs for key, formdefs in seen.items() if len(formdefs) > 1
-    }
-    return duplicate_keys
 
 
 def parse_trigger(trigger_info: JSONObject) -> Optional[JSONObject]:


### PR DESCRIPTION
Fixes #2221 

I think we forgot to remove the warning once the variables became the default (since the test was skipped). 