### PR TITLE
Clear data from fields if they are nested within a hidden component

### DIFF
--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -1,11 +1,16 @@
-from typing import Dict, Iterator, Optional
+import re
+from typing import Dict, Iterator, Optional, cast
 
-from openforms.typing import JSONObject
+from glom import glom
+
+from openforms.typing import DataMapping, JSONObject
 
 from .typing import Component
-from .utils import iter_components
+from .utils import flatten_by_path, is_visible_in_frontend, iter_components
 
 # TODO: mechanism to wrap/mark root components?
+
+RE_PATH = re.compile(r"(components|columns|rows)\.([0-9]+)")
 
 
 class FormioConfigurationWrapper:
@@ -19,6 +24,7 @@ class FormioConfigurationWrapper:
     _configuration: JSONObject
     # depth-first ordered of all components in the formio configuration tree
     _cached_component_map: Optional[Dict[str, Component]] = None
+    _reverse_flattened: None | dict[str, str] = None
 
     def __init__(self, configuration: JSONObject):
         self._configuration = configuration
@@ -52,3 +58,22 @@ class FormioConfigurationWrapper:
     @property
     def configuration(self) -> JSONObject:
         return self._configuration
+
+    @property
+    def reverse_flattened(self) -> dict[str, str]:
+        if self._reverse_flattened is None:
+            flattened = flatten_by_path(self.configuration)
+            self._reverse_flattened = {
+                component["key"]: path for path, component in flattened.items()
+            }
+        return self._reverse_flattened
+
+    def is_visible_in_frontend(self, key: str, values: DataMapping) -> bool:
+        config_path = self.reverse_flattened[key]
+        path_bits = [".".join(bit) for bit in RE_PATH.findall(config_path)]
+        nodes = []  # leftmost is root, rightmost is leaf
+        for depth in range(len(path_bits)):
+            path = ".".join(path_bits[: depth + 1])
+            component = cast(Component, glom(self.configuration, path))
+            nodes.append(component)
+        return all(is_visible_in_frontend(node, values) for node in nodes)

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -228,7 +228,7 @@ def conform_to_mask(value: str, mask: str) -> str:
     return "".join(result)
 
 
-def is_visible_in_frontend(component: JSONObject, data: DataMapping) -> bool:
+def is_visible_in_frontend(component: Component, data: DataMapping) -> bool:
     """Check if the component is visible because of frontend logic
 
     The rules in formio are expressed as:
@@ -241,6 +241,8 @@ def is_visible_in_frontend(component: JSONObject, data: DataMapping) -> bool:
             "eq": <compare value>
         }
 
+    .. warning:: this function currently does not take parent components into account
+       that may be hidden, which lead to this component being hidden too.
     """
     hidden = component.get("hidden")
     conditional = component.get("conditional")


### PR DESCRIPTION
Bandaid fixes #2340

Note: this causes problems for logic rules that rely on the values of these hidden fields - we can tackle that when we get to #2409