### PR TITLE
Fix broken StUF registration for some integrations

### DIFF
--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 
 import requests
 from lxml import etree
-from lxml.etree import Element
+from lxml.etree import _Element
 from requests import RequestException
 
 from openforms.config.models import GlobalConfiguration
@@ -111,7 +111,7 @@ class StufZDSClient(BaseClient):
         )
         self.options = options
 
-    def execute_call(self, *args, **kwargs) -> Element:
+    def execute_call(self, *args, **kwargs) -> _Element:
         """
         Method actual performing the SOAP call, with error handling.
 
@@ -171,7 +171,7 @@ class StufZDSClient(BaseClient):
         return xml
 
     def create_zaak_identificatie(self) -> str:
-        _, xml = self.execute_call(
+        xml = self.execute_call(
             soap_action="genereerZaakIdentificatie_Di02",
             template="stuf_zds/soap/genereerZaakIdentificatie.xml",
             endpoint_type=EndpointType.vrije_berichten,
@@ -243,7 +243,7 @@ class StufZDSClient(BaseClient):
         return self.partial_update_zaak(zaak_identificatie, data)
 
     def create_document_identificatie(self) -> str:
-        _, xml = self.execute_call(
+        xml = self.execute_call(
             soap_action="genereerDocumentIdentificatie_Di02",
             template="stuf_zds/soap/genereerDocumentIdentificatie.xml",
             endpoint_type=EndpointType.vrije_berichten,

--- a/src/stuf/stuf_zds/tests/test_backend.py
+++ b/src/stuf/stuf_zds/tests/test_backend.py
@@ -28,6 +28,8 @@ class StufZDSClientTests(StUFZDSTestBase):
     test the client class directly
     """
 
+    client: StufZDSClient
+
     def setUp(self):
         self.service = StufServiceFactory.create(
             zender_organisatie="ZenOrg",
@@ -81,7 +83,8 @@ class StufZDSClientTests(StUFZDSTestBase):
             ),
             additional_matcher=match_text("genereerZaakIdentificatie_Di02"),
         )
-        self.client.create_zaak_identificatie()
+        zaaknr = self.client.create_zaak_identificatie()
+        self.assertEqual(zaaknr, "foo")
 
         request = m.request_history[0]
         self.assertEqual(request.headers["Content-Type"], "application/soap+xml")


### PR DESCRIPTION
Fixes #2983

Short summary: our tests (and other integrations apparently) do return the following structure:

```
Envelope
  Header
  Body
```

which the destructuring accepts, as the root element only has two children.

However, for this particular bug, the response has the structure:

```
Envelope
  Body
```

which breaks unpacking.

Unpacking was never intentional here, so that that's being fixed and a regression test is added without the header element.