### PR TITLE
Add SDK changelog to RTD/Sphinx documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,27 +115,66 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: open-forms
+
+      - name: Determine SDK version to checkout
+        id: sdk-ref
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name (if present at all)
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # default to version in .sdk-release file
+          SDK_REF=$(cat .sdk-release | tr -d '[:space:]')
+
+          case $VERSION in
+            # if building master -> include main of SDK
+            master) SDK_REF=main;;
+            # PRs result in version 'merge' that'll go to master -> include main of SDK
+            merge) SDK_REF=main;;
+          esac
+
+          echo "sdk_ref=${SDK_REF}" >> $GITHUB_OUTPUT
+        working-directory: open-forms
+
+      - name: Checkout SDK repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'open-formulieren/open-forms-sdk'
+          ref: ${{ steps.sdk-ref.outputs.sdk_ref }}
+          path: open-forms-sdk
+
+      - name: Setup symlinks
+        run: |
+          ln -s $(pwd)/open-forms-sdk/CHANGELOG.rst open-forms/docs/changelog-sdk.rst
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
+        working-directory: open-forms
 
       - name: Install OS dependencies
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+        working-directory: open-forms
 
       - name: Install dependencies
         run: |
           pip install -r requirements/setuptools.txt
           pip install -r requirements/ci.txt
+        working-directory: open-forms
 
       - name: Build and test docs
         run: |
           export OPENSSL_CONF=$(pwd)/openssl.conf
           pytest check_sphinx.py -v --tb=auto
-        working-directory: docs
+        working-directory: open-forms/docs
 
   # see https://github.com/orgs/community/discussions/26671
   docker_build_setup:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ __pycache__
 # Generated files
 /docs/_build
 /certifi_ca_bundle
+# must be symlinked as the source file is in another repository
+/docs/changelog-sdk.rst
 
 # tests & coverage reports
 /reports/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,25 @@ build:
     - libxml2-dev
     - libxmlsec1-dev
     - libxmlsec1-openssl
+    - wget
   tools:
     python: '3.10'
+  jobs:
+    post_checkout:
+      # fetch the changelog from the SDK repository. Docs:
+      # https://docs.readthedocs.io/en/stable/environment-variables.html
+      - |
+        SDK_REF=$(cat .sdk-release | tr -d '[:space:]') # default to the version in .sdk-release file
+        case $READTHEDOCS_VERSION_TYPE in
+          # external = PR
+          external) SDK_REF=main;;
+          unknown) SDK_REF=main;;
+        esac
+
+        [ "$READTHEDOCS_VERSION_NAME" == "latest" ] && SDK_REF=main
+
+        URL=https://github.com/open-formulieren/open-forms-sdk/raw/${SDK_REF}/CHANGELOG.rst
+        wget $URL -O docs/changelog-sdk.rst
 
 python:
   install:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -179,6 +179,32 @@ When updating an existing installation:
        $ python src/manage.py migrate
 
 
+Documentation build
+===================
+
+The documentation lives in the ``docs`` folder.
+
+The documentation build includes the SDK changelog, which requires you to set up a
+symlink (or a dummy file). The preferred approach is using the real symlink.
+
+1. Ensure you have a clone of the SDK repository, e.g. in ``/path/to/open-forms-sdk``.
+
+2. Set up the symlink from the changelog file:
+
+   .. code-block:: bash
+
+       $ ln -s /path/to/open-forms-sdk/CHANGELOG.rst docs/changelog-sdk.rst
+
+3. Build the docs to verify it's all correct:
+
+   .. code-block:: bash
+
+       $ cd docs
+       $ make html
+
+Alternatively, instead of symlinking you can also just create the file
+``docs/changelog-sdk.rst`` with some dummy content.
+
 Testsuite
 =========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,3 +45,4 @@ To get you started, you might find some of these links relevant:
    configuration/index
    developers/index
    changelog
+   changelog-sdk


### PR DESCRIPTION
At some point it was mentioned the SDK changelog should also be published on readthedocs.

This approach includes it via symlink while keeping the source data in the respective repository.