### PR TITLE
[#1959] Reset `attribute_hashed` when setting info on AuthInfo from the session

### DIFF
--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -108,7 +108,7 @@ def set_auth_attribute_on_session(
                 "attribute": form_auth["attribute"],
                 "plugin": form_auth["plugin"],
             }
-            # TODO the "machtigingen" key dispeared
+            # TODO the "machtigingen" key disappeared
             store_auth_details(instance, auth_save)
             store_registrator_details(instance, registrator_save)
     else:

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.test.client import RequestFactory
 
 from rest_framework.request import Request
@@ -244,3 +244,36 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
 
             self.assertEqual(response.status_code, 302)
             m_send.assert_not_called()
+
+    @tag("gh-1959")
+    def test_setting_auth_attributes_flips_hashed_flag(self):
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form_url="http://tests/myform/",
+            auth_info__plugin="digid",
+            auth_info__value="123456789",
+            auth_info__attribute="bsn",
+        )
+
+        submission.auth_info.hash_identifying_attributes()
+
+        self.assertTrue(submission.auth_info.attribute_hashed)
+
+        user = StaffUserFactory()
+
+        request = factory.get("/foo")
+        request.user = user
+        request.session = {
+            FORM_AUTH_SESSION_KEY: {
+                "plugin": "digid",
+                "attribute": "bsn",
+                "value": "123456789",
+            }
+        }
+
+        set_auth_attribute_on_session(sender=None, instance=submission, request=request)
+
+        submission.refresh_from_db()
+
+        self.assertEqual(submission.auth_info.value, "123456789")
+        self.assertFalse(submission.auth_info.attribute_hashed)

--- a/src/openforms/authentication/tests/test_utils.py
+++ b/src/openforms/authentication/tests/test_utils.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+
+from openforms.submissions.tests.factories import SubmissionFactory
+
+from ..utils import store_auth_details, store_registrator_details
+
+
+class UtilsTests(TestCase):
+    def test_store_auth_details(self):
+        submission = SubmissionFactory.create()
+
+        with self.assertRaises(ValueError):
+            store_auth_details(
+                submission,
+                {"plugin": "digid", "attribute": "WRONG", "value": "some-value"},
+            )
+
+    def test_store_registrator_details(self):
+        submission = SubmissionFactory.create()
+
+        with self.assertRaises(ValueError):
+            store_registrator_details(
+                submission,
+                {"plugin": "digid", "attribute": "WRONG", "value": "some-value"},
+            )

--- a/src/openforms/authentication/utils.py
+++ b/src/openforms/authentication/utils.py
@@ -21,14 +21,19 @@ class FormAuth(BaseAuth):
     machtigen: Optional[dict]
 
 
-def store_auth_details(submission: Submission, form_auth: FormAuth) -> None:
+def store_auth_details(
+    submission: Submission, form_auth: FormAuth, attribute_hashed: bool = False
+) -> None:
     attribute = form_auth["attribute"]
 
     assert (
         attribute in AuthAttribute.values
     ), f"Unexpected auth attribute {attribute} specified"
 
-    AuthInfo.objects.update_or_create(submission=submission, defaults=form_auth)
+    AuthInfo.objects.update_or_create(
+        submission=submission,
+        defaults={**form_auth, **{"attribute_hashed": attribute_hashed}},
+    )
 
 
 def store_registrator_details(

--- a/src/openforms/authentication/utils.py
+++ b/src/openforms/authentication/utils.py
@@ -25,10 +25,8 @@ def store_auth_details(
     submission: Submission, form_auth: FormAuth, attribute_hashed: bool = False
 ) -> None:
     attribute = form_auth["attribute"]
-
-    assert (
-        attribute in AuthAttribute.values
-    ), f"Unexpected auth attribute {attribute} specified"
+    if attribute not in AuthAttribute.values:
+        raise ValueError(f"Unexpected auth attribute {attribute} specified")
 
     AuthInfo.objects.update_or_create(
         submission=submission,
@@ -40,10 +38,8 @@ def store_registrator_details(
     submission: Submission, registrator_auth: BaseAuth
 ) -> None:
     attribute = registrator_auth["attribute"]
-
-    assert (
-        attribute in AuthAttribute.values
-    ), f"Unexpected auth attribute {attribute} specified"
+    if attribute not in AuthAttribute.values:
+        raise ValueError(f"Unexpected auth attribute {attribute} specified")
 
     RegistratorInfo.objects.update_or_create(
         submission=submission, defaults=registrator_auth


### PR DESCRIPTION
Fixes #1959 

Should be backported to 2.0.x and 2.1.x