### PR TITLE
:arrow_up: Bump to cookie-consent 0.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -148,7 +148,7 @@ django-capture-tag==1.0
     # via -r requirements/base.in
 django-colorfield==0.7.0
     # via -r requirements/base.in
-django-cookie-consent==0.3.1
+django-cookie-consent==0.4.0
     # via -r requirements/base.in
 django-cors-headers==3.11.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -238,7 +238,7 @@ django-colorfield==0.7.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-cookie-consent==0.3.1
+django-cookie-consent==0.4.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -267,7 +267,7 @@ django-colorfield==0.7.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-cookie-consent==0.3.1
+django-cookie-consent==0.4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -202,7 +202,7 @@ django-colorfield==0.7.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-cookie-consent==0.3.1
+django-cookie-consent==0.4.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt


### PR DESCRIPTION
This version is Django 4.2 compatible

Part of #3049