### PR TITLE
[#2542] fix description formatting

### DIFF
--- a/src/openforms/utils/json_logic/descriptions.py
+++ b/src/openforms/utils/json_logic/descriptions.py
@@ -319,7 +319,19 @@ def op_today(*args, **kwargs) -> str:
 
 op_date = FunctionLike(_("date({args})"))
 op_datetime = FunctionLike(_("datetime({args})"))
-op_rdelta = TemplatedArgs(
-    _("{years} year(s), {months} month(s), {days} day(s)"),
-    arg_names=["years", "months", "days"],
-)
+
+
+@add_boilerplate()
+def op_rdelta(*args) -> str:
+    if len(args) == 1:
+        return gettext("{years} year(s)").format(years=args[0])
+    elif len(args) == 2:
+        return gettext("{years} year(s), {months} month(s)").format(
+            years=args[0],
+            months=args[1],
+        )
+    return gettext("{years} year(s), {months} month(s), {days} day(s)").format(
+        years=args[0],
+        months=args[1],
+        days=args[2],
+    )

--- a/src/openforms/utils/tests/test_json_logic.py
+++ b/src/openforms/utils/tests/test_json_logic.py
@@ -130,3 +130,27 @@ class RuleDescriptionTests(SimpleTestCase):
                 output = generate_rule_description(cast(JSON, rule))
 
                 self.assertEqual(output, expected_description)
+
+    def test_formatting_var_args(self):
+        """Assert that formatting of descriptions involving `rdelta` operations work
+        with different numbers of arguments"""
+
+        rule_descriptions = (
+            (
+                {"rdelta": [7]},
+                "7 year(s)",
+            ),
+            (
+                {"rdelta": [7, 5]},
+                "7 year(s), 5 month(s)",
+            ),
+            (
+                {"rdelta": [7, 5, 12]},
+                "7 year(s), 5 month(s), 12 day(s)",
+            ),
+        )
+        for rule, expected_description in rule_descriptions:
+            with self.subTest(rule=rule):
+                output = generate_rule_description(cast(JSON, rule))
+
+                self.assertEqual(output, expected_description)


### PR DESCRIPTION
Fixes #2542 

Formatting of JSON logic descriptions involving `rdelta` operations now works with varying numbers of arguments.