### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -59,7 +59,6 @@ django-tinymce
 django-treebeard
 django-yubin
 mozilla-django-oidc-db
-pyopenssl
 maykin-django-two-factor-auth[phonenumbers]
 django-timeline-logger
 django-csp

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -70,7 +70,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==39.0.1
+cryptography==41.0.1
     # via
     #   django-simple-certmanager
     #   josepy
@@ -333,9 +333,8 @@ pycparser==2.20
     # via cffi
 pyjwt==2.6.0
     # via gemma-zds-client
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via
-    #   -r requirements/base.in
     #   django-simple-certmanager
     #   josepy
     #   maykin-python3-saml

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -136,7 +136,7 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.1.0
     # via -r requirements/test-tools.in
-cryptography==39.0.1
+cryptography==41.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -649,7 +649,7 @@ pyjwt==2.6.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   gemma-zds-client
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -156,7 +156,7 @@ coverage==7.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-cryptography==39.0.1
+cryptography==41.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -770,7 +770,7 @@ pyjwt==2.6.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   gemma-zds-client
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -105,7 +105,7 @@ click-repl==0.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-cryptography==39.0.1
+cryptography==41.0.1
     # via
     #   -r requirements/base.txt
     #   django-simple-certmanager
@@ -520,9 +520,8 @@ pyjwt==2.6.0
     # via
     #   -r requirements/base.txt
     #   gemma-zds-client
-pyopenssl==23.0.0
+pyopenssl==23.2.0
     # via
-    #   -c requirements/base.in
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy


### PR DESCRIPTION
Bumped PyOpenSSL to be able to bump cryptography to 41.0.0+

See also: maykinmedia/django-digid-eherkenning#31