### PR TITLE
StUF postcode format fixes

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -538,6 +538,13 @@ class StufZDSPluginTests(StUFZDSTestBase):
             },
         )
 
+        with self.subTest("#2422: postcode must be normalized"):
+            self.assertXPathEquals(
+                xml_doc,
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:verblijfsadres/bg:aoa.postcode",
+                "1000AA",
+            )
+
         # don't expect registered data in extraElementen
         self.assertXPathNotExists(
             xml_doc, "//stuf:extraElementen/stuf:extraElement[@naam='voornaam']"

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -92,7 +92,7 @@
                                 {% include "stuf_zds/soap/includes/verblijfsadres.xml" %}
                             {% endif %}
                         </ZKN:vestiging>
-                    {% elif  initiator.kvk %}
+                    {% elif initiator.kvk %}
                         <ZKN:nietNatuurlijkPersoon StUF:entiteittype="NNP" StUF:verwerkingssoort="T">
                             <BG:inn.nnpId>{{ initiator.kvk }}</BG:inn.nnpId>
                             <BG:authentiek>J</BG:authentiek>

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/bezoekadres.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/bezoekadres.xml
@@ -3,7 +3,7 @@
     {% with verblijfsadres=initiator.verblijfsadres %}
     {% if verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
     {% if verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
-    {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode }}</BG:aoa.postcode>{% endif %}
+    {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode|cut:" " }}</BG:aoa.postcode>{% endif %}
     {% if verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
     {% if verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}
     {% if verblijfsadres.huisnummertoevoeging %}<BG:aoa.huisnummertoevoeging>{{ verblijfsadres.huisnummertoevoeging }}</BG:aoa.huisnummertoevoeging>{% endif %}

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/bezoekadres.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/bezoekadres.xml
@@ -1,9 +1,11 @@
 <BG:bezoekadres>
     <BG:authentiek>N</BG:authentiek>
-    {% if initiator.verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
-    {% if initiator.verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
-    {% if initiator.verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode }}</BG:aoa.postcode>{% endif %}
-    {% if initiator.verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
-    {% if initiator.verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}
-    {% if initiator.verblijfsadres.huisnummertoevoeging %}<BG:aoa.huisnummertoevoeging>{{ verblijfsadres.huisnummertoevoeging }}</BG:aoa.huisnummertoevoeging>{% endif %}
+    {% with verblijfsadres=initiator.verblijfsadres %}
+    {% if verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
+    {% if verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
+    {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode }}</BG:aoa.postcode>{% endif %}
+    {% if verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
+    {% if verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}
+    {% if verblijfsadres.huisnummertoevoeging %}<BG:aoa.huisnummertoevoeging>{{ verblijfsadres.huisnummertoevoeging }}</BG:aoa.huisnummertoevoeging>{% endif %}
+    {% endwith %}
  </BG:bezoekadres>

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/verblijfsadres.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/verblijfsadres.xml
@@ -3,7 +3,7 @@
     {% with verblijfsadres=initiator.verblijfsadres %}
     {% if verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
     {% if verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
-    {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode }}</BG:aoa.postcode>{% endif %}
+    {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode|cut:" " }}</BG:aoa.postcode>{% endif %}
     {% if verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
     {% if verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}
     {% if verblijfsadres.huisnummertoevoeging %}<BG:aoa.huisnummertoevoeging>{{ verblijfsadres.huisnummertoevoeging }}</BG:aoa.huisnummertoevoeging>{% endif %}

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/verblijfsadres.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/verblijfsadres.xml
@@ -1,9 +1,11 @@
 <BG:verblijfsadres>
     <BG:authentiek>N</BG:authentiek>
-    {% if initiator.verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
-    {% if initiator.verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
-    {% if initiator.verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode }}</BG:aoa.postcode>{% endif %}
-    {% if initiator.verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
-    {% if initiator.verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}
-    {% if initiator.verblijfsadres.huisnummertoevoeging %}<BG:aoa.huisnummertoevoeging>{{ verblijfsadres.huisnummertoevoeging }}</BG:aoa.huisnummertoevoeging>{% endif %}
+    {% with verblijfsadres=initiator.verblijfsadres %}
+    {% if verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
+    {% if verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
+    {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode }}</BG:aoa.postcode>{% endif %}
+    {% if verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
+    {% if verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}
+    {% if verblijfsadres.huisnummertoevoeging %}<BG:aoa.huisnummertoevoeging>{{ verblijfsadres.huisnummertoevoeging }}</BG:aoa.huisnummertoevoeging>{% endif %}
+    {% endwith %}
 </BG:verblijfsadres>


### PR DESCRIPTION
Fixes #2422 

* Fixes postcodes with spaces to not have spaces
* Fixed inclusion templates for address accessing wrong context data, leading to data not being included at all

Definitely needs backporting to 2.0.x, possibly to 1.1.x as well.