### PR TITLE
Fix upgrade to 2.0.x migration

### DIFF
--- a/src/openforms/forms/tests/test_migrations.py
+++ b/src/openforms/forms/tests/test_migrations.py
@@ -137,6 +137,12 @@ class FixBrokenConvertedLogicTests(TestMigrations):
 
     def setUpBeforeMigration(self, apps):
         form = Form.objects.create(name="Form", slug="form")
+        step = FormStep.objects.create(
+            form=form,
+            form_definition=FormDefinition.objects.create(
+                name="FD", configuration={"components": []}
+            ),
+        )
         rule1 = FormLogic.objects.create(
             form=form,
             json_logic_trigger={"==": [{"var": "test1"}, "trigger value"]},
@@ -185,12 +191,26 @@ class FixBrokenConvertedLogicTests(TestMigrations):
             ],
         )
 
+        rule3 = FormLogic.objects.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "test1"}, "test"]},
+            actions=[
+                # valid rule
+                {
+                    "name": "Rule 3 Action 1",
+                    "form_step": f"https://example.com/api/v1/forms/{form.uuid}/steps/{step.uuid}",
+                    "action": {"type": "step-not-applicable"},
+                }
+            ],
+        )
+
         self.form = form
         self.rule1 = rule1
         self.rule2 = rule2
+        self.rule3 = rule3
 
     def test_migrate_logic(self):
-        self.assertEqual(2, self.form.formlogic_set.count())
+        self.assertEqual(self.form.formlogic_set.count(), 3)
 
         self.rule1.refresh_from_db()
         self.rule2.refresh_from_db()

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -452,6 +452,9 @@ def advanced_formio_logic_to_backend_logic(form_definition: "FormDefinition") ->
 def fix_broken_rules(rules: models.QuerySet) -> None:
     fixed_rules = []
     for rule in rules:
+        for action in rule.actions:
+            if action.get("form_step"):
+                action["form_step"] = action["form_step"].replace("/api/v1", "/api/v2")
         serializer = LogicComponentActionSerializer(data=rule.actions, many=True)
         is_valid = serializer.is_valid()
         if not is_valid:


### PR DESCRIPTION
Closes #3117

Patch is not relevant for 2.1.x and 2.2.x/master, as the data migration has been removed in those versions.