### PR TITLE
🧪 Runs tests in reverse order in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,7 @@ jobs:
           --parallel-mode \
           src/manage.py test src \
             --parallel 2 \
-            --exclude-tag=e2e \
-            --reverse
+            --exclude-tag=e2e
           coverage combine
 
         env:
@@ -134,6 +133,71 @@ jobs:
           name: open-forms-oas
           path: openapi.yaml
           retention-days: 1
+
+  tests-reverse:
+    name: Run the Django test suite in reverse
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        # Needed because the postgres container does not provide a healthcheck
+        options:
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+          --name postgres
+      redis:
+        image: redis:6
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up backend environment
+        uses: maykinmedia/setup-django-backend@v1
+        with:
+          apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client'
+          python-version: '3.10.9'
+          optimize-postgres: 'yes'
+          pg-service: 'postgres'
+          setup-node: 'yes'
+          npm-ci-flags: '--legacy-peer-deps'
+
+      - name: Start CI docker services
+        run: |
+          docker-compose -f docker-compose.ci.yml up -d
+          docker-compose -f docker-compose.camunda.yml up -d
+        working-directory: docker
+
+      - name: Wait for Camunda to be up
+        run: |
+          endpoint="${CAMUNDA_API_BASE_URL}version"
+          version=""
+
+          until [ $version ]; do
+            echo "Checking if Camunda at ${CAMUNDA_API_BASE_URL} is up..."
+            version=$(curl -u ${CAMUNDA_USER}:${CAMUNDA_PASSWORD} "$endpoint" -s | jq -r ".version")
+            sleep 2
+          done
+
+          echo "Running Camunda $version"
+
+      - name: Run tests
+        run: |
+          python src/manage.py compilemessages
+          python src/manage.py collectstatic --noinput --link
+          src/manage.py test src \
+            --parallel 2 \
+            --exclude-tag=e2e \
+            --reverse
+
+        env:
+          DJANGO_SETTINGS_MODULE: openforms.conf.ci
+          SECRET_KEY: dummy
+          DB_USER: postgres
+          DB_PASSWORD: ''
 
   e2etests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
           --parallel-mode \
           src/manage.py test src \
             --parallel 2 \
-            --exclude-tag=e2e
+            --exclude-tag=e2e \
+            --reverse
           coverage combine
 
         env:


### PR DESCRIPTION
Closes #2999

This fails some tests because they or for some reason not isolated.

Unit tests should be able to run in random order.