### PR TITLE
Fix docs typo resulting in 404

### DIFF
--- a/README.NL.rst
+++ b/README.NL.rst
@@ -34,7 +34,7 @@ eindgebruikers als beheerders.
 .. image:: docs/introduction/_assets/open-forms-from-designer-to-form.png
     :width: 100%
 
-.. _`SDK`: https://github.com/open-formuliere/open-forms-sdk/
+.. _`SDK`: https://github.com/open-formulieren/open-forms-sdk/
 .. _`Common Ground`: https://commonground.nl/
 .. _`Open Zaak`: https://open-zaak.readthedocs.io/
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ both end users and administrators.
 .. image:: docs/introduction/_assets/open-forms-from-designer-to-form.png
     :width: 100%
 
-.. _`SDK`: https://github.com/open-formuliere/open-forms-sdk/
+.. _`SDK`: https://github.com/open-formulieren/open-forms-sdk/
 .. _`Common Ground`: https://commonground.nl/
 .. _`Open Zaak`: https://open-zaak.readthedocs.io/
 


### PR DESCRIPTION
Updates both the Dutch and English readme, fixing the link to open-forms-sdk. 