### PR TITLE
[#3077] use public form name for form_name variable

### DIFF
--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -1,5 +1,5 @@
 import html
-from mimetypes import types_map
+import mimetypes
 from typing import List, NoReturn, Optional, Tuple, TypedDict
 
 from django.conf import settings
@@ -53,7 +53,7 @@ class EmailRegistration(BasePlugin):
         subject = render_from_string(
             subject_template,
             {
-                "form_name": submission.form.admin_name,
+                "form_name": submission.form.name,
                 "submission_reference": submission.public_registration_reference,
             },
         )
@@ -138,7 +138,7 @@ class EmailRegistration(BasePlugin):
 
         attachment_formats = options.get("attachment_formats", [])
         for attachment_format in attachment_formats:
-            mime_type = types_map[f".{attachment_format}"]
+            mime_type = mimetypes.types_map[f".{attachment_format}"]
             if attachment_format in [AttachmentFormat.csv, AttachmentFormat.xlsx]:
                 export_data = create_submission_export(
                     Submission.objects.filter(pk=submission.pk).select_related(
@@ -147,7 +147,7 @@ class EmailRegistration(BasePlugin):
                 ).export(attachment_format)
 
                 attachment = (
-                    f"{submission.form.admin_name} - submission.{attachment_format}",
+                    f"{submission.form.name} - submission.{attachment_format}",
                     export_data,
                     mime_type,
                 )
@@ -177,7 +177,7 @@ class EmailRegistration(BasePlugin):
         subject = _(
             "[Open Forms] {form_name} - submission payment received {public_reference}"
         ).format(
-            form_name=submission.form.admin_name,
+            form_name=submission.form.name,
             public_reference=submission.public_registration_reference,
         )
         recipients = options.get("payment_emails")

--- a/src/openforms/registrations/contrib/email/templates/emails/email_registration.html
+++ b/src/openforms/registrations/contrib/email/templates/emails/email_registration.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% with co_signer=renderer.submission.get_co_signer form_name=renderer.submission.form.admin_name %}
+{% with co_signer=renderer.submission.get_co_signer form_name=renderer.submission.form.name %}
 {% if payment_received %}
     <p>{% blocktrans trimmed %}
         Submission payment received for {{ form_name }} (submitted on {{ datetime }})

--- a/src/openforms/registrations/contrib/email/templates/emails/email_registration.txt
+++ b/src/openforms/registrations/contrib/email/templates/emails/email_registration.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% with form_name=renderer.submission.form.admin_name %}{% autoescape off %}{% if payment_received %}{% blocktrans trimmed %}
+{% load i18n %}{% with form_name=renderer.submission.form.name %}{% autoescape off %}{% if payment_received %}{% blocktrans trimmed %}
 Submission payment received for {{ form_name }} (submitted on {{ datetime }})
 {% endblocktrans %}
 

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -119,7 +119,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         message = mail.outbox[0]
         self.assertEqual(
             message.subject,
-            f"Test submission custom subject - {submission.form.admin_name} - submission {submission.public_registration_reference}",
+            f"Test submission custom subject - {submission.form.name} - submission {submission.public_registration_reference}",
         )
         self.assertEqual(message.from_email, "info@open-forms.nl")
         self.assertEqual(message.to, ["foo@bar.nl", "bar@foo.nl"])
@@ -134,7 +134,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         detail_line = _(
             "Submission details for %(form_name)s (submitted on %(datetime)s)"
         ) % dict(
-            form_name=self.form.admin_name,
+            form_name=self.form.name,
             datetime="12:00:00 01-01-2021",
         )
         self.assertIn(detail_line, message_html)
@@ -286,7 +286,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             _(
                 "[Open Forms] {form_name} - submission payment received {public_reference}"
             ).format(
-                form_name=submission.form.admin_name,
+                form_name=submission.form.name,
                 public_reference=submission.public_registration_reference,
             ),
         )
@@ -303,7 +303,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         detail_line = _(
             "Submission payment received for %(form_name)s (submitted on %(datetime)s)"
         ) % dict(
-            form_name=self.form.admin_name,
+            form_name=self.form.name,
             datetime="12:00:00 01-01-2021",
         )
         self.assertIn(detail_line, message_html)
@@ -421,15 +421,11 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         csv_export, xlsx_export = message.attachments
 
         qs = Submission.objects.filter(pk=submission.pk).order_by("-pk")
-        self.assertEqual(
-            csv_export[0], f"{submission.form.admin_name} - submission.csv"
-        )
+        self.assertEqual(csv_export[0], f"{submission.form.name} - submission.csv")
         self.assertEqual(csv_export[1], create_submission_export(qs).export("csv"))
         self.assertEqual(csv_export[2], "text/csv")
 
-        self.assertEqual(
-            xlsx_export[0], f"{submission.form.admin_name} - submission.xlsx"
-        )
+        self.assertEqual(xlsx_export[0], f"{submission.form.name} - submission.xlsx")
         self.assertEqual(xlsx_export[1], create_submission_export(qs).export("xlsx"))
         self.assertEqual(
             xlsx_export[2],

--- a/src/openforms/setup.py
+++ b/src/openforms/setup.py
@@ -10,6 +10,7 @@ they are available for Django settings initialization.
     before Django is initialized.
 """
 import logging
+import mimetypes
 import os
 import sys
 import warnings
@@ -28,6 +29,9 @@ from requests import Session
 from self_certifi import load_self_signed_certs as _load_self_signed_certs
 
 logger = logging.getLogger(__name__)
+
+
+mimetypes.init()
 
 
 def setup_env():


### PR DESCRIPTION
Closes #3077 (partly)
Complement to PR #3093 