### PR TITLE
[#2493] :sparkles: Warnings for missing translations in admin

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -183,28 +183,13 @@ class FormAdmin(
             extra_context = {}
 
         # Give frontend access to proper field labels, to display in warning messages
-        form_translatable_fields = [
-            field
-            for field in self.model._meta.get_fields()
-            if field.name in get_translatable_fields_for_model(self.model)
-        ]
-        formstep_translatable_fields = [
-            field
-            for field in FormStep._meta.get_fields()
-            if field.name in get_translatable_fields_for_model(FormStep)
-        ]
-        email_template_translatable_fields = [
-            field
-            for field in ConfirmationEmailTemplate._meta.get_fields()
-            if field.name
-            in get_translatable_fields_for_model(ConfirmationEmailTemplate)
-        ]
-        extra_context["label_mapping"] = {
+        label_mapping = {
             underscore_to_camel(field.name): field.verbose_name
-            for field in form_translatable_fields
-            + formstep_translatable_fields
-            + email_template_translatable_fields
+            for model in (self.model, FormStep, ConfirmationEmailTemplate)
+            for field in model._meta.get_fields()
+            if field.name in get_translatable_fields_for_model(model)
         }
+        extra_context["label_mapping"] = label_mapping
 
         return super().changeform_view(
             request, object_id=object_id, form_url=form_url, extra_context=extra_context

--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -7,8 +7,11 @@ from django.urls import path, reverse
 from django.utils.html import format_html_join
 from django.utils.translation import ngettext, ugettext_lazy as _
 
+from modeltranslation.manager import get_translatable_fields_for_model
 from ordered_model.admin import OrderedInlineModelAdminMixin, OrderedTabularInline
 
+from openforms.api.utils import underscore_to_camel
+from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.payments.admin import PaymentBackendChoiceFieldMixin
 from openforms.registrations.admin import RegistrationBackendFieldMixin
 from openforms.utils.expressions import FirstNotBlank
@@ -173,6 +176,39 @@ class FormAdmin(
             )
 
         return response
+
+    @admin.options.csrf_protect_m
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        if not extra_context:
+            extra_context = {}
+
+        # Give frontend access to proper field labels, to display in warning messages
+        form_translatable_fields = [
+            field
+            for field in self.model._meta.get_fields()
+            if field.name in get_translatable_fields_for_model(self.model)
+        ]
+        formstep_translatable_fields = [
+            field
+            for field in FormStep._meta.get_fields()
+            if field.name in get_translatable_fields_for_model(FormStep)
+        ]
+        email_template_translatable_fields = [
+            field
+            for field in ConfirmationEmailTemplate._meta.get_fields()
+            if field.name
+            in get_translatable_fields_for_model(ConfirmationEmailTemplate)
+        ]
+        extra_context["label_mapping"] = {
+            underscore_to_camel(field.name): field.verbose_name
+            for field in form_translatable_fields
+            + formstep_translatable_fields
+            + email_template_translatable_fields
+        }
+
+        return super().changeform_view(
+            request, object_id=object_id, form_url=form_url, extra_context=extra_context
+        )
 
     def _async_changelist_view(self, request):
         # YOLO

--- a/src/openforms/forms/templates/admin/forms/form/change_form.html
+++ b/src/openforms/forms/templates/admin/forms/form/change_form.html
@@ -21,6 +21,8 @@
 {% get_available_languages as languages %}
 {{ languages|json_script:'languages' }}  {# Used to determine languages for FormIO translations #}
 
+{{ label_mapping|json_script:'label-mapping' }}  {# Used for missing translations warning #}
+
 <div
     class="react-form-create"
     data-form-uuid="{{ original.uuid|default:'' }}"

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -1179,6 +1179,12 @@
       "value": "Internal name/title of the form"
     }
   ],
+  "RfbS0v": [
+    {
+      "type": 0,
+      "value": "Language"
+    }
+  ],
   "Rk13i+": [
     {
       "type": 0,
@@ -1475,6 +1481,48 @@
       "value": "The variable key must be unique within a form"
     }
   ],
+  "ZEo3mR": [
+    {
+      "type": 0,
+      "value": "Form has translation enabled, but is missing "
+    },
+    {
+      "children": [
+        {
+          "offset": 0,
+          "options": {
+            "one": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " translation"
+                }
+              ]
+            },
+            "other": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " translations"
+                }
+              ]
+            }
+          },
+          "pluralType": "cardinal",
+          "type": 6,
+          "value": "count"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    }
+  ],
   "ZICfus": [
     {
       "type": 0,
@@ -1769,6 +1817,12 @@
       "value": "Internal name"
     }
   ],
+  "i7HknI": [
+    {
+      "type": 0,
+      "value": "Tab name"
+    }
+  ],
   "iZESbd": [
     {
       "type": 0,
@@ -1881,10 +1935,22 @@
       "value": "Add item"
     }
   ],
+  "lvxPCk": [
+    {
+      "type": 0,
+      "value": "Component label"
+    }
+  ],
   "mH3X/G": [
     {
       "type": 0,
       "value": "today"
+    }
+  ],
+  "mL6vhw": [
+    {
+      "type": 0,
+      "value": "Component key"
     }
   ],
   "mOgTIH": [
@@ -1957,6 +2023,48 @@
     {
       "type": 0,
       "value": "Whether to include the content of the confirmation page in the PDF."
+    }
+  ],
+  "ooyhQ7": [
+    {
+      "type": 0,
+      "value": "Form has translation enabled, but is missing "
+    },
+    {
+      "children": [
+        {
+          "offset": 0,
+          "options": {
+            "one": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " component translation"
+                }
+              ]
+            },
+            "other": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " component translations"
+                }
+              ]
+            }
+          },
+          "pluralType": "cardinal",
+          "type": 6,
+          "value": "count"
+        }
+      ],
+      "type": 8,
+      "value": "link"
     }
   ],
   "ow5AAO": [
@@ -2153,6 +2261,12 @@
       "value": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
     }
   ],
+  "vjHM9z": [
+    {
+      "type": 0,
+      "value": "Literal"
+    }
+  ],
   "vng/5K": [
     {
       "type": 0,
@@ -2235,6 +2349,12 @@
     {
       "type": 0,
       "value": "Phone Number Component"
+    }
+  ],
+  "z0FW+t": [
+    {
+      "type": 0,
+      "value": "Field name"
     }
   ],
   "z0bXZT": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -1183,6 +1183,12 @@
       "value": "Interne naam van het formulier voor onderscheid in overzichten"
     }
   ],
+  "RfbS0v": [
+    {
+      "type": 0,
+      "value": "Language"
+    }
+  ],
   "Rk13i+": [
     {
       "type": 0,
@@ -1479,6 +1485,48 @@
       "value": "De sleutel van een variabele moet uniek zijn binnen een formulier"
     }
   ],
+  "ZEo3mR": [
+    {
+      "type": 0,
+      "value": "Form has translation enabled, but is missing "
+    },
+    {
+      "children": [
+        {
+          "offset": 0,
+          "options": {
+            "one": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " translation"
+                }
+              ]
+            },
+            "other": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " translations"
+                }
+              ]
+            }
+          },
+          "pluralType": "cardinal",
+          "type": 6,
+          "value": "count"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    }
+  ],
   "ZICfus": [
     {
       "type": 0,
@@ -1773,6 +1821,12 @@
       "value": "Interne naam"
     }
   ],
+  "i7HknI": [
+    {
+      "type": 0,
+      "value": "Tab name"
+    }
+  ],
   "iZESbd": [
     {
       "type": 0,
@@ -1885,10 +1939,22 @@
       "value": "Item toevoegen"
     }
   ],
+  "lvxPCk": [
+    {
+      "type": 0,
+      "value": "Component label"
+    }
+  ],
   "mH3X/G": [
     {
       "type": 0,
       "value": "vandaag"
+    }
+  ],
+  "mL6vhw": [
+    {
+      "type": 0,
+      "value": "Component key"
     }
   ],
   "mOgTIH": [
@@ -1961,6 +2027,48 @@
     {
       "type": 0,
       "value": "Whether to include the content of the confirmation page in the PDF."
+    }
+  ],
+  "ooyhQ7": [
+    {
+      "type": 0,
+      "value": "Form has translation enabled, but is missing "
+    },
+    {
+      "children": [
+        {
+          "offset": 0,
+          "options": {
+            "one": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " component translation"
+                }
+              ]
+            },
+            "other": {
+              "value": [
+                {
+                  "type": 7
+                },
+                {
+                  "type": 0,
+                  "value": " component translations"
+                }
+              ]
+            }
+          },
+          "pluralType": "cardinal",
+          "type": 6,
+          "value": "count"
+        }
+      ],
+      "type": 8,
+      "value": "link"
     }
   ],
   "ow5AAO": [
@@ -2157,6 +2265,12 @@
       "value": "De inhoud van bevestigingspagina na het versturen van de inzending. Dit sjabloon mag variabelen bevatten met inzendings-gegevens. Laat dit veld leeg om de standaardinstelling te gebruiken."
     }
   ],
+  "vjHM9z": [
+    {
+      "type": 0,
+      "value": "Literal"
+    }
+  ],
   "vng/5K": [
     {
       "type": 0,
@@ -2239,6 +2353,12 @@
     {
       "type": 0,
       "value": "Telefoonnummer veld"
+    }
+  ],
+  "z0FW+t": [
+    {
+      "type": 0,
+      "value": "Field name"
     }
   ],
   "z0bXZT": [

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -14,6 +14,7 @@ const FormContext = React.createContext({
   formVariables: {},
   plugins: {},
   languages: [],
+  translationEnabled: false,
 });
 FormContext.displayName = 'FormContext';
 

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -3,7 +3,7 @@ global URLify;
  */
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import MessageList from 'components/admin/MessageList';
@@ -14,8 +14,10 @@ import FormIOBuilder from 'components/formio_builder/builder';
 
 import AuthenticationWarning from './AuthenticationWarning';
 import ChangedFormDefinitionWarning from './ChangedFormDefinitionWarning';
+import {FormContext, FormStepContext} from './Context';
 import LanguageTabs from './LanguageTabs';
 import LogicWarning from './LogicWarning';
+import MissingComponentTranslationsWarning from './MissingComponentTranslationsWarning';
 import PluginWarning from './PluginWarning';
 import useDetectConfigurationChanged from './useDetectConfigurationChanged';
 import useDetectSimpleLogicErrors from './useDetectSimpleLogicErrors';
@@ -66,6 +68,9 @@ const FormStepDefinition = ({
       },
     });
   };
+
+  const {translationEnabled} = useContext(FormContext);
+  const {componentTranslations} = useContext(FormStepContext);
 
   const {changed, affectedForms} = useDetectConfigurationChanged(url, configuration);
   const {warnings} = useDetectSimpleLogicErrors(configuration);
@@ -304,6 +309,13 @@ const FormStepDefinition = ({
           )}
         </LanguageTabs>
       </fieldset>
+
+      {translationEnabled ? (
+        <MissingComponentTranslationsWarning
+          configuration={configuration}
+          componentTranslations={componentTranslations}
+        />
+      ) : null}
 
       <h2>Velden</h2>
 

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -14,7 +14,7 @@ import FormIOBuilder from 'components/formio_builder/builder';
 
 import AuthenticationWarning from './AuthenticationWarning';
 import ChangedFormDefinitionWarning from './ChangedFormDefinitionWarning';
-import {FormContext, FormStepContext} from './Context';
+import {FormContext} from './Context';
 import LanguageTabs from './LanguageTabs';
 import LogicWarning from './LogicWarning';
 import MissingComponentTranslationsWarning from './MissingComponentTranslationsWarning';

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -70,7 +70,6 @@ const FormStepDefinition = ({
   };
 
   const {translationEnabled} = useContext(FormContext);
-  const {componentTranslations} = useContext(FormStepContext);
 
   const {changed, affectedForms} = useDetectConfigurationChanged(url, configuration);
   const {warnings} = useDetectSimpleLogicErrors(configuration);

--- a/src/openforms/js/components/admin/form_design/MissingComponentTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingComponentTranslationsWarning.js
@@ -83,7 +83,7 @@ const MissingComponentTranslationsWarning = ({configuration, componentTranslatio
 
   const formattedWarning = (
     <FormattedMessage
-      description="Component translations are missing"
+      description="Warning message for missing component translations"
       defaultMessage="Form has translation enabled, but is missing <link>{count, plural,
         one {# component translation}
         other {# component translations}

--- a/src/openforms/js/components/admin/form_design/MissingComponentTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingComponentTranslationsWarning.js
@@ -1,0 +1,126 @@
+import FormioUtils from 'formiojs/utils';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import MessageList from 'components/admin/MessageList';
+import Modal from 'components/admin/Modal';
+import {ChangelistColumn, ChangelistTable} from 'components/admin/tables';
+import {TRANSLATABLE_FIELDS, getValuesOfField} from 'components/formio_builder/builder';
+import jsonScriptToVar from 'utils/json-script';
+
+const extractTranslatableValues = configuration => {
+  let translatableValues = [];
+  FormioUtils.eachComponent(
+    configuration.components,
+    component => {
+      translatableValues[component.label] = [];
+      for (const field of TRANSLATABLE_FIELDS) {
+        if (getValuesOfField(component, field)) {
+          for (const value of getValuesOfField(component, field)) {
+            translatableValues.push({
+              componentKey: component.key,
+              componentLabel: component.label,
+              literal: value,
+            });
+          }
+        }
+      }
+    },
+    true
+  );
+  return translatableValues;
+};
+
+const MissingComponentTranslationsTable = ({children: missingTranslations}) => (
+  <ChangelistTable data={missingTranslations}>
+    <ChangelistColumn objProp="componentKey">
+      <FormattedMessage description="Key of the Form component" defaultMessage="Component key" />
+    </ChangelistColumn>
+
+    <ChangelistColumn objProp="componentLabel">
+      <FormattedMessage
+        description="Label of the Form component"
+        defaultMessage="Component label"
+      />
+    </ChangelistColumn>
+
+    <ChangelistColumn objProp="language">
+      <FormattedMessage description="Readable label for the language" defaultMessage="Language" />
+    </ChangelistColumn>
+
+    <ChangelistColumn objProp="literal">
+      <FormattedMessage description="Literal to be translated" defaultMessage="Literal" />
+    </ChangelistColumn>
+  </ChangelistTable>
+);
+
+MissingComponentTranslationsTable.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.object),
+};
+
+const MissingComponentTranslationsWarning = ({configuration, componentTranslations}) => {
+  const languages = jsonScriptToVar('languages');
+  const languageCodeMapping = Object.fromEntries(languages);
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const onShowModal = event => {
+    event.preventDefault();
+    setModalOpen(true);
+  };
+
+  const translatableValues = extractTranslatableValues(configuration);
+
+  let missingTranslations = [];
+  for (const entry of translatableValues) {
+    for (const [languageCode, _languageLabel] of languages) {
+      let translations = componentTranslations[languageCode] || {};
+      if (!translations[entry.literal])
+        missingTranslations.push({language: languageCodeMapping[languageCode], ...entry});
+    }
+  }
+
+  const formattedWarning = (
+    <FormattedMessage
+      description="Component translations are missing"
+      defaultMessage="Form has translation enabled, but is missing <link>{count, plural,
+        one {# component translation}
+        other {# component translations}
+    }</link>"
+      values={{
+        count: missingTranslations.length,
+        link: chunks => (
+          <a href="#" onClick={onShowModal}>
+            {chunks}
+          </a>
+        ),
+      }}
+    />
+  );
+
+  if (!missingTranslations.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <Modal
+        isOpen={modalOpen}
+        closeModal={() => setModalOpen(false)}
+        title={`Missing translations`}
+      >
+        <MissingComponentTranslationsTable>{missingTranslations}</MissingComponentTranslationsTable>
+      </Modal>
+
+      <MessageList messages={[{level: 'warning', message: formattedWarning}]} />
+    </>
+  );
+};
+
+MissingComponentTranslationsWarning.propTypes = {
+  configuration: PropTypes.object.isRequired,
+  componentTranslations: PropTypes.object.isRequired,
+};
+
+export default MissingComponentTranslationsWarning;

--- a/src/openforms/js/components/admin/form_design/MissingComponentTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingComponentTranslationsWarning.js
@@ -32,6 +32,32 @@ const extractTranslatableValues = configuration => {
   return translatableValues;
 };
 
+const extractMissingComponentTranslations = (configuration, componentTranslations) => {
+  const languageCodeMapping = Object.fromEntries(LANGUAGES);
+
+  const translatableValues = extractTranslatableValues(configuration);
+
+  let missingTranslations = [];
+  for (const entry of translatableValues) {
+    for (const [languageCode, _languageLabel] of LANGUAGES) {
+      let translations = componentTranslations[languageCode] || {};
+      if (!translations[entry.literal])
+        missingTranslations.push({language: languageCodeMapping[languageCode], ...entry});
+    }
+  }
+  missingTranslations.sort((a, b) => {
+    if (a.componentKey !== b.componentKey) {
+      return a.componentKey.localeCompare(b.componentKey);
+    }
+    if (a.language !== b.language) {
+      return a.language.localeCompare(b.language);
+    }
+    return a.literal.localeCompare(b.literal);
+  });
+
+  return missingTranslations;
+};
+
 const MissingComponentTranslationsTable = ({children: missingTranslations}) => (
   <ChangelistTable data={missingTranslations}>
     <ChangelistColumn objProp="componentKey">
@@ -67,8 +93,6 @@ MissingComponentTranslationsTable.propTypes = {
 };
 
 const MissingComponentTranslationsWarning = ({configuration, componentTranslations}) => {
-  const languageCodeMapping = Object.fromEntries(LANGUAGES);
-
   const [modalOpen, setModalOpen] = useState(false);
 
   const onShowModal = event => {
@@ -76,25 +100,10 @@ const MissingComponentTranslationsWarning = ({configuration, componentTranslatio
     setModalOpen(true);
   };
 
-  const translatableValues = extractTranslatableValues(configuration);
-
-  let missingTranslations = [];
-  for (const entry of translatableValues) {
-    for (const [languageCode, _languageLabel] of LANGUAGES) {
-      let translations = componentTranslations[languageCode] || {};
-      if (!translations[entry.literal])
-        missingTranslations.push({language: languageCodeMapping[languageCode], ...entry});
-    }
-  }
-  missingTranslations.sort((a, b) => {
-    if (a.componentKey !== b.componentKey) {
-      return a.componentKey.localeCompare(b.componentKey);
-    }
-    if (a.language !== b.language) {
-      return a.language.localeCompare(b.language);
-    }
-    return a.literal.localeCompare(b.literal);
-  });
+  const missingTranslations = extractMissingComponentTranslations(
+    configuration,
+    componentTranslations
+  );
 
   const formattedWarning = (
     <FormattedMessage
@@ -139,3 +148,4 @@ MissingComponentTranslationsWarning.propTypes = {
 };
 
 export default MissingComponentTranslationsWarning;
+export {extractMissingComponentTranslations};

--- a/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
@@ -118,7 +118,7 @@ const MissingTranslationsWarning = ({form, formSteps}) => {
 
   const formattedWarning = (
     <FormattedMessage
-      description="Translations are missing"
+      description="Warning message for missing translations"
       defaultMessage="Form has translation enabled, but is missing <link>{count, plural,
         one {# translation}
         other {# translations}

--- a/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
@@ -55,27 +55,44 @@ MissingTranslationsTable.propTypes = {
   children: PropTypes.arrayOf(PropTypes.object),
 };
 
-const MissingTranslationsWarning = ({form, formSteps, ...args}) => {
+const MissingTranslationsWarning = ({form, formSteps}) => {
   let formStepTranslations = [];
 
   for (const [index, formStep] of formSteps.entries()) {
     formStepTranslations = formStepTranslations.concat(
-      extractMissingTranslations(formStep.translations, 'Steps and fields')
+      extractMissingTranslations(
+        formStep.translations,
+        <FormattedMessage defaultMessage="Steps and fields" description="Form design tab title" />
+      )
     );
   }
 
   const missingTranslations = [].concat(
-    extractMissingTranslations(form.translations, 'Form', ['name', 'explanationTemplate']),
-    extractMissingTranslations(form.translations, 'Confirmation', [
-      'submissionConfirmationTemplate',
-    ]),
-    extractMissingTranslations(form.translations, 'Literals', [
-      'beginText',
-      'previousText',
-      'changeText',
-      'confirmText',
-    ]),
-    extractMissingTranslations(form.confirmationEmailTemplate.translations, 'Confirmation'),
+    extractMissingTranslations(
+      form.translations,
+      <FormattedMessage defaultMessage="Form" description="Form fields tab title" />,
+      ['name', 'explanationTemplate']
+    ),
+    extractMissingTranslations(
+      form.translations,
+      <FormattedMessage
+        defaultMessage="Confirmation"
+        description="Form confirmation options tab title"
+      />,
+      ['submissionConfirmationTemplate']
+    ),
+    extractMissingTranslations(
+      form.translations,
+      <FormattedMessage defaultMessage="Literals" description="Form literals tab title" />,
+      ['beginText', 'previousText', 'changeText', 'confirmText']
+    ),
+    extractMissingTranslations(
+      form.confirmationEmailTemplate.translations,
+      <FormattedMessage
+        defaultMessage="Confirmation"
+        description="Form confirmation options tab title"
+      />
+    ),
     formStepTranslations
   );
 

--- a/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import MessageList from 'components/admin/MessageList';
+import Modal from 'components/admin/Modal';
+import {ChangelistColumn, ChangelistTable} from 'components/admin/tables';
+import jsonScriptToVar from 'utils/json-script';
+
+const extractMissingTranslations = (translations, tabName, fieldNames) => {
+  const labelMapping = jsonScriptToVar('label-mapping');
+  const languages = jsonScriptToVar('languages');
+  const languageCodeMapping = Object.fromEntries(languages);
+
+  let missingTranslations = [];
+  for (const [languageCode, mapping] of Object.entries(translations)) {
+    for (const [key, translation] of Object.entries(mapping)) {
+      if (!translation) {
+        if (fieldNames === undefined) {
+          missingTranslations.push({
+            fieldName: labelMapping[key],
+            language: languageCodeMapping[languageCode],
+            tabName: tabName,
+          });
+        } else if (fieldNames.includes(key)) {
+          missingTranslations.push({
+            fieldName: labelMapping[key],
+            language: languageCodeMapping[languageCode],
+            tabName: tabName,
+          });
+        }
+      }
+    }
+  }
+  return missingTranslations;
+};
+
+const MissingTranslationsTable = ({children: missingTranslations}) => (
+  <ChangelistTable data={missingTranslations}>
+    <ChangelistColumn objProp="tabName">
+      <FormattedMessage description="Name of the tab in the Form admin" defaultMessage="Tab name" />
+    </ChangelistColumn>
+
+    <ChangelistColumn objProp="language">
+      <FormattedMessage description="Readable label for the language" defaultMessage="Language" />
+    </ChangelistColumn>
+
+    <ChangelistColumn objProp="fieldName">
+      <FormattedMessage description="Name of the translatable field" defaultMessage="Field name" />
+    </ChangelistColumn>
+  </ChangelistTable>
+);
+
+MissingTranslationsTable.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.object),
+};
+
+const MissingTranslationsWarning = ({form, formSteps, ...args}) => {
+  let formStepTranslations = [];
+
+  for (const [index, formStep] of formSteps.entries()) {
+    formStepTranslations = formStepTranslations.concat(
+      extractMissingTranslations(formStep.translations, 'Steps and fields')
+    );
+  }
+
+  const missingTranslations = [].concat(
+    extractMissingTranslations(form.translations, 'Form', ['name', 'explanationTemplate']),
+    extractMissingTranslations(form.translations, 'Confirmation', [
+      'submissionConfirmationTemplate',
+    ]),
+    extractMissingTranslations(form.translations, 'Literals', [
+      'beginText',
+      'previousText',
+      'changeText',
+      'confirmText',
+    ]),
+    extractMissingTranslations(form.confirmationEmailTemplate.translations, 'Confirmation'),
+    formStepTranslations
+  );
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const onShowModal = event => {
+    event.preventDefault();
+    setModalOpen(true);
+  };
+
+  const formattedWarning = (
+    <FormattedMessage
+      description="Translations are missing"
+      defaultMessage="Form has translation enabled, but is missing <link>{count, plural,
+        one {# translation}
+        other {# translations}
+    }</link>"
+      values={{
+        count: missingTranslations.length,
+        link: chunks => (
+          <a href="#" onClick={onShowModal}>
+            {chunks}
+          </a>
+        ),
+      }}
+    />
+  );
+
+  if (!missingTranslations.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <Modal
+        isOpen={modalOpen}
+        closeModal={() => setModalOpen(false)}
+        title={`Missing translations`}
+      >
+        <MissingTranslationsTable>{missingTranslations}</MissingTranslationsTable>
+      </Modal>
+
+      <MessageList messages={[{level: 'warning', message: formattedWarning}]} />
+    </>
+  );
+};
+
+MissingTranslationsWarning.propTypes = {
+  form: PropTypes.object.isRequired,
+  formSteps: PropTypes.array.isRequired,
+};
+
+export default MissingTranslationsWarning;

--- a/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
+++ b/src/openforms/js/components/admin/form_design/MissingTranslationsWarning.js
@@ -9,11 +9,12 @@ import jsonScriptToVar from 'utils/json-script';
 
 import {extractMissingComponentTranslations} from './MissingComponentTranslationsWarning';
 
+const LABEL_MAPPING = jsonScriptToVar('label-mapping', {default: {}});
+const LANGUAGES = jsonScriptToVar('languages', {default: []});
+
 const extractMissingTranslations = (translations, tabName, fieldNames, fallbackFields) => {
-  const labelMapping = jsonScriptToVar('label-mapping');
-  const languages = jsonScriptToVar('languages');
-  const defaultLangCode = languages[0][0];
-  const languageCodeMapping = Object.fromEntries(languages);
+  const defaultLangCode = LANGUAGES[0][0];
+  const languageCodeMapping = Object.fromEntries(LANGUAGES);
   let skipWarningsFor = [];
 
   let missingTranslations = [];
@@ -27,13 +28,13 @@ const extractMissingTranslations = (translations, tabName, fieldNames, fallbackF
       if (!translation && !skipWarningsFor.includes(key)) {
         if (fieldNames === undefined) {
           missingTranslations.push({
-            fieldName: labelMapping[key],
+            fieldName: LABEL_MAPPING[key],
             language: languageCodeMapping[languageCode],
             tabName: tabName,
           });
         } else if (fieldNames.includes(key)) {
           missingTranslations.push({
-            fieldName: labelMapping[key],
+            fieldName: LABEL_MAPPING[key],
             language: languageCodeMapping[languageCode],
             tabName: tabName,
           });

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1117,7 +1117,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
       ) : null}
 
       {state.form.translationEnabled ? (
-        <MissingTranslationsWarning form={state.form} formSteps={state.formSteps} state={state} />
+        <MissingTranslationsWarning form={state.form} formSteps={state.formSteps} />
       ) : null}
 
       <FormContext.Provider

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1134,6 +1134,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
             availablePrefillPlugins: state.availablePrefillPlugins,
           },
           languages: state.languageInfo.languages,
+          translationEnabled: state.form.translationEnabled,
         }}
       >
         <Tabs defaultIndex={activeTab ? parseInt(activeTab, 10) : null}>

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -33,6 +33,7 @@ import FormObjectTools from './FormObjectTools';
 import FormSteps from './FormSteps';
 import FormSubmit from './FormSubmit';
 import {DEFAULT_LANGUAGE} from './LanguageTabs';
+import MissingTranslationsWarning from './MissingTranslationsWarning';
 import PaymentFields from './PaymentFields';
 import {EMPTY_PRICE_RULE, PriceLogic} from './PriceLogic';
 import ProductFields from './ProductFields';
@@ -1113,6 +1114,10 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
             description="Generic error message"
           />
         </div>
+      ) : null}
+
+      {state.form.translationEnabled ? (
+        <MissingTranslationsWarning form={state.form} formSteps={state.formSteps} state={state} />
       ) : null}
 
       <FormContext.Provider

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -459,4 +459,3 @@ FormIOBuilder.propTypes = {
 };
 
 export default FormIOBuilder;
-export {TRANSLATABLE_FIELDS, getValuesOfField};

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -459,3 +459,4 @@ FormIOBuilder.propTypes = {
 };
 
 export default FormIOBuilder;
+export {TRANSLATABLE_FIELDS, getValuesOfField};

--- a/src/openforms/js/components/formio_builder/translation.js
+++ b/src/openforms/js/components/formio_builder/translation.js
@@ -114,7 +114,7 @@ export const persistComponentTranslations = (container, component) => {
   delete component.openForms.translations;
 };
 
-const extractComponentLiterals = component => {
+export const extractComponentLiterals = component => {
   const allTranslatableProperties = [
     ...ALWAYS_TRANSLATABLE_PROPERTIES,
     ...(ADDITIONAL_PROPERTIES_BY_COMPONENT_TYPE[component.type] || []),

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -829,6 +829,11 @@
     "description": "Form name field help text",
     "originalDefault": "Internal name/title of the form"
   },
+  "RfbS0v": {
+    "defaultMessage": "Language",
+    "description": "Readable label for the language",
+    "originalDefault": "Language"
+  },
   "Rk13i+": {
     "defaultMessage": "Initial value",
     "description": "Variable table initial value title",
@@ -1003,6 +1008,11 @@
     "defaultMessage": "The variable key must be unique within a form",
     "description": "Unique key error message",
     "originalDefault": "The variable key must be unique within a form"
+  },
+  "ZEo3mR": {
+    "defaultMessage": "Form has translation enabled, but is missing <link>{count, plural, one {# translation} other {# translations} }</link>",
+    "description": "Warning message for missing translations",
+    "originalDefault": "Form has translation enabled, but is missing <link>{count, plural, one {# translation} other {# translations} }</link>"
   },
   "ZICfus": {
     "defaultMessage": "Previous text",
@@ -1249,6 +1259,11 @@
     "description": "Form name field label",
     "originalDefault": "Internal name"
   },
+  "i7HknI": {
+    "defaultMessage": "Tab name",
+    "description": "Name of the tab in the Form admin",
+    "originalDefault": "Tab name"
+  },
   "iZESbd": {
     "defaultMessage": "is less than",
     "description": "\"<\" operator description",
@@ -1339,10 +1354,20 @@
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
   },
+  "lvxPCk": {
+    "defaultMessage": "Component label",
+    "description": "Label of the Form component",
+    "originalDefault": "Component label"
+  },
   "mH3X/G": {
     "defaultMessage": "today",
     "description": "\"today\" operand type",
     "originalDefault": "today"
+  },
+  "mL6vhw": {
+    "defaultMessage": "Component key",
+    "description": "Key of the Form component",
+    "originalDefault": "Component key"
   },
   "mOgTIH": {
     "defaultMessage": "the variable",
@@ -1403,6 +1428,11 @@
     "defaultMessage": "Whether to include the content of the confirmation page in the PDF.",
     "description": "Include confirmation page content in PDF",
     "originalDefault": "Whether to include the content of the confirmation page in the PDF."
+  },
+  "ooyhQ7": {
+    "defaultMessage": "Form has translation enabled, but is missing <link>{count, plural, one {# component translation} other {# component translations} }</link>",
+    "description": "Warning message for missing component translations",
+    "originalDefault": "Form has translation enabled, but is missing <link>{count, plural, one {# component translation} other {# component translations} }</link>"
   },
   "ow5AAO": {
     "defaultMessage": "The form is invalid. Please correct the errors below.",
@@ -1554,6 +1584,11 @@
     "description": "Confirmation template help text",
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
   },
+  "vjHM9z": {
+    "defaultMessage": "Literal",
+    "description": "Literal to be translated",
+    "originalDefault": "Literal"
+  },
   "vng/5K": {
     "defaultMessage": "Set a key name before you can configure this variable",
     "description": "JSON editor: object entry has empty key name",
@@ -1623,6 +1658,11 @@
     "defaultMessage": "Phone Number Component",
     "description": "Phone Number Component field label",
     "originalDefault": "Phone Number Component"
+  },
+  "z0FW+t": {
+    "defaultMessage": "Field name",
+    "description": "Name of the translatable field",
+    "originalDefault": "Field name"
   },
   "z0bXZT": {
     "defaultMessage": "Action",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -829,6 +829,11 @@
     "description": "Form name field help text",
     "originalDefault": "Internal name/title of the form"
   },
+  "RfbS0v": {
+    "defaultMessage": "Language",
+    "description": "Readable label for the language",
+    "originalDefault": "Language"
+  },
   "Rk13i+": {
     "defaultMessage": "Beginwaarde",
     "description": "Variable table initial value title",
@@ -1003,6 +1008,11 @@
     "defaultMessage": "De sleutel van een variabele moet uniek zijn binnen een formulier",
     "description": "Unique key error message",
     "originalDefault": "The variable key must be unique within a form"
+  },
+  "ZEo3mR": {
+    "defaultMessage": "Form has translation enabled, but is missing <link>{count, plural, one {# translation} other {# translations} }</link>",
+    "description": "Warning message for missing translations",
+    "originalDefault": "Form has translation enabled, but is missing <link>{count, plural, one {# translation} other {# translations} }</link>"
   },
   "ZICfus": {
     "defaultMessage": "'Vorige' tekst",
@@ -1249,6 +1259,11 @@
     "description": "Form name field label",
     "originalDefault": "Internal name"
   },
+  "i7HknI": {
+    "defaultMessage": "Tab name",
+    "description": "Name of the tab in the Form admin",
+    "originalDefault": "Tab name"
+  },
   "iZESbd": {
     "defaultMessage": "is kleiner dan",
     "description": "\"<\" operator description",
@@ -1339,10 +1354,20 @@
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
   },
+  "lvxPCk": {
+    "defaultMessage": "Component label",
+    "description": "Label of the Form component",
+    "originalDefault": "Component label"
+  },
   "mH3X/G": {
     "defaultMessage": "vandaag",
     "description": "\"today\" operand type",
     "originalDefault": "today"
+  },
+  "mL6vhw": {
+    "defaultMessage": "Component key",
+    "description": "Key of the Form component",
+    "originalDefault": "Component key"
   },
   "mOgTIH": {
     "defaultMessage": "de variabele",
@@ -1403,6 +1428,11 @@
     "defaultMessage": "Whether to include the content of the confirmation page in the PDF.",
     "description": "Include confirmation page content in PDF",
     "originalDefault": "Whether to include the content of the confirmation page in the PDF."
+  },
+  "ooyhQ7": {
+    "defaultMessage": "Form has translation enabled, but is missing <link>{count, plural, one {# component translation} other {# component translations} }</link>",
+    "description": "Warning message for missing component translations",
+    "originalDefault": "Form has translation enabled, but is missing <link>{count, plural, one {# component translation} other {# component translations} }</link>"
   },
   "ow5AAO": {
     "defaultMessage": "De gegevens zijn ongeldig. Los de problemen hieronder op.",
@@ -1554,6 +1584,11 @@
     "description": "Confirmation template help text",
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
   },
+  "vjHM9z": {
+    "defaultMessage": "Literal",
+    "description": "Literal to be translated",
+    "originalDefault": "Literal"
+  },
   "vng/5K": {
     "defaultMessage": "Er moet een sleutelnaam ingesteld worden voordat deze variabele geconfigureerd kan worden",
     "description": "JSON editor: object entry has empty key name",
@@ -1623,6 +1658,11 @@
     "defaultMessage": "Telefoonnummer veld",
     "description": "Phone Number Component field label",
     "originalDefault": "Phone Number Component"
+  },
+  "z0FW+t": {
+    "defaultMessage": "Field name",
+    "description": "Name of the translatable field",
+    "originalDefault": "Field name"
   },
   "z0bXZT": {
     "defaultMessage": "Actie",


### PR DESCRIPTION
Fixes #2493 

This doesn't include warnings for missing translations in the global config, that should probably implemented on the backend