### PR TITLE
Assume image/heif and image/heic are the same.

### DIFF
--- a/src/openforms/formio/api/validators.py
+++ b/src/openforms/formio/api/validators.py
@@ -65,6 +65,9 @@ class MimeTypeValidator:
             whole_file = head + value.read()
             mime_type = magic.from_buffer(whole_file, mime=True)
 
+        if mime_type == "image/heif":
+            mime_type = "image/heic"
+
         if not (
             self.any_allowed
             or mimetype_allowed(mime_type, self._regular_mimes, self._wildcard_mimes)
@@ -97,6 +100,11 @@ class MimeTypeValidator:
                     filename=value.name, file_type=f".{ext}"
                 )
             )
+        elif mime_type == "image/heic" and value.content_type in (
+            "image/heic",
+            "image/heif",
+        ):
+            return
         elif mime_type != value.content_type:
             raise serializers.ValidationError(
                 _("The file '{filename}' is not a {file_type}.").format(

--- a/src/openforms/formio/tests/test_validators.py
+++ b/src/openforms/formio/tests/test_validators.py
@@ -140,6 +140,30 @@ class MimeTypeValidatorTests(SimpleTestCase):
         ):
             validator(self.CORRECT_GIF)
 
+    def test_mif1_brand_heif_files_are_acceptable_heic(self):
+        # lib magic has a hard time recognizing the HEVC is used and a heif container actutally is heic
+        validator = validators.MimeTypeValidator({"image/heic"})
+        sample_1 = SimpleUploadedFile(
+            "sample1.heic", b"\x00\x00\x00\x18ftypmif1", content_type="image/heif"
+        )
+
+        try:
+            validator(sample_1)
+        except ValidationError as e:
+            self.fail(f"Valid file failed validation: {e}")
+
+    def test_heic_brand_heif_files_are_recognized_as_heic(self):
+        # lib magic has a hard time recognizing the HEVC is used and a heif container actutally is heic
+        validator = validators.MimeTypeValidator({})  # accept any
+        sample_2 = SimpleUploadedFile(
+            "sample2.heic", b"\x00\x00\x00\x18ftypheic", content_type="image/heif"
+        )
+
+        try:
+            validator(sample_2)
+        except ValidationError as e:
+            self.fail(f"Valid file failed validation: {e}")
+
     def test_validate_files_multiple_mime_types(self):
         """Assert that validation of files associated with multiple mime types works
 

--- a/src/openforms/formio/tests/test_validators.py
+++ b/src/openforms/formio/tests/test_validators.py
@@ -164,6 +164,16 @@ class MimeTypeValidatorTests(SimpleTestCase):
         except ValidationError as e:
             self.fail(f"Valid file failed validation: {e}")
 
+    def test_heic_brand_heif_files_are_not_recognized_as_png(self):
+        # lib magic has a hard time recognizing the HEVC is used and a heif container actutally is heic
+        validator = validators.MimeTypeValidator({"image/png"})  # accept any
+        sample_2 = SimpleUploadedFile(
+            "sample2.heic", b"\x00\x00\x00\x18ftypheic", content_type="image/heif"
+        )
+
+        with self.assertRaises(ValidationError):
+            validator(sample_2)
+
     def test_validate_files_multiple_mime_types(self):
         """Assert that validation of files associated with multiple mime types works
 


### PR DESCRIPTION
Part of a fix for #2911 

heif is a container format. heic is a heif file with a certain type of compressed file in there.

libmagic doesn't recognize all heics as such, nor can PIL/pillow in dialogue with the product owner, this solution suffices for the usecase.

Alternative would be to do all of the following:
- add heif explicitly to the allowed filetype options which isn't great UX;
- install extra dependency (like wand or a pillow file reader) to inspect the whole file.