### PR TITLE
[#2494] fix XML template

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -813,16 +813,16 @@ class StufZDSPluginTests(StUFZDSTestBase):
                     },
                 },
                 {
-                    "key": "vestigingsnummer",
+                    "key": "postcode",
                     "type": "textfield",
                     "registration": {
-                        "attribute": RegistrationAttribute.initiator_vestigingsnummer,
+                        "attribute": RegistrationAttribute.initiator_postcode,
                     },
                 },
             ],
             submitted_data={
                 "handelsnaam": "Foo",
-                "vestigingsnummer": "0815",
+                "postcode": "2022XY",
             },
         )
 
@@ -895,6 +895,7 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "//zkn:object/zkn:identificatie": "foo-zaak",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:statutaireNaam": "Foo",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:authentiek": "N",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:bezoekadres/bg:aoa.postcode": "2022XY",
             },
         )
 

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -81,7 +81,7 @@
                                 {% include "stuf_zds/soap/includes/verblijfsadres.xml" %}
                             {% endif %}
                         </ZKN:natuurlijkPersoon>
-                    {% elif initiator.kvk and initiator.vestigingsNummer %}
+                    {% elif initiator.vestigingsNummer %}
                         <ZKN:vestiging StUF:entiteittype="VES" StUF:verwerkingssoort="T">
                             <BG:vestigingsNummer>{{ initiator.vestigingsNummer }}</BG:vestigingsNummer>
                             <BG:authentiek>N</BG:authentiek>
@@ -91,20 +91,19 @@
                                 {% include "stuf_zds/soap/includes/verblijfsadres.xml" %}
                             {% endif %}
                         </ZKN:vestiging>
-                    {% elif initiator.kvk %}
+                    {% elif initiator.kvk or initiator.handelsnaam %}
                         <ZKN:nietNatuurlijkPersoon StUF:entiteittype="NNP" StUF:verwerkingssoort="T">
-                            <BG:inn.nnpId>{{ initiator.kvk }}</BG:inn.nnpId>
-                            <BG:authentiek>J</BG:authentiek>
+                            {% if initiator.kvk %}
+                                <BG:inn.nnpId>{{ initiator.kvk }}</BG:inn.nnpId>
+                                <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+                            {% else %}
+                                <BG:authentiek StUF:metagegeven="true">N</BG:authentiek>
+                            {% endif %}
+                            {% if initiator.handelsnaam %}<BG:statutaireNaam>{{ initiator.handelsnaam }}</BG:statutaireNaam>{% endif %}
                             {% if initiator.verblijfsadres.postcode or initiator.verblijfsadres.woonplaatsNaam %}
                                 {% include "stuf_zds/soap/includes/bezoekadres.xml" %}
                             {% endif %}
                         </ZKN:nietNatuurlijkPersoon>
-                    {% elif initiator.handelsnaam %}
-                        <ZKN:nietNatuurlijkPersoon StUF:entiteittype="NNP" StUF:verwerkingssoort="T">
-                            <BG:statutaireNaam>{{ initiator.handelsnaam }}</BG:statutaireNaam>
-                            <BG:authentiek>N</BG:authentiek>
-                        </ZKN:nietNatuurlijkPersoon>
-
                     {% elif not global_config.allow_empty_initiator %}
                         <ZKN:natuurlijkPersoon StUF:entiteittype="NPS" StUF:verwerkingssoort="T">
                             <BG:inp.bsn>111222333</BG:inp.bsn>


### PR DESCRIPTION
Fixes #2494 

- details of the verblijfsadres were missing from the template for non-natural persons without auth