### PR TITLE
[#2362] fix Ogone payment plugin

### DIFF
--- a/src/openforms/payments/contrib/ogone/plugin.py
+++ b/src/openforms/payments/contrib/ogone/plugin.py
@@ -40,6 +40,7 @@ RETURN_ACTION_PARAM = "action"
 
 @register("ogone-legacy")
 class OgoneLegacyPaymentPlugin(BasePlugin):
+    return_method = ("GET", "POST")
     verbose_name = _("Ogone legacy")
     configuration_options = OgoneOptionsSerializer
 
@@ -76,7 +77,10 @@ class OgoneLegacyPaymentPlugin(BasePlugin):
         client = OgoneClient(merchant)
 
         try:
-            params = client.get_validated_params(request.query_params)
+            if request.method == "GET":
+                params = client.get_validated_params(request.query_params)
+            elif request.method == "POST":
+                params = client.get_validated_params(request.data)
         except InvalidSignature as e:
             logger.warning(f"invalid SHASIGN for payment {payment}")
             logevent.payment_flow_failure(payment, self, e)

--- a/src/openforms/payments/views.py
+++ b/src/openforms/payments/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView
 
 from drf_spectacular.types import OpenApiTypes
@@ -215,7 +216,7 @@ class PaymentReturnView(PaymentFlowBaseView, GenericAPIView):
         if payment.plugin_id != payment.form.payment_backend:
             raise ParseError(detail="plugin not allowed")
 
-        if plugin.return_method.upper() != request.method.upper():
+        if request.method.upper() not in plugin.return_method:
             raise MethodNotAllowed(request.method)
 
         try:
@@ -245,6 +246,7 @@ class PaymentReturnView(PaymentFlowBaseView, GenericAPIView):
     def get(self, request, *args, **kwargs):
         return self._handle_return(request, *args, **kwargs)
 
+    @method_decorator(csrf_exempt)
     def post(self, request, *args, **kwargs):
         return self._handle_return(request, *args, **kwargs)
 


### PR DESCRIPTION
Fixes #2362

- Allow both GET and POST requests in the return method of the plugin and adjust the corresponding view
- The ticket mentions two further requirements: making the endpoint CSRF-exempt and validating the origin via SHA-IN/SHA-OUT. These are already satisfied (there was no CSRF-protection for Ogone, and the origin of the request is already validated in the `handle_return` method of the plugin (via `client.get_validated_params()`)