### PR TITLE
Fix focus shift/flicker in form builder

### DIFF
--- a/src/openforms/js/components/formio_builder/translation.js
+++ b/src/openforms/js/components/formio_builder/translation.js
@@ -225,7 +225,7 @@ export const handleComponentValueLiterals = (
   allComponentTranslations,
   propertyPath,
   values,
-  previousLiteralsRef
+  previousLiterals
 ) => {
   // don't bother doing anything if it's not the right component type.
   switch (component.type) {
@@ -241,17 +241,23 @@ export const handleComponentValueLiterals = (
     default:
       return null;
   }
-  let translations = {};
+  let translations = component?.openForms?.translations || {};
   const nonEmptyValues = values.filter(item => !isEmpty(item));
   if (!nonEmptyValues.length) return null;
   nonEmptyValues.forEach(({label = ''}, index) => {
-    merge(
-      translations,
-      addTranslationForLiteral(component, allComponentTranslations, undefined, label)
+    const componentCopy = {
+      ...component,
+      openForms: {...component.openForms, translations: translations},
+    };
+    translations = addTranslationForLiteral(
+      componentCopy,
+      allComponentTranslations,
+      undefined,
+      label
     );
     // track the value as 'previous literal' in the ref
     const _propertyPath = `${propertyPath}[${index}].label`;
-    set(previousLiteralsRef.current, [_propertyPath], label);
+    set(previousLiterals, [_propertyPath], label);
   });
   return translations;
 };

--- a/src/openforms/js/components/formio_builder/translation.spec.js
+++ b/src/openforms/js/components/formio_builder/translation.spec.js
@@ -177,14 +177,12 @@ describe('Component value label literals', () => {
     [radioComponent, 'values'],
     [selectBoxesComponent, 'values'],
   ])('are exposed in the translations structure (%#)', (component, path) => {
-    const mockRef = {current: {}};
-
     const translations = handleComponentValueLiterals(
       {...component},
       componentTranslations,
       path,
       values,
-      mockRef
+      {}
     );
 
     expect(translations.nl).toEqual([


### PR DESCRIPTION
Fixes #2819 (better fix)
Fixes #2889
Fixes #2840

Essentially this moves the translation hooks into the custom WebformBuilder class which seems to solve a number of problems:

* Initialize the translations before any change event fires when the modal to edit the component opens
* Do tap into the change events to keep track of literals (which is now done on the `editForm` instance instead of a React ref)
* Fix a bug in formio where the `key` configuration/component is not re-rendered after setting a unique value (original issue is #2819)
* This patch *accidentally* fixes the form builder dismissal removing the translations state (#2840)

We are no longer relying on obscure `onChange` options of the formio form class (and having to call the original parent methods etc.), but instead limit this to pure builder functionality.

Hopefully this makes the whole approach a bit more stable, but it would still be beneficial to completely replace this form builder with something React-based where you don't have to reason as much about re-rendering after value/prop changes.