### PR TITLE
:alien: TokenProxy causing problems locally

### DIFF
--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -23,10 +23,6 @@
                 "token"
             ],
             [
-                "authtoken",
-                "tokenproxy"
-            ],
-            [
                 "mozilla_django_oidc_db",
                 "openidconnectconfig"
             ],

--- a/src/openforms/fixtures/default_groups.json
+++ b/src/openforms/fixtures/default_groups.json
@@ -669,26 +669,6 @@
                 "token"
             ],
             [
-                "add_tokenproxy",
-                "authtoken",
-                "tokenproxy"
-            ],
-            [
-                "change_tokenproxy",
-                "authtoken",
-                "tokenproxy"
-            ],
-            [
-                "delete_tokenproxy",
-                "authtoken",
-                "tokenproxy"
-            ],
-            [
-                "view_tokenproxy",
-                "authtoken",
-                "tokenproxy"
-            ],
-            [
                 "add_accessattempt",
                 "axes",
                 "accessattempt"


### PR DESCRIPTION
Loading the default_admin_index.json locally was crashing for me locally

```
(open-forms) ➜  open-forms git:(master) runtests src --exclude-tag=e2e
Using existing test database for alias 'default'...
Traceback (most recent call last):
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/contrib/contenttypes/models.py", line 19, in get_by_natural_key
    ct = self._cache[self.db][(app_label, model)]
KeyError: ('authtoken', 'tokenproxy')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/serializers/base.py", line 292, in deserialize_m2m_values
    values.append(m2m_convert(pk))
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/serializers/base.py", line 278, in m2m_convert
    return model._default_manager.db_manager(using).get_by_natural_key(*value).pk
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/contrib/contenttypes/models.py", line 21, in get_by_natural_key
    ct = self.get(app_label=app_label, model=model)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/db/models/query.py", line 435, in get
    raise self.model.DoesNotExist(
django_admin_index.models.ContentTypeProxy.DoesNotExist: ContentTypeProxy matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/serializers/base.py", line 239, in save_deferred_fields
    values = deserialize_m2m_values(field, field_value, using, handle_forward_references=False)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/serializers/base.py", line 298, in deserialize_m2m_values
    raise M2MDeserializationError(e, pk)
django.core.serializers.base.M2MDeserializationError: (DoesNotExist('ContentTypeProxy matching query does not exist.'), ['authtoken', 'tokenproxy'])

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bbt/code/open-forms/src/manage.py", line 24, in <module>
    execute_from_command_line(sys.argv)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/commands/test.py", line 23, in run_from_argv
    super().run_from_argv(argv)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/commands/test.py", line 55, in handle
    failures = test_runner.run_tests(test_labels)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/test/runner.py", line 725, in run_tests
    old_config = self.setup_databases(aliases=databases)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/test/runner.py", line 643, in setup_databases
    return _setup_databases(
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/test/utils.py", line 179, in setup_databases
    connection.creation.create_test_db(
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/db/backends/base/creation.py", line 74, in create_test_db
    call_command(
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/__init__.py", line 181, in call_command
    return command.execute(*args, **defaults)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/commands/migrate.py", line 268, in handle
    emit_post_migrate_signal(
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/sql.py", line 42, in emit_post_migrate_signal
    models.signals.post_migrate.send(
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 180, in send
    return [
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 181, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
  File "/home/bbt/code/open-forms/src/openforms/accounts/apps.py", line 22, in update_admin_index
    call_command("loaddata", "default_admin_index", verbosity=0, stdout=StringIO())
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/__init__.py", line 181, in call_command
    return command.execute(*args, **defaults)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/modeltranslation/management/commands/loaddata.py", line 49, in handle
    return super(Command, self).handle(*fixture_labels, **options)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/commands/loaddata.py", line 78, in handle
    self.loaddata(fixture_labels)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/management/commands/loaddata.py", line 125, in loaddata
    obj.save_deferred_fields(using=self.using)
  File "/home/bbt/.virtualenvs/open-forms/lib/python3.10/site-packages/django/core/serializers/base.py", line 241, in save_deferred_fields
    raise DeserializationError.WithData(e.original_exc, label, self.object.pk, e.pk)
django.core.serializers.base.DeserializationError: ContentTypeProxy matching query does not exist.: (admin_index.appgroup:pk=8) field_value was '['authtoken', 'tokenproxy']'

```