### PR TITLE
[#2942] Fix undefined auth attributes

### DIFF
--- a/src/openforms/js/components/form/coSign.js
+++ b/src/openforms/js/components/form/coSign.js
@@ -34,7 +34,7 @@ const EDIT_FORM_TABS = [
               url: getFullyQualifiedUrl('/api/v2/authentication/plugins'),
             },
             valueProperty: 'id',
-            template: `<span>{{ item.label }}, provides: {{ item.providesAuth.join(', ') }}</span>`,
+            template: `<span>{{ item.label }}, provides: {{ item.providesAuth }}</span>`,
           },
         ],
       },


### PR DESCRIPTION
Fixes #2942 

Now it looks like this (I added a KvK to the first demo plugin to test how it looks when there are multiple auth attributes):
![Screenshot from 2023-03-29 12-10-44](https://user-images.githubusercontent.com/19154114/228502012-b9beb999-31a7-4767-84cc-a10ca663ab10.png)

I don't really understand why the .join() syntax wasn't working, or why the list gets automatically formatted now :thinking: 