### PR TITLE
[#3015] Don't automatically add protocol to URL

### DIFF
--- a/docs/manual/templates.rst
+++ b/docs/manual/templates.rst
@@ -275,7 +275,9 @@ Variabele                           Beschrijving
 ``{{ form_name }}``                 De naam van het formulier.
 ``{{ save_date }}``                 De datum waarop het formulier is opgeslagen.
 ``{{ expiration_date }}``           De datum waarop het formulier zal vervallen.
-``{{ continue_url }}``              De URL om het formulier te hervatten.
+``{{ continue_url }}``              De URL om het formulier te hervatten. Deze URL begint al met ``https://``,
+                                    dus u kunt 'Nee' kiezen wanneer de pop-up in de editor vraagt om dit toe te
+                                    voegen.
 ==================================  ===========================================================================
 
 

--- a/src/openforms/conf/tinymce_config.json
+++ b/src/openforms/conf/tinymce_config.json
@@ -9,5 +9,5 @@
     "content_style": "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
     "default_link_target": "_blank",
     "link_default_protocol": "https",
-    "link_assume_external_targets": "https"
+    "link_assume_external_targets": true
 }


### PR DESCRIPTION
Fixes #3015 

Configuration documentation for tinymce 5: [link_assume_external_targets](https://www.tiny.cloud/docs/plugins/opensource/link/#link_assume_external_targets)

Now, instead of getting the protocol automatically appended, there is a prompt asking if you want to append it:
![Screenshot from 2023-04-25 15-52-00](https://user-images.githubusercontent.com/19154114/234298457-d7adae07-9644-4eed-9d00-0830ea771165.png)

Should be backported to 2.0.x and 2.1.x
