### PR TITLE
[#2716] include co-sign identifier (bsn) in submission report

### DIFF
--- a/src/openforms/authentication/contrib/demo/tests/test_plugin.py
+++ b/src/openforms/authentication/contrib/demo/tests/test_plugin.py
@@ -198,6 +198,7 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, TestCase):
                     "plugin": "demo",
                     "representation": "",
                     "identifier": "111222333",
+                    "co_sign_auth_attribute": "bsn",
                     "fields": {},
                 },
             )

--- a/src/openforms/authentication/contrib/digid/tests/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid/tests/test_auth_procedure.py
@@ -380,6 +380,7 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, DigiDConfigMixin, TestCas
                 "plugin": "digid",
                 "identifier": "12345678",
                 "representation": "",
+                "co_sign_auth_attribute": "bsn",
                 "fields": {},
             },
         )

--- a/src/openforms/authentication/contrib/digid_mock/tests/test_plugin.py
+++ b/src/openforms/authentication/contrib/digid_mock/tests/test_plugin.py
@@ -140,6 +140,7 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, TestCase):
                     "plugin": "digid-mock",
                     "identifier": "111222333",
                     "representation": "",
+                    "co_sign_auth_attribute": "bsn",
                     "fields": {},
                 },
             )

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eherkenning_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eherkenning_auth.py
@@ -415,6 +415,7 @@ class CoSignLoginAuthenticationTests(
                 "plugin": "eherkenning",
                 "identifier": "123456782",
                 "representation": "",
+                "co_sign_auth_attribute": "kvk",
                 "fields": {},
             },
         )

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
@@ -415,6 +415,7 @@ class CoSignLoginAuthenticationTests(SubmissionsMixin, EIDASConfigMixin, TestCas
                 "plugin": "eidas",
                 "identifier": "112233445",
                 "representation": "",
+                "co_sign_auth_attribute": "pseudo",
                 "fields": {},
             },
         )

--- a/src/openforms/authentication/tests/mocks.py
+++ b/src/openforms/authentication/tests/mocks.py
@@ -10,7 +10,7 @@ from ..registry import Registry
 
 class Plugin(BasePlugin):
     verbose_name = "some human readable label"
-    provides_auth = "dummy"
+    provides_auth = AuthAttribute.bsn
 
     def start_login(self, request, form, form_url):
         return HttpResponse("start")

--- a/src/openforms/authentication/tests/test_views.py
+++ b/src/openforms/authentication/tests/test_views.py
@@ -341,15 +341,14 @@ class CoSignAuthenticationFlowTests(SubmissionsMixin, APITestCase):
                 "plugin": "plugin1",
                 "identifier": "mock-id",
                 "representation": "",
+                "co_sign_auth_attribute": "bsn",
                 "fields": {
                     "mock_field_1": "field 1",
                     "mock_field_2": "",
                 },
             },
         )
-        mock_add_co_sign_representation.assert_called_once_with(
-            self.submission, "dummy"
-        )
+        mock_add_co_sign_representation.assert_called_once_with(self.submission, "bsn")
 
     @override_settings(CORS_ALLOW_ALL_ORIGINS=True)
     def test_co_sign_flow_invalid_submission_id(self):

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -340,6 +340,7 @@ class AuthenticationReturnView(AuthenticationFlowBaseView):
             co_sign_data = {
                 **plugin.handle_co_sign(self.request, form),
                 "plugin": plugin.identifier,
+                "co_sign_auth_attribute": plugin.provides_auth,
             }
             serializer = CoSignDataSerializer(data=co_sign_data)
             serializer.is_valid(raise_exception=True)

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from django.utils.safestring import SafeString
+from django.utils.translation import gettext_lazy as _
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.forms.models import Form
 
 if TYPE_CHECKING:
@@ -36,15 +38,26 @@ class Report:
 
     @property
     def co_signer(self) -> str:
-        if not self.submission.co_sign_data:
+        """Retrieve and normalize data about the co-signer of a form"""
+
+        if not (co_sign_data := self.submission.co_sign_data):
             return ""
 
-        if not (co_signer := self.submission.co_sign_data.get("representation", "")):
+        representation = co_sign_data.get("representation") or ""
+        identifier = co_sign_data["identifier"]
+        co_sign_auth_attribute = co_sign_data["co_sign_auth_attribute"]
+        auth_attribute_label = AuthAttribute[co_sign_auth_attribute].label
+
+        if not representation:
             logger.warning(
                 "Incomplete co-sign data for submission %s", self.submission.uuid
             )
 
-        return co_signer
+        return _("{representation} ({auth_attribute}: {identifier})").format(
+            representation=representation,
+            auth_attribute=auth_attribute_label,
+            identifier=identifier,
+        )
 
     @property
     def confirmation_page_content(self) -> SafeString:

--- a/src/openforms/submissions/serializers.py
+++ b/src/openforms/submissions/serializers.py
@@ -4,6 +4,7 @@ type model fields.
 """
 from rest_framework import serializers
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.authentication.registry import register
 
 
@@ -11,6 +12,7 @@ class CoSignDataSerializer(serializers.Serializer):
     plugin = serializers.ChoiceField(choices=())
     identifier = serializers.CharField()
     representation = serializers.CharField(required=False, allow_blank=True, default="")
+    co_sign_auth_attribute = serializers.ChoiceField(choices=AuthAttribute.choices)
     # TODO: validate fields shape depending on value of plugin (polymorphic serializer)
     fields = serializers.DictField(
         child=serializers.CharField(allow_blank=True),

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -428,6 +428,7 @@ class SubmissionTests(TestCase):
             {
                 "plugin": "digid",
                 "identifier": "123456782",
+                "co_sign_auth_attribute": "bsn",
                 "fields": {
                     "name": "Jane Doe",
                 },

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -222,6 +222,7 @@ class SubmissionReportCoSignTests(TestCase):
             submission__co_sign_data={
                 "plugin": "digid",
                 "identifier": "123456782",
+                "co_sign_auth_attribute": "bsn",
                 "fields": {
                     "voornaam": "Tina",
                     "geslachtsnaam": "Shikari",
@@ -229,18 +230,50 @@ class SubmissionReportCoSignTests(TestCase):
                 "representation": "T. Shikari",
             },
         )
-
         rendered: str = report.generate_submission_report_pdf()
-
         report.refresh_from_db()
+
         self.assertTrue(report.content.name.endswith(".pdf"))
+
         expected = format_html(
             """
             <div class="submission-step-row">
                 <div class="submission-step-row__label">{key}</div>
-                <div class="submission-step-row__value">T. Shikari</div>
+                <div class="submission-step-row__value">T. Shikari ({auth_attribute}: 123456782)</div>
             </div>
             """,
             key=_("Co-signed by"),
+            auth_attribute=_("BSN"),
         )
         self.assertInHTML(expected, rendered, count=1)
+
+    def test_incomplete_cosign_data_missing_representation(self):
+        report = SubmissionReportFactory.create(
+            content="",
+            submission__completed=True,
+            submission__co_sign_data={
+                "plugin": "digid",
+                "identifier": "123456782",
+                "co_sign_auth_attribute": "bsn",
+                "fields": {
+                    "voornaam": "Tina",
+                    "geslachtsnaam": "Shikari",
+                },
+                "representation": "",
+            },
+        )
+
+        rendered: str = report.generate_submission_report_pdf()
+        report.refresh_from_db()
+
+        identifier = format_html(
+            """
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">{key}</div>
+                <div class="submission-step-row__value"> ({auth_attribute}: 123456782)</div>
+            </div>
+            """,
+            key=_("Co-signed by"),
+            auth_attribute=_("BSN"),
+        )
+        self.assertIn(identifier, rendered)

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -239,11 +239,17 @@ class SubmissionReportCoSignTests(TestCase):
             """
             <div class="submission-step-row">
                 <div class="submission-step-row__label">{key}</div>
-                <div class="submission-step-row__value">T. Shikari ({auth_attribute}: 123456782)</div>
+                <div class="submission-step-row__value">{co_sign_display}</div>
             </div>
             """,
             key=_("Co-signed by"),
-            auth_attribute=_("BSN"),
+            co_sign_display=_(
+                "{representation} ({auth_attribute}: {identifier})"
+            ).format(
+                representation="T. Shikari",
+                auth_attribute=_("BSN"),
+                identifier="123456782",
+            ),
         )
         self.assertInHTML(expected, rendered, count=1)
 
@@ -270,10 +276,16 @@ class SubmissionReportCoSignTests(TestCase):
             """
             <div class="submission-step-row">
                 <div class="submission-step-row__label">{key}</div>
-                <div class="submission-step-row__value"> ({auth_attribute}: 123456782)</div>
+                <div class="submission-step-row__value">{co_sign_display}</div>
             </div>
             """,
             key=_("Co-signed by"),
-            auth_attribute=_("BSN"),
+            co_sign_display=_(
+                "{representation} ({auth_attribute}: {identifier})"
+            ).format(
+                representation="",
+                auth_attribute=_("BSN"),
+                identifier="123456782",
+            ),
         )
         self.assertIn(identifier, rendered)


### PR DESCRIPTION
Closes #2716 

* the identifier (bsn) of form co-signers is included in the submission report, alongside first + last name