### PR TITLE
Fix static asset serving with storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,9 +4,9 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   staticDirs: [
-    {from: '../static/admin', to: 'admin'},
-    {from: '../static/fonts', to: 'fonts'},
-    {from: '../static/img', to: 'img'},
+    {from: '../static/admin', to: 'static/admin'},
+    {from: '../static/fonts', to: 'static/fonts'},
+    {from: '../static/img', to: 'static/img'},
   ],
   addons: [
     '@storybook/addon-links',
@@ -25,12 +25,16 @@ module.exports = {
       path.resolve(__dirname, '../src/openforms/js'),
     ];
 
-    config.plugins = config.plugins.concat([new MiniCssExtractPlugin()]);
+    config.plugins = config.plugins.concat([
+      new MiniCssExtractPlugin({
+        filename: 'static/bundles/[name].css',
+      }),
+    ]);
 
     config.module.rules = config.module.rules.concat([
       // .scss
       {
-        test: /\.(sa|sc)ss$/,
+        test: /\.scss$/,
         use: [
           // Writes css files.
           MiniCssExtractPlugin.loader,
@@ -62,7 +66,6 @@ module.exports = {
         ],
       },
     ]);
-
     return config;
   },
 };

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<!-- In order to include these styles, the Django command `collectstatic` has to be used first -->
+<link rel="stylesheet" href="./static/admin/css/base.css" />
+<link rel="stylesheet" href="./static/admin/css/forms.css" />
+<link rel="stylesheet" href="./static/admin/css/widgets.css" />
+<link rel="stylesheet" href="./static/admin/css/admin-index.css" />

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,3 @@
-// In order to include these styles, the Django command `collectstatic` has to be used first
-import '../static/admin/css/admin-index.css';
-import '../static/admin/css/base.css';
-import '../static/admin/css/forms.css';
-import '../static/admin/css/widgets.css';
-
 import '../src/openforms/scss/screen.scss';
 import '../src/openforms/scss/admin/admin_overrides.scss';
 import {reactIntl} from './reactIntl.js';

--- a/src/openforms/scss/components/admin/_button.scss
+++ b/src/openforms/scss/components/admin/_button.scss
@@ -1,7 +1,9 @@
+@use 'microscope-sass/lib/bem';
+
 @import '../../vars';
 
 .button {
-  &--plain {
+  @include bem.modifier('plain') {
     width: 100%;
     border: none;
     background: transparent;
@@ -24,7 +26,7 @@
     }
   }
 
-  &--center {
+  @include bem.modifier('center') {
     text-align: center;
   }
 }
@@ -32,7 +34,7 @@
 .button-container {
   display: inline-block;
 
-  &--padded {
+  @include bem.modifier('padded') {
     padding: 1em;
   }
 }


### PR DESCRIPTION
Closes #2666

Fixed for both dev server and static build on a subpath.

* Emit the own CSS into a subpath matching the real structure
* Load the Django/library CSS via preview-head instead of adding it to the webpack toolchain. This simplifies things a lot.