### PR TITLE
✨[#2389] Add language code to submission exports

### DIFF
--- a/src/openforms/submissions/exports.py
+++ b/src/openforms/submissions/exports.py
@@ -51,6 +51,9 @@ def create_submission_export(queryset: SubmissionQuerySet) -> tablib.Dataset:
 
     first_submission = queryset[0]
     headers = ["Formuliernaam", "Inzendingdatum"]
+    if first_submission.form.translation_enabled:
+        headers.append("Taalcode")
+
     for data_node in iter_submission_data_nodes(first_submission):
         if hasattr(data_node, "component"):
             headers.append(data_node.component["key"])
@@ -66,7 +69,11 @@ def create_submission_export(queryset: SubmissionQuerySet) -> tablib.Dataset:
         submission_data = [
             submission.form.admin_name,
             inzending_datum,
-            *[data_node.value for data_node in iter_submission_data_nodes(submission)],
+        ]
+        if first_submission.form.translation_enabled:
+            submission_data.append(submission.language_code)
+        submission_data += [
+            data_node.value for data_node in iter_submission_data_nodes(submission)
         ]
         data.append(submission_data)
     return data

--- a/src/openforms/submissions/tests/test_exports.py
+++ b/src/openforms/submissions/tests/test_exports.py
@@ -260,7 +260,7 @@ class ExportTests(TestCase):
     @freeze_time()
     def test_submissions_of_forms_with_translation_enabled_have_language_codes(self):
         SubmissionFactory.create(
-            form=FormFactory.create(translation_enabled=True),
+            form__translation_enabled=True,
             language_code="en",
         )
         export = create_submission_export(Submission.objects.all())

--- a/src/openforms/submissions/tests/test_exports.py
+++ b/src/openforms/submissions/tests/test_exports.py
@@ -255,3 +255,14 @@ class ExportTests(TestCase):
                 "sub1.input2",
             ),
         )
+
+    @tag("gh-2389")
+    @freeze_time()
+    def test_submissions_of_forms_with_translation_enabled_have_language_codes(self):
+        SubmissionFactory.create(
+            form=FormFactory.create(translation_enabled=True),
+            language_code="en",
+        )
+        export = create_submission_export(Submission.objects.all())
+
+        self.assertIn(("Taalcode", "en"), zip(export.headers, export[0]))


### PR DESCRIPTION
Adds "Taalcode" field to submission exports for forms with `translation_enabled`.

Closes #2389