### PR TITLE
One more dark theme fix

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -232,3 +232,9 @@ div.flatpickr-calendar.open {
     color: var(--body-fg) !important;
   }
 }
+
+.form-row {
+  .form-builder__container {
+    color: var(--body-fg);
+  }
+}


### PR DESCRIPTION
The content component and the file component in the Form Definition change page still had dark text when in dark mode. 