### PR TITLE
[#1530] Remove migration

### DIFF
--- a/src/openforms/forms/migrations/0079_replace_cosign_component.py
+++ b/src/openforms/forms/migrations/0079_replace_cosign_component.py
@@ -2,39 +2,13 @@
 
 from django.db import migrations
 
-from openforms.formio.utils import iter_components
 
-
-def replace_old_cosign_component(apps, schema_editor):
-    FormDefinition = apps.get_model("forms", "FormDefinition")
-
-    form_definitions = FormDefinition.objects.all()
-
-    form_definitions_to_update = []
-    for form_definition in form_definitions:
-        updated_form_definition = False
-        for comp in iter_components(configuration=form_definition.configuration):
-            if comp["type"] != "coSign":
-                continue
-
-            comp.update({"type": "cosign", "validateOn": "blur"})
-            updated_form_definition = True
-
-        if updated_form_definition:
-            form_definitions_to_update.append(form_definition)
-
-    if form_definitions_to_update:
-        FormDefinition.objects.bulk_update(
-            form_definitions_to_update, fields=["configuration"]
-        )
-
-
+# Initially we thought the new cosign component would replace the old one,
+# but actually they will both exist for a while
 class Migration(migrations.Migration):
 
     dependencies = [
         ("forms", "0078_form_suspension_allowed"),
     ]
 
-    operations = [
-        migrations.RunPython(replace_old_cosign_component, migrations.RunPython.noop),
-    ]
+    operations = []

--- a/src/openforms/forms/tests/test_migrations.py
+++ b/src/openforms/forms/tests/test_migrations.py
@@ -807,47 +807,6 @@ class TestRemoveConfirmationEmailBackwardsOptions(TestMigrations):
         )
 
 
-class TestReplaceOldCosignComponent(TestMigrations):
-    migrate_from = "0078_form_suspension_allowed"
-    migrate_to = "0079_replace_cosign_component"
-    app = "forms"
-
-    def setUpBeforeMigration(self, apps):
-        FormDefinition = apps.get_model("forms", "FormDefinition")
-        self.form_definition = FormDefinition.objects.create(
-            name="Definition with Co-sign",
-            slug="definition-with-cosign",
-            configuration={
-                "components": [
-                    {
-                        "label": "Co-sign",
-                        "description": "Im a cosign component",
-                        "authPlugin": "digid",
-                        "key": "medeOndertekenen1",
-                        "type": "coSign",
-                    }
-                ]
-            },
-        )
-
-    def test_forward_migration(self):
-        self.form_definition.refresh_from_db()
-
-        cosign_component = self.form_definition.configuration["components"][0]
-
-        self.assertEqual(
-            cosign_component,
-            {
-                "label": "Co-sign",
-                "description": "Im a cosign component",
-                "authPlugin": "digid",
-                "key": "medeOndertekenen1",
-                "type": "cosign",
-                "validateOn": "blur",
-            },
-        )
-
-
 class TestAddShowInSummaryDefault(TestMigrations):
     migrate_from = "0079_replace_cosign_component"
     migrate_to = "0080_add_show_in_summary_default"


### PR DESCRIPTION
Fixes #1530 

Remove the migration that was meant to convert the old cosign component to the new cosign component. We decided later that the old flow should be kept.