### PR TITLE
:sparkles: [#2519] -- skip upgrade checks in some cases

### DIFF
--- a/src/openforms/upgrades/tests/test_upgrade_paths.py
+++ b/src/openforms/upgrades/tests/test_upgrade_paths.py
@@ -81,6 +81,26 @@ class UpgradePathTests(TestCase):
             with self.assertRaises(VersionParseError):
                 check_upgrade_path("0b5b0c04ff322bf098872081319decfe558c9f73", "2.0")
 
+    def test_already_on_target(self):
+        """
+        Assert that the checks are skipped if you are already on a version that matches
+        the target version (2.0.1 matches ~2.0).
+        """
+        UPGRADE_PATHS = {
+            "2.0": UpgradeConstraint(
+                valid_ranges={
+                    VersionRange(minimum="1.1"),
+                },
+                # throws exception if checks _are_ being executed
+                scripts=["i-do-not-exist"],
+            ),
+        }
+        with mock_upgrade_paths(UPGRADE_PATHS):
+            with self.subTest(from_version="2.0.1", to="2.0.2"):
+                self.assertTrue(check_upgrade_path("2.0.1", "2.0.2"))
+            with self.subTest(from_version="2.0.1", to="2.1.2"):
+                self.assertTrue(check_upgrade_path("2.0.1", "2.1.2"))
+
 
 class DjangoScriptTests(SimpleTestCase):
     def test_check_management_commands(self):

--- a/src/openforms/upgrades/upgrade_paths.py
+++ b/src/openforms/upgrades/upgrade_paths.py
@@ -141,6 +141,7 @@ def check_upgrade_path(from_version: str, to_version: str) -> bool:
     except ValueError as exc:
         raise VersionParseError(to_version) from exc
 
+    target_version = None
     for target_version, upgrade_constraint in UPGRADE_PATHS.items():
         # 1. start by trying an exact match, which always wins
         if target_version == to_version:
@@ -161,6 +162,13 @@ def check_upgrade_path(from_version: str, to_version: str) -> bool:
         in_version = Version(from_version)
     except ValueError as exc:
         raise VersionParseError(from_version) from exc
+
+    # handles the case where there's a check for 2.0 coming from < 2.0, but skip the
+    # checks if you're on 2.0.1 or something like that.
+    if target_version:
+        compare_spec = SimpleSpec(f"~={target_version}")
+        if in_version in compare_spec:
+            return True
 
     if not any(
         (


### PR DESCRIPTION
Closes #2519 

* If the current version matches a loose match to the target version, it is implied you already passed those checks before and we don't need to run them again.