### PR TITLE
[#2197] Token authorisation: auth successful signal

### DIFF
--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 # Custom signals
 #
 co_sign_authentication_success = Signal()
+authentication_success = Signal()
 """
 Signal a succesful co-sign authentication.
 

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 #
 # Custom signals
 #
-co_sign_authentication_success = Signal()
 authentication_success = Signal()
+co_sign_authentication_success = Signal()
 """
 Signal a succesful co-sign authentication.
 

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -1,15 +1,21 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
+from django.test import override_settings
+from django.test.client import RequestFactory
 
 from rest_framework.test import APIRequestFactory, APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
+from openforms.forms.tests.factories import FormStepFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 
 from ..constants import FORM_AUTH_SESSION_KEY
 from ..registry import Registry
 from ..signals import set_auth_attribute_on_session
-from .mocks import RequiresAdminPlugin, mock_register
+from ..views import AuthenticationReturnView
+from .mocks import Plugin, RequiresAdminPlugin, mock_register
 
 factory = APIRequestFactory()
 
@@ -67,3 +73,79 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
 
         instance.refresh_from_db()
         self.assertEqual(instance.auth_info.value, "123")
+
+    @override_settings(
+        CORS_ALLOW_ALL_ORIGINS=False, CORS_ALLOWED_ORIGINS=["http://foo.bar"]
+    )
+    def test_successful_auth_sends_signal(self):
+        register = Registry()
+        register("plugin1")(Plugin)
+        plugin = register["plugin1"]
+
+        step = FormStepFactory(
+            form__slug="myform",
+            form__authentication_backends=["plugin1"],
+            form_definition__login_required=True,
+        )
+        form = step.form
+
+        # we need an arbitrary request
+        factory = RequestFactory()
+        init_request = factory.get("/foo")
+        url = plugin.get_return_url(init_request, form)
+        next_url = "http://foo.bar"
+        request = factory.get(url, {"next": next_url})
+
+        # Add session information to the request:
+        request.session = {
+            FORM_AUTH_SESSION_KEY: {
+                "plugin": "plugin1",
+                "attribute": Plugin.provides_auth,
+                "value": "123",
+            }
+        }
+
+        return_view = AuthenticationReturnView.as_view(register=register)
+
+        with patch(
+            "openforms.authentication.views.authentication_success.send"
+        ) as m_send:
+            response = return_view(request, slug=form.slug, plugin_id=plugin.identifier)
+
+            self.assertEqual(response.status_code, 302)
+            m_send.assert_called()
+
+    @override_settings(
+        CORS_ALLOW_ALL_ORIGINS=False, CORS_ALLOWED_ORIGINS=["http://foo.bar"]
+    )
+    def test_unsuccessful_auth_does_not_sends_signal(self):
+        register = Registry()
+        register("plugin1")(Plugin)
+        plugin = register["plugin1"]
+
+        step = FormStepFactory(
+            form__slug="myform",
+            form__authentication_backends=["plugin1"],
+            form_definition__login_required=True,
+        )
+        form = step.form
+
+        # we need an arbitrary request
+        factory = RequestFactory()
+        init_request = factory.get("/foo")
+        url = plugin.get_return_url(init_request, form)
+        next_url = "http://foo.bar"
+        request = factory.get(url, {"next": next_url})
+
+        return_view = AuthenticationReturnView.as_view(register=register)
+
+        # No FORM_AUTH_SESSION_KEY in the session, since auth was unsuccessful
+        request.session = {}
+
+        with patch(
+            "openforms.authentication.views.authentication_success.send"
+        ) as m_send:
+            response = return_view(request, slug=form.slug, plugin_id=plugin.identifier)
+
+            self.assertEqual(response.status_code, 302)
+            m_send.assert_not_called()

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -26,10 +26,10 @@ from openforms.submissions.serializers import CoSignDataSerializer
 from openforms.utils.redirect import allow_redirect_url
 
 from .base import BasePlugin
-from .constants import CO_SIGN_PARAMETER
+from .constants import CO_SIGN_PARAMETER, FORM_AUTH_SESSION_KEY
 from .exceptions import InvalidCoSignData
 from .registry import register
-from .signals import co_sign_authentication_success
+from .signals import authentication_success, co_sign_authentication_success
 
 logger = logging.getLogger(__name__)
 
@@ -319,6 +319,9 @@ class AuthenticationReturnView(AuthenticationFlowBaseView):
                     {"plugin_id": plugin_id, "location": location},
                 )
                 return HttpResponseBadRequest("redirect not allowed")
+
+        if hasattr(request, "session") and FORM_AUTH_SESSION_KEY in request.session:
+            authentication_success.send(sender=self.__class__, request=request)
 
         return response
 


### PR DESCRIPTION
Part of #1297

**Changes**
- Added `openforms.authentication.signals.authentication_success`