### PR TITLE
[#2198] Add AOF persistence to Redis container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,11 @@ services:
 
   redis:
     image: redis:6
+    command: ["redis-server", "--appendonly", "yes"]
     networks:
       - open-forms-dev
+    volumes:
+      - data:/data
 
   smtp:
     image: namshi/smtp
@@ -137,6 +140,7 @@ volumes:
   private_media:
   log:
   certifi_ca_bundle:
+  data:
 
 networks:
   open-forms-dev:

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -6,7 +6,7 @@ Installation
 You can install Open Forms in several ways, depending on your intended purpose
 and expertise.
 
-1. Deploy using :ref:`Ansible <installation_ansible>` for public testing and 
+1. Deploy using :ref:`Ansible <installation_ansible>` for public testing and
    production purposes
 2. Run with :ref:`Docker-Compose <installation_docker_compose>` on your computer for private testing purposes
 3. Run from `Python code`_ on your computer for development purposes
@@ -29,4 +29,5 @@ and expertise.
    file_uploads
    self_signed
    form_hosting
+   redis
    issues/index

--- a/docs/installation/redis.rst
+++ b/docs/installation/redis.rst
@@ -4,21 +4,73 @@
 Redis configuration
 ===================
 
-To prevent Celery tasks to be lost in the case where Redis crashes, it it advisable to run Redis with `AOF`_
-(Append Only File) persistence enabled.
+.. note:: The intended audience for this documentation is DevOps engineers
 
-This is because Redis by default runs with snapshotting enabled.
-This means that Redis saves the DB to disk if a certain number of write operations have been performed in a certain
-period of time. By default, Redis will save the DB (see the default `redis.conf file`_ for more details):
+In Open-Forms, `Redis`_ is used as cache, as message broker (for Celery) and as a backend for Celery to store the results
+of the tasks.
+
+Redis is an in-memory data-store, which means that it is susceptible to data loss in the event of abrupt termination or
+power failures unless the default configuration is modified [#]_.
+
+.. _Redis: https://redis.io/
+.. [#] https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#redis
+
+Configuring Redis as robust message broker
+==========================================
+
+By default, Redis runs with snapshotting enabled.
+This means that Redis saves the DB (database) to disk if a certain number of write operations have been performed in a
+certain period of time. By default, Redis will save the DB (see the default `redis.conf file`_ for more details):
 
 * After 3600 seconds (an hour) if at least 1 change was performed
 * After 300 seconds (5 minutes) if at least 100 changes were performed
 * After 60 seconds if at least 10000 changes were performed
 
-In Open Forms, Redis is used by Celery as both the broker and the results backend. If Redis crashes (for example because
-it runs out of memory), all tasks that were queued and not picked up by a worker would be lost if no persistence is
-enabled. This means that submissions might not be processed and sent to the registration backend.
-
-
-.. _AOF: https://redis.io/docs/management/persistence/
 .. _redis.conf file: https://redis.io/docs/management/config-file/
+
+If Redis is abruptly terminated and any changes have not been written to the DB, the data will be lost. For Open-Forms,
+this means that Celery tasks that have been queued and have not yet been picked up by a worker might be lost.
+
+The easiest workaround for this problem is to enable `AOF`_ (Append Only File) persistence in Redis. From the Redis
+documentation:
+
+
+    AOF persistence logs every write operation received by the server. These operations can then be replayed again at
+    server startup, reconstructing the original dataset. Commands are logged using the same format as the Redis protocol
+    itself.
+
+By default, changes are persisted every second. This means that the window for data loss is reduced to 1 s.
+
+Other (more complex) solutions are also possible, but out-of-scope for this documentation. For example:
+
+* Run HA (High Availability) with `Redis sentinel`_.
+* Run a `Redis cluster`_ instead of a single node.
+* Run Redis with `replication`_.
+* Run Celery with a `different broker`_, for example RabbitMQ (see ``CELERY_BROKER_URL``
+  in the :ref:`installation_environment_config`).
+
+
+.. _Redis sentinel: https://redis.io/docs/management/sentinel/
+.. _AOF: https://redis.io/docs/management/persistence/
+.. _Redis cluster: https://redis.io/docs/management/scaling/
+.. _replication: https://redis.io/docs/management/replication/
+.. _different broker: https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#configuration
+
+Deploying multiple Redis instances
+==================================
+
+By default, Open-Forms uses a single Redis instance that is shared for cache, Celery message broker and Celery backend
+for storing results.
+
+By adding AOF persistence for the message broker, it is possible that the performance of the cache or results
+backend degrades. This may be because the cache/results backend may lead to many writes to the append-only file.
+
+If you observe this problem, you may consider deploying a Redis instance for each individual use case (cache,
+message broker, results backend). These can be configured through the environment variables
+``CACHE_<suffix>``, ``CELERY_BROKER_URL`` and ``CELERY_RESULT_BACKEND`` (see :ref:`installation_environment_config`
+for more details on these environment variables). Using this strategy, different Redis configuration files can be
+used for each instance to tune them for the intended usage:
+
+* cache: default snapshotting is okay, cache data loss is not an issue
+* message broker: AOF-configuration recommended
+* result store: AOF-configuration recommended

--- a/docs/installation/redis.rst
+++ b/docs/installation/redis.rst
@@ -1,0 +1,24 @@
+.. _installation_redis:
+
+===================
+Redis configuration
+===================
+
+To prevent Celery tasks to be lost in the case where Redis crashes, it it advisable to run Redis with `AOF`_
+(Append Only File) persistence enabled.
+
+This is because Redis by default runs with snapshotting enabled.
+This means that Redis saves the DB to disk if a certain number of write operations have been performed in a certain
+period of time. By default, Redis will save the DB (see the default `redis.conf file`_ for more details):
+
+* After 3600 seconds (an hour) if at least 1 change was performed
+* After 300 seconds (5 minutes) if at least 100 changes were performed
+* After 60 seconds if at least 10000 changes were performed
+
+In Open Forms, Redis is used by Celery as both the broker and the results backend. If Redis crashes (for example because
+it runs out of memory), all tasks that were queued and not picked up by a worker would be lost if no persistence is
+enabled. This means that submissions might not be processed and sent to the registration backend.
+
+
+.. _AOF: https://redis.io/docs/management/persistence/
+.. _redis.conf file: https://redis.io/docs/management/config-file/


### PR DESCRIPTION
Fixes #2198 

### Concepts important to understand the problem

**Celery late acknowledgement:**
In celery, workers acknowledge messages to signify that a message has been handled. Failing to acknowledge the message will cause it to be redelivered. We use late acknowledgement, which means that the task (delivered as a message) is acknowledged _after_ being executed (so if the worker dies while executing, the message is redelivered).

**Celery prefetch limit:**
The prefetch limit is the maximum number of unacknowledged messages that a worker can prefetch. The setting `worker_prefetch_multiplier` is the number of messages to prefetch per process per worker. We have it set to 1, which means that the worker process can hold at most 1 task in addition to the one that's executing.

**Redis snapshotting:**
Redis by default runs with snapshotting enabled. This means that Redis saves the DB to disk if a certain number of write operations have been performed in a certain period of time. By default, Redis will save the DB:

* After 3600 seconds (an hour) if at least 1 change was performed
* After 300 seconds (5 minutes) if at least 100 changes were performed
* After 60 seconds if at least 10000 changes were performed

### Problem

If Redis runs out of memory and crashes, all tasks that were queued and not picked up by a worker are lost.

### Solution

To solve this, we added AOF (Append Only File) persistence to Redis. This means that every write operation received by the server will be logged. On restarting Redis after it has been killed, its state before the crash will be regenerated and therefore no tasks will be lost.