### PR TITLE
Add additional robustness tests with hypothesis

### DIFF
--- a/src/openforms/tests/search_strategies.py
+++ b/src/openforms/tests/search_strategies.py
@@ -1,0 +1,43 @@
+from string import ascii_letters
+
+from django.core.exceptions import ValidationError
+
+from hypothesis import strategies as st
+
+from openforms.forms.models.form_variable import variable_key_validator
+from openforms.typing import JSONPrimitive, JSONValue
+
+json_primitives: st.SearchStrategy[JSONPrimitive]
+json_primitives = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_infinity=False, allow_nan=False),
+    st.text(),
+)
+
+
+def json_collections(
+    values,
+) -> st.SearchStrategy[dict[str, JSONValue] | list[JSONValue]]:
+    return st.one_of(
+        st.dictionaries(keys=st.text(), values=values),
+        st.lists(values),
+    )
+
+
+def json_values(*, max_leaves: int = 15) -> st.SearchStrategy[JSONValue]:
+    return st.recursive(json_primitives, json_collections, max_leaves=max_leaves)
+
+
+def valid_key(key: str) -> bool:
+    try:
+        variable_key_validator(key)
+    except ValidationError:
+        return False
+    return True
+
+
+formio_component_key = st.text(min_size=1, alphabet=".-" + ascii_letters).filter(
+    valid_key
+)

--- a/src/openforms/variables/tests/test_validators.py
+++ b/src/openforms/variables/tests/test_validators.py
@@ -5,7 +5,8 @@ from django.test import SimpleTestCase
 
 from hypothesis import given, strategies as st
 
-from openforms.typing import JSONPrimitive, JSONValue
+from openforms.tests.search_strategies import json_values
+from openforms.typing import JSONValue
 
 from ..validators import HeaderValidator, ValidationError
 
@@ -18,29 +19,6 @@ CR = "\x0d"
 LF = "\x0a"
 NUL = "\x00"
 FIELD_VALUE_ALPHABET = "".join((VCHAR, OBS_TEXT, SP, HTAB))
-
-
-json_primitives: st.SearchStrategy[JSONPrimitive]
-json_primitives = st.one_of(
-    st.none(),
-    st.booleans(),
-    st.integers(),
-    st.floats(allow_infinity=False, allow_nan=False),
-    st.text(),
-)
-
-
-def json_collections(
-    values,
-) -> st.SearchStrategy[dict[str, JSONValue] | list[JSONValue]]:
-    return st.one_of(
-        st.dictionaries(keys=st.text(), values=values),
-        st.lists(values),
-    )
-
-
-def json_values(*, max_leaves: int = 15) -> st.SearchStrategy[JSONValue]:
-    return st.recursive(json_primitives, json_collections, max_leaves=max_leaves)
 
 
 def field_names() -> st.SearchStrategy[str]:


### PR DESCRIPTION
Closes #2814

The possible combinations of the 'conditional' component key are now parametrized via hypothesis, with an example as seen to be crashing in Sentry.

The actual fix was already included in 9c00f7f4cb4079d4949105faec76c77f68d6d3fd so no further action is required.