### PR TITLE
:wastebasket: Deprecate the password field

### DIFF
--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -366,6 +366,7 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
             ).to_be_visible()
 
             await add_new_step(page)
+            await page.get_by_text("Verouderd").click()
             await drag_and_drop_component(page, "Wachtwoord")
             # save with the defaults
             await page.get_by_role("button", name="Opslaan").first.click()

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -48,7 +48,6 @@ const getBuilderOptions = () => {
           phoneNumber: true,
           postcode: true,
           file: true,
-          password: true,
         },
       },
       custom_special: {
@@ -242,6 +241,7 @@ const getBuilderOptions = () => {
         weight: 15,
         components: {
           postcode: true,
+          password: true,
         },
       },
     },


### PR DESCRIPTION
After checking customer instances and getting in touch with customers, it turns out nobody is actually using this component. Given that the data is stored in plain text and pre-existing security/expectation concerns, it is decided to not invest any more effort but instead move the component to the deprecated group.

In the future we'll probably convert any possible existing components to textfields and remove it alltogether.