### PR TITLE
Bump Celery to latest patch release

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,7 +33,7 @@ cairocffi==1.2.0
     #   weasyprint
 cairosvg==2.5.2
     # via weasyprint
-celery==5.2.3
+celery==5.2.7
     # via
     #   -r requirements/base.in
     #   celery-once
@@ -479,10 +479,9 @@ zgw-consumers==0.22.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==59.6.0
+setuptools==65.5.1
     # via
     #   -r requirements/base.in
-    #   celery
     #   django-axes
     #   drf-jsonschema
     #   josepy

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -73,7 +73,7 @@ cairosvg==2.5.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
-celery==5.2.3
+celery==5.2.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -965,11 +965,10 @@ zgw-consumers==0.22.0
     #   -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==59.6.0
+setuptools==65.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   celery
     #   django-axes
     #   drf-jsonschema
     #   josepy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -89,7 +89,7 @@ cairosvg==2.5.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-celery==5.2.3
+celery==5.2.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1177,11 +1177,10 @@ zgw-consumers==0.22.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1
     # via pip-tools
-setuptools==59.6.0
+setuptools==65.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   celery
     #   django-axes
     #   drf-jsonschema
     #   josepy

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -50,7 +50,7 @@ cairosvg==2.5.2
     # via
     #   -r requirements/base.txt
     #   weasyprint
-celery==5.2.3
+celery==5.2.7
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -735,11 +735,10 @@ zgw-consumers==0.22.0
     #   open-forms-ext-token-exchange
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==59.6.0
+setuptools==65.5.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-    #   celery
     #   django-axes
     #   drf-jsonschema
     #   josepy


### PR DESCRIPTION
This allows us to use modern setuptools versions as the dependency is no longer required by Celery.

The flower containers are now broken with our current image build(s).