### PR TITLE
[#2622] Fix Heisenbugs

### DIFF
--- a/src/openforms/prefill/tests/test_admin.py
+++ b/src/openforms/prefill/tests/test_admin.py
@@ -1,8 +1,11 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from django_webtest import WebTest
 
 from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.config.models import GlobalConfiguration
 
 from ..models import PrefillConfig
 
@@ -13,7 +16,19 @@ class PrefillConfigTests(WebTest):
 
         self.assertEqual(str(instance), PrefillConfig._meta.verbose_name)
 
-    def test_registry_list_for_defaults(self):
+    @patch(
+        "openforms.plugins.registry.GlobalConfiguration.get_solo",
+        return_value=GlobalConfiguration(
+            plugin_configuration={
+                "registration": {
+                    "stufbg": {"enabled": True},
+                    "haalcentraal": {"enabled": True},
+                    "kvk-kvknumber": {"enabled": True},
+                },
+            }
+        ),
+    )
+    def test_registry_list_for_defaults(self, m_global_config):
         user = SuperUserFactory.create()
         (
             config,

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_failure_modes.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_failure_modes.py
@@ -6,6 +6,7 @@ import requests_mock
 from freezegun import freeze_time
 from privates.test import temp_private_root
 
+from openforms.config.models import GlobalConfiguration
 from openforms.submissions.constants import RegistrationStatuses
 from openforms.submissions.tests.factories import SubmissionFactory
 from stuf.stuf_zds.models import StufZDSConfig
@@ -37,6 +38,16 @@ class PartialRegistrationFailureTests(StUFZDSTestBase):
         cls.config_patcher = patch(
             "openforms.registrations.contrib.stuf_zds.plugin.StufZDSConfig.get_solo",
             return_value=StufZDSConfig(service=cls.service),
+        )
+        cls.general_config_patcher = patch(
+            "openforms.plugins.plugin.GlobalConfiguration.get_solo",
+            return_value=GlobalConfiguration(
+                plugin_configuration={
+                    "registration": {
+                        "stuf_zds": {"enabled": True},
+                    },
+                }
+            ),
         )
 
         # set up a simple form to track the partial result storing state
@@ -71,6 +82,9 @@ class PartialRegistrationFailureTests(StUFZDSTestBase):
 
         self.config_patcher.start()
         self.addCleanup(self.config_patcher.stop)
+
+        self.general_config_patcher.start()
+        self.addCleanup(self.general_config_patcher.stop)
 
         self.requests_mock = requests_mock.Mocker()
         self.requests_mock.start()

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_failure_modes.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_failure_modes.py
@@ -95,9 +95,8 @@ class PartialRegistrationFailureTests(StUFZDSTestBase):
             additional_matcher=match_text("zakLk01"),
         )
 
+        register_submission(self.submission.id)
         with self.subTest("Initial registration fails"):
-            register_submission(self.submission.id)
-
             self.submission.refresh_from_db()
             self.assertEqual(
                 self.submission.registration_status, RegistrationStatuses.failed
@@ -172,9 +171,8 @@ class PartialRegistrationFailureTests(StUFZDSTestBase):
             additional_matcher=match_text("genereerDocumentIdentificatie_Di02"),
         )
 
+        register_submission(self.submission.id)
         with self.subTest("Document id generation fails"):
-            register_submission(self.submission.id)
-
             self.submission.refresh_from_db()
             self.assertEqual(
                 self.submission.registration_status, RegistrationStatuses.failed
@@ -268,9 +266,8 @@ class PartialRegistrationFailureTests(StUFZDSTestBase):
             additional_matcher=match_text("edcLk01"),
         )
 
+        register_submission(self.submission.id)
         with self.subTest("Document id generation fails"):
-            register_submission(self.submission.id)
-
             self.submission.refresh_from_db()
             self.assertEqual(
                 self.submission.registration_status, RegistrationStatuses.failed


### PR DESCRIPTION
Fixes #2622 

Todo:
- [x] AttributeError: Can't pickle local object => Problem was that the test was relying on GlobalConfiguration without patching it
- [x] Excel file => See comment on issue
- [x] AttributeError: 'Text' object has no attribute 'options' => Not too sure, I couldn't reproduce it anymore. I saw it was using also Global configuration for the enabled plugins, it tried patching that. Let's see if it occurs again?