### PR TITLE
Issue/2286 add formdefinition translations to submissionstep endpoint

### DIFF
--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -118,7 +118,6 @@ def inject_variables(
                 continue
 
             try:
-                # XXX should translation only occur on labels?
                 if isinstance(property_value, str):
                     property_value = translate(property_value)
                 elif isinstance(property_value, list) and isinstance(

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -194,8 +194,9 @@ def evaluate_form_logic(
             new_value = updated_step_data.get(key, empty)
             original_value = initial_data.get(key, empty)
             # Reset the value of any field that may have become hidden again after evaluating the logic
-            component_empty_value = get_component_empty_value(component)
-            if original_value is not empty and original_value != component_empty_value:
+            if original_value is not empty and original_value != (
+                component_empty_value := get_component_empty_value(component)
+            ):
                 if (
                     component
                     and not is_visible_in_frontend(component, data_container.data)

--- a/src/openforms/translations/tests/utils.py
+++ b/src/openforms/translations/tests/utils.py
@@ -1,7 +1,9 @@
-from typing import Type
+from typing import TypeVar
 
 import factory
 from modeltranslation.translator import translator
+
+_F = TypeVar("_F", bound=type[factory.django.DjangoModelFactory])
 
 
 class TranslatedMixin(factory.base.Factory):
@@ -26,9 +28,7 @@ class TranslatedMixin(factory.base.Factory):
         return kwargs
 
 
-def make_translated(
-    factory_class: Type[factory.django.DjangoModelFactory],
-) -> Type[factory.django.DjangoModelFactory]:
+def make_translated(factory_class: _F) -> _F:
     """
     Make a Factory that creates translated instances.
 


### PR DESCRIPTION
Closes #2286

Discussion:

1. I'm always hesitant with changing assertions of existing tests.
`openforms.submissions.tests.test_submit_form_step.FormStepSubmissionTests` fail because they assert the complete configuration which now contains translations. That's the only reason I pop them off iff not Form.translation_enabled, instead of returning an empty object.
2. We're already changing the components in `evaluate_form_logic` for the strings that support template rendering. With a small modification we could apply translation to *all* appropriate strings. And then maybe don't need to pass the translations to the client at all because translations are all done server-side, question mark question mark.  The form builder is still a big blind spot for me. This might touch on #2478. But I think on the client, the _check_logic already triggers re-renders.