### PR TITLE
enable opt-in to use X-Forwarded-Host headers

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -184,6 +184,11 @@ Other settings
 * ``IS_HTTPS``: Used to construct absolute URLs and controls a variety of
   security settings. Defaults to the inverse of ``DEBUG``.
 
+* ``USE_X_FORWARDED_HOST``: whether to grab the domain/host from the
+  ``X-Forwarded-Host`` request header or not. This header is typically set by reverse
+  proxies (such as nginx, traefik, Apache...). Default ``False`` - this is a header
+  that can be spoofed and you need to ensure you control it before enabling this.
+
 * ``DB_ENGINE``: Backend to use as database system. See
   `Django DATABASE settings`_ for a full list of backends. Only the default is
   supported but others might work. Defaults to ``django.db.backends.postgresql``

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -35,6 +35,7 @@ DEBUG = config("DEBUG", default=False)
 
 # = domains we're running on
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="", split=True)
+USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", default=False)
 
 IS_HTTPS = config("IS_HTTPS", default=not DEBUG)
 

--- a/src/openforms/tests/test_x_forwarded_host.py
+++ b/src/openforms/tests/test_x_forwarded_host.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright (C) 2021 Dimpact
+from django.test import RequestFactory, SimpleTestCase, override_settings, tag
+
+
+@tag("x-forwarded-for")
+class XForwardedHostTests(SimpleTestCase):
+    """
+    Test the opt-in behaviour of the X-Forwarded-For header.
+    """
+
+    factory = RequestFactory()
+
+    def test_default_disabled(self):
+        request = self.factory.get(
+            "/",
+            HTTP_X_FORWARDED_HOST="evil.com",
+        )
+
+        self.assertEqual(
+            request.get_host(),
+            "testserver",
+        )
+
+    @override_settings(
+        USE_X_FORWARDED_HOST=True,
+        ALLOWED_HOSTS=["upstream.proxy"],
+    )
+    def test_enabled(self):
+        request = self.factory.get(
+            "/",
+            HTTP_X_FORWARDED_HOST="upstream.proxy",
+        )
+
+        self.assertEqual(
+            request.get_host(),
+            "upstream.proxy",
+        )


### PR DESCRIPTION
Discussed with Sergei:

* Django only uses this header if the setting is explicitly enabled
* Only a single value is supported. This header can occur as
  comma-separated list if multiple upstream proxies are used. It's up to
  your infrastructure to ensure only a single value is passed to Django.

Use this if you cannot set the `Host` header (for example, using istio
in Kubernetes).