### PR TITLE
[#2820] Translations in edit form are not working properly yet

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormStep.js
+++ b/src/openforms/js/components/admin/form_design/FormStep.js
@@ -19,7 +19,7 @@ const FormStep = ({data, onEdit, onComponentMutated, onFieldChange, onReplace}) 
     isReusable,
     isNew,
     validationErrors = [],
-    componentTranslations = {},
+    componentTranslations,
   } = data;
   const previousFormDefinition = usePrevious(formDefinition);
   let forceBuilderUpdate = false;

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -46,7 +46,7 @@ const FormStepDefinition = ({
   loginRequired = false,
   isReusable = false,
   translations = {},
-  componentTranslations = {},
+  componentTranslations,
   configuration = emptyConfiguration,
   onChange,
   onComponentMutated,
@@ -357,7 +357,7 @@ FormStepDefinition.propTypes = {
       nextText: PropTypes.string.isRequired,
     })
   ),
-  componentTranslations: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+  componentTranslations: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)).isRequired,
 };
 
 const ConfigurationErrors = ({errors = []}) => {

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -134,6 +134,7 @@ const newStepData = {
   url: '',
   _generatedId: '', // Consumers should generate this if there is no form definition url
   isNew: true,
+  componentTranslations: {},
   validationErrors: [],
 };
 

--- a/src/openforms/js/components/admin/form_design/types/FormStep.js
+++ b/src/openforms/js/components/admin/form_design/types/FormStep.js
@@ -20,7 +20,7 @@ const FormStep = PropTypes.shape({
       nextText: PropTypes.string.isRequired,
     })
   ),
-  componentTranslations: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+  componentTranslations: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)).isRequired,
 });
 
 export default FormStep;

--- a/src/openforms/js/components/form/content.js
+++ b/src/openforms/js/components/form/content.js
@@ -58,40 +58,34 @@ const CONTENT_EDIT_TABS = {
         {
           components: [
             {
-              ...TRANSLATIONS,
-              hideLabel: true,
-              components: [
-                {
-                  key: 'languages',
-                  type: 'tabs',
-                  components: getSupportedLanguages().map(([languageCode, _label]) => {
-                    return {
-                      key: languageCode,
-                      label: languageCode.toUpperCase(),
-                      components: [
-                        {
-                          label: 'Literal',
-                          hideLabel: true,
-                          key: `openForms.translations.${languageCode}[0].literal`,
-                          input: true,
-                          unique: true,
-                          type: 'hidden',
-                        },
-                        {
-                          label: 'Translation',
-                          hideLabel: true,
-                          key: `openForms.translations.${languageCode}[0].translation`,
-                          input: true,
-                          type: 'textarea',
-                          editor: 'ckeditor',
-                          as: 'html',
-                          rows: 3,
-                        },
-                      ],
-                    };
-                  }),
-                },
-              ],
+              key: 'languages',
+              type: 'tabs',
+              components: getSupportedLanguages().map(([languageCode, _label]) => {
+                return {
+                  key: languageCode,
+                  label: languageCode.toUpperCase(),
+                  components: [
+                    {
+                      label: 'Literal',
+                      hideLabel: true,
+                      key: `openForms.translations.${languageCode}[0].literal`,
+                      input: true,
+                      unique: true,
+                      type: 'hidden',
+                    },
+                    {
+                      label: 'Translation',
+                      hideLabel: true,
+                      key: `openForms.translations.${languageCode}[0].translation`,
+                      input: true,
+                      type: 'textarea',
+                      editor: 'ckeditor',
+                      as: 'html',
+                      rows: 3,
+                    },
+                  ],
+                };
+              }),
             },
           ],
         },

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -466,7 +466,7 @@ FormIOBuilder.propTypes = {
   configuration: PropTypes.object,
   onChange: PropTypes.func,
   onComponentMutated: PropTypes.func,
-  componentTranslations: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+  componentTranslations: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)).isRequired,
   componentNamespace: PropTypes.arrayOf(PropTypes.object),
   forceUpdate: PropTypes.bool,
 };

--- a/src/openforms/js/utils/hooks.js
+++ b/src/openforms/js/utils/hooks.js
@@ -2,6 +2,8 @@ import isEqual from 'lodash/isEqual';
 import {useEffect} from 'react';
 import usePrevious from 'react-use/esm/usePrevious';
 
+// FIXME: code is duplicated between this file and components/admin/form_design/logic/hooks
+
 /**
  * Invoke a callback if the value has changed (deep equal comparison).
  */


### PR DESCRIPTION
Fixes #2820 

Notes:
- I don't seem to be able to reproduce the original issue anymore (the content component not saving the translations). But I wrote a playwright test and it still seems to show that it doesn't work.
- What seems to happen now is that if you: 

   1. create a component and add some translations
   2. save the component
   3. Open the component to edit it
   4. click X in the top right of the modal to close without any changes
   5. Open the component again

then the translations have vanished.
