### PR TITLE
:heavy_minus_sign: Drop django-capture-on-commit-callbacks

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -157,7 +157,6 @@ django==3.2.16
     #   django-appconf
     #   django-axes
     #   django-camunda
-    #   django-capture-on-commit-callbacks
     #   django-choices
     #   django-cookie-consent
     #   django-cors-headers
@@ -216,8 +215,6 @@ django-camunda==0.12.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-capture-on-commit-callbacks==1.3.0
-    # via -r requirements/test-tools.in
 django-capture-tag==1.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -185,7 +185,6 @@ django==3.2.16
     #   django-appconf
     #   django-axes
     #   django-camunda
-    #   django-capture-on-commit-callbacks
     #   django-choices
     #   django-cookie-consent
     #   django-cors-headers
@@ -244,10 +243,6 @@ django-better-admin-arrayfield==1.4.2
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
 django-camunda==0.12.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-django-capture-on-commit-callbacks==1.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -13,7 +13,6 @@ tblib
 testfixtures
 pep8
 pytest  # documentation tests
-django-capture-on-commit-callbacks
 
 # Code formatting
 black

--- a/src/openforms/forms/tests/test_management.py
+++ b/src/openforms/forms/tests/test_management.py
@@ -1,7 +1,6 @@
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
-from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from freezegun import freeze_time
 from privates.test import temp_private_root
 
@@ -33,7 +32,7 @@ class DeleteFormExportFilesTest(TestCase):
         storage = forms_export.export_content.storage
 
         with freeze_time("2022-01-09T00:00:00Z"):
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 call_command("delete_export_files")
 
         self.assertFalse(FormsExport.objects.filter(pk=forms_export.pk).exists())

--- a/src/openforms/payments/tests/test_views.py
+++ b/src/openforms/payments/tests/test_views.py
@@ -5,8 +5,6 @@ from django.http import HttpResponseRedirect
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
-from django_capture_on_commit_callbacks import capture_on_commit_callbacks
-
 from openforms.config.models import GlobalConfiguration
 from openforms.submissions.tests.factories import SubmissionFactory
 
@@ -88,7 +86,7 @@ class ViewsTests(TestCase):
         with self.subTest("return ok"):
             update_payments_mock.reset_mock()
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.get(url)
 
             self.assertEqual(response.content, b"")
@@ -99,7 +97,7 @@ class ViewsTests(TestCase):
         with self.subTest("return bad method"):
             update_payments_mock.reset_mock()
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.post(url)
 
             self.assertEqual(response.status_code, 405)
@@ -111,7 +109,7 @@ class ViewsTests(TestCase):
             bad_payment = SubmissionPaymentFactory.for_backend("bad_plugin")
             bad_url = bad_plugin.get_return_url(base_request, bad_payment)
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.get(bad_url)
 
             self.assertEqual(response.data["detail"], "unknown plugin")
@@ -125,7 +123,7 @@ class ViewsTests(TestCase):
             )
             bad_url = bad_plugin.get_return_url(base_request, bad_payment)
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.get(bad_url)
 
             self.assertEqual(response.data["detail"], "redirect not allowed")
@@ -141,7 +139,7 @@ class ViewsTests(TestCase):
         ):
             update_payments_mock.reset_mock()
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.post(url)
 
             self.assertEqual(response.content, b"")
@@ -152,7 +150,7 @@ class ViewsTests(TestCase):
         with self.subTest("webhook bad method"):
             update_payments_mock.reset_mock()
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.get(url)
 
             self.assertEqual(response.status_code, 405)
@@ -163,7 +161,7 @@ class ViewsTests(TestCase):
             update_payments_mock.reset_mock()
             bad_url = bad_plugin.get_webhook_url(base_request)
 
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 response = self.client.get(bad_url)
 
             self.assertEqual(response.data["detail"], "unknown plugin")

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 
-from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from privates.test import temp_private_root
 from testfixtures import LogCapture
 
@@ -138,7 +137,7 @@ class SubmissionTests(TestCase):
         with self.subTest("validate testdata setup"):
             self.assertTrue(attachment.content.storage.exists(attachment.content.name))
 
-        with capture_on_commit_callbacks(execute=True):
+        with self.captureOnCommitCallbacks(execute=True):
             submission.remove_sensitive_data()
 
         submission.refresh_from_db()
@@ -208,7 +207,7 @@ class SubmissionTests(TestCase):
             self.assertTrue(attachment.content.storage.exists(attachment.content.path))
 
         # delete the submission, it must cascade
-        with capture_on_commit_callbacks(execute=True):
+        with self.captureOnCommitCallbacks(execute=True):
             submission.delete()
 
         self.assertFalse(Submission.objects.filter(pk=submission.pk).exists())
@@ -238,7 +237,7 @@ class SubmissionTests(TestCase):
             "django.core.files.storage.FileSystemStorage.delete", side_effect=exc
         ) as mock_delete:
             with LogCapture(level=logging.WARNING) as capture:
-                with capture_on_commit_callbacks(execute=True):
+                with self.captureOnCommitCallbacks(execute=True):
                     submission.delete()
 
         mock_delete.assert_called_once_with(attachment.content.name)

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 from django.test import override_settings
 from django.utils import timezone
 
-from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from freezegun import freeze_time
 from privates.test import temp_private_root
 from rest_framework import status
@@ -89,7 +88,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
         self._add_submission_to_session(submission)
         endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
 
-        with capture_on_commit_callbacks(execute=True):
+        with self.captureOnCommitCallbacks(execute=True):
             response = self.client.post(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -220,7 +219,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
 
         # The auth details are cleaned by the signal handler
         with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
-            with capture_on_commit_callbacks(execute=True):
+            with self.captureOnCommitCallbacks(execute=True):
                 self.client.post(endpoint)
 
         cleaned_session = self.client.session

--- a/src/openforms/submissions/tests/test_submission_suspension.py
+++ b/src/openforms/submissions/tests/test_submission_suspension.py
@@ -17,7 +17,6 @@ from django.test import override_settings
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -114,7 +113,7 @@ class SubmissionSuspensionTests(SubmissionsMixin, APITestCase):
         self._add_submission_to_session(submission)
         endpoint = reverse("api:submission-suspend", kwargs={"uuid": submission.uuid})
 
-        with capture_on_commit_callbacks(execute=True) as callbacks:
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
             response = self.client.post(endpoint, {"email": "hello@open-forms.nl"})
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -158,7 +157,7 @@ class SubmissionSuspensionTests(SubmissionsMixin, APITestCase):
         self._add_submission_to_session(submission)
         endpoint = reverse("api:submission-suspend", kwargs={"uuid": submission.uuid})
 
-        with capture_on_commit_callbacks(execute=True) as callbacks:
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
             response = self.client.post(endpoint, {"email": "hello@open-forms.nl"})
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/src/openforms/submissions/tests/test_temporary_uploads.py
+++ b/src/openforms/submissions/tests/test_temporary_uploads.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 from django.test import RequestFactory, tag
 
-from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from freezegun import freeze_time
 from privates.test import temp_private_root
 from rest_framework import status
@@ -135,7 +134,7 @@ class TemporaryFileUploadTest(SubmissionsMixin, APITestCase):
 
         url = reverse("api:submissions:temporary-file", kwargs={"uuid": upload.uuid})
 
-        with capture_on_commit_callbacks(execute=True):
+        with self.captureOnCommitCallbacks(execute=True):
             response = self.client.delete(
                 url,
                 HTTP_ACCEPT="application/json",
@@ -165,7 +164,7 @@ class TemporaryFileUploadTest(SubmissionsMixin, APITestCase):
         path = upload.content.path
         self.assertTrue(os.path.exists(path))
 
-        with capture_on_commit_callbacks(execute=True):
+        with self.captureOnCommitCallbacks(execute=True):
             upload.delete()
 
         # expect the file and instance to be deleted
@@ -185,7 +184,7 @@ class TemporaryFileUploadTest(SubmissionsMixin, APITestCase):
         for path in paths:
             self.assertTrue(os.path.exists(path))
 
-        with capture_on_commit_callbacks(execute=True):
+        with self.captureOnCommitCallbacks(execute=True):
             TemporaryFileUpload.objects.all().delete()
 
         for path in paths:


### PR DESCRIPTION
Django 3.2+ has it built in, so the third party package is no longer needed.