### PR TITLE
[Draft] :sparkles: [#2661] Service fetch configuration modal in Form Designer

### DIFF
--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -15,14 +15,18 @@ const FormContext = React.createContext({
   plugins: {},
   languages: [],
   translationEnabled: false,
+});
+FormContext.displayName = 'FormContext';
+
+const FormLogicContext = React.createContext({
   services: [],
   serviceFetchConfigurations: [],
 });
-FormContext.displayName = 'FormContext';
+FormContext.displayName = 'FormLogicContext';
 
 const APIContext = React.createContext({
   crsftoken: '',
 });
 APIContext.displayName = 'APIContext';
 
-export {APIContext, FormContext, TinyMceContext, FeatureFlagsContext};
+export {APIContext, FormContext, FormLogicContext, TinyMceContext, FeatureFlagsContext};

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -15,6 +15,8 @@ const FormContext = React.createContext({
   plugins: {},
   languages: [],
   translationEnabled: false,
+  services: [],
+  serviceFetchConfigurations: [],
 });
 FormContext.displayName = 'FormContext';
 

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -702,6 +702,7 @@ function reducer(draft, action) {
     }
     case 'CHANGE_USER_DEFINED_VARIABLE': {
       const {key, propertyName, propertyValue} = action.payload;
+      console.log(action.payload);
 
       const index = draft.formVariables.findIndex(variable => variable.key === key);
 

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -24,7 +24,7 @@ import {getUniqueRandomString} from 'utils/random';
 
 import Appointments, {KEYS as APPOINTMENT_CONFIG_KEYS} from './Appointments';
 import Confirmation from './Confirmation';
-import {APIContext, FormContext} from './Context';
+import {APIContext, FormContext, FormLogicContext} from './Context';
 import DataRemoval from './DataRemoval';
 import FormConfigurationFields from './FormConfigurationFields';
 import FormDetailFields from './FormDetailFields';
@@ -1278,12 +1278,19 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
           </TabPanel>
 
           <TabPanel>
-            <FormLogic
-              logicRules={state.logicRules}
-              onChange={onRuleChange}
-              onDelete={index => dispatch({type: 'DELETED_RULE', payload: {index: index}})}
-              onAdd={() => dispatch({type: 'ADD_RULE'})}
-            />
+            <FormLogicContext.Provider
+              value={{
+                services: [],
+                serviceFetchConfigurations: [],
+              }}
+            >
+              <FormLogic
+                logicRules={state.logicRules}
+                onChange={onRuleChange}
+                onDelete={index => dispatch({type: 'DELETED_RULE', payload: {index: index}})}
+                onAdd={() => dispatch({type: 'ADD_RULE'})}
+              />
+            </FormLogicContext.Provider>
           </TabPanel>
 
           <TabPanel>

--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.js
@@ -79,7 +79,7 @@ const Action = ({prefixText, action, errors = {}, onChange, onDelete}) => {
               }
               extraModifiers={['large']}
             >
-              <ServiceFetchConfigurationPicker />
+              <ServiceFetchConfigurationPicker onFormSave={closeModal} onChange={onChange} />
             </FormModal>
           </div>
         </div>

--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.js
@@ -1,20 +1,27 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useContext} from 'react';
-import {useIntl} from 'react-intl';
+import React, {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import DeleteIcon from 'components/admin/DeleteIcon';
+import FormModal from 'components/admin/FormModal';
 import DSLEditorNode from 'components/admin/form_design/logic/DSLEditorNode';
 import DataPreview from 'components/admin/form_design/logic/DataPreview';
 import {ACTION_TYPES} from 'components/admin/form_design/logic/constants';
 import Select from 'components/admin/forms/Select';
 
+import ServiceFetchConfigurationPicker from '../../variables/ServiceFetchConfigurationPicker';
 import {ActionComponent} from './Actions';
 import {ActionError, Action as ActionType} from './types';
 
 const Action = ({prefixText, action, errors = {}, onChange, onDelete}) => {
   const intl = useIntl();
   const hasErrors = Object.entries(errors).length > 0;
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
 
   return (
     <div className="logic-action">
@@ -47,6 +54,33 @@ const Action = ({prefixText, action, errors = {}, onChange, onDelete}) => {
             </DSLEditorNode>
 
             <ActionComponent action={action} errors={errors} onChange={onChange} />
+
+            <button
+              type="button"
+              className="button"
+              onClick={() => {
+                setIsModalOpen(true);
+              }}
+            >
+              <FormattedMessage
+                description="Button to toggle service fetch configuration modal"
+                defaultMessage="Add service fetch configuration"
+              />
+            </button>
+
+            <FormModal
+              isOpen={isModalOpen}
+              closeModal={closeModal}
+              title={
+                <FormattedMessage
+                  description="Service fetch configuration selection modal title"
+                  defaultMessage="Service fetch configuration"
+                />
+              }
+              extraModifiers={['large']}
+            >
+              <ServiceFetchConfigurationPicker />
+            </FormModal>
           </div>
         </div>
       </div>

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.js
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.js
@@ -1,0 +1,213 @@
+import PropTypes from 'prop-types';
+import React, {useContext} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {SubmitAction} from 'components/admin/forms/ActionButton';
+import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+import JsonWidget from 'components/admin/forms/JsonWidget';
+import Select from 'components/admin/forms/Select';
+import SubmitRow from 'components/admin/forms/SubmitRow';
+
+import {FormLogicContext} from '../Context';
+
+const HTTP_METHODS = [
+  ['GET', 'GET'],
+  ['POST', 'POST'],
+];
+const EXPRESSION_MAPPING_LANGUAGES = [
+  ['JsonLogic', 'JsonLogic'],
+  ['jq', 'jq'],
+];
+
+const ServiceFetchConfigurationForm = ({data = {}, onFormSubmit, onChange}) => {
+  const intl = useIntl();
+  const formLogicContext = useContext(FormLogicContext);
+
+  const serviceChoices = formLogicContext.services.map(service => {
+    return [service.url, service.label];
+  });
+
+  return (
+    <form
+      className="aligned react-modal__form"
+      onSubmit={event => onFormSubmit && onFormSubmit(event)}
+    >
+      <Fieldset
+        title={
+          <FormattedMessage
+            defaultMessage="Basic"
+            description="Service fetch configuration modal basic fieldset title"
+          />
+        }
+        extraClassName="admin-fieldset"
+      >
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.service'}
+            label={
+              <FormattedMessage
+                defaultMessage="Service"
+                description="Service fetch configuration modal form Service field label"
+              />
+            }
+          >
+            <Select
+              name="fetchConfiguration.httpMethod"
+              choices={serviceChoices}
+              value={data.service}
+              onChange={onChange}
+            />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.path'}
+            label={
+              <FormattedMessage
+                defaultMessage="Path"
+                description="Service fetch configuration modal form Path field label"
+              />
+            }
+          >
+            <TextInput value={data.path} onChange={onChange} maxLength="1000" />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.method'}
+            label={
+              <FormattedMessage
+                defaultMessage="HTTP method"
+                description="Service fetch configuration modal form HTTP method field label"
+              />
+            }
+          >
+            <Select
+              name="fetchConfiguration.method"
+              choices={HTTP_METHODS}
+              value={data.method || 'GET'}
+              onChange={onChange}
+            />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.queryParams'}
+            label={
+              <FormattedMessage
+                defaultMessage="Query parameters"
+                description="Service fetch configuration modal form query parameters field label"
+              />
+            }
+          >
+            <JsonWidget
+              name="fetchConfiguration.queryParams"
+              logic={data.queryParams || {}}
+              cols={20}
+              onChange={onChange}
+            />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.headers'}
+            label={
+              <FormattedMessage
+                defaultMessage="Request headers"
+                description="Service fetch configuration modal form request headers field label"
+              />
+            }
+          >
+            <JsonWidget
+              name="fetchConfiguration.headers"
+              logic={data.headers || {}}
+              cols={20}
+              onChange={onChange}
+            />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.body'}
+            label={
+              <FormattedMessage
+                defaultMessage="Request body"
+                description="Service fetch configuration modal form request body field label"
+              />
+            }
+          >
+            <JsonWidget
+              name="fetchConfiguration.body"
+              logic={data.body || {}}
+              cols={20}
+              onChange={onChange}
+            />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.dataMappingType'}
+            label={
+              <FormattedMessage
+                defaultMessage="Mapping expression language"
+                description="Service fetch configuration modal form mapping expression language field label"
+              />
+            }
+          >
+            <Select
+              name="fetchConfiguration.dataMappingType"
+              choices={EXPRESSION_MAPPING_LANGUAGES}
+              value={data.dataMappingType || ''}
+              onChange={onChange}
+              allowBlank
+            />
+          </Field>
+        </FormRow>
+
+        <FormRow>
+          <Field
+            name={'fetchConfiguration.mappingExpression'}
+            label={
+              <FormattedMessage
+                defaultMessage="Mapping expression"
+                description="Service fetch configuration modal form mapping expression field label"
+              />
+            }
+          >
+            <JsonWidget
+              name="fetchConfiguration.mappingExpression"
+              logic={data.mappingExpression || {}}
+              cols={20}
+              onChange={onChange}
+            />
+          </Field>
+        </FormRow>
+      </Fieldset>
+
+      <SubmitRow>
+        <SubmitAction
+          text={intl.formatMessage({
+            description: 'Confirm service fetch configuration',
+            defaultMessage: 'Confirm',
+          })}
+          onClick={onFormSubmit}
+        />
+      </SubmitRow>
+    </form>
+  );
+};
+
+ServiceFetchConfigurationForm.propTypes = {
+  onFormSubmit: PropTypes.func,
+};
+
+export default ServiceFetchConfigurationForm;

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.js
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.js
@@ -22,7 +22,7 @@ const EXPRESSION_MAPPING_LANGUAGES = [
   ['jq', 'jq'],
 ];
 
-const ServiceFetchConfigurationForm = ({data = {}, onFormSubmit, onChange}) => {
+const ServiceFetchConfigurationForm = ({data = {}, onChange, onFormSave}) => {
   // TODO ensure that onChange actually updates state with data
   const intl = useIntl();
   const formLogicContext = useContext(FormLogicContext);
@@ -30,12 +30,9 @@ const ServiceFetchConfigurationForm = ({data = {}, onFormSubmit, onChange}) => {
   const serviceChoices = formLogicContext.services.map(service => {
     return [service.url, service.label];
   });
-
+  console.log(onChange);
   return (
-    <form
-      className="aligned react-modal__form"
-      onSubmit={event => onFormSubmit && onFormSubmit(event)}
-    >
+    <div>
       <Fieldset
         title={
           <FormattedMessage
@@ -195,15 +192,14 @@ const ServiceFetchConfigurationForm = ({data = {}, onFormSubmit, onChange}) => {
       </Fieldset>
 
       <SubmitRow>
-        <SubmitAction
-          text={intl.formatMessage({
-            description: 'Confirm service fetch configuration',
-            defaultMessage: 'Confirm',
-          })}
-          onClick={onFormSubmit}
-        />
+        <button type="button" className="button" onClick={onFormSave}>
+          <FormattedMessage
+            description="Confirm service fetch configuration"
+            defaultMessage="Confirm"
+          />
+        </button>
       </SubmitRow>
-    </form>
+    </div>
   );
 };
 

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.js
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.js
@@ -23,6 +23,7 @@ const EXPRESSION_MAPPING_LANGUAGES = [
 ];
 
 const ServiceFetchConfigurationForm = ({data = {}, onFormSubmit, onChange}) => {
+  // TODO ensure that onChange actually updates state with data
   const intl = useIntl();
   const formLogicContext = useContext(FormLogicContext);
 

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.stories.mdx
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationForm.stories.mdx
@@ -1,0 +1,50 @@
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs';
+
+import {FormContext} from '../Context';
+import ServiceFetchConfigurationForm from './ServiceFetchConfigurationForm';
+
+<Meta title="Form design/ServiceFetchConfigurationForm" component={ServiceFetchConfigurationForm} />
+
+# Field
+
+Form to edit/create a ServiceFetchConfiguration
+
+export const Template = args => (
+  <FormContext.Provider
+    value={{
+      services: [
+        {
+          url: 'http://openforms.dev/services/foo',
+          label: 'Service 1',
+          type: 'ORC',
+          apiRootUrl: 'https://some-api.com/api/v1/',
+        },
+        {
+          url: 'http://openforms.dev/services/foo',
+          label: 'Service 2',
+          type: 'ORC',
+          apiRootUrl: 'https://some-other-api.com/api/v1/',
+        },
+      ],
+    }}
+  >
+    <ServiceFetchConfigurationForm {...args} />;
+  </FormContext.Provider>
+);
+
+## Presentation
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      data: {path: '/foo', httpMethod: 'POST'},
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Props
+
+<ArgsTable story="Default" />

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.js
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.js
@@ -91,6 +91,8 @@ const ServiceFetchConfigurationPicker = ({data = {}, onChange}) => {
                 choices={serviceFetchConfigurationChoices}
                 value={data.serviceFetchConfiguration || ''}
                 onChange={({...args}) => {
+                  // TODO ensure this onChange sets the state config data to the values of
+                  // the selected config
                   onChange({...args});
                   setShowServiceFetchConfigurationForm(true);
                 }}

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.js
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.js
@@ -1,0 +1,117 @@
+import PropTypes from 'prop-types';
+import React, {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import FAIcon from 'components/admin/FAIcon';
+import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import Select from 'components/admin/forms/Select';
+
+import {FormLogicContext} from './../Context';
+import ServiceFetchConfigurationForm from './ServiceFetchConfigurationForm';
+
+const ServiceFetchConfigurationPicker = ({data = {}, onChange}) => {
+  const intl = useIntl();
+  const formLogicContext = useContext(FormLogicContext);
+
+  const [selectExisting, setSelectExisting] = useState(false);
+  const [showServiceFetchConfigurationForm, setShowServiceFetchConfigurationForm] = useState(false);
+
+  const serviceFetchConfigurationChoices = formLogicContext.serviceFetchConfigurations.map(
+    fetchConfig => {
+      return [
+        fetchConfig.url,
+        `${fetchConfig.method} ${fetchConfig.path} (${fetchConfig.service})`,
+      ];
+    }
+  );
+
+  return (
+    <div className="servicefetchconfiguration-picker">
+      <div className="tiles tiles--horizontal">
+        <button type="button" className="tiles__tile" onClick={() => setSelectExisting(true)}>
+          <FAIcon
+            icon="recycle"
+            extraClassname="fa-2x"
+            title={intl.formatMessage({
+              description: 'select service fetch configuration icon title',
+              defaultMessage: 'Select service fetch configuration',
+            })}
+          />
+          <span>
+            <FormattedMessage
+              description="Select existing service fetch configuration tile"
+              defaultMessage="Select existing service fetch configuration"
+            />
+          </span>
+        </button>
+
+        <span className="tiles__separator">&bull;</span>
+
+        <button
+          type="button"
+          className="tiles__tile"
+          onClick={() => {
+            setSelectExisting(!selectExisting);
+            setShowServiceFetchConfigurationForm(true);
+          }}
+        >
+          <FAIcon
+            icon="pen-to-square"
+            extraClassname="fa-2x"
+            title={intl.formatMessage({
+              description: 'create service fetch configuration icon title',
+              defaultMessage: 'Create service fetch configuration',
+            })}
+          />
+          <span>
+            <FormattedMessage
+              description="Create service fetch configuration tile"
+              defaultMessage="Create a new service fetch configuration"
+            />
+          </span>
+        </button>
+      </div>
+
+      {selectExisting ? (
+        <div className="servicefetchconfiguration-select">
+          <FormRow>
+            <Field
+              name={'fetchConfiguration.existing'}
+              label={
+                <FormattedMessage
+                  defaultMessage="Choose service fetch configuration"
+                  description="Service fetch configuration modal select existing field label"
+                />
+              }
+            >
+              <Select
+                name="fetchConfiguration.existing"
+                choices={serviceFetchConfigurationChoices}
+                value={data.serviceFetchConfiguration || ''}
+                onChange={({...args}) => {
+                  onChange({...args});
+                  setShowServiceFetchConfigurationForm(true);
+                }}
+                allowBlank
+              />
+            </Field>
+          </FormRow>
+        </div>
+      ) : null}
+
+      {showServiceFetchConfigurationForm ? (
+        <div className="servicefetchconfiguration-form">
+          <ServiceFetchConfigurationForm data={{}} />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+ServiceFetchConfigurationPicker.propTypes = {
+  onReplace: PropTypes.func.isRequired,
+};
+
+export default ServiceFetchConfigurationPicker;

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.js
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.js
@@ -11,7 +11,7 @@ import Select from 'components/admin/forms/Select';
 import {FormLogicContext} from './../Context';
 import ServiceFetchConfigurationForm from './ServiceFetchConfigurationForm';
 
-const ServiceFetchConfigurationPicker = ({data = {}, onChange}) => {
+const ServiceFetchConfigurationPicker = ({data = {}, onChange, onFormSave}) => {
   const intl = useIntl();
   const formLogicContext = useContext(FormLogicContext);
 
@@ -105,7 +105,7 @@ const ServiceFetchConfigurationPicker = ({data = {}, onChange}) => {
 
       {showServiceFetchConfigurationForm ? (
         <div className="servicefetchconfiguration-form">
-          <ServiceFetchConfigurationForm data={{}} />
+          <ServiceFetchConfigurationForm data={{}} onFormSave={onFormSave} onChange={onChange} />
         </div>
       ) : null}
     </div>

--- a/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.stories.mdx
+++ b/src/openforms/js/components/admin/form_design/variables/ServiceFetchConfigurationPicker.stories.mdx
@@ -1,0 +1,80 @@
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs';
+
+import {FormContext} from '../Context';
+import ServiceFetchConfigurationPicker from './ServiceFetchConfigurationPicker';
+
+<Meta
+  title="Form design/ServiceFetchConfigurationPicker"
+  component={ServiceFetchConfigurationPicker}
+/>
+
+# Field
+
+Form that is shown when adding a ServiceFetchConfiguration, first the user must choose whether to
+use an existing configuration or to create a new one.
+
+export const Template = args => (
+  <FormContext.Provider
+    value={{
+      services: [
+        {
+          url: 'http://openforms.dev/services/foo',
+          label: 'Service 1',
+          type: 'ORC',
+          apiRootUrl: 'https://some-api.com/api/v1/',
+        },
+        {
+          url: 'http://openforms.dev/services/foo',
+          label: 'Service 2',
+          type: 'ORC',
+          apiRootUrl: 'https://some-other-api.com/api/v1/',
+        },
+      ],
+      serviceFetchConfigurations: [
+        {
+          url: 'http://openforms.dev/service-fetch-configurations/foo',
+          service: 'http://openforms.dev/services/foo',
+          path: '/some-path',
+          method: 'GET',
+          headers: {'X-Foo': 'foo'},
+          queryParams: {parameter: 'value'},
+          body: {field1: 'value', field2: 'value2'},
+          dataMappingType: 'jq',
+          mappingExpression: '.field.nested',
+        },
+        {
+          url: 'http://openforms.dev/service-fetch-configurations/bar',
+          service: 'http://openforms.dev/services/bar',
+          path: '/some-other-path',
+          method: 'POST',
+          headers: {'X-Foo': 'bar'},
+          queryParams: {parameter: 'value'},
+          body: {field1: 'value', field2: 'value2'},
+          dataMappingType: 'JsonLogic',
+          mappingExpression: '{"var": "field"}',
+        },
+      ],
+    }}
+  >
+    <ServiceFetchConfigurationPicker {...args} />;
+  </FormContext.Provider>
+);
+
+## Presentation
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      onChange: () => {
+        null;
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Props
+
+<ArgsTable story="Default" />

--- a/src/openforms/scss/components/admin/_ReactModal.scss
+++ b/src/openforms/scss/components/admin/_ReactModal.scss
@@ -44,6 +44,11 @@
         margin-bottom: 0;
       }
     }
+
+    &--large {
+      width: 50vw;
+      height: 75vh;
+    }
   }
 
   &__header {

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -21,6 +21,7 @@
 @import './logic-trigger';
 @import './logic-action';
 @import './logic-type-selection';
+@import './servicefetchconfiguration_form';
 
 // form list
 @import './form-category';

--- a/src/openforms/scss/components/admin/_servicefetchconfiguration_form.scss
+++ b/src/openforms/scss/components/admin/_servicefetchconfiguration_form.scss
@@ -1,0 +1,3 @@
+.servicefetchconfiguration-form {
+  margin-top: 2em;
+}


### PR DESCRIPTION
Fixes #2661 

Based on #2620, which should be merged first


TODO:
- [x] Create form to create/edit ServiceFetchConfigurations
- [x] Picker to choose between existing/new
  - [x] when picking existing, show a dropdown to select a configuration, then use this data as input for the form
  - [x] when picking new, simply show the form
- [ ] implement onChange for form / select
- [ ] show existing config
- [ ] When editing existing, add a button to `Save` or `Copy and save`
- [ ] on close, remove data?
- [ ] Fix styling
  - [ ] margin for modal form
  - [ ] buttons
  - [ ] keep displaying select existing vs create new tiles or not?