### PR TITLE
:lipstick: fix cookie banner for chrome on Android

### DIFF
--- a/src/openforms/js/public.js
+++ b/src/openforms/js/public.js
@@ -17,3 +17,35 @@ const init = () => {
 };
 
 onLoaded(init);
+
+// observe whether cookiebanner is in sticky mode or not
+// note: rootMargin must be specified in pixels or percent, not REMs/EMs.
+const observer = new IntersectionObserver(
+  ([e]) => e.target.classList.toggle('stuck', e.intersectionRatio < 1),
+  {root: document.querySelector('body'), rootMargin: '0px 0px 31px 0px', threshold: [1]}
+);
+
+observer.observe(document.querySelector('.cookie-notice'));
+
+// in case page height is less than the full device height
+// (this is a state where the IntersectionObserver will not be triggered, but shadow still needs to be removed)
+const hasScrollbar = document.body.scrollHeight > window.innerHeight;
+
+if (hasScrollbar === false) {
+  document.querySelector('.cookie-notice').classList.add('no-shadow');
+}
+
+// ugly solution that may sent too many requests:
+
+// window.onscroll = function () {
+//   var totalPageHeight = document.body.scrollHeight;
+//   var scrollPoint = window.scrollY + window.innerHeight;
+
+//   // check if we hit the bottom of the page
+//   if (scrollPoint >= totalPageHeight) {
+//     console.log('scrolled to the bottom');
+//     document.querySelector('.cookie-notice').classList.add('stuck');
+//   } else {
+//     document.querySelector('.cookie-notice').classList.remove('stuck');
+//   }
+// };

--- a/src/openforms/templates/includes/cookie-notice.html
+++ b/src/openforms/templates/includes/cookie-notice.html
@@ -5,26 +5,29 @@
 {% url 'cookie_consent_cookie_group_list' as manage_url %}
 
 {% if cookie_groups and request.path != manage_url %}
-<div class="cookie-notice">
 
-    <span class="cookie-notice__text">
-        {% blocktrans trimmed %}
-        We use cookies to optimize and improve our website and services.
-        You can <a class="utrecht-link utrecht-link--openforms" href="{{ manage_url }}">manage your preferences</a>.
-        {% endblocktrans %}
-    </span>
+<div class="cookie-notice-wrapper">
 
-    <div class="cookie-notice__buttons">
-        <form action="{% url 'cookie_consent_accept' varname='' %}" method="post" class="cookie-notice__form cookie-notice__form--accept">
-            {% csrf_token %}
-            <input type="hidden" name="next" value="{{ request.build_absolute_uri }}" />
-            <button type="submit" class="button">{% trans "Accept all" %}</button>
-        </form>
-        <form action="{% url 'cookie_consent_decline' varname='' %}" method="post" class="cookie-notice__form cookie-notice__form--decline">
-            {% csrf_token %}
-            <input type="hidden" name="next" value="{{ request.build_absolute_uri }}" />
-            <button type="submit" class="button">{% trans "Decline all" %}</button>
-        </form>
+    <div class="cookie-notice">
+        <span class="cookie-notice__text">
+            {% blocktrans trimmed %}
+            We use cookies to optimize and improve our website and services.
+            You can <a class="utrecht-link utrecht-link--openforms" href="{{ manage_url }}">manage your preferences</a>.
+            {% endblocktrans %}
+        </span>
+
+        <div class="cookie-notice__buttons">
+            <form action="{% url 'cookie_consent_accept' varname='' %}" method="post" class="cookie-notice__form cookie-notice__form--accept">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.build_absolute_uri }}" />
+                <button type="submit" class="button">{% trans "Accept all" %}</button>
+            </form>
+            <form action="{% url 'cookie_consent_decline' varname='' %}" method="post" class="cookie-notice__form cookie-notice__form--decline">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.build_absolute_uri }}" />
+                <button type="submit" class="button">{% trans "Decline all" %}</button>
+            </form>
+        </div>
     </div>
 </div>
 {% endif %}

--- a/src/openforms/templates/master.html
+++ b/src/openforms/templates/master.html
@@ -42,7 +42,7 @@
         to get some actual content.
     {% endblock %}
 
-    {% include "includes/cookie-notice.html" %}
+    {% comment %} {% include "includes/cookie-notice.html" %} {% endcomment %}
     <script src="{% static 'bundles/public.js' %}"></script>
     {% block extra_js %}{% endblock %}
     {% if enable_analytics %}
@@ -52,3 +52,4 @@
 </body>
 </html>
 {% endwith %}
+

--- a/src/openforms/ui/static/ui/scss/components/cookie-notice/_index.scss
+++ b/src/openforms/ui/static/ui/scss/components/cookie-notice/_index.scss
@@ -5,6 +5,21 @@
 @import '../../../../../../scss/components/form/button';
 @import './vars';
 
+// center at bottom of page
+.cookie-notice-wrapper {
+  position: sticky;
+  display: block;
+  // note: rootMargin for IntersectionObserver must be specified in pixels or percent, not REMs/EMs.
+  bottom: 30px;
+  width: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  padding: 0;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .cookie-notice {
   @include margin(true, $properties: padding);
   @include body;
@@ -12,9 +27,6 @@
   width: 100%;
   @include responsive(max-width, 95vw, 95vw, 75vw, 75vw);
 
-  // center at bottom of page
-  position: fixed;
-  bottom: 3rem;
   left: 0;
   right: 0;
   z-index: 1;
@@ -24,12 +36,21 @@
   background: $cookie-notice-background;
   box-shadow: $cookie-notice-shadow;
 
+  // toggle-class for IntersectionObserver
+  &.stuck {
+    box-shadow: none;
+  }
+  // toggle-class for page where page height is less than the full device height
+  &.no-shadow {
+    box-shadow: none;
+  }
+
   @include responsive(display, block, block, flex, flex);
   justify-content: space-between;
   align-items: center;
+  max-width: 75vw;
 
   @include mobile-only {
-    bottom: 7rem;
     left: 10px;
     right: 10px;
     width: auto;

--- a/src/openforms/ui/templates/ui/views/abstract/base.html
+++ b/src/openforms/ui/templates/ui/views/abstract/base.html
@@ -15,6 +15,8 @@
         </main>
     {% endblock %}
 
+    {% include "includes/cookie-notice.html" %}
+
     {% block footer %}
         {% include "ui/components/footer/footer.html" %}
     {% endblock %}


### PR DESCRIPTION
Increase banner distance on bottom for all screen sizes, specifically Android.
Fixes  open-formulieren/open-forms#2549