### PR TITLE
[2219] update fix for CSS-unit issue with design tokens in email header logo

### DIFF
--- a/src/openforms/emails/context.py
+++ b/src/openforms/emails/context.py
@@ -8,11 +8,11 @@ from openforms.utils.urls import build_absolute_uri
 
 def get_wrapper_context(html_content=""):
     config = GlobalConfiguration.get_solo()
-    design_token = config.design_token_values or {}
+    design_tokens = config.design_token_values or {}
     ctx = {
         "content": mark_safe(html_content),
         "main_website_url": config.main_website,
-        "style": _get_design_token_values(design_token),
+        "style": _get_design_token_values(design_tokens),
     }
     if config.logo:
         ctx["logo_url"] = build_absolute_uri(config.logo.url)
@@ -20,13 +20,32 @@ def get_wrapper_context(html_content=""):
     return ctx
 
 
+def _filter(value: str) -> str:
+    if value.isnumeric():
+        return value
+    elif value.endswith("px"):
+        return value.strip("px")
+    else:
+        return ""
+
+
 def _get_design_token_values(tokens):
     """
-    convert and apply defaults for use in template
+    convert and apply defaults for use in email template
+
+    Dimension values for design tokens specified as CSS or as attributes
+    of HTML tags need to be handled differently because of issues with the
+    desktop client of MS Outlook. The former are used as passed in by the
+    user; the latter are filtered via ``filter_design_token_values``.
 
     TODO: convert to use style-dict assets merged with database tokens
     TODO: figure out how to use the remote stylesheet for this
     """
+    height = glom(tokens, "header-logo.height.value", default="50px")
+    width = glom(tokens, "header-logo.width.value", default="auto")
+    height_attr = _filter(height)
+    width_attr = _filter(width)
+
     return {
         "header": {
             "fg": glom(tokens, "page-header.fg.value", default="#000000"),
@@ -36,8 +55,12 @@ def _get_design_token_values(tokens):
             # Setting height to a default of 50 obtaines the same result on the
             # website that uses flexbox shrink, to size the logo to it's minimum
             # size.
-            "height": glom(tokens, "header-logo.height.value", default="50px"),
-            "width": glom(tokens, "header-logo.width.value", default="auto"),
+            "height": height,
+            "width": width,
+            # attr values are for specifying dimensions as attributes of the
+            # HTML image tag
+            "height_attr": height_attr,
+            "width_attr": width_attr,
         },
         "footer": {
             "fg": glom(tokens, "page-footer.fg.value", default="#ffffff"),

--- a/src/openforms/emails/templates/emails/wrapper.html
+++ b/src/openforms/emails/templates/emails/wrapper.html
@@ -10,10 +10,8 @@
                     <td align="left" style="padding: 20px; color: {{ style.header.fg }}; background-color: {{ style.header.bg }};">
                         {% if logo_url %}
                             <a style="text-decoration: none;" href="{{ main_website_url }}">
-                                <img style="{% spaceless %}
-                                    {% if style.logo.width %}width: {{ style.logo.width }}; {% endif %}
-                                    {% if style.logo.height %}height: {{ style.logo.height }}; {% endif %}
-                                {% endspaceless %}" src="{{ logo_url }}" />
+                                <img {% if style.logo.width_attr %}width="{{ style.logo.width_attr }}" {% endif %} {% if style.logo.height_attr %}height="{{ style.logo.height_attr }}" {% endif %}
+				                style="{% spaceless %} {% if style.logo.width %}width: {{ style.logo.width }}; {% endif %} {% if style.logo.height %}height: {{ style.logo.height }}; {% endif %} {% endspaceless %}" src="{{ logo_url }}" />
                             </a>
                         {% endif %}
                     </td>


### PR DESCRIPTION
Fixes #2219.

- the original fix no longer works for the latest version of MS Outlook's desktop client
- the update adds the logo height/width as HTML tags with the unit removed (or an empty string if the unit is anything other than "px")