### PR TITLE
[#2525] Crash validation date

### DIFF
--- a/src/openforms/formio/dynamic_config/date.py
+++ b/src/openforms/formio/dynamic_config/date.py
@@ -52,7 +52,7 @@ def mutate(component: FormioDateComponent, data: DataMapping) -> None:
         if config is None:
             continue
 
-        if (mode := config.get("mode")) is None:
+        if (mode := config.get("mode")) in [None, ""]:
             continue
 
         # formio has set the datePicker.{key} value

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, tag
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -264,3 +264,17 @@ class DynamicDateConfigurationTests(SimpleTestCase):
         new_component = self._get_dynamic_config(component, {})
 
         self.assertEqual(new_component["datePicker"]["maxDate"], "2022-09-12T14:08:00Z")
+
+    @tag("gh-2525")
+    def test_configuration_after_delete_validation(self):
+        component = {
+            "type": "date",
+            "key": "aDate",
+            # This is the configuration that gets saved if the maxDate validation is removed in the editForm
+            "openForms": {"maxDate": {"mode": ""}},
+            "datePicker": {"maxDate": None},
+        }
+
+        new_component = self._get_dynamic_config(component, {})
+
+        self.assertIsNone(new_component["datePicker"]["maxDate"])

--- a/src/openforms/js/components/form/date.js
+++ b/src/openforms/js/components/form/date.js
@@ -37,7 +37,7 @@ const getMinMaxValidationEditForm = fieldName => {
         type: 'select',
         key: `openForms.${fieldName}.mode`,
         label: 'Mode preset',
-        defaultValue: 'fixedValue',
+        defaultValue: '',
         data: {
           values: [
             {
@@ -218,7 +218,7 @@ class DateField extends DateTimeField {
         // actual, calculated `minDate`/`maxDate` value dynamically.
         openForms: {
           minDate: {
-            mode: 'fixedValue',
+            mode: '',
             // options for future/past mode
             includeToday: null,
             // options for relativeToVariable mode
@@ -231,7 +231,7 @@ class DateField extends DateTimeField {
             },
           },
           maxDate: {
-            mode: 'fixedValue',
+            mode: '',
             // options for future/past mode
             includeToday: null,
             // options for relativeToVariable mode


### PR DESCRIPTION
Fixes #2525 

There were 2 problems:
- When removing the validation method in the edit form, the mode was saved as an empty string in the configuration. The backend was only considering the possibility of the mode being `None` for empty values.
- The edit form showed the default value even if the `mode` was `""`. This is also shown in the json, even though when looking at the configuration saved, this was the empty string. 

*Changes*:
- Backend skips updating the configuration if mode is `""` in addition to `None`
- Default value is now `""` for the `mode`