### PR TITLE
Add tests for openforms.api.validators

### DIFF
--- a/src/openforms/api/tests/test_validators.py
+++ b/src/openforms/api/tests/test_validators.py
@@ -1,6 +1,9 @@
+from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
 
 from rest_framework import serializers
+
+from openforms.accounts.models import User
 
 from ..validators import AllOrNoneRequiredFieldsValidator, ModelValidator
 
@@ -53,3 +56,61 @@ class AllOrNoneRequiredFieldsValidatorTests(SimpleTestCase):
                 is_valid = serializer.is_valid()
 
                 self.assertFalse(is_valid)
+
+
+def validate_not_staff(user: User):
+    err = ValidationError("May not be staff", code="privileges")
+    if user.is_staff:
+        raise ValidationError({"is_staff": err})
+
+
+def validate_non_field_attrs_not_set(user: User):
+    if hasattr(user, "extra_field"):
+        raise ValidationError("Non-model field attr set", code="bad_attr")
+
+
+class UserSerializer(serializers.ModelSerializer):
+    extra_field = serializers.CharField(required=False)
+
+    class Meta:
+        model = User
+        fields = ("username", "email", "is_staff", "extra_field")
+        extra_kwargs = {
+            "username": {
+                "validators": []
+            },  # disable unique validator which does queries
+        }
+        validators = [
+            ModelValidator[User](validate_not_staff),
+        ]
+
+
+class ModelValidatorTests(SimpleTestCase):
+    def test_runs_validator_function_on_serializer_data(self):
+        serializer = UserSerializer(
+            data={
+                "username": "bob",
+                "email": "bob@example.com",
+                "is_staff": True,
+            }
+        )
+
+        is_valid = serializer.is_valid()
+
+        self.assertFalse(is_valid)
+        self.assertIn("is_staff", serializer.errors)
+        self.assertEqual(serializer.errors["is_staff"][0].code, "privileges")
+
+    def test_non_model_field_attrs_not_set(self):
+        serializer = UserSerializer(
+            data={
+                "username": "bob",
+                "email": "bob@example.com",
+                "is_staff": False,
+                "extra_field": "may not be present",
+            }
+        )
+
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)

--- a/src/openforms/api/tests/test_validators.py
+++ b/src/openforms/api/tests/test_validators.py
@@ -1,0 +1,55 @@
+from django.test import SimpleTestCase
+
+from rest_framework import serializers
+
+from ..validators import AllOrNoneRequiredFieldsValidator, ModelValidator
+
+
+class AllOrNoneRequiredFieldsValidatorSerializer(serializers.Serializer):
+    foo = serializers.CharField(required=False, allow_null=True)
+    bar = serializers.CharField(required=False, allow_null=True)
+
+    class Meta:
+        validators = [AllOrNoneRequiredFieldsValidator("foo", "bar")]
+
+
+class AllOrNoneRequiredFieldsValidatorTests(SimpleTestCase):
+    def test_no_fields_provided(self):
+        empty_data_examples = (
+            {"foo": None, "bar": None},
+            {"foo": None},
+            {},
+        )
+        for empty_data in empty_data_examples:
+            with self.subTest(data=empty_data):
+                serializer = AllOrNoneRequiredFieldsValidatorSerializer(data=empty_data)
+
+                is_valid = serializer.is_valid()
+
+                self.assertTrue(is_valid)
+
+    def test_all_fields_provided(self):
+        serializer = AllOrNoneRequiredFieldsValidatorSerializer(
+            data={"foo": "foo", "bar": "bar"}
+        )
+
+        is_valid = serializer.is_valid()
+
+        self.assertTrue(is_valid)
+
+    def test_subset_of_fields_provided(self):
+        partial_data_examples = (
+            {"foo": None, "bar": "bar"},
+            {"foo": "foo", "bar": None},
+            {"foo": "foo"},
+            {"bar": "bar"},
+        )
+        for incomplete_data in partial_data_examples:
+            with self.subTest(data=incomplete_data):
+                serializer = AllOrNoneRequiredFieldsValidatorSerializer(
+                    data=incomplete_data
+                )
+
+                is_valid = serializer.is_valid()
+
+                self.assertFalse(is_valid)

--- a/src/openforms/emails/api/serializers.py
+++ b/src/openforms/emails/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from openforms.api.validators import AllOrNoneRequiredFieldsValidator
+from openforms.api.validators import AllOrNoneTruthyFieldsValidator
 from openforms.translations.api.serializers import ModelTranslationsSerializer
 
 from ..models import ConfirmationEmailTemplate
@@ -17,5 +17,5 @@ class ConfirmationEmailTemplateSerializer(serializers.ModelSerializer):
             "translations",
         )
         validators = [
-            AllOrNoneRequiredFieldsValidator("subject", "content"),
+            AllOrNoneTruthyFieldsValidator("subject", "content"),
         ]

--- a/src/openforms/emails/tests/test_api_serializers.py
+++ b/src/openforms/emails/tests/test_api_serializers.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, override_settings, tag
 from django.utils.translation import gettext as _
 
-from openforms.api.validators import AllOrNoneRequiredFieldsValidator
+from openforms.api.validators import AllOrNoneTruthyFieldsValidator
 
 from ..api.serializers import ConfirmationEmailTemplateSerializer
 from .factories import ConfirmationEmailTemplateFactory
@@ -53,7 +53,7 @@ class ConfirmationTemplateSerializerTests(TestCase):
             error = _find_error(
                 non_field_errors,
                 code="required",
-                message=AllOrNoneRequiredFieldsValidator.message.format(
+                message=AllOrNoneTruthyFieldsValidator.message.format(
                     fields="subject, content"
                 ),
             )

--- a/src/openforms/forms/tests/test_api_forms.py
+++ b/src/openforms/forms/tests/test_api_forms.py
@@ -976,7 +976,7 @@ class FormsAPITests(APITestCase):
                 self.assertEqual(
                     response.json()["invalidParams"][0]["reason"],
                     _(
-                        "The fields {fields} must all be provided if one of them is provided."
+                        "The fields {fields} must all have a non-empty value as soon as one of them does."
                     ).format(fields="subject, content"),
                 )
 
@@ -1627,7 +1627,7 @@ class FormsAPITranslationTests(APITestCase):
                     "name": "confirmationEmailTemplate.translations.en.nonFieldErrors",
                     "code": "required",
                     "reason": _(
-                        "The fields {fields} must all be provided if one of them is provided."
+                        "The fields {fields} must all have a non-empty value as soon as one of them does."
                     ).format(fields="subject, content"),
                 }
             ],


### PR DESCRIPTION
* Fixes drop in test coverage due to the `ModelValidator`
* Added explicit tests for the `AllOrNoneRequiredFieldsValidator` which was drive-by coverage from other tests