### PR TITLE
replace get_component usage with configuration_wrapper

### DIFF
--- a/src/openforms/formio/tests/assertions.py
+++ b/src/openforms/formio/tests/assertions.py
@@ -4,7 +4,14 @@ from glom import GlomError, glom
 
 from openforms.typing import JSONObject, JSONValue
 
-from ..utils import get_component
+from ..typing import Component
+from ..utils import iter_components
+
+
+def _get_component(configuration: JSONObject, key: str) -> Component | None:
+    for component in iter_components(configuration=configuration, recursive=True):
+        if component["key"] == key:
+            return component
 
 
 class FormioMixin:
@@ -19,7 +26,7 @@ class FormioMixin:
         :arg properties_map: a mapping of formio property name to expected property
           value. Note that the dict keys can be dotted paths for nested properties.
         """
-        component = get_component(configuration, key)
+        component = _get_component(configuration, key)
         if component is None:
             self.fail(f"Component with key '{key}' not found in configuration.")
 

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import elasticapm
@@ -35,18 +34,6 @@ def iter_components(
                 yield from iter_components(
                     configuration=component, recursive=recursive, _is_root=False
                 )
-
-
-@elasticapm.capture_span(span_type="app.formio.configuration")
-def get_component(configuration: JSONObject, key: str) -> Optional[Component]:
-    warnings.warn(
-        "`openforms.formio.utils.get_component` is not efficient, use "
-        "`openforms.formio.utils.FormioConfigurationWrapper` instead.",
-        DeprecationWarning,
-    )
-    for component in iter_components(configuration=configuration, recursive=True):
-        if component["key"] == key:
-            return component
 
 
 @elasticapm.capture_span(span_type="app.formio.configuration")

--- a/src/openforms/forms/api/serializers/form_variable.py
+++ b/src/openforms/forms/api/serializers/form_variable.py
@@ -7,7 +7,6 @@ from rest_framework.exceptions import ValidationError
 
 from openforms.api.fields import RelatedFieldFromContext
 from openforms.api.serializers import ListWithChildSerializer
-from openforms.formio.utils import get_component
 from openforms.variables.constants import FormVariableSources
 from openforms.variables.service import get_static_variables
 
@@ -126,7 +125,8 @@ class FormVariableSerializer(serializers.HyperlinkedModelSerializer):
         if (form_definition := attrs.get("form_definition")) and attrs.get(
             "source"
         ) == FormVariableSources.component:
-            component = get_component(form_definition.configuration, attrs["key"])
+            config_wrapper = form_definition.configuration_wrapper
+            component = config_wrapper.component_map.get(attrs["key"])
             if not component:
                 raise ValidationError(
                     {

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -10,7 +10,6 @@ from glom import Path, glom
 
 from openforms.formio.utils import (
     component_in_editgrid,
-    get_component,
     get_component_datatype,
     get_component_default_value,
     is_layout_component,
@@ -211,7 +210,8 @@ class FormVariable(models.Model):
         if self.source != FormVariableSources.component or not self.form_definition:
             return
 
-        component = get_component(self.form_definition.configuration, self.key)
+        config_wrapper = self.form_definition.configuration_wrapper
+        component = config_wrapper.component_map.get(self.key)
 
         if self.initial_value is None:
             self.initial_value = get_component_default_value(component)


### PR DESCRIPTION
Related to #2042

We're factoring out get_component usage in favour of a caching datastructure, which should boost performance a bit on the python level.