### PR TITLE
:pushpin: Pin lxml to not use binary wheels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,13 @@ FROM python:3.8-slim-buster AS backend-build
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         build-essential \
+        python3-dev \
         git \
         libpq-dev \
         libxml2-dev \
+        libxslt-dev \
         libxmlsec1-dev \
+        zlib1g-dev \
         libxmlsec1-openssl \
         # weasyprint deps
         libcairo2 \

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,6 +6,10 @@ furl
 glom
 git+https://github.com/maykinmedia/json-logic-py.git@f877f5326231bdcf4621783278f22c8565ec7913#egg=maykin-json-logic-py
 html5lib
+# see https://github.com/onelogin/python3-saml/issues/292 and
+# https://bugs.launchpad.net/lxml/+bug/1960668 -> we can avoid this by compiling lxml
+# against the system libxml2
+--no-binary lxml
 lxml
 O365  # microsoft graph
 phonenumbers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,8 @@
 #
 #    ./bin/compile_dependencies.sh
 #
+--no-binary lxml
+
 amqp==5.0.9
     # via kombu
 asgiref==3.5.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,8 @@
 #
 #    ./bin/compile_dependencies.sh
 #
+--no-binary lxml
+
 alabaster==0.7.12
     # via sphinx
 amqp==5.0.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,8 @@
 #
 #    ./bin/compile_dependencies.sh
 #
+--no-binary lxml
+
 alabaster==0.7.12
     # via
     #   -c requirements/ci.txt


### PR DESCRIPTION
This is in preparation to upgrading python3-saml and then lxml to their latest versions.

lxml breaks on some edge cases becaues it was statically built against a different libxml2 than *other* xml-based tooling using at runtime ( because that's dynamically linked), causing some tree lookups to fail.

* python3-saml issue: https://github.com/onelogin/python3-saml/issues/292
* upstream bug: https://bugs.launchpad.net/lxml/+bug/1960668