### PR TITLE
[#2808] fix overflowing filenames

### DIFF
--- a/src/openforms/formio/api/validators.py
+++ b/src/openforms/formio/api/validators.py
@@ -73,9 +73,7 @@ class MimeTypeValidator:
             or mimetype_allowed(mime_type, self._regular_mimes, self._wildcard_mimes)
         ):
             raise serializers.ValidationError(
-                _("The file '{filename}' is not a valid file type.").format(
-                    filename=value.name
-                ),
+                _("The provided file is not a valid file type.")
             )
 
         # Contents is allowed. Do extension or submitted content_type agree?
@@ -96,9 +94,7 @@ class MimeTypeValidator:
                 return
 
             raise serializers.ValidationError(
-                _("The file '{filename}' is not a {file_type}.").format(
-                    filename=value.name, file_type=f".{ext}"
-                )
+                _("The provided file is not a {file_type}.").format(file_type=f".{ext}")
             )
         elif mime_type == "image/heic" and value.content_type in (
             "image/heic",
@@ -107,7 +103,7 @@ class MimeTypeValidator:
             return
         elif mime_type != value.content_type:
             raise serializers.ValidationError(
-                _("The file '{filename}' is not a {file_type}.").format(
+                _("The provided file is not a {file_type}.").format(
                     filename=value.name, file_type=f".{ext}"
                 )
             )

--- a/src/openforms/formio/tests/test_api_fileupload.py
+++ b/src/openforms/formio/tests/test_api_fileupload.py
@@ -110,8 +110,8 @@ class FormIOTemporaryFileUploadTest(SubmissionsMixin, APITestCase):
 
         self.assertContains(
             response,
-            _("The file '{filename}' is not a {file_type}.").format(
-                **{"file_type": ".png", "filename": "pixel.png"}
+            _("The provided file is not a {file_type}.").format(
+                **{"file_type": ".png"}
             ),
             status_code=status.HTTP_400_BAD_REQUEST,
         )

--- a/src/openforms/formio/tests/test_validators.py
+++ b/src/openforms/formio/tests/test_validators.py
@@ -66,7 +66,7 @@ class MimeTypeValidatorTests(SimpleTestCase):
         validator = validators.MimeTypeValidator()
 
         with self.assertRaisesMessage(
-            ValidationError, "The file 'pixel.png' is not a .png."
+            ValidationError, "The provided file is not a .png."
         ):
             validator(file)
 
@@ -79,7 +79,7 @@ class MimeTypeValidatorTests(SimpleTestCase):
         validator = validators.MimeTypeValidator()
 
         with self.assertRaisesMessage(
-            ValidationError, "The file 'pixel.jpg' is not a .jpg."
+            ValidationError, "The provided file is not a .jpg."
         ):
             validator(file)
 
@@ -136,7 +136,7 @@ class MimeTypeValidatorTests(SimpleTestCase):
         validator = validators.MimeTypeValidator({"image/png"})
 
         with self.assertRaisesMessage(
-            ValidationError, "The file 'pixel.gif' is not a valid file type."
+            ValidationError, "The provided file is not a valid file type."
         ):
             validator(self.CORRECT_GIF)
 


### PR DESCRIPTION
Fixes #2808

- overflow is prevented by removing the second occurrence of the filename from the error message (the filename is already displayed, hence the second occurrence is redundant)
- existing tests modified to reflect changes