### PR TITLE
Truncate logic descriptions that are too long

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormLogic.js
+++ b/src/openforms/js/components/admin/form_design/FormLogic.js
@@ -142,13 +142,18 @@ const Rule = ({
   }
 
   const onDescriptionGenerated = generatedDescription => {
-    const newDescription = intl.formatMessage(
+    let newDescription = intl.formatMessage(
       {
         description: 'Logic expression generated description',
         defaultMessage: 'When {desc}',
       },
       {desc: generatedDescription}
     );
+
+    // backend allows 100 chars max
+    if (newDescription.length >= 100) {
+      newDescription = `${newDescription.substring(0, 99)}…`;
+    }
     onChange({target: {name: 'description', value: newDescription}});
   };
 

--- a/src/openforms/js/components/admin/form_design/logic/LogicDescription.js
+++ b/src/openforms/js/components/admin/form_design/logic/LogicDescription.js
@@ -62,6 +62,7 @@ const LogicDescriptionInput = ({
       onFocus={() => setHasFocus(true)}
       onBlur={() => setHasFocus(false)}
       {...textInputProps}
+      maxLength="100"
     />
   );
 };


### PR DESCRIPTION
Fixes #2569

* Limit the user input to max 100 chars
* Automatically truncate server-side generated description to 100 chars