### PR TITLE
:bug: emit openforms-theme as default theme

### DIFF
--- a/src/openforms/scss/screen.scss
+++ b/src/openforms/scss/screen.scss
@@ -1,5 +1,5 @@
 // design tokens
-@import '@open-formulieren/design-tokens/dist/root.css';
+@import '@open-formulieren/design-tokens/dist/index.css';
 
 @import '../ui/static/ui/scss/settings';
 @import './vendor';

--- a/src/openforms/templates/master.html
+++ b/src/openforms/templates/master.html
@@ -5,7 +5,7 @@
 {% firstof analytics_tools_config.analytics_cookie_consent_group.varname '_dummy' as analytics_varname %}
 {% with request|cookie_group_accepted:analytics_varname as enable_analytics %}
 
-<html lang="nl" class="view {{ config.theme_classname }} {% block view_class %}view--{{ request.resolver_match.namespaces|join:'-' }}-{{ request.resolver_match.url_name }}{% endblock %}">
+<html lang="nl" class="view {% firstof config.theme_classname 'openforms-theme' %} {% block view_class %}view--{{ request.resolver_match.namespaces|join:'-' }}-{{ request.resolver_match.url_name }}{% endblock %}">
 <head>
     <meta charset="utf-8">
     <title>{% block title %}Openforms{% endblock %}</title>


### PR DESCRIPTION
Fixes #2225

Unless another theme is explicitly specified, emit the openforms-theme class for the design tokens and include the theme-scoped design token CSS variables rather than overriding the :root selector.

Newer SDK builds specify design token values for components other than our own --of prefix, which breaks themes other than our own.