### PR TITLE
[#2601] disable autocomplete for username/password in admin

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -136,7 +136,7 @@ django-better-admin-arrayfield==1.4.2
     # via
     #   -r requirements/base.in
     #   mozilla-django-oidc-db
-django-camunda==0.12.0
+django-camunda==0.13.0
     # via -r requirements/base.in
 django-capture-tag==1.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -222,7 +222,7 @@ django-better-admin-arrayfield==1.4.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-django-camunda==0.12.0
+django-camunda==0.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -253,7 +253,7 @@ django-better-admin-arrayfield==1.4.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-django-camunda==0.12.0
+django-camunda==0.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -180,7 +180,7 @@ django-better-admin-arrayfield==1.4.2
     #   -c requirements/base.in
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-django-camunda==0.12.0
+django-camunda==0.13.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt

--- a/src/stuf/admin.py
+++ b/src/stuf/admin.py
@@ -10,7 +10,8 @@ class StufServiceAdminAdminForm(forms.ModelForm):
     class Meta:
         model = StufService
         widgets = {
-            "password": PasswordInput(),
+            # turn off autocomplete: https://stackoverflow.com/q/33113891
+            "password": PasswordInput(attrs={"autocomplete": "new-password"}),
         }
         fields = "__all__"
 


### PR DESCRIPTION
Closes #2601 (partly; see the complementing [PR](https://github.com/maykinmedia/django-camunda/pull/9) for [django-camunda)](https://github.com/maykinmedia/django-camunda) 

* Disable autocomplete for username/password fields in Stuf services