### PR TITLE
Catch invalid appointment configs in command

### DIFF
--- a/src/openforms/appointments/management/commands/appointment.py
+++ b/src/openforms/appointments/management/commands/appointment.py
@@ -32,9 +32,19 @@ class Command(BaseCommand):
                     f"Invalid plugin: {plugin}. Choices are: {available_plugins.keys()}"
                 )
             config_class = import_string(available_plugins[plugin])
-            self.client = config_class.get_solo().get_client()
+            try:
+                self.client = config_class.get_solo().get_client()
+                # Sanity check:
+                self.client.get_available_products()
+            except Exception as e:
+                raise CommandError(f"Plugin is not properly configured: {e}")
         else:
-            self.client = get_client()
+            try:
+                self.client = get_client()
+            except ValueError:
+                raise CommandError(
+                    "No plugin is configured. Use --plugin PLUGIN to use a specific plugin."
+                )
 
         self.stdout.write(f"Using plugin: {plugin}")
 


### PR DESCRIPTION
I noticed that if you have no configuration set up, it fails with hard to interpret errors.

This gives at least some more pointers, and also before starting the process.