### PR TITLE
 copy the "Bevestingsmailsjabloon" when a form is copied

### DIFF
--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -1,4 +1,5 @@
 import uuid as _uuid
+from contextlib import suppress
 from copy import deepcopy
 from typing import List, Optional
 
@@ -363,6 +364,7 @@ class Form(models.Model):
 
     @transaction.atomic
     def copy(self):
+        from ...emails.models import ConfirmationEmailTemplate
         from .form_variable import FormVariable
 
         form_steps = self.formstep_set.all().select_related("form_definition")
@@ -407,6 +409,11 @@ class Form(models.Model):
             variable.pk = None
             variable.form = copy
             variable.save()
+
+        with suppress(ConfirmationEmailTemplate.DoesNotExist):
+            self.confirmation_email_template.pk = None
+            self.confirmation_email_template.form = copy
+            self.confirmation_email_template.save()
 
         return copy
 

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -14,6 +14,7 @@ from django_webtest import WebTest
 
 from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
 from openforms.config.models import GlobalConfiguration, RichTextColor
+from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
 from openforms.forms.tests.factories import FormLogicFactory
 from openforms.tests.utils import disable_2fa
 from openforms.utils.admin import SubmitActions
@@ -516,6 +517,9 @@ class FormAdminCopyTests(TestCase):
         form = FormFactory.create(
             authentication_backends=["digid"], internal_name="internal"
         )
+        confirmation_email_template = ConfirmationEmailTemplateFactory(
+            form=form, subject="Test"
+        )
         form_step = FormStepFactory.create(form=form, form_definition__is_reusable=True)
         logic = FormLogicFactory.create(
             form=form,
@@ -548,6 +552,11 @@ class FormAdminCopyTests(TestCase):
 
         copied_form_step_form_definition = copied_form_step.form_definition
         self.assertEqual(copied_form_step_form_definition, form_step.form_definition)
+
+        self.assertEqual(copied_form.confirmation_email_template.subject, "Test")
+        self.assertNotEqual(
+            copied_form.confirmation_email_template.id, confirmation_email_template.id
+        )
 
 
 @disable_2fa


### PR DESCRIPTION
This pull request fixes #3070 by erasing `self.confirmation_email_template.pk` and updating the relation to `copy` so its added as a new row with the correct foreign key. 