### PR TITLE
:fire: requirements/setuptools.txt not needed anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements/setuptools.txt
           pip install -r requirements/ci.txt \
             --use-pep517 \
             --use-feature=no-binary-enable-wheel-cache
@@ -188,7 +187,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements/setuptools.txt
           pip install -r requirements/ci.txt \
             --use-pep517 \
             --use-feature=no-binary-enable-wheel-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN mkdir /app/src
 # Ensure we use the latest version of pip
 RUN pip install pip -U
 COPY ./requirements /app/requirements
-RUN pip install -r requirements/setuptools.txt
 
 ARG TARGET_ENVIRONMENT=production
 RUN pip install -r requirements/${TARGET_ENVIRONMENT}.txt

--- a/requirements/setuptools.txt
+++ b/requirements/setuptools.txt
@@ -1,1 +1,0 @@
-setuptools


### PR DESCRIPTION
The version of setuptools was unpinned anyway and the library that required this has been updated a while ago. We also have a pinned setuptools version in the requirements.