### PR TITLE
Fix broken component key flow

### DIFF
--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -52,7 +52,11 @@ class WebformBuilder extends WebformBuilderFormio {
   // steps as an option to the webform.
   findNamespaceRoot(component) {
     const customNamespace = this.webform?.options?.openForms?.componentNamespace;
-    if (!isEmpty(customNamespace)) return customNamespace;
+    if (!isEmpty(customNamespace)) {
+      // exclude components that don't have an ID yet, otherwise the first component of
+      // a type gets a key suffixed with '1';
+      return customNamespace.filter(comp => !!comp.id);
+    }
 
     return super.findNamespaceRoot(component);
   }

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -420,6 +420,7 @@ const FormIOBuilder = ({
         })
         .then(() => {
           instance.root.triggerChange(flags, changed, modifiedByHuman);
+          instance.root.redraw();
         });
     }
   };

--- a/src/openforms/tests/e2e/base.py
+++ b/src/openforms/tests/e2e/base.py
@@ -16,10 +16,11 @@ HEADLESS = "NO_E2E_HEADLESS" not in os.environ
 BROWSER: Literal["chromium", "firefox", "webkit"] = os.getenv(
     "E2E_DRIVER", default="chromium"
 )  # type:ignore
+SLOW_MO = int(os.environ.get("SLOW_MO", "100"))
 
 LAUNCH_KWARGS = {
     "headless": HEADLESS,
-    "slow_mo": 100 if HEADLESS else None,
+    "slow_mo": SLOW_MO,
 }
 
 


### PR DESCRIPTION
* Fixes the initial key getting a suffix due to unsaved component
* Fixes the UI not properly showing the underlying updated key (the data actually seemed fine)
* Now tests locally also use a 100ms delay, which made the test failing on CI but passing locally (because the JS itself didn't fully complete and there was a small flicker where the UI was as expected)

This mutable refs + formio state + react state is a _horrible_ combination and would definitely benefit from a react-based form builder to get some sanity back.