### PR TITLE
:arrow_up: Upgrade sentry-sdk version to latest

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -80,7 +80,7 @@ drf-spectacular
 
 # WSGI servers & monitoring - production oriented
 uwsgi
-sentry-sdk  # error monitoring
+sentry-sdk[django]  # error monitoring
 elastic-apm  # Elastic APM integration
 flower # task monitoring
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -122,6 +122,7 @@ django==3.2.18
     #   maykin-django-two-factor-auth
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
+    #   sentry-sdk
     #   zgw-consumers
 django-admin-index==2.0.0
     # via -r requirements/base.in
@@ -395,7 +396,7 @@ self-certifi==1.0.0
     # via -r requirements/base.in
 semantic-version==2.10.0
     # via -r requirements/base.in
-sentry-sdk==0.17.3
+sentry-sdk[django]==1.17.0
     # via -r requirements/base.in
 simplejson==3.17.6
     # via mail-parser
@@ -438,7 +439,7 @@ tzlocal==2.1
     # via o365
 uritemplate==3.0.1
     # via drf-spectacular
-urllib3==1.26.6
+urllib3==1.26.15
     # via
     #   elastic-apm
     #   requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -194,6 +194,7 @@ django==3.2.18
     #   maykin-django-two-factor-auth
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
+    #   sentry-sdk
     #   zgw-consumers
 django-admin-index==2.0.0
     # via
@@ -759,7 +760,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-sentry-sdk==0.17.3
+sentry-sdk[django]==1.17.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -875,7 +876,7 @@ uritemplate==3.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   drf-spectacular
-urllib3==1.26.6
+urllib3==1.26.15
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -223,6 +223,7 @@ django==3.2.18
     #   maykin-django-two-factor-auth
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
+    #   sentry-sdk
     #   zgw-consumers
 django-admin-index==2.0.0
     # via
@@ -894,7 +895,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-sentry-sdk==0.17.3
+sentry-sdk[django]==1.17.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1060,7 +1061,7 @@ uritemplate==3.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   drf-spectacular
-urllib3==1.26.6
+urllib3==1.26.15
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -160,6 +160,7 @@ django==3.2.18
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   open-forms-ext-token-exchange
+    #   sentry-sdk
     #   zgw-consumers
 django-admin-index==2.0.0
     # via
@@ -608,7 +609,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-sentry-sdk==0.17.3
+sentry-sdk[django]==1.17.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -675,7 +676,7 @@ uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-urllib3==1.26.6
+urllib3==1.26.15
     # via
     #   -r requirements/base.txt
     #   elastic-apm


### PR DESCRIPTION
Updated per https://docs.sentry.io/platforms/python/guides/django/ and dependabot alert

(we don't use `send_default_pii=True` so the dependabot alert is not really relevant, but our SDK version was lagging behind a lot anyway)