### PR TITLE
[#1530] Part 1: add new co-sign component

### DIFF
--- a/src/openforms/js/components/form/co-sign.js
+++ b/src/openforms/js/components/form/co-sign.js
@@ -1,0 +1,64 @@
+import {Formio} from 'formiojs';
+
+import {
+  AUTOCOMPLETE,
+  CLEAR_ON_HIDE,
+  DEFAULT_VALUE,
+  DESCRIPTION,
+  HIDDEN,
+  IS_SENSITIVE_DATA,
+  KEY,
+  LABEL_REQUIRED,
+  PRESENTATION,
+} from './edit/options';
+import DEFAULT_TABS, {ADVANCED, REGISTRATION, TRANSLATIONS, VALIDATION} from './edit/tabs';
+import {localiseSchema} from './i18n';
+
+const FormioEmail = Formio.Components.components.email;
+
+class CosignField extends FormioEmail {
+  static schema(...extend) {
+    const schema = FormioEmail.schema(
+      {
+        type: 'cosign',
+        validateOn: 'blur',
+      },
+      ...extend
+    );
+    return localiseSchema(schema);
+  }
+
+  static get builderInfo() {
+    return {
+      title: 'Co-sign',
+      group: 'advanced',
+      icon: 'pen-nib',
+      schema: CosignField.schema(),
+    };
+  }
+
+  static editForm() {
+    const BASIC_TAB = {
+      key: 'basic',
+      label: 'Basic',
+      components: [
+        LABEL_REQUIRED,
+        KEY,
+        DESCRIPTION,
+        PRESENTATION,
+        HIDDEN,
+        CLEAR_ON_HIDE,
+        IS_SENSITIVE_DATA,
+        DEFAULT_VALUE,
+        {...AUTOCOMPLETE, placeholder: 'email'},
+      ],
+    };
+    const TABS = {
+      ...DEFAULT_TABS,
+      components: [BASIC_TAB, ADVANCED, VALIDATION, REGISTRATION, TRANSLATIONS],
+    };
+    return {components: [TABS]};
+  }
+}
+
+export default CosignField;

--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -55,7 +55,7 @@ const getBuilderOptions = () => {
           bsn: true,
           npFamilyMembers: true,
           signature: true,
-          coSign: true,
+          cosign: true,
           map: true,
           editgrid: true,
         },
@@ -238,6 +238,7 @@ const getBuilderOptions = () => {
         components: {
           postcode: true,
           password: true,
+          coSign: true,
         },
       },
     },

--- a/src/openforms/js/formio_module.js
+++ b/src/openforms/js/formio_module.js
@@ -1,5 +1,6 @@
 import BsnField from './components/form/bsn';
 import CheckboxField from './components/form/checkbox';
+import CosignField from './components/form/co-sign';
 import CoSignField from './components/form/coSign';
 import ColumnField from './components/form/columns';
 import Component from './components/form/component';
@@ -56,6 +57,7 @@ const FormIOModule = {
     fieldset: FieldSet,
     licenseplate: LicensePlate,
     coSign: CoSignField,
+    cosign: CosignField,
     npFamilyMembers: NpFamilyMembers,
     columns: ColumnField,
     content: ContentField,


### PR DESCRIPTION
Part of #1530

To do:
- [ ] Add a new co-sign component that is an email field (Q: no need to select plugin for auth?) - backend

