### PR TITLE
:arrow_up: Bump design tokens to 0.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
-        "@open-formulieren/design-tokens": "^0.21.2",
+        "@open-formulieren/design-tokens": "^0.23.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^3.12.6",
         "@trivago/prettier-plugin-sort-imports": "^4.0.0",
@@ -3739,9 +3739,9 @@
       }
     },
     "node_modules/@open-formulieren/design-tokens": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.21.2.tgz",
-      "integrity": "sha512-/PT5R0zPpqCdvUvBoRT4JaHnGz98eYgBFP0ZeCyUc+UHHOUG2mUPRSxo+a2FYyAtu7wo2GStFzY0uj43M+Y6ZQ=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.23.0.tgz",
+      "integrity": "sha512-6vIaSC7oL11ZIiAG47ffdBShYQpmAXYGI5n86jLqrU7q5fPxVQT7Z2Bjk8K+my3myN5TXR552tViRwSntM0NzQ=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -33133,9 +33133,9 @@
       }
     },
     "@open-formulieren/design-tokens": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.21.2.tgz",
-      "integrity": "sha512-/PT5R0zPpqCdvUvBoRT4JaHnGz98eYgBFP0ZeCyUc+UHHOUG2mUPRSxo+a2FYyAtu7wo2GStFzY0uj43M+Y6ZQ=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.23.0.tgz",
+      "integrity": "sha512-6vIaSC7oL11ZIiAG47ffdBShYQpmAXYGI5n86jLqrU7q5fPxVQT7Z2Bjk8K+my3myN5TXR552tViRwSntM0NzQ=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://maykinmedia.nl",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.21.2",
+    "@open-formulieren/design-tokens": "^0.23.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^3.12.6",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",


### PR DESCRIPTION
To align the version with the version used in the SDK.