### PR TITLE
Remove ambiguity in endpoint documention

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1003,27 +1003,15 @@ paths:
   /api/v2/forms:
     get:
       operationId: forms_list
-      description: |-
-        Geef een lijst van actieve formulieren, inclusief verwijzingen naar de formulierstappen. De formulierstappen komen voor in de volgorde waarin ze zichtbaar moeten zijn.
-
-        **Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je gebruikersrechten**
-
-        Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden - deze zijn enkel relevant voor interne formulierconfiguratie. Het gaat om de velden:
-
-        - `internalName`
-        - `registrationBackend`
-        - `registrationBackendOptions`
-        - `paymentBackend`
-        - `paymentBackendOptions`
-        - `product`
-        - `category`
-        - `isDeleted`
-        - `submissionConfirmationTemplate`
-        - `submissionsRemovalOptions`
-        - `confirmationEmailTemplate`
-        - `confirmationEmailOption`
-        - `displayMainWebsiteLink`
-        - `translations`
+      description: "List the active forms, including the pointers to the form steps.\
+        \ Form steps are included in order as they should appear.\n\n**Warning: the\
+        \ response data depends on user permissions**\n\nNon-staff users receive a\
+        \ subset of all the documented fields. The fields reserved for staff users\
+        \ are used for internal form configuration. These are: \n\n- `internalName`\n\
+        - `registrationBackend`\n- `registrationBackendOptions`\n- `paymentBackend`\n\
+        - `paymentBackendOptions`\n- `product`\n- `category`\n- `isDeleted`\n- `submissionConfirmationTemplate`\n\
+        - `submissionsRemovalOptions`\n- `confirmationEmailTemplate`\n- `confirmationEmailOption`\n\
+        - `displayMainWebsiteLink`\n- `translations`"
       summary: List forms
       parameters:
       - in: header
@@ -1578,15 +1566,16 @@ paths:
         \ form definition. Multiple definitions are combined in logical steps to build\
         \ a multi-step/page form for end-users to fill out. Form definitions can be\
         \ (and are) re-used among different forms.\n\n**Warning: the response data\
-        \ depends on user permissions**\n\nNon-staff users receive a subset of the\
-        \ documented fields which are usedfor internal form configuration. These fields\
-        \ are:\n\n- `internalName`\n- `registrationBackend`\n- `registrationBackendOptions`\n\
-        - `paymentBackend`\n- `paymentBackendOptions`\n- `product`\n- `category`\n\
-        - `isDeleted`\n- `submissionConfirmationTemplate`\n- `submissionsRemovalOptions`\n\
-        - `confirmationEmailTemplate`\n- `confirmationEmailOption`\n- `displayMainWebsiteLink`\n\
-        - `translations`\n\nIf the form doesn't have translations enabled, its default\
-        \ language is forced by setting a language cookie and reflected in the Content-Language\
-        \ response header. Normal HTTP Content Negotiation rules apply."
+        \ depends on user permissions**\n\nNon-staff users receive a subset of all\
+        \ the documented fields. The fields reserved for staff users are used for\
+        \ internal form configuration. These are: \n\n- `internalName`\n- `registrationBackend`\n\
+        - `registrationBackendOptions`\n- `paymentBackend`\n- `paymentBackendOptions`\n\
+        - `product`\n- `category`\n- `isDeleted`\n- `submissionConfirmationTemplate`\n\
+        - `submissionsRemovalOptions`\n- `confirmationEmailTemplate`\n- `confirmationEmailOption`\n\
+        - `displayMainWebsiteLink`\n- `translations`\n\nIf the form doesn't have translations\
+        \ enabled, its default language is forced by setting a language cookie and\
+        \ reflected in the Content-Language response header. Normal HTTP Content Negotiation\
+        \ rules apply."
       summary: Retrieve form details
       parameters:
       - in: header

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -198,8 +198,9 @@ _FORM_ADMIN_FIELDS_MARKDOWN = get_admin_fields_markdown(FormSerializer)
             "List the active forms, including the pointers to the form steps. "
             "Form steps are included in order as they should appear.\n\n"
             "**Warning: the response data depends on user permissions**\n\n"
-            "Non-staff users receive a subset of the documented fields which are used "
-            "for internal form configuration. These fields are:\n\n{admin_fields}"
+            "Non-staff users receive a subset of all the documented fields. The fields "
+            "reserved for staff users are used for internal form configuration. These "
+            "are: \n\n{admin_fields}"
         ).format(admin_fields=_FORM_ADMIN_FIELDS_MARKDOWN),
     ),
     retrieve=extend_schema(
@@ -212,9 +213,9 @@ _FORM_ADMIN_FIELDS_MARKDOWN = get_admin_fields_markdown(FormSerializer)
             "steps to build a multi-step/page form for end-users to fill out. Form "
             "definitions can be (and are) re-used among different forms.\n\n"
             "**Warning: the response data depends on user permissions**\n\n"
-            "Non-staff users receive a subset of the documented fields which are used"
-            "for internal form configuration. These fields are:\n\n"
-            "{admin_fields}\n\n"
+            "Non-staff users receive a subset of all the documented fields. The fields "
+            "reserved for staff users are used for internal form configuration. These "
+            "are: \n\n{admin_fields}\n\n"
             "If the form doesn't have translations enabled, its default language is "
             "forced by setting a language cookie and reflected in the Content-Language "
             "response header. Normal HTTP Content Negotiation rules apply."


### PR DESCRIPTION
The sentence could be read that the listed fields were only for non-staff users, while it's the other way around.

Came up while discussing another issue with Paul.