### PR TITLE
Decouple admin localisation from public UI

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -250,6 +250,8 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
+    # must come after django's middleware so that we can override the result from django
+    "openforms.translations.middleware.AdminLocaleMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/src/openforms/middleware.py
+++ b/src/openforms/middleware.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
 
+from django.http import HttpRequest
 from django.middleware.csrf import get_token
 
 from openforms.config.models import GlobalConfiguration
+from openforms.typing import RequestHandler
 
 SESSION_EXPIRES_IN_HEADER = "X-Session-Expires-In"
 CSRF_TOKEN_HEADER_NAME = "X-CSRFToken"
@@ -15,10 +17,10 @@ class SessionTimeoutMiddleware:
     is configured in our GlobalConfiguration
     """
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: RequestHandler):
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest):
         config = GlobalConfiguration.get_solo()
         timeout = (
             config.admin_session_timeout
@@ -38,10 +40,10 @@ class CsrfTokenMiddleware:
     Add a CSRF Token to a response header
     """
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: RequestHandler):
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest):
         response = self.get_response(request)
 
         # Only add the CSRF token header if it's an api endpoint
@@ -58,10 +60,10 @@ class CanNavigateBetweenStepsMiddleware:
     that have not been completed yet.
     """
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: RequestHandler):
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest):
         response = self.get_response(request)
 
         # Only add the header if it's an api endpoint

--- a/src/openforms/tests/test_session_expiry.py
+++ b/src/openforms/tests/test_session_expiry.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib import admin
 from django.test import override_settings
 from django.urls import path
 from django.utils import timezone
@@ -41,6 +42,7 @@ class SessionTestView(APIView):
 
 urlpatterns = [
     path("tests/session", SessionTestView.as_view()),
+    path("admin/", admin.site.urls),
 ]
 
 

--- a/src/openforms/translations/middleware.py
+++ b/src/openforms/translations/middleware.py
@@ -1,0 +1,54 @@
+import logging
+
+from django.conf import settings
+from django.http import HttpRequest
+from django.utils import translation
+
+from openforms.typing import RequestHandler
+from openforms.utils.urls import is_admin_request
+
+logger = logging.getLogger(__name__)
+
+
+def _remove_language_cookie_from_request(request: HttpRequest) -> None:
+    """
+    Produce a request instance without cookie-based language information.
+
+    settings.LANGUAGE_COOKIE_NAME
+    """
+    logger.debug(
+        "Removing the language cookie (if present) from request %r",
+        request,
+        extra={"request": request},
+    )
+    cookie_name = settings.LANGUAGE_COOKIE_NAME
+    if cookie_name in request.COOKIES:
+        del request.COOKIES[cookie_name]
+        logger.debug(
+            "Cookie %s was present but is now ignored.",
+            cookie_name,
+            extra={"request": request},
+        )
+
+
+class AdminLocaleMiddleware:
+    """
+    Discard the language cookie for locale-information.
+
+    While the language cookie is the primary mechanism to specify the desired language,
+    this applies to the public UI and not the admin. For the admin UI, we either use
+    the browser Accept-Language header or look up user preferences stored in the user
+    account itself.
+    """
+
+    def __init__(self, get_response: RequestHandler):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        # we do not language-code prefixed URLs
+        if is_admin_request(request):
+            _remove_language_cookie_from_request(request)
+            language = translation.get_language_from_request(request, check_path=False)
+            translation.activate(language)
+        response = self.get_response(request)
+        return response

--- a/src/openforms/translations/tests/test_admin_language_decoupling.py
+++ b/src/openforms/translations/tests/test_admin_language_decoupling.py
@@ -1,0 +1,29 @@
+from django.urls import reverse
+
+from django_webtest import WebTest
+
+from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.tests.utils import disable_2fa
+
+
+@disable_2fa
+class AdminLanguageTests(WebTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = SuperUserFactory.create()
+
+    def test_language_cookie_ignored_by_admin(self):
+        # sets the language cookie
+        _response = self.app.put_json(reverse("api:i18n:language"), {"code": "en"})
+        assert _response.headers["Content-Language"] == "en"
+        assert self.app.cookies["openforms_language"] == "en"
+
+        admin_index = self.app.get(
+            reverse("admin:index"),
+            headers={"Accept-Language": "nl-NL, nl;q=0.9, en;q=0.5"},
+            user=self.user,
+        )
+
+        self.assertEqual(admin_index["Content-Language"], "nl")

--- a/src/openforms/typing.py
+++ b/src/openforms/typing.py
@@ -1,4 +1,7 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Protocol, Union
+
+from django.http import HttpRequest
+from django.http.response import HttpResponseBase
 
 JSONPrimitive = Union[str, int, None, float, bool]
 
@@ -7,3 +10,8 @@ JSONValue = Union[JSONPrimitive, "JSONObject", List["JSONValue"]]
 JSONObject = Dict[str, JSONValue]
 
 DataMapping = Dict[str, Any]  # key: value pair
+
+
+class RequestHandler(Protocol):
+    def __call__(self, request: HttpRequest) -> HttpResponseBase:  # pragma: no cover
+        ...

--- a/src/openforms/utils/tests/test_urls.py
+++ b/src/openforms/utils/tests/test_urls.py
@@ -1,5 +1,5 @@
 from django.test import RequestFactory, TestCase, override_settings
-from django.urls import path, re_path
+from django.urls import path, re_path, reverse
 
 from openforms.utils.urls import build_absolute_uri, is_admin_request, reverse_plus
 
@@ -148,3 +148,14 @@ class IsAdminRequestTest(TestCase):
                 request = factory.get("/api/v1/foo", HTTP_REFERER=referer)
 
                 self.assertFalse(is_admin_request(request))
+
+    def test_is_admin_request_direct(self):
+        """
+        Test for requests directly hitting admin URLs.
+        """
+        factory = RequestFactory()
+        request = factory.get(reverse("admin:login"))
+
+        result = is_admin_request(request)
+
+        self.assertTrue(result)

--- a/src/openforms/utils/urls.py
+++ b/src/openforms/utils/urls.py
@@ -105,7 +105,10 @@ def is_admin_request(request: RequestType) -> bool:
 
     :arg request: the request object to be checked.
     """
+    admin_path_prefix = reverse("admin:index")
+    if request.path.startswith(admin_path_prefix):
+        return True
     if not (referrer := request.headers.get("Referer")):
         return False
-    admin_base = request.build_absolute_uri(reverse("admin:index"))
+    admin_base = request.build_absolute_uri(admin_path_prefix)
     return referrer.startswith(admin_base)


### PR DESCRIPTION
Closes #2685

This makes it so the admin uses the browser language preferences instead of the language cookie.

I will create a separate PR/feature so that admin users can manage their (language) preferences.