### PR TITLE
Convey language information via HTTP headers

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1488,8 +1488,19 @@ paths:
     get:
       operationId: forms_retrieve
       description: "Retrieve the details/configuration of a particular form. \n\n\
-        For forms that don't have translations enabled, the default language is activated,\
-        \ otherwise the browser preferences determine the active language."
+        A form is a collection of form steps, where each form step points to a formio.js\
+        \ form definition. Multiple definitions are combined in logical steps to build\
+        \ a multi-step/page form for end-users to fill out. Form definitions can be\
+        \ (and are) re-used among different forms.\n\n**Warning: the response data\
+        \ depends on user permissions**\n\nNon-staff users receive a subset of the\
+        \ documented fields which are usedfor internal form configuration. These fields\
+        \ are:\n\n- `internalName`\n- `registrationBackend`\n- `registrationBackendOptions`\n\
+        - `paymentBackend`\n- `paymentBackendOptions`\n- `product`\n- `category`\n\
+        - `isDeleted`\n- `submissionConfirmationTemplate`\n- `submissionsRemovalOptions`\n\
+        - `confirmationEmailTemplate`\n- `confirmationEmailOption`\n- `displayMainWebsiteLink`\n\
+        \nIf the form doesn't have translations enabled, its default language is forced\
+        \ by setting a language cookie and reflected in the Content-Language response\
+        \ header. Normal HTTP Content Negotiation rules apply."
       summary: Retrieve form details
       parameters:
       - in: header

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -65,6 +65,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -78,6 +80,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '502':
           content:
             application/json:
@@ -91,6 +95,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/appointments/dates:
     get:
       operationId: appointments_dates_list
@@ -131,6 +137,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/appointments/locations:
     get:
       operationId: appointments_locations_list
@@ -165,6 +173,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/appointments/products:
     get:
       operationId: appointments_products_list
@@ -188,6 +198,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/appointments/times:
     get:
       operationId: appointments_times_list
@@ -235,6 +247,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/authentication/{uuid}/session:
     delete:
       operationId: submission_session_destroy
@@ -268,6 +282,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/authentication/plugins:
     get:
       operationId: authentication_plugins_list
@@ -299,6 +315,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/categories:
     get:
       operationId: categories_list
@@ -323,6 +341,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/categories/{uuid}:
     get:
       operationId: categories_retrieve
@@ -352,6 +372,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/config/privacy_policy_info:
     get:
       operationId: config_privacy_policy_info_retrieve
@@ -375,6 +397,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/dmn/decision-definitions:
     get:
       operationId: dmn_decision_definitions_list
@@ -410,6 +434,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -423,6 +449,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -436,6 +464,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/dmn/decision-definitions/versions:
     get:
       operationId: dmn_decision_definitions_versions_list
@@ -482,6 +512,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -495,6 +527,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -508,6 +542,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/dmn/decision-definitions/xml:
     get:
       operationId: dmn_decision_definitions_xml_retrieve
@@ -550,6 +586,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -563,6 +601,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -576,6 +616,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/dmn/plugins:
     get:
       operationId: dmn_plugins_list
@@ -601,6 +643,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -614,6 +658,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/form-definitions:
     get:
       operationId: form_definitions_list
@@ -645,6 +691,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     post:
       operationId: form_definitions_create
       summary: Create a form definition
@@ -674,6 +722,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/form-definitions/{uuid}:
     get:
       operationId: form_definitions_retrieve
@@ -705,6 +755,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: form_definitions_update
       summary: Update all details of a form definition
@@ -741,6 +793,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     patch:
       operationId: form_definitions_partial_update
       summary: Update some details of a form definition
@@ -776,6 +830,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     delete:
       operationId: form_definitions_destroy
       summary: Delete a form definition
@@ -802,6 +858,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/form-definitions/{uuid}/configuration:
     get:
       operationId: form_definitions_configuration_retrieve
@@ -839,6 +897,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/formio/fileupload:
     post:
       operationId: formio_fileupload_create
@@ -875,6 +935,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             text/plain:
@@ -888,6 +950,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
       parameters:
       - in: header
         name: X-CSRFToken
@@ -950,6 +1014,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     post:
       operationId: forms_create
       description: |-
@@ -1015,6 +1081,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms-import:
     post:
       operationId: forms_import_create
@@ -1046,6 +1114,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{form_uuid_or_slug}/steps:
     get:
       operationId: forms_steps_list
@@ -1078,6 +1148,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     post:
       operationId: forms_steps_create
       summary: Create a form step
@@ -1119,6 +1191,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{form_uuid_or_slug}/steps/{uuid}:
     get:
       operationId: forms_steps_retrieve
@@ -1155,6 +1229,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: forms_steps_update
       summary: Update all details of a form step
@@ -1202,6 +1278,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     patch:
       operationId: forms_steps_partial_update
       summary: Update some details of a form step
@@ -1248,6 +1326,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     delete:
       operationId: forms_steps_destroy
       summary: Delete a form step
@@ -1279,6 +1359,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{form_uuid_or_slug}/versions:
     get:
       operationId: forms_versions_list
@@ -1311,6 +1393,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     post:
       operationId: forms_versions_create
       description: Save the current version of the form so that it can later be retrieved
@@ -1352,6 +1436,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{form_uuid_or_slug}/versions/{uuid}/restore:
     post:
       operationId: forms_versions_restore_create
@@ -1396,35 +1482,14 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{uuid_or_slug}:
     get:
       operationId: forms_retrieve
-      description: |-
-        Manage forms.
-
-        Forms are collections of form steps, where each form step points to a formio.js
-        form definition. Multiple definitions are combined in logical steps to build a
-        multi-step/page form for end-users to fill out. Form definitions can be (and are)
-        re-used among different forms.
-
-        **Warning: the response data depends on user permissions**
-
-        Non-staff users receive a subset of the documented fields which are used
-        for internal form configuration. These fields are:
-
-        - `internalName`
-        - `registrationBackend`
-        - `registrationBackendOptions`
-        - `paymentBackend`
-        - `paymentBackendOptions`
-        - `product`
-        - `category`
-        - `isDeleted`
-        - `submissionConfirmationTemplate`
-        - `submissionsRemovalOptions`
-        - `confirmationEmailTemplate`
-        - `confirmationEmailOption`
-        - `displayMainWebsiteLink`
+      description: "Retrieve the details/configuration of a particular form. \n\n\
+        For forms that don't have translations enabled, the default language is activated,\
+        \ otherwise the browser preferences determine the active language."
       summary: Retrieve form details
       parameters:
       - in: header
@@ -1462,6 +1527,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: forms_update
       description: |-
@@ -1533,6 +1600,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     patch:
       operationId: forms_partial_update
       description: |-
@@ -1603,6 +1672,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     delete:
       operationId: forms_destroy
       description: Destroying a form leads to a soft-delete to protect related submissions.
@@ -1640,48 +1711,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
-  /api/v2/forms/{uuid_or_slug}/activate_default_language:
-    post:
-      operationId: forms_activate_default_language_create
-      description: |-
-        Activate the default language of a form.
-
-        In case translation is not enabled for the Form, the default language is set to
-        settings.LANGUAGE_CODE.
-      summary: Activate the default language for a Form
-      parameters:
-      - in: header
-        name: X-CSP-Nonce
-        schema:
-          type: string
-        description: The value of the CSP nonce generated by the page embedding the
-          SDK. If provided, fields containing rich text from WYSIWYG editors will
-          be post-processed to allow inline styles with the provided nonce. If the
-          embedding page emits a `style-src` policy containing `unsafe-inline`, then
-          you can omit this header without losing functionality. We recommend favouring
-          the nonce mechanism though.
-      - in: path
-        name: uuid_or_slug
-        schema:
-          type: string
-        description: Either a UUID4 or a slug identifiying the form.
-        required: true
-      tags:
-      - forms
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CurrentLanguage'
-          description: ''
-          headers:
-            X-Session-Expires-In:
-              $ref: '#/components/headers/X-Session-Expires-In'
-            X-CSRFToken:
-              $ref: '#/components/headers/X-CSRFToken'
-            X-Is-Form-Designer:
-              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{uuid_or_slug}/admin-message:
     post:
       operationId: forms_admin_message_create
@@ -1737,6 +1768,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{uuid_or_slug}/copy:
     post:
       operationId: forms_copy_create
@@ -1782,6 +1815,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/json:
               schema:
@@ -1831,6 +1866,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{uuid_or_slug}/logic-rules:
     get:
       operationId: forms_logic_rules_list
@@ -1864,6 +1901,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '401':
           content:
             application/json:
@@ -1877,6 +1916,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -1890,6 +1931,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -1903,6 +1946,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -1916,6 +1961,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: forms_logic_rules_update
       description: By sending a list of LogicRules to this endpoint, all the LogicRules
@@ -1967,6 +2014,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -1980,6 +2029,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '401':
           content:
             application/json:
@@ -1993,6 +2044,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -2006,6 +2059,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -2019,6 +2074,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -2032,6 +2089,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{uuid_or_slug}/price-logic-rules:
     get:
       operationId: forms_price_logic_rules_list
@@ -2065,6 +2124,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '401':
           content:
             application/json:
@@ -2078,6 +2139,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -2091,6 +2154,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -2104,6 +2169,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -2117,6 +2184,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: forms_price_logic_rules_update
       description: By sending a list of FormPriceLogic to this endpoint, all the FormPriceLogic
@@ -2168,6 +2237,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -2181,6 +2252,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '401':
           content:
             application/json:
@@ -2194,6 +2267,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -2207,6 +2282,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -2220,6 +2297,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -2233,6 +2312,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/forms/{uuid_or_slug}/variables:
     get:
       operationId: forms_variables_list
@@ -2274,6 +2355,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '401':
           content:
             application/json:
@@ -2287,6 +2370,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -2300,6 +2385,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -2313,6 +2400,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -2326,6 +2415,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: forms_variables_update
       description: By sending a list of FormVariables to this endpoint, all the FormVariables
@@ -2377,6 +2468,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -2390,6 +2483,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '401':
           content:
             application/json:
@@ -2403,6 +2498,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -2416,6 +2513,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -2429,6 +2528,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -2442,6 +2543,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/i18n/info:
     get:
       operationId: i18n_info_retrieve
@@ -2472,6 +2575,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/i18n/language:
     put:
       operationId: i18n_language_update
@@ -2500,6 +2605,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -2513,6 +2620,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         5XX:
           content:
             application/json:
@@ -2526,6 +2635,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/location/get-street-name-and-city:
     get:
       operationId: get_street_name_and_city_list
@@ -2561,6 +2672,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/payment/plugins:
     get:
       operationId: payment_plugins_list
@@ -2591,6 +2704,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/ping:
     get:
       operationId: ping_retrieve
@@ -2611,6 +2726,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         4XX:
           content:
             application/json:
@@ -2624,6 +2741,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/prefill/plugins:
     get:
       operationId: prefill_plugins_list
@@ -2649,6 +2768,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/prefill/plugins/{plugin}/attributes:
     get:
       operationId: prefill_plugins_attributes_list
@@ -2680,6 +2801,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/products:
     get:
       operationId: products_list
@@ -2722,6 +2845,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/products/{uuid}:
     get:
       operationId: products_retrieve
@@ -2769,6 +2894,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/registration/attributes:
     get:
       operationId: registration_attributes_list
@@ -2794,6 +2921,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/registration/plugins:
     get:
       operationId: registration_plugins_list
@@ -2823,6 +2952,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/registration/plugins/camunda/process-definitions:
     get:
       operationId: registration_plugins_camunda_process_definitions_list
@@ -2848,6 +2979,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/registration/plugins/zgw/informatieobjecttypen:
     get:
       operationId: registration_plugins_zgw_informatieobjecttypen_list
@@ -2873,6 +3006,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions:
     get:
       operationId: submissions_list
@@ -2905,6 +3040,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     post:
       operationId: submissions_create
       description: Start a submission for a particular form. The submission is added
@@ -2940,6 +3077,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -2953,6 +3092,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -2966,6 +3107,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '422':
           content:
             application/json:
@@ -2979,6 +3122,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '503':
           content:
             application/json:
@@ -2992,6 +3137,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
       parameters:
       - in: header
         name: X-CSRFToken
@@ -3033,6 +3180,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{submission_uuid}/steps/{step_uuid}:
     get:
       operationId: submissions_steps_retrieve
@@ -3071,6 +3220,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3084,6 +3235,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     put:
       operationId: submissions_steps_update
       description: |-
@@ -3136,6 +3289,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '201':
           content:
             application/json:
@@ -3149,6 +3304,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -3162,6 +3319,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3175,6 +3334,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '422':
           content:
             application/json:
@@ -3188,6 +3349,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '503':
           content:
             application/json:
@@ -3201,6 +3364,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{submission_uuid}/steps/{step_uuid}/_check_logic:
     post:
       operationId: submissions_steps__check_logic_create
@@ -3247,6 +3412,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3260,6 +3427,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '422':
           content:
             application/json:
@@ -3273,6 +3442,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '503':
           content:
             application/json:
@@ -3286,6 +3457,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{submission_uuid}/steps/{step_uuid}/validate:
     post:
       operationId: submissions_steps_validate_create
@@ -3332,6 +3505,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -3345,6 +3520,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3358,6 +3535,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '422':
           content:
             application/json:
@@ -3371,6 +3550,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '503':
           content:
             application/json:
@@ -3384,6 +3565,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{uuid}:
     get:
       operationId: submissions_retrieve
@@ -3414,6 +3597,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{uuid}/{token}/status:
     get:
       operationId: submissions_status_retrieve
@@ -3454,6 +3639,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3467,6 +3654,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '429':
           content:
             application/json:
@@ -3480,6 +3669,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{uuid}/_complete:
     post:
       operationId: submissions__complete_create
@@ -3542,6 +3733,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/json:
@@ -3555,6 +3748,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '422':
           content:
             application/json:
@@ -3568,6 +3763,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '503':
           content:
             application/json:
@@ -3581,6 +3778,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{uuid}/_suspend:
     post:
       operationId: submissions__suspend_create
@@ -3632,6 +3831,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '422':
           content:
             application/json:
@@ -3645,6 +3846,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '503':
           content:
             application/json:
@@ -3658,6 +3861,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{uuid}/co-sign:
     get:
       operationId: submissions_co_sign_retrieve
@@ -3688,6 +3893,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3701,6 +3908,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/json:
@@ -3714,6 +3923,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '405':
           content:
             application/json:
@@ -3727,6 +3938,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{uuid}/summary:
     get:
       operationId: submissions_summary_list
@@ -3759,6 +3972,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/files/{uuid}:
     get:
       operationId: submissions_files_retrieve
@@ -3795,6 +4010,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
     delete:
       operationId: submissions_files_destroy
       description: "Delete temporary file upload by the uploader. \n\nThis is called\
@@ -3828,6 +4045,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         4XX:
           content:
             application/json:
@@ -3841,6 +4060,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         5XX:
           content:
             application/json:
@@ -3854,6 +4075,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/translations/formio:
     get:
       operationId: translations_formio_retrieve
@@ -3873,6 +4096,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/validation/plugins:
     get:
       operationId: validation_plugins_list
@@ -3898,6 +4123,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/validation/plugins/{validator}:
     post:
       operationId: validation_run
@@ -3948,6 +4175,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/variables/static:
     get:
       operationId: variables_static_list
@@ -3973,6 +4202,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '403':
           content:
             application/json:
@@ -3986,6 +4217,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /auth/{slug}/{plugin_id}/return:
     get:
       operationId: auth_return_retrieve
@@ -4045,6 +4278,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: No response body
         '400':
           headers:
@@ -4059,6 +4294,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4077,6 +4314,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4095,6 +4334,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4163,6 +4404,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4187,6 +4430,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: No response body
         '400':
           headers:
@@ -4201,6 +4446,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4219,6 +4466,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4237,6 +4486,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             text/html:
               schema:
@@ -4306,6 +4557,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '302':
           headers:
             Location:
@@ -4322,6 +4575,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: No response body
         '400':
           content:
@@ -4336,6 +4591,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             text/html:
@@ -4349,6 +4606,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /payment/{plugin_id}/webhook:
     get:
       operationId: payment_webhook_retrieve
@@ -4385,6 +4644,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: No response body
         '400':
           headers:
@@ -4399,6 +4660,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4417,6 +4680,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4457,6 +4722,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: No response body
         '400':
           headers:
@@ -4471,6 +4738,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4489,6 +4758,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4551,6 +4822,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '400':
           content:
             application/problem+json:
@@ -4564,6 +4837,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
         '404':
           content:
             application/problem+json:
@@ -4578,6 +4853,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /payment/{uuid}/return:
     get:
       operationId: payment_return_retrieve
@@ -4623,6 +4900,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: Tempomrary redirect
         '400':
           headers:
@@ -4637,6 +4916,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4655,6 +4936,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4705,6 +4988,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           description: Tempomrary redirect
         '400':
           headers:
@@ -4719,6 +5004,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4737,6 +5024,8 @@ paths:
               $ref: '#/components/headers/X-CSRFToken'
             X-Is-Form-Designer:
               $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
           content:
             application/problem+json:
               schema:
@@ -4745,6 +5034,14 @@ paths:
             or the `plugin_id` does not exist.
 components:
   headers:
+    Content-Language:
+      schema:
+        type: string
+        enum:
+        - en
+        - nl
+      description: Language code of the currently activated language.
+      required: true
     X-CSRFToken:
       schema:
         type: string
@@ -4938,15 +5235,6 @@ components:
       required:
       - configuration
       - index
-    CurrentLanguage:
-      type: object
-      properties:
-        activeLanguage:
-          allOf:
-          - $ref: '#/components/schemas/AvailableLanguagesEnum'
-          description: RFC5646 language tag, e.g. `en` or `en-us`
-      required:
-      - activeLanguage
     DataTypeEnum:
       enum:
       - string

--- a/src/openforms/api/drf_spectacular/hooks.py
+++ b/src/openforms/api/drf_spectacular/hooks.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.plumbing import build_parameter_type
@@ -10,6 +11,7 @@ from openforms.middleware import (
     SESSION_EXPIRES_IN_HEADER,
 )
 
+from .functional import lazy_enum
 from .plumbing import build_response_header_component
 
 # Session Expires header
@@ -36,6 +38,13 @@ IS_FORM_DESIGNER_COMPONENT = build_response_header_component(
     ),
 )
 
+# Content-Language header
+CONTENT_LANGUAGE_COMPONENT = build_response_header_component(
+    name="Content-Language",
+    description=_("Language code of the currently activated language."),
+    enum=lazy_enum(lambda: [code for code, _ in settings.LANGUAGES]),
+)
+
 
 def add_middleware_headers(result, generator, request, public):
     """
@@ -44,6 +53,7 @@ def add_middleware_headers(result, generator, request, public):
     generator.registry.register_on_missing(SESSION_EXPIRES_IN_COMPONENT)
     generator.registry.register_on_missing(CSRF_TOKEN_COMPONENT)
     generator.registry.register_on_missing(IS_FORM_DESIGNER_COMPONENT)
+    generator.registry.register_on_missing(CONTENT_LANGUAGE_COMPONENT)
 
     for path in result["paths"].values():
         for operation in path.values():
@@ -59,6 +69,7 @@ def add_middleware_headers(result, generator, request, public):
                         SESSION_EXPIRES_IN_HEADER: SESSION_EXPIRES_IN_COMPONENT.ref,
                         CSRF_TOKEN_HEADER_NAME: CSRF_TOKEN_COMPONENT.ref,
                         IS_FORM_DESIGNER_HEADER_NAME: IS_FORM_DESIGNER_COMPONENT.ref,
+                        "Content-Language": CONTENT_LANGUAGE_COMPONENT.ref,
                     }
                 )
 

--- a/src/openforms/api/drf_spectacular/plumbing.py
+++ b/src/openforms/api/drf_spectacular/plumbing.py
@@ -11,6 +11,7 @@ def build_response_header_parameter(
     description: str,
     schema_type: type = str,
     required: bool = True,
+    **kwargs,
 ):
     parameter = build_parameter_type(
         name=name,
@@ -18,6 +19,7 @@ def build_response_header_parameter(
         location=OpenApiParameter.HEADER,
         description=description,
         required=required,
+        **kwargs,
     )
 
     # following drf_spectacular.openapi.AutoSchema._get_response_headers_for_code, this is
@@ -33,12 +35,14 @@ def build_response_header_component(
     description: str,
     schema_type: type = str,
     required: bool = True,
+    **kwargs,
 ) -> ResolvedComponent:
     parameter = build_response_header_parameter(
         name=name,
         description=description,
         schema_type=schema_type,
         required=required,
+        **kwargs,
     )
     component = ResolvedComponent(
         name=name,

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -711,6 +711,7 @@ CORS_EXPOSE_HEADERS = [
     "X-Session-Expires-In",
     "X-CSRFToken",
     "X-Is-Form-Designer",
+    "Content-Language",
 ]
 CORS_ALLOW_CREDENTIALS = True  # required to send cross domain cookies
 

--- a/src/openforms/forms/api/serializers/__init__.py
+++ b/src/openforms/forms/api/serializers/__init__.py
@@ -1,9 +1,4 @@
-from .form import (
-    CurrentLanguageSerializer,
-    FormExportSerializer,
-    FormImportSerializer,
-    FormSerializer,
-)
+from .form import FormExportSerializer, FormImportSerializer, FormSerializer
 from .form_admin_message import FormAdminMessageSerializer
 from .form_definition import FormDefinitionDetailSerializer, FormDefinitionSerializer
 from .form_step import FormStepSerializer
@@ -13,7 +8,6 @@ from .logic.form_logic import FormLogicSerializer
 from .logic.form_logic_price import FormPriceLogicSerializer
 
 __all__ = [
-    "CurrentLanguageSerializer",
     "FormLogicSerializer",
     "FormPriceLogicSerializer",
     "FormSerializer",

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -19,7 +19,6 @@ from openforms.payments.api.fields import PaymentOptionsReadOnlyField
 from openforms.payments.registry import register as payment_register
 from openforms.products.models import Product
 from openforms.registrations.registry import register as registration_register
-from openforms.translations.api.serializers import LanguageCodeField
 
 from ...constants import ConfirmationEmailOptions
 from ...models import Category, Form
@@ -360,7 +359,3 @@ class FormImportSerializer(serializers.Serializer):
     file = serializers.FileField(
         help_text=_("The file that contains the form, form definitions and form steps.")
     )
-
-
-class CurrentLanguageSerializer(serializers.Serializer):
-    active_language = LanguageCodeField()

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -175,10 +175,19 @@ _FORM_ADMIN_FIELDS_MARKDOWN = "\n".join(
         summary=_("Retrieve form details"),
         parameters=[UUID_OR_SLUG_PARAMETER],
         description=_(
-            "Retrieve the details/configuration of a particular form. \n\nFor forms "
-            "that don't have translations enabled, the default language is activated, "
-            "otherwise the browser preferences determine the active language."
-        ),
+            "Retrieve the details/configuration of a particular form. \n\n"
+            "A form is a collection of form steps, where each form step points to a "
+            "formio.js form definition. Multiple definitions are combined in logical "
+            "steps to build a multi-step/page form for end-users to fill out. Form "
+            "definitions can be (and are) re-used among different forms.\n\n"
+            "**Warning: the response data depends on user permissions**\n\n"
+            "Non-staff users receive a subset of the documented fields which are used"
+            "for internal form configuration. These fields are:\n\n"
+            "{admin_fields}\n\n"
+            "If the form doesn't have translations enabled, its default language is "
+            "forced by setting a language cookie and reflected in the Content-Language "
+            "response header. Normal HTTP Content Negotiation rules apply."
+        ).format(admin_fields=_FORM_ADMIN_FIELDS_MARKDOWN),
     ),
     create=extend_schema(summary=_("Create form")),
     update=extend_schema(

--- a/src/openforms/forms/tests/test_api_forms.py
+++ b/src/openforms/forms/tests/test_api_forms.py
@@ -21,6 +21,8 @@ from ..constants import ConfirmationEmailOptions
 from ..models import Form
 from .factories import FormFactory, FormStepFactory
 
+TranslatedFormFactory = make_translated(FormFactory)
+
 
 class FormSerializerTests(APITestCase):
     def test_public_fields_meta_exist_in_fields_meta(self):
@@ -1075,7 +1077,6 @@ class FormsAPITranslationTests(APITestCase):
     def setUpTestData(cls):
         super().setUpTestData()
 
-        TranslatedFormFactory = make_translated(FormFactory)
         cls.en_form = TranslatedFormFactory.create(
             _language="en",
             begin_text="start",
@@ -1085,20 +1086,27 @@ class FormsAPITranslationTests(APITestCase):
         )
 
     def test_detail_shows_translated_values_based_on_request_header(self):
-        self.en_form.translation_enabled = True
-        self.en_form.save()
-        url = reverse("api:form-detail", kwargs={"uuid_or_slug": self.en_form.uuid})
+        form = TranslatedFormFactory.create(
+            _language="en",
+            translation_enabled=True,
+            begin_text="start",
+            previous_text="prev",
+            change_text="change",
+            confirm_text="confirm",
+        )
+
+        url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
 
         response = self.client.get(url, HTTP_ACCEPT_LANGUAGE="en")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.headers["Content-Language"], "en")
-        form = response.json()
+        data = response.json()
 
-        self.assertTrue(form["name"])  # it has a name from the factory
+        self.assertTrue(data["name"])  # it has a name from the factory
 
         def literal_value(field):
-            return form["literals"][field]["value"]
+            return data["literals"][field]["value"]
 
         self.assertEqual(literal_value("beginText"), "start")
         self.assertEqual(literal_value("previousText"), "prev")


### PR DESCRIPTION
Related to #2255

After some discussion with Chris about the impact on the SDK and in light of #2351, relying on the HTTP headers will reduce the amount of API calls needed to make.

Changing the client language is no server state change, so that side-effect can be performed inside the GET form-detail call.