### PR TITLE
Replace Template(...).render(...) usage with openforms.template.render_from_string

### DIFF
--- a/docs/developers/backend/core/templating.rst
+++ b/docs/developers/backend/core/templating.rst
@@ -22,6 +22,8 @@ Module functionality
 
 .. autoattribute:: openforms.template.sandbox_backend
 
+.. autoattribute:: openforms.template.openforms_backend
+
 Validators
 ----------
 

--- a/src/openforms/authentication/contrib/tests/saml_utils.py
+++ b/src/openforms/authentication/contrib/tests/saml_utils.py
@@ -1,11 +1,12 @@
 from base64 import b64encode
 from hashlib import sha1
+from pathlib import Path
 from typing import Optional
-
-from django.template import Context, Template
 
 from digid_eherkenning.models import EherkenningConfiguration
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
+
+from openforms.template import render_from_string
 
 
 def create_test_artifact(service_entity_id: str = "") -> str:
@@ -18,11 +19,8 @@ def create_test_artifact(service_entity_id: str = "") -> str:
 
 
 def get_artifact_response(filepath: str, context: Optional[dict] = None) -> bytes:
-    with open(filepath, "r") as template_source_file:
-        template = Template(template_source_file.read())
-
-    rendered = template.render(Context(context or {}))
-    return rendered.encode("utf-8")
+    template_source = Path(filepath).read_text()
+    return render_from_string(template_source, context or {}).encode("utf-8")
 
 
 def get_encrypted_attribute(attr: str, identifier: str):

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -293,11 +293,11 @@ TEMPLATES = [
             ],
             "loaders": TEMPLATE_LOADERS,
             "builtins": [
+                # TODO: these can be deleted once the validator is done via backend.
                 "openforms.emails.templatetags.appointments",
                 "openforms.emails.templatetags.form_summary",
                 "openforms.emails.templatetags.payment",
                 "openforms.emails.templatetags.products",
-                "openforms.config.templatetags.privacy_policy",
             ],
         },
     },

--- a/src/openforms/config/models.py
+++ b/src/openforms/config/models.py
@@ -8,7 +8,6 @@ from django.core.validators import (
     RegexValidator,
 )
 from django.db import models
-from django.template import Context, Template
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
@@ -23,6 +22,7 @@ from tinymce.models import HTMLField
 from openforms.data_removal.constants import RemovalMethods
 from openforms.emails.validators import URLSanitationValidator
 from openforms.payments.validators import validate_payment_order_id_prefix
+from openforms.template import openforms_backend, render_from_string
 from openforms.template.validators import DjangoTemplateValidator
 from openforms.utils.fields import SVGOrImageField
 from openforms.utils.translations import ensure_default_language, runtime_gettext
@@ -483,11 +483,12 @@ class GlobalConfiguration(SingletonModel):
     def __str__(self):
         return force_str(self._meta.verbose_name)
 
-    def render_privacy_policy_label(self):
-        template = self.privacy_policy_label
-        rendered_content = Template(template).render(Context({}))
-
-        return rendered_content
+    def render_privacy_policy_label(self) -> str:
+        return render_from_string(
+            self.privacy_policy_label,
+            context={"global_configuration": self},
+            backend=openforms_backend,
+        )
 
     def plugin_enabled(self, module: str, plugin_identifier: str):
         enabled = glom(

--- a/src/openforms/config/templatetags/privacy_policy.py
+++ b/src/openforms/config/templatetags/privacy_policy.py
@@ -7,9 +7,9 @@ from ..models import GlobalConfiguration
 register = template.Library()
 
 
-@register.simple_tag()
-def privacy_policy():
-    conf = GlobalConfiguration.get_solo()
+@register.simple_tag(takes_context=True)
+def privacy_policy(context):
+    conf = context.get("global_configuration") or GlobalConfiguration.get_solo()
     if conf.privacy_policy_url:
         template_string = (
             """<a href="{}" target="_blank" rel="noreferrer noopener">{}</a>"""

--- a/src/openforms/emails/utils.py
+++ b/src/openforms/emails/utils.py
@@ -4,7 +4,6 @@ from typing import Any, List, Optional, Sequence, Tuple
 from urllib.parse import urlsplit
 
 from django.conf import settings
-from django.template import Context, Template
 from django.template.loader import get_template
 
 from mail_cleaner.mail import send_mail_plus
@@ -12,6 +11,7 @@ from mail_cleaner.sanitizer import sanitize_content as _sanitize_content
 from mail_cleaner.text import strip_tags_plus
 
 from openforms.config.models import GlobalConfiguration
+from openforms.template import openforms_backend, render_from_string
 
 from .context import get_wrapper_context
 
@@ -87,4 +87,4 @@ def send_mail_html(
 
 def render_email_template(template: str, context: dict, **extra_context: Any) -> str:
     render_context = {**context, **extra_context}
-    return Template(template).render(Context(render_context))
+    return render_from_string(template, render_context, backend=openforms_backend)

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
 
 from django.conf import settings
 from django.db import models, transaction
-from django.template import Context, Template
 from django.utils.translation import get_language, gettext_lazy as _
 
 import elasticapm
@@ -17,6 +16,7 @@ from openforms.config.models import GlobalConfiguration
 from openforms.formio.datastructures import FormioConfigurationWrapper
 from openforms.forms.models import FormStep
 from openforms.payments.constants import PaymentStatus
+from openforms.template import openforms_backend, render_from_string
 from openforms.typing import JSONObject
 from openforms.utils.validators import AllowedRedirectValidator, SerializerValidator
 
@@ -455,9 +455,7 @@ class Submission(models.Model):
             "public_reference": self.public_registration_reference,
             **self.data,
         }
-
-        rendered_content = Template(template).render(Context(context_data))
-        return rendered_content
+        return render_from_string(template, context_data, backend=openforms_backend)
 
     def render_summary_page(self) -> List[JSONObject]:
         """Use the renderer logic to decide what to display in the summary page.

--- a/src/openforms/template/__init__.py
+++ b/src/openforms/template/__init__.py
@@ -12,9 +12,9 @@ Possible future features:
 * Caching for string-based templates
 * ...
 """
-from .backends.sandboxed_django import backend as sandbox_backend
+from .backends.sandboxed_django import backend as sandbox_backend, openforms_backend
 
-__all__ = ["render_from_string", "parse", "sandbox_backend"]
+__all__ = ["render_from_string", "parse", "sandbox_backend", "openforms_backend"]
 
 
 def parse(source: str, backend=sandbox_backend):

--- a/src/openforms/template/backends/sandboxed_django.py
+++ b/src/openforms/template/backends/sandboxed_django.py
@@ -1,4 +1,7 @@
+from typing import cast
+
 from django.template.backends.django import DjangoTemplates
+from django.utils.functional import SimpleLazyObject
 
 
 class SandboxedDjangoTemplates(DjangoTemplates):
@@ -46,4 +49,28 @@ class SandboxedDjangoTemplates(DjangoTemplates):
 backend = SandboxedDjangoTemplates({})
 """
 An instance of the 'sandboxed' Django templates backend.
+"""
+
+
+def get_openforms_backend():
+    return SandboxedDjangoTemplates(
+        {
+            "OPTIONS": {
+                "builtins": [
+                    "openforms.emails.templatetags.appointments",
+                    "openforms.emails.templatetags.form_summary",
+                    "openforms.emails.templatetags.payment",
+                    "openforms.emails.templatetags.products",
+                    "openforms.config.templatetags.privacy_policy",
+                ],
+            }
+        }
+    )
+
+
+openforms_backend = cast(
+    SandboxedDjangoTemplates, SimpleLazyObject(get_openforms_backend)
+)
+"""
+Sandbox instance supporting custom tags for form designers.
 """


### PR DESCRIPTION
Closes #1904

This still uses the Django template engine, but instead uses sandboxes that don't allow using non-public custom tags and/or include files from our source code.