### PR TITLE
Reduce data loaded from API in form designer

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -663,21 +663,33 @@ paths:
   /api/v2/form-definitions:
     get:
       operationId: form_definitions_list
-      description: |-
-        **Warning: the response data depends on user permissions**
-
-        Non-staff users receive a subset of the documented fields which are used
-        for internal form configuration. These fields are:
-
-        - `translations`
+      description: "Get a list of existing form definitions, where a single item may\
+        \ be a re-usable or single-use definition. This includes form definitions\
+        \ not currently used in any form(s) at all.\n\nYou can filter this list down\
+        \ to only re-usable definitions or definitions used in a particular form.\n\
+        \n**Note**: filtering on both `is_reusable` and `used_in` at the same time\
+        \ is implemented as an OR-filter.\n\n**Warning: the response data depends\
+        \ on user permissions**\n\nNon-staff users receive a subset of all the documented\
+        \ fields. The fields reserved for staff users are used for internal form configuration.\
+        \ These are: \n\n- `translations`"
       summary: List form step definitions
       parameters:
+      - in: query
+        name: is_reusable
+        schema:
+          type: boolean
       - name: page
         required: false
         in: query
         description: A page number within the paginated result set.
         schema:
           type: integer
+      - in: query
+        name: used_in
+        schema:
+          type: string
+          format: uuid
+        description: UUID of the form the definition is used in.
       tags:
       - forms
       - form-definitions

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -795,6 +795,7 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
     ),
+    "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_THROTTLE_RATES": {
         # used by regular throttle classes
         "anon": throttle_rate_anon,

--- a/src/openforms/forms/api/filters.py
+++ b/src/openforms/forms/api/filters.py
@@ -1,9 +1,60 @@
-from django_filters import rest_framework as filters
+from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
 
-from ..models import FormVariable
+from django_filters import rest_framework as filters
+from django_filters.constants import EMPTY_VALUES
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+
+from ..models import Form, FormDefinition, FormVariable
 
 
 class FormVariableFilter(filters.FilterSet):
     class Meta:
         model = FormVariable
         fields = ("source",)
+
+
+class FormDefinitionFilter(filters.FilterSet):
+    used_in = extend_schema_field(OpenApiTypes.UUID)(
+        filters.ModelChoiceFilter(
+            queryset=Form.objects.all(),
+            to_field_name="uuid",
+            field_name="formstep__form",
+            distinct=True,
+            help_text=_("UUID of the form the definition is used in."),
+        )
+    )
+
+    class Meta:
+        model = FormDefinition
+        fields = ("is_reusable",)
+        or_fields = ("is_reusable", "used_in")
+
+    def filter_queryset(self, queryset):
+        """
+        Override base implementation to add OR-behaviour instead of the standard AND.
+
+        See https://github.com/carltongibson/django-filter/discussions/1426
+        """
+        _or = Q()
+
+        for name in self.Meta.or_fields:
+            # this essentially re-implements django_filters.filters.Filter.filter,
+            # as otherwise we would have to introspect private django query/queryset API
+            # *shudders*
+            or_filter_value = self.form.cleaned_data.pop(name)
+            if or_filter_value in EMPTY_VALUES:
+                continue
+            or_filter = self.filters[name]
+            if or_filter.distinct:
+                queryset = queryset.distinct()
+            lookup = "%s__%s" % (or_filter.field_name, or_filter.lookup_expr)
+            q_expr = Q(**{lookup: or_filter_value})
+            if or_filter.exclude:
+                q_expr = ~q_expr
+            _or |= q_expr
+
+        if _or:
+            queryset = queryset.filter(_or)
+        return super().filter_queryset(queryset)

--- a/src/openforms/js/components/admin/form_design/data/index.js
+++ b/src/openforms/js/components/admin/form_design/data/index.js
@@ -7,5 +7,5 @@
  */
 
 export {saveCompleteForm} from './complete-form';
-export {loadPlugins, PluginLoadingError} from './plugins';
+export {loadFromBackend, BackendLoadingError} from './supporting-data';
 export {default as loadForm} from './read-form';

--- a/src/openforms/js/components/admin/form_design/data/supporting-data.js
+++ b/src/openforms/js/components/admin/form_design/data/supporting-data.js
@@ -1,20 +1,20 @@
 import {get} from 'utils/fetch';
 
-class PluginLoadingError extends Error {
-  constructor(message, plugin, response) {
+class BackendLoadingError extends Error {
+  constructor(message, specification, response) {
     super(message);
-    this.plugin = plugin;
+    this.specification = specification;
     this.response = response;
   }
 }
 
 // TODO: add error handling in the fetch wrappers to throw exceptions + add error
 // boundaries in the component tree.
-const loadPlugins = async (plugins = []) => {
-  const promises = plugins.map(async plugin => {
-    let response = await get(plugin.endpoint);
+const loadFromBackend = async (specifications = []) => {
+  const promises = specifications.map(async specification => {
+    let response = await get(specification.endpoint);
     if (!response.ok) {
-      throw new PluginLoadingError('Failed to load plugins', plugin, response);
+      throw new BackendLoadingError('Failed to load specifications', specification, response);
     }
     let responseData = response.data;
 
@@ -32,7 +32,7 @@ const loadPlugins = async (plugins = []) => {
     while (responseData.next) {
       response = await get(responseData.next);
       if (!response.ok) {
-        throw new PluginLoadingError('Failed to load plugins', plugin, response);
+        throw new BackendLoadingError('Failed to load specifications', specification, response);
       }
       responseData = response.data;
       allResults = [...allResults, ...responseData.results];
@@ -43,4 +43,4 @@ const loadPlugins = async (plugins = []) => {
   return results;
 };
 
-export {loadPlugins, PluginLoadingError};
+export {loadFromBackend, BackendLoadingError};

--- a/src/openforms/js/components/admin/form_design/data/supporting-data.js
+++ b/src/openforms/js/components/admin/form_design/data/supporting-data.js
@@ -12,7 +12,8 @@ class BackendLoadingError extends Error {
 // boundaries in the component tree.
 const loadFromBackend = async (specifications = []) => {
   const promises = specifications.map(async specification => {
-    let response = await get(specification.endpoint);
+    const {endpoint, query = {}} = specification;
+    let response = await get(endpoint, query);
     if (!response.ok) {
       throw new BackendLoadingError('Failed to load specifications', specification, response);
     }

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -885,7 +885,11 @@ const FormCreationForm = ({csrftoken, formUuid, formUrl, formHistoryUrl}) => {
   const backendDataToLoad = [
     {endpoint: LANGUAGE_INFO_ENDPOINT, stateVar: 'languageInfo'},
     {endpoint: PAYMENT_PLUGINS_ENDPOINT, stateVar: 'availablePaymentBackends'},
-    {endpoint: FORM_DEFINITIONS_ENDPOINT, stateVar: 'formDefinitions'},
+    {
+      endpoint: FORM_DEFINITIONS_ENDPOINT,
+      query: {is_reusable: true, used_in: formUuid || ''},
+      stateVar: 'formDefinitions',
+    },
     {endpoint: REGISTRATION_BACKENDS_ENDPOINT, stateVar: 'availableRegistrationBackends'},
     {endpoint: AUTH_PLUGINS_ENDPOINT, stateVar: 'availableAuthPlugins'},
     {endpoint: CATEGORIES_ENDPOINT, stateVar: 'availableCategories'},


### PR DESCRIPTION
Fixes #2504

- [x] Add API endpoint filters for form definitions
- [x] Update JS to only load relevant data using the new filters

Finally renamed the `pluginsToLoad` misnomer now I had to touch this code anyway.