### PR TITLE
[#2250] fix broken analytics tools

### DIFF
--- a/src/openforms/analytics_tools/templates/analytics_tools/google.html
+++ b/src/openforms/analytics_tools/templates/analytics_tools/google.html
@@ -5,9 +5,9 @@
     Google Tag Manager / Analytics code.
 {% endcomment %}
 
-{% if analytics_tools_config.enable_google_analytics and analytics_tools_config.gtm_code %}
+{% if analytics_tools_config.is_google_analytics_enabled and analytics_tools_config.gtm_code %}
 <!-- Google Tag Manager -->
-<script nonce="{{ request.csp_nonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script id="google-tag-manager" nonce="{{ request.csp_nonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
@@ -16,9 +16,9 @@ n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertB
 <!-- End Google Tag Manager -->
 {% endif %}
 
-{% if analytics_tools_config.enable_google_analytics and analytics_tools_config.ga_code %}
+{% if analytics_tools_config.is_google_analytics_enabled and analytics_tools_config.ga_code %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_tools_config.ga_code|escapejs }}"></script>
+<script id="google-analytics" async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_tools_config.ga_code|escapejs }}"></script>
 <script nonce="{{ request.csp_nonce }}">
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}

--- a/src/openforms/analytics_tools/templates/analytics_tools/matomo.html
+++ b/src/openforms/analytics_tools/templates/analytics_tools/matomo.html
@@ -4,9 +4,9 @@
 {% load solo_tags %}
 {% get_solo 'analytics_tools.AnalyticsToolsConfiguration' as analytics_tools_config %}
 
-{% if analytics_tools_config.matomo_enabled %}
+{% if analytics_tools_config.is_matomo_enabled %}
 <!-- Matomo -->
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+<script id="matomo-analytics" type="text/javascript" nonce="{{ request.csp_nonce }}">
   var _paq = window._paq = window._paq || [];
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);

--- a/src/openforms/analytics_tools/templates/analytics_tools/piwik.html
+++ b/src/openforms/analytics_tools/templates/analytics_tools/piwik.html
@@ -5,9 +5,9 @@
     django-piwik-analytics for example.
 {% endcomment %}
 
-{% if analytics_tools_config.piwik_enabled %}
+{% if analytics_tools_config.is_piwik_enabled %}
 <!-- Piwik -->
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+<script id="piwik-analytics" type="text/javascript" nonce="{{ request.csp_nonce }}">
 var pkBaseURL = "//{{ analytics_tools_config.piwik_url|escapejs }}";
 document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
 </script><script type="text/javascript" nonce="{{ request.csp_nonce }}">

--- a/src/openforms/analytics_tools/templates/analytics_tools/piwik_pro.html
+++ b/src/openforms/analytics_tools/templates/analytics_tools/piwik_pro.html
@@ -1,8 +1,8 @@
 {% load solo_tags %}
 {% get_solo 'analytics_tools.AnalyticsToolsConfiguration' as analytics_tools_config %}
-{% if analytics_tools_config.piwik_pro_enabled %}
+{% if analytics_tools_config.is_piwik_pro_enabled %}
 <!-- End Piwik PRO head tag -->
-<script type="text/javascript">
+<script id="piwik-pro-analytics" type="text/javascript">
   var _paq = _paq || [];
   _paq.push(["trackPageView"]);
   _paq.push(["enableLinkTracking"]);

--- a/src/openforms/analytics_tools/templates/analytics_tools/siteimprove.html
+++ b/src/openforms/analytics_tools/templates/analytics_tools/siteimprove.html
@@ -5,8 +5,8 @@
     Documentation: https://support.siteimprove.com/hc/en-gb/articles/206343703-Adding-Siteimprove-Analytics-JavaScript-to-your-website
 {% endcomment %}
 
-{% if analytics_tools_config.siteimprove_enabled %}
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+{% if analytics_tools_config.is_siteimprove_enabled %}
+<script id="siteimprove-analytics" type="text/javascript" nonce="{{ request.csp_nonce }}">
 /*<![CDATA[*/
 (function() {
 var sz = document.createElement('script'); sz.type = 'text/javascript'; sz.async = true;

--- a/src/openforms/analytics_tools/tests/test_analytics_rendering.py
+++ b/src/openforms/analytics_tools/tests/test_analytics_rendering.py
@@ -1,0 +1,123 @@
+from django.urls import reverse
+
+from cookie_consent.models import CookieGroup
+from django_webtest import WebTest
+
+from openforms.analytics_tools.models import AnalyticsToolsConfiguration
+from openforms.forms.tests.factories import FormFactory
+from openforms.utils.tests.cache import clear_caches
+
+
+class AnalyticsToolsRenderingTest(WebTest):
+    """Integration tests for rendering of analytics snippets.
+
+    The tests check that the analytics snippets are rendered if they are
+    enabled (by the admin) and cookies are accepted (by the user). They
+    do *not* test whether the scripts are properly executed, which requires
+    either manual testing or functional tests with Selenium.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        clear_caches()
+        super().setUpTestData()
+        form = FormFactory.create()
+        cls.url = reverse("forms:form-detail", kwargs={"slug": form.slug})
+        config = AnalyticsToolsConfiguration.get_solo()
+        config.analytics_cookie_consent_group = CookieGroup.objects.get(
+            varname="analytical"
+        )
+        config.save()
+        cls.config = config
+
+    def test_google_analytics_rendering(self):
+        """Assert that the Google Analytics script is rendered"""
+
+        # Enable and configure Google analytics
+        self.config.enable_google_analytics = True
+        self.config.gtm_code = "GTM-XXXX"
+        self.config.ga_code = "UA-XXXXX-Y"
+        self.config.save()
+
+        # Accept cookies
+        form_page = self.app.get(self.url)
+        accept_form = form_page.forms[0]
+        refreshed_form_page = accept_form.submit().follow()
+
+        google_tag_manager = refreshed_form_page.pyquery("#google-tag-manager")
+        google_analytics = refreshed_form_page.pyquery("#google-analytics")
+
+        self.assertTrue(google_tag_manager.is_("script"))
+        self.assertTrue(google_analytics.is_("script"))
+
+    def test_matomo_rendering(self):
+        """Assert that the Matomo script is rendered"""
+
+        # Enable and configure Matomo
+        self.config.enable_matomo_site_analytics = True
+        self.config.matomo_site_id = 1234
+        self.config.matomo_url = self.url
+        self.config.save()
+
+        # Accept cookies
+        form_page = self.app.get(self.url)
+        accept_form = form_page.forms[0]
+        refreshed_form_page = accept_form.submit().follow()
+
+        matomo = refreshed_form_page.pyquery("#matomo-analytics")
+
+        self.assertTrue(matomo.is_("script"))
+
+    def test_piwik_pro_rendering(self):
+        """Assert that the Piwik Pro script is rendered"""
+
+        # Enable and configure Piwik Pro
+        self.config.enable_piwik_pro_site_analytics = True
+        self.config.piwik_pro_site_id = 1234
+        self.config.piwik_pro_url = self.url
+        self.config.save()
+
+        # Accept cookies
+        form_page = self.app.get(self.url)
+        accept_form = form_page.forms[0]
+        refreshed_form_page = accept_form.submit().follow()
+
+        piwik_pro = refreshed_form_page.pyquery("#piwik-pro-analytics")
+
+        self.assertTrue(piwik_pro.is_("script"))
+
+    def test_piwik_rendering(self):
+        """Assert that the Piwik script is rendered"""
+
+        # Enable and configure Piwik
+        self.config.enable_piwik_site_analytics = True
+        self.config.piwik_site_id = 1234
+        self.config.piwik_url = self.url
+        self.config.save()
+
+        # Accept cookies
+        form_page = self.app.get(self.url)
+        accept_form = form_page.forms[0]
+        refreshed_form_page = accept_form.submit().follow()
+
+        piwik = refreshed_form_page.pyquery("#piwik-analytics")
+
+        self.assertTrue(piwik.is_("script"))
+
+    def test_site_improve_rendering(self):
+        """Assert that the Siteimprove script is rendered"""
+
+        # Enable and configure Siteimprove
+        self.config.enable_siteimprove_analytics = True
+        self.config.siteimprove_id = 1234
+        self.config.siteimprove_url = self.url
+        self.config.save()
+
+        # Accept cookies
+        form_page = self.app.get(self.url)
+        accept_form = form_page.forms[0]
+        refreshed_form_page = accept_form.submit().follow()
+
+        siteimprove = refreshed_form_page.pyquery("#siteimprove-analytics")
+
+        self.assertTrue(siteimprove.is_("script"))


### PR DESCRIPTION
Fixes #2250
- all analytics tools (except Google Analytics) failed to render because the wrong property was tested in the templates
- fixed the templates
- added integration tests for the rendering of analytics snippets