### PR TITLE
[#2337] Catch KeyError for prefills

### DIFF
--- a/src/openforms/prefill/__init__.py
+++ b/src/openforms/prefill/__init__.py
@@ -98,7 +98,11 @@ def inject_prefill(
 
     prefilled_data = submission.get_prefilled_data()
     for key, prefill_value in prefilled_data.items():
-        component = configuration_wrapper[key]
+        try:
+            component = configuration_wrapper[key]
+        except KeyError:
+            # The component to prefill is not in this step
+            continue
 
         if not (prefill := component.get("prefill")):
             continue


### PR DESCRIPTION
Fixes #2337 

Not sure  if this will require backport, because the commit that added this code is present in 1.5 and master (not 1.7 or 2.0 :thinking: )

https://github.com/open-formulieren/open-forms/commit/d176eb04c0c0e5a8baf7e91ac369ab1654578620