### PR TITLE
♻ Make all search strategies callable

### DIFF
--- a/src/openforms/formio/tests/test_utils.py
+++ b/src/openforms/formio/tests/test_utils.py
@@ -65,8 +65,8 @@ class FormioUtilsTest(SimpleTestCase):
     @given(
         hidden=st.booleans(),
         show=st.one_of(st.none(), st.booleans(), st.just("")),
-        when=st.one_of(st.none(), formio_component_key, st.just("")),
-        eq=json_primitives,
+        when=st.one_of(st.none(), formio_component_key(), st.just("")),
+        eq=json_primitives(),
     )
     # Sentry 326223
     @example(hidden=True, show="", when=None, eq="")

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -2,21 +2,18 @@ from django.test import TestCase
 
 from hypothesis import given
 from hypothesis.extra.django import TestCase as HypothesisTestCase
-from json_logic.typing import Primitive
 
 from openforms.forms.api.datastructures import FormVariableWrapper
 from openforms.forms.api.serializers.logic.action_serializers import (
     LogicComponentActionSerializer,
 )
 from openforms.forms.tests.factories import FormFactory, FormVariableFactory
-from openforms.tests.search_strategies import json_values
+from openforms.tests.search_strategies import json_primitives
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
-
-json_values_primitive = json_values().filter(lambda j: isinstance(j, Primitive))
 
 
 class LogicComponentActionSerializerPropertyTest(HypothesisTestCase):
-    @given(json_values_primitive)
+    @given(json_primitives())
     def test_date_format_validation_against_primitive_json_values(self, json_value):
         """Assert that serializer is invalid for random Primitive json data types
         (str, int, etc.) as logic action values for date variables

--- a/src/openforms/tests/search_strategies.py
+++ b/src/openforms/tests/search_strategies.py
@@ -7,14 +7,15 @@ from hypothesis import strategies as st
 from openforms.forms.models.form_variable import variable_key_validator
 from openforms.typing import JSONPrimitive, JSONValue
 
-json_primitives: st.SearchStrategy[JSONPrimitive]
-json_primitives = st.one_of(
-    st.none(),
-    st.booleans(),
-    st.integers(),
-    st.floats(allow_infinity=False, allow_nan=False),
-    st.text(),
-)
+
+def json_primitives() -> st.SearchStrategy[JSONPrimitive]:
+    return st.one_of(
+        st.none(),
+        st.booleans(),
+        st.integers(),
+        st.floats(allow_infinity=False, allow_nan=False),
+        st.text(),
+    )
 
 
 def json_collections(
@@ -27,7 +28,7 @@ def json_collections(
 
 
 def json_values(*, max_leaves: int = 15) -> st.SearchStrategy[JSONValue]:
-    return st.recursive(json_primitives, json_collections, max_leaves=max_leaves)
+    return st.recursive(json_primitives(), json_collections, max_leaves=max_leaves)
 
 
 def valid_key(key: str) -> bool:
@@ -38,6 +39,5 @@ def valid_key(key: str) -> bool:
     return True
 
 
-formio_component_key = st.text(min_size=1, alphabet=".-" + ascii_letters).filter(
-    valid_key
-)
+def formio_component_key() -> st.SearchStrategy[str]:
+    return st.text(min_size=1, alphabet=".-" + ascii_letters).filter(valid_key)


### PR DESCRIPTION
All strategies in hypothesis are callable. This turns all our own into callables too, even if they don't have parameters. Less to think about. A refactor in the strictest sense of the word: no change of functionality at all, just an ergonomic rephrasing.