### PR TITLE
[#2826] validate date value in logic rules

### DIFF
--- a/src/openforms/forms/api/validators.py
+++ b/src/openforms/forms/api/validators.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from django.utils.translation import gettext as _
 
@@ -15,24 +15,6 @@ from openforms.utils.json_logic.api.validators import JsonLogicValidator
 from openforms.variables.service import get_static_variables
 
 from ..validation.registry import register as formio_validators_registry
-
-
-class JsonLogicActionValueValidator(JsonLogicValidator):
-    code = "invalid"
-    message = _("This field needs to refer to a form component")
-
-    def __call__(self, value: Union[dict, str]) -> None:
-        if isinstance(value, (str, int, bool)):
-            return
-
-        # ensure that the expression itself is valid
-        super().__call__(value)
-
-        expression = JSONLogicExpression.from_expression(value)
-        tree = expression.as_tree()
-        assert isinstance(tree, Operation)
-        if tree.arguments[0] == "":
-            raise serializers.ValidationError(self.message, code=self.code)
 
 
 class JsonLogicTriggerValidator(JsonLogicValidator):

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+
+from hypothesis import given
+from hypothesis.extra.django import TestCase as HypothesisTestCase
+from json_logic.typing import Primitive
+
+from openforms.forms.api.datastructures import FormVariableWrapper
+from openforms.forms.api.serializers.logic.action_serializers import (
+    LogicComponentActionSerializer,
+)
+from openforms.forms.tests.factories import FormFactory, FormVariableFactory
+from openforms.tests.search_strategies import json_values
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+
+json_values_primitive = json_values().filter(lambda j: isinstance(j, Primitive))
+
+
+class LogicComponentActionSerializerPropertyTest(HypothesisTestCase):
+    @given(json_values_primitive)
+    def test_date_format_validation_against_primitive_json_values(self, json_value):
+        """Assert that serializer is invalid for random Primitive json data types
+        (str, int, etc.) as logic action values for date variables
+        """
+        form = FormFactory.create()
+        FormVariableFactory.create(
+            source=FormVariableSources.user_defined,
+            key="date_var",
+            form=form,
+            data_type=FormVariableDataTypes.date,
+        )
+        form_vars = FormVariableWrapper(form=form)
+
+        serializer = LogicComponentActionSerializer(
+            data={
+                "variable": "date_var",
+                "action": {
+                    "type": "variable",
+                    "value": json_value,
+                },
+            },
+            context={"request": None, "form_variables": form_vars},
+        )
+        self.assertFalse(serializer.is_valid())
+
+
+class LogicComponentActionSerializerTest(TestCase):
+    def test_date_variable_with_non_trivial_json_trigger(self):
+        """Check that valid JSON expressions are not ruled out by date format validation"""
+        form = FormFactory.create()
+        FormVariableFactory.create(
+            source=FormVariableSources.user_defined,
+            key="someDate",
+            form=form,
+            data_type=FormVariableDataTypes.date,
+        )
+        FormVariableFactory.create(
+            source=FormVariableSources.user_defined,
+            key="anotherDate",
+            form=form,
+            data_type=FormVariableDataTypes.date,
+        )
+        form_vars = FormVariableWrapper(form=form)
+
+        serializer = LogicComponentActionSerializer(
+            data={
+                "json_logic_trigger": {
+                    "==": [
+                        {"var": "someDate"},
+                        {},
+                    ]
+                },
+                "variable": "anotherDate",
+                "action": {
+                    "type": "variable",
+                    "value": {"var": "anotherDate"},
+                },
+            },
+            context={"request": None, "form_variables": form_vars},
+        )
+
+        self.assertTrue(serializer.is_valid())

--- a/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
+++ b/src/openforms/forms/tests/variables/test_variables_in_logic_trigger.py
@@ -81,7 +81,6 @@ class VariablesInLogicBulkAPITests(APITestCase):
         FormVariableFactory.create(
             source=FormVariableSources.user_defined, key="testUserDefined", form=form
         )
-
         form_logic_data = [
             {
                 "form": f"http://testserver{reverse('api:form-detail', kwargs={'uuid_or_slug': form.uuid})}",
@@ -116,6 +115,84 @@ class VariablesInLogicBulkAPITests(APITestCase):
             "The specified variable is not related to the form",
             error["invalidParams"][0]["reason"],
         )
+
+    def test_invalid_date_format_for_user_defined_variable(self):
+        user = SuperUserFactory.create()
+        form = FormFactory.create()
+        FormVariableFactory.create(
+            source=FormVariableSources.user_defined,
+            key="date_var",
+            form=form,
+            data_type=FormVariableDataTypes.date,
+        )
+        form_logic_data = [
+            {
+                "form": f"http://testserver{reverse('api:form-detail', kwargs={'uuid_or_slug': form.uuid})}",
+                "order": 0,
+                "json_logic_trigger": {"!!": [True]},
+                "actions": [
+                    {
+                        "variable": "date_var",
+                        "action": {
+                            "type": "variable",
+                            "value": "07-03-2023",  # not isoformat
+                        },
+                    }
+                ],
+            }
+        ]
+
+        self.client.force_authenticate(user=user)
+        url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
+        response = self.client.put(url, data=form_logic_data)
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
+        error = response.json()
+
+        self.assertEqual("invalid", error["code"])
+        self.assertEqual(
+            "Value for date variable must be a string in the format yyyy-mm-dd (e.g. 2023-07-03)",
+            error["invalidParams"][0]["reason"],
+        )
+        self.assertEqual(error["invalidParams"][0]["name"], "0.actions.0.action.value")
+
+    def test_valid_date_format_for_user_defined_variable(self):
+        user = SuperUserFactory.create()
+        form = FormFactory.create()
+        FormVariableFactory.create(
+            source=FormVariableSources.user_defined,
+            key="date_var",
+            form=form,
+            data_type=FormVariableDataTypes.date,
+        )
+        form_logic_data = [
+            {
+                "form": f"http://testserver{reverse('api:form-detail', kwargs={'uuid_or_slug': form.uuid})}",
+                "order": 0,
+                "json_logic_trigger": {
+                    "==": [
+                        {"var": "now"},
+                        "2021-07-16T21:15:00+00:00",
+                    ]
+                },
+                "actions": [
+                    {
+                        "variable": "date_var",
+                        "action": {
+                            "type": "variable",
+                            "value": "2023-03-07",  # isoformat
+                        },
+                    }
+                ],
+            }
+        ]
+
+        self.client.force_authenticate(user=user)
+        url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
+        response = self.client.put(url, data=form_logic_data)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_static_variable_in_trigger(self):
         user = SuperUserFactory.create()


### PR DESCRIPTION
Fixes #2826

* values for date variables in logic rules should be specified in ISO 8601fomat
* removed `JsonLogicActionValueValidator` since it's no longer needed and replaced with basic `JsonLogicValidator`