### PR TITLE
[#2641] Fix checking domains for links in emails

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -30,6 +30,7 @@ semantic-version
 tabulate
 weasyprint
 zeep
+tldextract
 # Pinned setuptools to a version lower than 58 to allow pyzmail36 to be
 # installed, as required by django-yubin.
 setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -234,6 +234,8 @@ face==20.1.1
     # via glom
 faker==7.0.1
     # via zgw-consumers
+filelock==3.9.0
+    # via tldextract
 flower==1.2.0
     # via -r requirements/base.in
 frozendict==2.3.4
@@ -255,7 +257,9 @@ html5lib==1.1
 humanize==3.14.0
     # via flower
 idna==2.10
-    # via requests
+    # via
+    #   requests
+    #   tldextract
 inflection==0.5.1
     # via
     #   django-camunda
@@ -386,10 +390,13 @@ requests==2.26.0
     #   requests-mock
     #   requests-oauthlib
     #   requests-toolbelt
+    #   tldextract
     #   zeep
     #   zgw-consumers
 requests-file==1.5.1
-    # via zeep
+    # via
+    #   tldextract
+    #   zeep
 requests-mock==1.8.0
     # via zgw-consumers
 requests-oauthlib==1.3.0
@@ -443,6 +450,8 @@ tinycss2==1.1.0
     #   cairosvg
     #   cssselect2
     #   weasyprint
+tldextract==3.4.0
+    # via -r requirements/base.in
 tornado==6.1
     # via flower
 tzlocal==2.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -418,6 +418,11 @@ faker==7.0.1
     #   -r requirements/base.txt
     #   factory-boy
     #   zgw-consumers
+filelock==3.9.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   tldextract
 flake8==6.0.0
     # via -r requirements/test-tools.in
 flower==1.2.0
@@ -464,6 +469,7 @@ idna==2.10
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   requests
+    #   tldextract
     #   trio
 imagesize==1.2.0
     # via sphinx
@@ -740,12 +746,14 @@ requests==2.26.0
     #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
+    #   tldextract
     #   zeep
     #   zgw-consumers
 requests-file==1.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   tldextract
     #   zeep
 requests-mock==1.8.0
     # via
@@ -884,6 +892,10 @@ tinycss2==1.1.0
     #   cairosvg
     #   cssselect2
     #   weasyprint
+tldextract==3.4.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 toml==0.10.2
     # via pytest
 tomli==1.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -468,6 +468,11 @@ faker==7.0.1
     #   -r requirements/ci.txt
     #   factory-boy
     #   zgw-consumers
+filelock==3.9.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   tldextract
 flake8==6.0.0
     # via
     #   -c requirements/ci.txt
@@ -529,6 +534,7 @@ idna==2.10
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   requests
+    #   tldextract
     #   trio
 imagesize==1.2.0
     # via
@@ -878,12 +884,14 @@ requests==2.26.0
     #   requests-oauthlib
     #   requests-toolbelt
     #   sphinx
+    #   tldextract
     #   zeep
     #   zgw-consumers
 requests-file==1.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   tldextract
     #   zeep
 requests-mock==1.8.0
     # via
@@ -1065,6 +1073,10 @@ tinycss2==1.1.0
     #   cairosvg
     #   cssselect2
     #   weasyprint
+tldextract==3.4.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 toml==0.10.2
     # via
     #   -c requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -350,6 +350,10 @@ faker==7.0.1
     # via
     #   -r requirements/base.txt
     #   zgw-consumers
+filelock==3.9.0
+    # via
+    #   -r requirements/base.txt
+    #   tldextract
 flower==1.2.0
     # via
     #   -c requirements/base.in
@@ -386,6 +390,7 @@ idna==2.10
     # via
     #   -r requirements/base.txt
     #   requests
+    #   tldextract
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
@@ -586,11 +591,13 @@ requests==2.26.0
     #   requests-mock
     #   requests-oauthlib
     #   requests-toolbelt
+    #   tldextract
     #   zeep
     #   zgw-consumers
 requests-file==1.5.1
     # via
     #   -r requirements/base.txt
+    #   tldextract
     #   zeep
 requests-mock==1.8.0
     # via
@@ -677,6 +684,10 @@ tinycss2==1.1.0
     #   cairosvg
     #   cssselect2
     #   weasyprint
+tldextract==3.4.0
+    # via
+    #   -c requirements/base.in
+    #   -r requirements/base.txt
 tornado==6.1
     # via
     #   -r requirements/base.txt

--- a/src/openforms/emails/tests/test_confirmation_email.py
+++ b/src/openforms/emails/tests/test_confirmation_email.py
@@ -3,6 +3,7 @@ import re
 from copy import deepcopy
 from datetime import date, datetime
 from decimal import Decimal
+from unittest import skipIf
 from unittest.mock import patch
 
 from django.core import mail
@@ -31,7 +32,7 @@ from openforms.submissions.tests.factories import (
     SubmissionStepFactory,
 )
 from openforms.submissions.utils import send_confirmation_email
-from openforms.tests.utils import NOOP_CACHES
+from openforms.tests.utils import NOOP_CACHES, can_connect
 from openforms.utils.tests.html_assert import HTMLAssertMixin, strip_all_attributes
 from openforms.utils.urls import build_absolute_uri
 
@@ -124,6 +125,10 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
         ):
             email.full_clean()
 
+    @skipIf(
+        not can_connect("https://publicsuffix.org/list/public_suffix_list.dat"),
+        "URL sanitation test require the download of the Public Suffix list",
+    )
     def test_validate_content_netloc_sanitation_validation(self):
         config = GlobalConfiguration.get_solo()
         config.email_template_netloc_allowlist = ["good.net"]

--- a/src/openforms/emails/tests/test_validators.py
+++ b/src/openforms/emails/tests/test_validators.py
@@ -47,3 +47,6 @@ class URLSanitationValidatorTest(TestCase):
                 ValidationError, message.format(netloc="bad.net")
             ):
                 validator("bla bla http://bad.net/xyz?123 bla bla ")
+
+        with self.subTest("Valid with http://www."):
+            validator("http://www.good.net")

--- a/src/openforms/emails/tests/test_validators.py
+++ b/src/openforms/emails/tests/test_validators.py
@@ -1,3 +1,5 @@
+from unittest import skipIf
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -5,8 +7,13 @@ from django.utils.translation import gettext_lazy as _
 
 from openforms.config.models import GlobalConfiguration
 from openforms.emails.validators import URLSanitationValidator
+from openforms.tests.utils import can_connect
 
 
+@skipIf(
+    not can_connect("https://publicsuffix.org/list/public_suffix_list.dat"),
+    "URL sanitation test require the download of the Public Suffix list",
+)
 class URLSanitationValidatorTest(TestCase):
     def test_validator(self):
         config = GlobalConfiguration.get_solo()

--- a/src/openforms/emails/validators.py
+++ b/src/openforms/emails/validators.py
@@ -22,6 +22,10 @@ class URLSanitationValidator:
         from openforms.config.models import GlobalConfiguration
         from openforms.emails.utils import get_system_netloc_allowlist
 
+        url_matches = list(URL_REGEX.finditer(value))
+        if len(url_matches) == 0:
+            return
+
         config = GlobalConfiguration.get_solo()
 
         allowlist = (
@@ -29,7 +33,7 @@ class URLSanitationValidator:
         )
         allowed_domains = [tldextract.extract(url).domain for url in allowlist]
 
-        for m in URL_REGEX.finditer(value):
+        for m in url_matches:
             parsed_url = tldextract.extract(m.group())
             domain = parsed_url.domain
             if domain not in allowed_domains:


### PR DESCRIPTION
Fixes #2641 

See the note about caching for `tldextract`: https://github.com/john-kurkowski/tldextract#note-about-caching
Questions: 
- Shall we keep the runtime bootstrapping behaviour? 
- How do we deal with updating the file with the suffixes? 
- Should we set the env var `TLDEXTRACT_CACHE`? 