### PR TITLE
Fix prefill plugin check in warning (new form builder)

### DIFF
--- a/src/openforms/js/components/admin/form_design/PluginWarning.js
+++ b/src/openforms/js/components/admin/form_design/PluginWarning.js
@@ -21,18 +21,10 @@ const PluginWarning = ({loginRequired, configuration}) => {
       configuration.components.map(checkPrefillsAuth);
     }
 
-    if (
-      !(
-        configuration.prefill &&
-        Object.keys(configuration.prefill).length &&
-        configuration.prefill.plugin !== ''
-      )
-    )
-      return;
+    const pluginId = configuration?.prefill?.plugin;
+    if (!pluginId) return;
 
-    const prefillPlugin = availablePrefillPlugins.find(
-      plugin => plugin.id === configuration.prefill.plugin
-    );
+    const prefillPlugin = availablePrefillPlugins.find(plugin => plugin.id === pluginId);
     const requiredAuthAttribute = prefillPlugin.requiresAuth;
 
     if (!requiredAuthAttribute) return;


### PR DESCRIPTION
Closes #3112

The new form builder normalizes the schema and this means text fields always have a 'prefill' object in their configuration, with plugin and attribute set to null if there's no prefill.

The warning now checks the behaviour only if a plugin is configured using the operator to shortcut if parts are missing in the nested object lookup.