### PR TITLE
:zap: Optimize form list endpoint

### DIFF
--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -284,7 +284,11 @@ class FormViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(active=True).filter(_is_deleted=False)
         elif self.action == "list":
             # So that the admin can display deleted forms, but the list endpoint doesn't return them
-            queryset = queryset.filter(_is_deleted=False)
+            queryset = (
+                queryset.filter(_is_deleted=False)
+                .select_related("confirmation_email_template")
+                .prefetch_related("category", "product")
+            )
 
         # ⚡️ - the prefetches are not required for the variables/logic bulk (update/read)
         # endpoints, so we clear prefetches and select_related calls.


### PR DESCRIPTION
* Prefetch related form categories and products to avoid N+1 queries on these related resources
* Select related email confirmation template (o2o field, so prefetch wouldn't help/reduce data)