### PR TITLE
Introduce FormioData data structure

### DIFF
--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -107,6 +107,8 @@ class FormioData(UserDict):
     details (such as using ``glom`` for this).
     """
 
+    data: dict[str, JSONValue]
+
     def __getitem__(self, key: Hashable):
         return cast(JSONValue, glom(self.data, key))
 

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -89,6 +89,24 @@ class FormioConfigurationWrapper:
 
 
 class FormioData(UserDict):
+    """
+    Handle formio (submission) data transparently.
+
+    Form.io supports component keys in the format 'topLevel.nested' which get converted
+    to deep-setting of object properties (using ``lodash.set`` internally). This
+    datastructure mimicks that interface in Python so we can more naturally perform
+    operations like:
+
+    .. code-block:: python
+
+        data = FormioData()
+        for component in iter_components(...):
+            data[component["key"]] = ...
+
+    without having to worry about potential deep assignments or leak implementation
+    details (such as using ``glom`` for this).
+    """
+
     def __getitem__(self, key: Hashable):
         return cast(JSONValue, glom(self.data, key))
 

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -84,3 +84,7 @@ class FormioConfigurationWrapper:
             component = cast(Component, glom(self.configuration, path))
             nodes.append(component)
         return all(is_visible_in_frontend(node, values) for node in nodes)
+
+
+class FormioData(dict):
+    pass

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -17,7 +17,7 @@ from openforms.prefill import inject_prefill
 from openforms.submissions.models import Submission, SubmissionStep
 from openforms.typing import DataMapping
 
-from .datastructures import FormioConfigurationWrapper
+from .datastructures import FormioConfigurationWrapper, FormioData
 from .dynamic_config import (
     get_translated_custom_error_messages,
     rewrite_formio_components,
@@ -35,6 +35,7 @@ __all__ = [
     "inject_variables",
     "format_value",
     "rewrite_formio_components_for_request",
+    "FormioData",
 ]
 
 

--- a/src/openforms/formio/tests/test_datastructures.py
+++ b/src/openforms/formio/tests/test_datastructures.py
@@ -38,3 +38,28 @@ class FormioDataTests(TestCase):
         formio_data["foo.bar"] = "baz"
 
         self.assertEqual(formio_data, {"foo": {"bar": "baz"}})
+
+    def test_containment(self):
+        formio_data = FormioData(
+            {
+                "top": "level",
+                "container": {
+                    "nested": "leaf",
+                },
+            }
+        )
+
+        with self.subTest("top level container"):
+            self.assertTrue("top" in formio_data)
+
+        with self.subTest("nested container"):
+            self.assertTrue("container" in formio_data)
+
+        with self.subTest("nested leaf"):
+            self.assertTrue("container.nested" in formio_data)
+
+        with self.subTest("top level absent"):
+            self.assertFalse("absent" in formio_data)
+
+        with self.subTest("nested absent"):
+            self.assertFalse("container.absent" in formio_data)

--- a/src/openforms/formio/tests/test_datastructures.py
+++ b/src/openforms/formio/tests/test_datastructures.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+from ..datastructures import FormioData
+
+
+class FormioDataTests(TestCase):
+    def test_mimicks_dict_interface(self):
+        formio_data = FormioData({"foo": "bar"})
+
+        self.assertEqual(formio_data, {"foo": "bar"})
+        self.assertEqual(formio_data["foo"], "bar")
+        self.assertIsNone(formio_data.get("okay"))
+
+        with self.assertRaises(KeyError):
+            formio_data["bad_key_no_cookie"]
+
+        with self.assertRaises(ValueError):
+            FormioData(["bad type"])  # type: ignore
+
+        with self.assertRaises(TypeError):
+            FormioData(None)  # type: ignore
+
+    def test_translate_dotted_lookup_paths(self):
+        formio_data = FormioData({"foo": {"bar": "baz"}})
+
+        with self.subTest("top-level key lookup"):
+            self.assertEqual(formio_data["foo"], {"bar": "baz"})
+            self.assertEqual(formio_data.get("foo"), {"bar": "baz"})
+
+        with self.subTest("nested key lookup"):
+            self.assertEqual(formio_data["foo.bar"], "baz")
+            self.assertEqual(formio_data.get("foo.bar"), "baz")
+            self.assertEqual(formio_data.get("foo.baz", "a default"), "a default")
+
+    def test_translate_dotted_setter_paths(self):
+        formio_data = FormioData({})
+
+        formio_data["foo.bar"] = "baz"
+
+        self.assertEqual(formio_data, {"foo": {"bar": "baz"}})

--- a/src/openforms/formio/tests/test_datastructures.py
+++ b/src/openforms/formio/tests/test_datastructures.py
@@ -63,3 +63,26 @@ class FormioDataTests(TestCase):
 
         with self.subTest("nested absent"):
             self.assertFalse("container.absent" in formio_data)
+
+    def test_initializing_with_dotted_paths_expands(self):
+        formio_data = FormioData(
+            {
+                "container.nested1": "foo",
+                "otherContainer.nested1": "bar",
+                "container.nested2": "baz",
+                "topLevel": True,
+            }
+        )
+
+        expected = {
+            "container": {
+                "nested1": "foo",
+                "nested2": "baz",
+            },
+            "otherContainer": {
+                "nested1": "bar",
+            },
+            "topLevel": True,
+        }
+
+        self.assertEqual(formio_data, expected)

--- a/src/openforms/formio/tests/test_datastructures.py
+++ b/src/openforms/formio/tests/test_datastructures.py
@@ -18,7 +18,7 @@ class FormioDataTests(TestCase):
             FormioData(["bad type"])  # type: ignore
 
         with self.assertRaises(TypeError):
-            FormioData(None)  # type: ignore
+            FormioData(123)  # type: ignore
 
     def test_translate_dotted_lookup_paths(self):
         formio_data = FormioData({"foo": {"bar": "baz"}})

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -23,6 +23,7 @@ from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.filters import PermissionFilterMixin
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.api.throttle_classes import PollingRateThrottle
+from openforms.formio.service import FormioData
 from openforms.forms.models import FormStep
 from openforms.logging import logevent
 from openforms.prefill import prefill_variables
@@ -575,16 +576,13 @@ class SubmissionStepViewSet(
 
         data = form_data_serializer.validated_data["data"]
         if data:
-            # TODO: probably we should use a recursive merge here, in the event that
-            # keys like ``foo.bar`` and ``foo.baz`` are used which construct a foo object
-            # with keys bar and baz.
-            merged_data = {**submission.data, **data}
+            merged_data = FormioData({**submission.data, **data})
             submission_step.data = DirtyData(data)
 
             new_configuration = evaluate_form_logic(
                 submission,
                 submission_step,
-                merged_data,
+                merged_data.data,
                 dirty=True,
                 request=request,
             )

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -10,7 +10,7 @@ from openforms.formio.service import (
     inject_variables,
     translate_function,
 )
-from openforms.formio.utils import get_component_empty_value, is_visible_in_frontend
+from openforms.formio.utils import get_component_empty_value
 from openforms.logging import logevent
 from openforms.typing import DataMapping
 
@@ -151,6 +151,7 @@ def evaluate_form_logic(
         if is_visible:
             continue
 
+        # Reset the value of any field that may have become hidden again after evaluating the logic
         original_value = initial_data.get(key, empty)
         empty_value = get_component_empty_value(component)
         if original_value is empty or original_value == empty_value:
@@ -194,18 +195,6 @@ def evaluate_form_logic(
 
             new_value = updated_step_data.get(key, default=empty)
             original_value = initial_data.get(key, default=empty)
-            # Reset the value of any field that may have become hidden again after evaluating the logic
-            if original_value is not empty and original_value != (
-                component_empty_value := get_component_empty_value(component)
-            ):
-                if (
-                    component
-                    and not is_visible_in_frontend(component, data_container.data)
-                    and component.get("clearOnHide")
-                ):
-                    data_diff[key] = component_empty_value
-                    continue
-
             if new_value is empty or new_value == original_value:
                 continue
             data_diff[key] = new_value

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -87,6 +87,7 @@ class ComponentModificationTests(TestCase):
         }
         self.assertEqual(configuration, expected)
 
+    @tag("gh-1871", "gh-2340", "gh-2409")
     def test_hiding_component_empties_its_data(self):
         form = FormFactory.create()
         form_step = FormStepFactory.create(

--- a/src/openforms/variables/utils.py
+++ b/src/openforms/variables/utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time
 from typing import TYPE_CHECKING
 
-from openforms.typing import JSONObject
+from openforms.typing import JSONObject, JSONValue
 from openforms.utils.date import parse_date
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -31,27 +31,22 @@ def check_initial_value(initial_value: JSONObject, data_type: str) -> JSONObject
         return DEFAULT_INITIAL_VALUE[data_type]
 
 
-def get_variables_for_context(submission: "Submission") -> dict[str, JSONObject]:
+def get_variables_for_context(submission: "Submission") -> dict[str, JSONValue]:
     """Return the key/value pairs of static variables and submission variables.
 
     This returns the saved component variables and user defined variables for a submission, plus the static variables
     (which are never saved). Note that depending on when it is called, the 'auth' static variables
     (auth_bsn, auth_kvk...) can be already hashed.
-
-    .. note::
-       This has inherent problems with form variables having dots in the keys. These
-       should expand to nested dicts/objects, but currently they are injected in the
-       template as "foo.bar" context keys which cannot actually be used (probably).
-
-       See https://github.com/open-formulieren/open-forms/issues/2784 for a possible
-       solution in the future.
     """
+    from openforms.formio.service import FormioData
+
     from .service import get_static_variables
 
-    return {
+    formio_data = FormioData(
         **{
             variable.key: variable.initial_value
             for variable in get_static_variables(submission=submission)
         },
         **submission.data,
-    }
+    )
+    return formio_data.data


### PR DESCRIPTION
Closes #2784

Adds a datastructure to deal with the formio keys that can contain periods (`.`) which expand into nested objects.

There are now some chained calls that convert between `FormioData` <-> `dict` that would probably benefit from changing their signature to accept `FormioData`, but I'm not sure how troublesome that will be if we need to do backportable fixes in those areas :thinking: Let's discuss?