### PR TITLE
[#2219] Fixed CSS-unit issue with design-tokens in email header logo

### DIFF
--- a/src/openforms/emails/context.py
+++ b/src/openforms/emails/context.py
@@ -36,7 +36,7 @@ def _get_design_token_values(tokens):
             # Setting height to a default of 50 obtaines the same result on the
             # website that uses flexbox shrink, to size the logo to it's minimum
             # size.
-            "height": glom(tokens, "header-logo.height.value", default="50"),
+            "height": glom(tokens, "header-logo.height.value", default="50px"),
             "width": glom(tokens, "header-logo.width.value", default="auto"),
         },
         "footer": {

--- a/src/openforms/emails/templates/emails/wrapper.html
+++ b/src/openforms/emails/templates/emails/wrapper.html
@@ -10,10 +10,10 @@
                     <td align="left" style="padding: 20px; color: {{ style.header.fg }}; background-color: {{ style.header.bg }};">
                         {% if logo_url %}
                             <a style="text-decoration: none;" href="{{ main_website_url }}">
-                                <img
-                                    {% if style.logo.width %}width="{{ style.logo.width }}" {% endif %}
-                                    {% if style.logo.height %}height="{{ style.logo.height }}" {% endif %}
-                                    src="{{ logo_url }}" />
+                                <img style="{% spaceless %}
+                                    {% if style.logo.width %}width: {{ style.logo.width }}; {% endif %}
+                                    {% if style.logo.height %}height: {{ style.logo.height }}; {% endif %}
+                                {% endspaceless %}" src="{{ logo_url }}" />
                             </a>
                         {% endif %}
                     </td>


### PR DESCRIPTION
The design-token values have CSS units, which don't work as HTML height/width attribute in every client (or browser yubin preview)

Fixes #2219

Note this was reported on 1.1.7 (branch with backport https://github.com/open-formulieren/open-forms/tree/fix/2219-email-logo-size-token-11x)