### PR TITLE
fix migration failure

### DIFF
--- a/src/openforms/forms/migrations/0033_formvariable_datamigration.py
+++ b/src/openforms/forms/migrations/0033_formvariable_datamigration.py
@@ -18,7 +18,7 @@ def create_form_variables_for_form(apps, schema_editor):
     )
 
     for form in forms_without_form_variables:
-        FormVariable.objects.create_for_form(form)
+        FormVariable.objects.create_for_form(form, fix_prefill_config=True)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Fixes #2262 

- add parameter to create_for_form to log and patch invalid plugin config
- add test to reproduce migration failure and check patch