### PR TITLE
Fix logic crashes in celery task

### DIFF
--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import asdict
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from django.db.models import Model
@@ -498,13 +499,11 @@ def submission_logic_evaluated(
     Convert into JSON-serializable data types and schedule the celery task.
     """
     timestamp = timezone.now().isoformat()
-    _evaluated_rules = [
-        {
-            "rule_id": evaluated_rule.rule.id,
-            "triggered": evaluated_rule.triggered,
-        }
-        for evaluated_rule in evaluated_rules
-    ]
+    _evaluated_rules = []
+    for evaluated_rule in map(asdict, evaluated_rules):
+        evaluated_rule["rule_id"] = evaluated_rule["rule"].id
+        del evaluated_rule["rule"]
+        _evaluated_rules.append(evaluated_rule)
 
     log_logic_evaluation.delay(
         submission_id=submission.id,

--- a/src/openforms/logging/logic.py
+++ b/src/openforms/logging/logic.py
@@ -55,10 +55,14 @@ def log_logic_evaluation(
         rule_introspection = introspect_json_logic(trigger)
         # Gathering all the input component of each evaluated rule
         input_data += rule_introspection.get_input_components(
-            components_map, initial_data
+            components_map, initial_data, evaluated_rule.action_log_data["context"]
         )
         targeted_components = get_targeted_components(
-            rule, components_map, all_variables, initial_data
+            rule,
+            components_map,
+            all_variables,
+            initial_data,
+            evaluated_rule.action_log_data,
         )
         evaluated_rule_data = {
             "raw_logic_expression": trigger,

--- a/src/openforms/logging/logic.py
+++ b/src/openforms/logging/logic.py
@@ -55,7 +55,7 @@ def log_logic_evaluation(
         rule_introspection = introspect_json_logic(trigger)
         # Gathering all the input component of each evaluated rule
         input_data += rule_introspection.get_input_components(
-            components_map, initial_data, evaluated_rule.action_log_data["context"]
+            components_map, initial_data
         )
         targeted_components = get_targeted_components(
             rule,

--- a/src/openforms/logging/tasks.py
+++ b/src/openforms/logging/tasks.py
@@ -3,12 +3,13 @@ from typing import List, TypedDict
 
 from openforms.celery import app
 from openforms.forms.models import FormLogic
-from openforms.typing import JSONObject
+from openforms.typing import JSONObject, JSONValue
 
 
 class EvaluatedRuleDict(TypedDict):
     rule_id: int
     triggered: bool
+    action_log_data: dict[int, JSONValue]
 
 
 @app.task(ignore_result=True)
@@ -36,7 +37,11 @@ def log_logic_evaluation(
         )
     }
     _evaluated_rules = [
-        EvaluatedRule(rule=rules[item["rule_id"]], triggered=item["triggered"])
+        EvaluatedRule(
+            rule=rules[item["rule_id"]],
+            triggered=item["triggered"],
+            action_log_data=item["action_log_data"],
+        )
         for item in evaluated_rules
     ]
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -213,7 +213,7 @@ class VariableAction(ActionOperation):
         return {
             "key": self.variable,
             "type_display": LogicActionTypes.get_label(LogicActionTypes.variable),
-            "value": log_data["value"],
+            "value": log_data.get("value", ""),  # error caught by log_errors in `eval`
         }
 
 

--- a/src/openforms/submissions/logic/log_utils.py
+++ b/src/openforms/submissions/logic/log_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from openforms.forms.models import FormLogic, FormVariable
 from openforms.logging import logevent
-from openforms.typing import JSONObject
+from openforms.typing import JSONObject, JSONValue
 
 logger = logging.getLogger(__name__)
 
@@ -14,17 +14,17 @@ def get_targeted_components(
     components_map: dict,
     all_variables: Dict[str, FormVariable],
     initial_data: dict,
+    action_log_data: dict[int, JSONValue],
 ) -> List[dict]:
-    targeted_components = []
-    for action_operation in rule.action_operations:
-        action_log_data = action_operation.get_action_log_data(
+    return [
+        action_operation.get_action_log_data(
             component_map=components_map,
             all_variables=all_variables,
             initial_data=initial_data,
+            log_data=action_log_data.get(str(i), {}),  # XXX who str'd my int?
         )
-        targeted_components.append(action_log_data)
-
-    return targeted_components
+        for i, action_operation in enumerate(rule.action_operations)
+    ]
 
 
 @contextlib.contextmanager

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -118,9 +118,6 @@ class EvaluatedRule:
     # This is a mapping, not a sequence, because operations may not log data.
     action_log_data: dict[int, JSONValue] = field(default_factory=dict)
 
-    def __post_init__(self):
-        self.action_log_data["context"] = self.action_log_data.get("context", {})
-
 
 def iter_evaluate_rules(
     rules: Iterable[FormLogic],
@@ -156,11 +153,7 @@ def iter_evaluate_rules(
                     jsonLogic(rule.json_logic_trigger, data_container.data)
                 )
 
-            evaluated_rule = EvaluatedRule(
-                rule=rule,
-                triggered=triggered,
-                action_log_data={"context": data_container.data},
-            )
+            evaluated_rule = EvaluatedRule(rule=rule, triggered=triggered)
 
             if not triggered:
                 on_rule_check(evaluated_rule)

--- a/src/openforms/submissions/logic/service_fetching.py
+++ b/src/openforms/submissions/logic/service_fetching.py
@@ -1,12 +1,24 @@
+from dataclasses import dataclass
+
 import jq
 from json_logic import jsonLogic
 
 from openforms.forms.models import FormVariable
-from openforms.typing import DataMapping, JSONValue
+from openforms.typing import DataMapping, JSONObject, JSONValue
 from openforms.variables.models import DataMappingTypes, ServiceFetchConfiguration
 
 
-def perform_service_fetch(var: FormVariable, context: DataMapping) -> JSONValue:
+@dataclass
+class FetchResult:
+    value: JSONValue
+    request_parameters: JSONObject
+    response_json: JSONValue
+    # zds Client returns json, we don't have access to
+    # response_body: str  # base64 as services could return any bytearray
+    # response_headers: JSONObject
+
+
+def perform_service_fetch(var: FormVariable, context: DataMapping) -> FetchResult:
     """Fetch a value from a http-service, perform a transformation on it and
     return the result.
 
@@ -36,4 +48,9 @@ def perform_service_fetch(var: FormVariable, context: DataMapping) -> JSONValue:
             value = jsonLogic(expression, raw_value)
         case _:
             value = raw_value
-    return value
+
+    return FetchResult(
+        value=value,
+        request_parameters=request_args,
+        response_json=raw_value,
+    )

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
@@ -65,7 +65,8 @@ class ServiceFetchConfigVariableBindingTests(SimpleTestCase):
             )
         )
 
-        value = perform_service_fetch(var, {})
+        result = perform_service_fetch(var, {})
+        value = result.value
 
         self.assertEqual(value["url"], "https://httpbin.org/get")
 
@@ -384,7 +385,8 @@ class ServiceFetchConfigVariableBindingTests(SimpleTestCase):
             )
         )
 
-        value = perform_service_fetch(var, {})
+        result = perform_service_fetch(var, {})
+        value = result.value
 
         self.assertEqual(value, "https://httpbin.org/get")
 
@@ -401,7 +403,8 @@ class ServiceFetchConfigVariableBindingTests(SimpleTestCase):
             )
         )
 
-        value = perform_service_fetch(var, {})
+        result = perform_service_fetch(var, {})
+        value = result.value
 
         self.assertEqual(value, "https://httpbin.org/get")
 
@@ -420,7 +423,8 @@ class ServiceFetchConfigVariableBindingTests(SimpleTestCase):
             )
         )
 
-        value = perform_service_fetch(var, {})
+        result = perform_service_fetch(var, {})
+        value = result.value
 
         self.assertEqual(value, "https://httpbin.org/get")
 

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1,12 +1,17 @@
+import json
 from unittest import expectedFailure
 
+from django.db import connection
 from django.test import override_settings, tag
 
 from freezegun import freeze_time
+from hypothesis import assume, example, given
+from hypothesis.extra.django import TestCase as HypothesisTestCase
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
+from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -14,7 +19,12 @@ from openforms.forms.tests.factories import (
     FormVariableFactory,
 )
 from openforms.logging.models import TimelineLogProxy
+from openforms.typing import JSONValue
+from openforms.utils.json_logic.api.validators import JsonLogicValidator
 from openforms.variables.constants import FormVariableDataTypes
+from openforms.variables.tests.test_validators import (  # NOTE: this is moved in master
+    jsonb_values,
+)
 
 from ...form_logic import evaluate_form_logic
 from ..factories import SubmissionFactory, SubmissionStepFactory
@@ -905,8 +915,25 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         self.assertEqual(data["step"]["data"], {})
 
 
+def is_valid_expression(expr: dict):
+    try:
+        JsonLogicValidator()(expr)
+    except Exception:
+        return False
+    return True
+
+
+def is_jsonb_invariant(value: JSONValue) -> bool:
+    serialized = json.dumps(value)
+    query = "SELECT %s::jsonb"
+    with connection.cursor() as cursor:
+        cursor.execute(query, params=(serialized,))
+        result = cursor.fetchone()[0]
+    return json.loads(result) == value
+
+
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
+class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase, HypothesisTestCase):
     def test_evaluate_logic_with_default_values(self):
         form = FormFactory.create(
             generate_minimal_setup=True,
@@ -1267,3 +1294,72 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
         logged_rule = logs[0].content_object
 
         self.assertEqual(logged_rule, logic_rule)
+
+    @given(jsonb_values())
+    @example({"var": "foo"})
+    @example([])
+    @example(1.801439850948199e16)
+    def test_it_logs_setting_variable(self, new_value: JSONValue):
+        assume(is_jsonb_invariant(new_value))
+
+        if isinstance(new_value, (dict, list)):
+            assume(is_valid_expression(new_value))
+
+        var = FormVariableFactory.create(key="myKey")
+
+        FormLogicFactory.create(
+            form=var.form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "variable": "myKey",
+                    "action": {
+                        "type": LogicActionTypes.variable,
+                        "value": new_value,
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=var.form)
+        submission_step = SubmissionStepFactory.create(
+            submission=submission,
+        )
+
+        evaluate_form_logic(submission, submission_step, submission.get_merged_data())
+
+        log_entry = TimelineLogProxy.objects.get(
+            template="logging/events/submission_logic_evaluated.txt",
+        )
+        extra_data = log_entry.extra_data
+        if not is_valid_expression(new_value):
+            # is primitive
+            self.assertEqual(extra_data["resolved_data"]["myKey"], new_value)
+
+        self.assertEqual(
+            extra_data["evaluated_rules"][0]["targeted_components"][0]["key"], "myKey"
+        )
+        self.assertEqual(
+            extra_data["evaluated_rules"][0]["targeted_components"][0]["type_display"],
+            "Stel de waarde van een variabele in",
+        )
+
+    def test_logging_static_variable_use_in_trigger(self):
+        submission = SubmissionFactory.create()
+        json_logic_trigger = {
+            "==": [{"var": "today"}, {"+": [{"today": []}, {"rdelta": [0, 0, 0]}]}]
+        }
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger=json_logic_trigger,
+            actions=[],
+        )
+        submission_step = SubmissionStepFactory.create(
+            submission=submission,
+        )
+
+        evaluate_form_logic(submission, submission_step, submission.get_merged_data())
+
+        log_entry = TimelineLogProxy.objects.get(
+            template="logging/events/submission_logic_evaluated.txt",
+        )
+        self.assertIn("today", log_entry.extra_data["input_data"])

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1297,6 +1297,7 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase, HypothesisTestC
 
     @given(jsonb_values())
     @example({"var": "foo"})
+    @example([{"/": None}])
     @example([])
     @example(1.801439850948199e16)  # this is filtered out by the assume
     def test_it_logs_setting_variable(self, new_value: JSONValue):
@@ -1334,11 +1335,7 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase, HypothesisTestC
         if isinstance(new_value, JSONPrimitive):
             # for primitives we know the value
             self.assertEqual(resolved_value, new_value)
-        elif is_valid_expression(new_value):
-            # could be flaky, but it's extremely unlikely to randomly get a valid
-            # "var" expression —like the one from the @example— but nested somewhere.
-            self.assertIn(resolved_value, (None, new_value))
-        else:
+        elif not is_valid_expression(new_value):
             # object but invalid json logic expression
             self.assertEqual(resolved_value, "None")
 

--- a/src/openforms/utils/json_logic/datastructures.py
+++ b/src/openforms/utils/json_logic/datastructures.py
@@ -46,7 +46,6 @@ class ExpressionIntrospection:
         self,
         components_map: ComponentsMap,
         input_data: dict[str, JSON],
-        context: DataMapping,
     ) -> list[InputVar]:
         inputs = []
 
@@ -58,24 +57,17 @@ class ExpressionIntrospection:
 
             # TODO: this *may* be nested var.var expressions
             key = cast(str, node.arguments[0])
-            if key not in components_map:
-                try:
-                    inputs.append(
-                        InputVar(
-                            key=key, value=glom(context, key), step_name="", label=""
-                        )
-                    )
-                except PathAccessError:
-                    pass  # well, we tried.
-                continue
-            component_meta = components_map[key]
+            step_name = label = ""
+            if component_meta := components_map.get(key):
+                step_name = component_meta.form_step.form_definition.name
+                label = component_meta.component.get("label", "")
             inputs.append(
                 InputVar(
                     key=key,
-                    value=input_data.get(key, ""),
-                    step_name=component_meta.form_step.form_definition.name,
+                    value=glom(input_data, key, default=""),
+                    step_name=step_name,
                     # TODO: take translations into account?
-                    label=component_meta.component.get("label", ""),
+                    label=label,
                 )
             )
 

--- a/src/openforms/utils/json_logic/datastructures.py
+++ b/src/openforms/utils/json_logic/datastructures.py
@@ -5,6 +5,7 @@ from json_logic.meta import JSONLogicExpressionTree, Operation
 from json_logic.typing import JSON, Primitive
 
 from openforms.formio.typing import Component
+from openforms.typing import DataMapping
 
 from .descriptions import _generate_description
 
@@ -43,6 +44,7 @@ class ExpressionIntrospection:
         self,
         components_map: ComponentsMap,
         input_data: dict[str, JSON],
+        context: DataMapping,
     ) -> list[InputVar]:
         inputs = []
 
@@ -54,6 +56,11 @@ class ExpressionIntrospection:
 
             # TODO: this *may* be nested var.var expressions
             key = cast(str, node.arguments[0])
+            if key not in components_map:
+                inputs.append(
+                    InputVar(key=key, value=context[key], step_name="", label="")
+                )
+                continue
             component_meta = components_map[key]
             inputs.append(
                 InputVar(

--- a/src/openforms/utils/json_logic/datastructures.py
+++ b/src/openforms/utils/json_logic/datastructures.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, cast
 
+from glom import glom
+from glom.core import PathAccessError
 from json_logic.meta import JSONLogicExpressionTree, Operation
 from json_logic.typing import JSON, Primitive
 
@@ -57,9 +59,14 @@ class ExpressionIntrospection:
             # TODO: this *may* be nested var.var expressions
             key = cast(str, node.arguments[0])
             if key not in components_map:
-                inputs.append(
-                    InputVar(key=key, value=context[key], step_name="", label="")
-                )
+                try:
+                    inputs.append(
+                        InputVar(
+                            key=key, value=glom(context, key), step_name="", label=""
+                        )
+                    )
+                except PathAccessError:
+                    pass  # well, we tried.
                 continue
             component_meta = components_map[key]
             inputs.append(

--- a/src/openforms/utils/json_logic/datastructures.py
+++ b/src/openforms/utils/json_logic/datastructures.py
@@ -2,12 +2,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, cast
 
 from glom import glom
-from glom.core import PathAccessError
 from json_logic.meta import JSONLogicExpressionTree, Operation
 from json_logic.typing import JSON, Primitive
 
 from openforms.formio.typing import Component
-from openforms.typing import DataMapping
 
 from .descriptions import _generate_description
 


### PR DESCRIPTION
Closes #2893

Good news: this doesn't crash the actual logic evaluation

Bad news: crashes do happen in the celery tasks and not only for non-primitive JSON types.