### PR TITLE
:construction_worker: Add CI job to install dev deps on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,29 @@ env:
   SELENIUM_WEBDRIVER: Chrome
 
 jobs:
+  macos-deps:
+    name: Install dev dependencies on MacOS
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
+      - name: Install OS-level packages
+        run: |
+          brew install libxmlsec1
+      - name: Install dependencies
+        run: |
+          export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
+          pip install -r requirements/dev.txt \
+            --use-pep517 \
+            --use-feature=no-binary-enable-wheel-cache
+        env:
+          STATIC_DEPS: 'true'
+
   tests:
     name: Run the Django test suite
     runs-on: ubuntu-latest


### PR DESCRIPTION
Proves that dev deps can be installed on _a_ MacOS version & ensures we don't accidentally break this in the future.

It also documents some possibly necessary workarounds/manual actions.