### PR TITLE
Appointments: get all locations an filter products by location

### DIFF
--- a/src/openforms/appointments/admin.py
+++ b/src/openforms/appointments/admin.py
@@ -38,7 +38,7 @@ class AppointmentsConfigAdmin(SingletonModelAdmin):
                     **kwargs,
                 )
 
-            locations = plugin.get_locations([])
+            locations = plugin.get_locations()
             field_copy = copy(db_field)
             field_copy.choices = [
                 (location.identifier, location.name) for location in locations

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -82,8 +82,10 @@ class BasePlugin(ABC, AbstractBasePlugin):
 
     @abstractmethod
     def get_available_products(
-        self, current_products: Optional[List[AppointmentProduct]] = None
-    ) -> List[AppointmentProduct]:  # pragma: no cover
+        self,
+        current_products: list[AppointmentProduct] | None = None,
+        location_id: str = "",
+    ) -> list[AppointmentProduct]:  # pragma: no cover
         """
         Retrieve all available products and services to create an appointment for.
 
@@ -92,6 +94,8 @@ class BasePlugin(ABC, AbstractBasePlugin):
 
         :param current_products: List of :class:`AppointmentProduct`, as obtained from
           another :meth:`get_available_products` call.
+        :param location_id: ID of the location to filter products on - plugins may
+          support this.
         :returns: List of :class:`AppointmentProduct`
         """
         raise NotImplementedError()
@@ -102,11 +106,12 @@ class BasePlugin(ABC, AbstractBasePlugin):
         products: list[AppointmentProduct] | None = None,
     ) -> list[AppointmentLocation]:  # pragma: no cover
         """
-        Retrieve all available locations for given ``products``.
+        Retrieve all available locations.
 
         :param products: List of :class:`AppointmentProduct`, as obtained from
           :meth:`get_available_products`. If ``None`` or unspecified, all possible
-          locations are returned.
+          locations are returned. Otherwise, if the plugin supports it, locations are
+          filtered given the products.
         :returns: List of :class:`AppointmentLocation`
         """
         raise NotImplementedError()

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -98,13 +98,16 @@ class BasePlugin(ABC, AbstractBasePlugin):
 
     @abstractmethod
     def get_locations(
-        self, products: List[AppointmentProduct]
-    ) -> List[AppointmentLocation]:  # pragma: no cover
+        self,
+        products: list[AppointmentProduct] | None = None,
+    ) -> list[AppointmentLocation]:  # pragma: no cover
         """
         Retrieve all available locations for given ``products``.
 
         :param products: List of :class:`AppointmentProduct`, as obtained from
-          :meth:`get_available_products`. :returns: List of :class:`AppointmentLocation`
+          :meth:`get_available_products`. If ``None`` or unspecified, all possible
+          locations are returned.
+        :returns: List of :class:`AppointmentLocation`
         """
         raise NotImplementedError()
 

--- a/src/openforms/appointments/contrib/demo/plugin.py
+++ b/src/openforms/appointments/contrib/demo/plugin.py
@@ -22,7 +22,7 @@ class DemoAppointment(BasePlugin):
             AppointmentProduct(identifier="2", name="Test product 2"),
         ]
 
-    def get_locations(self, products):
+    def get_locations(self, products=None):
         return [AppointmentLocation(identifier="1", name="Test location")]
 
     def get_dates(self, products, location, start_at=None, end_at=None):

--- a/src/openforms/appointments/contrib/jcc/__init__.py
+++ b/src/openforms/appointments/contrib/jcc/__init__.py
@@ -1,0 +1,9 @@
+"""
+Plugin for JCC-Afspraken internetafsprakenadapter GGS2 (april 2020)
+
+Website: https://www.jccsoftware.nl/afspraken/
+
+The service documentation is contained in the WSDL: GenericGuidanceSystem2.wsdl
+
+Developers (Maykin): A PDF with documentation can be found in the team share.
+"""

--- a/src/openforms/appointments/contrib/jcc/client.py
+++ b/src/openforms/appointments/contrib/jcc/client.py
@@ -1,7 +1,9 @@
+from zeep.client import Client
+
 from .models import JccConfig
 
 
-def get_client():
+def get_client() -> Client:
     service = JccConfig.get_solo().service
     assert service is not None
     return service.build_client()

--- a/src/openforms/appointments/contrib/jcc/plugin.py
+++ b/src/openforms/appointments/contrib/jcc/plugin.py
@@ -48,8 +48,15 @@ class JccAppointment(BasePlugin):
     verbose_name = _("JCC")
 
     def get_available_products(
-        self, current_products: Optional[List[AppointmentProduct]] = None
-    ) -> List[AppointmentProduct]:
+        self,
+        current_products: list[AppointmentProduct] | None = None,
+        location_id: str = "",
+    ) -> list[AppointmentProduct]:
+        if location_id:
+            logger.debug(
+                "Plugin does not support filtering products by location.",
+                extra={"location_id": location_id},
+            )
 
         client = get_client()
         try:

--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovLocationsResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovLocationsResponse.xml
@@ -1,0 +1,8 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:gen="http://www.genericCBS.org/GenericCBS/">
+   <soapenv:Body>
+      <getGovLocationsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <locationIDs xmlns="">1</locationIDs>
+         <locationIDs xmlns="">2</locationIDs>
+      </getGovLocationsResponse>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
@@ -12,11 +12,11 @@ from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
 from stuf.tests.factories import SoapServiceFactory
 
-from ...constants import AppointmentDetailsStatus
-from ...contrib.jcc.models import JccConfig
-from ...contrib.jcc.tests.test_plugin import mock_response
-from ...models import AppointmentsConfig
-from ...tests.factories import AppointmentInfoFactory
+from ....constants import AppointmentDetailsStatus
+from ....models import AppointmentsConfig
+from ....tests.factories import AppointmentInfoFactory
+from ..models import JccConfig
+from ..tests.test_plugin import mock_response
 
 
 class ProductsListTests(SubmissionsMixin, TestCase):

--- a/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
@@ -43,14 +43,6 @@ class ProductsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class ProductListsWithFixedLocationTests(
-    MockConfigMixin, SubmissionsMixin, APITestCase
-):
-    extra_appointments_config = {
-        "limit_to_location": "1"
-    }  # see ./mocks/getGovLocationsForProductResponse.xml
-
-
 class LocationsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
@@ -43,6 +43,14 @@ class ProductsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class ProductListsWithFixedLocationTests(
+    MockConfigMixin, SubmissionsMixin, APITestCase
+):
+    extra_appointments_config = {
+        "limit_to_location": "1"
+    }  # see ./mocks/getGovLocationsForProductResponse.xml
+
+
 class LocationsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_api_endpoints.py
@@ -1,43 +1,25 @@
-import os
-
-from django.conf import settings
-from django.test import TestCase
 from django.urls import reverse
 
 import requests_mock
+from rest_framework.test import APITestCase
 from zeep.exceptions import Error as ZeepError
 
 from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
-from stuf.tests.factories import SoapServiceFactory
 
 from ....constants import AppointmentDetailsStatus
-from ....models import AppointmentsConfig
 from ....tests.factories import AppointmentInfoFactory
-from ..models import JccConfig
-from ..tests.test_plugin import mock_response
+from .utils import MockConfigMixin, mock_response
 
 
-class ProductsListTests(SubmissionsMixin, TestCase):
+class ProductsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.submission = SubmissionFactory.create()
         cls.endpoint = reverse("api:appointments-products-list")
-
-        appointments_config = AppointmentsConfig.get_solo()
-        appointments_config.plugin = "jcc"
-        appointments_config.save()
-
-        config = JccConfig.get_solo()
-        wsdl = os.path.abspath(
-            os.path.join(
-                settings.DJANGO_PROJECT_DIR,
-                "appointments/contrib/jcc/tests/mock/GenericGuidanceSystem2.wsdl",
-            )
-        )
-        config.service = SoapServiceFactory.create(url=wsdl)
-        config.save()
 
     @requests_mock.Mocker()
     def test_get_products_returns_all_products(self, m):
@@ -61,25 +43,13 @@ class ProductsListTests(SubmissionsMixin, TestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class LocationsListTests(SubmissionsMixin, TestCase):
+class LocationsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.submission = SubmissionFactory.create()
         cls.endpoint = reverse("api:appointments-locations-list")
-
-        appointments_config = AppointmentsConfig.get_solo()
-        appointments_config.plugin = "jcc"
-        appointments_config.save()
-
-        config = JccConfig.get_solo()
-        wsdl = os.path.abspath(
-            os.path.join(
-                settings.DJANGO_PROJECT_DIR,
-                "appointments/contrib/jcc/tests/mock/GenericGuidanceSystem2.wsdl",
-            )
-        )
-        config.service = SoapServiceFactory.create(url=wsdl)
-        config.save()
 
     def setUp(self):
         super().setUp()
@@ -112,25 +82,13 @@ class LocationsListTests(SubmissionsMixin, TestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class DatesListTests(SubmissionsMixin, TestCase):
+class DatesListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.submission = SubmissionFactory.create()
         cls.endpoint = reverse("api:appointments-dates-list")
-
-        appointments_config = AppointmentsConfig.get_solo()
-        appointments_config.plugin = "jcc"
-        appointments_config.save()
-
-        config = JccConfig.get_solo()
-        wsdl = os.path.abspath(
-            os.path.join(
-                settings.DJANGO_PROJECT_DIR,
-                "appointments/contrib/jcc/tests/mock/GenericGuidanceSystem2.wsdl",
-            )
-        )
-        config.service = SoapServiceFactory.create(url=wsdl)
-        config.save()
 
     def setUp(self):
         super().setUp()
@@ -167,25 +125,13 @@ class DatesListTests(SubmissionsMixin, TestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class TimesListTests(SubmissionsMixin, TestCase):
+class TimesListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
+
         cls.submission = SubmissionFactory.create()
         cls.endpoint = reverse("api:appointments-times-list")
-
-        appointments_config = AppointmentsConfig.get_solo()
-        appointments_config.plugin = "jcc"
-        appointments_config.save()
-
-        config = JccConfig.get_solo()
-        wsdl = os.path.abspath(
-            os.path.join(
-                settings.DJANGO_PROJECT_DIR,
-                "appointments/contrib/jcc/tests/mock/GenericGuidanceSystem2.wsdl",
-            )
-        )
-        config.service = SoapServiceFactory.create(url=wsdl)
-        config.save()
 
     def setUp(self):
         super().setUp()
@@ -229,23 +175,7 @@ class TimesListTests(SubmissionsMixin, TestCase):
         self.assertEqual(response.status_code, 403)
 
 
-class CancelAppointmentTests(SubmissionsMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        appointments_config = AppointmentsConfig.get_solo()
-        appointments_config.plugin = "jcc"
-        appointments_config.save()
-
-        config = JccConfig.get_solo()
-        wsdl = os.path.abspath(
-            os.path.join(
-                settings.DJANGO_PROJECT_DIR,
-                "appointments/contrib/jcc/tests/mock/GenericGuidanceSystem2.wsdl",
-            )
-        )
-        config.service = SoapServiceFactory.create(url=wsdl)
-        config.save()
-
+class CancelAppointmentTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @requests_mock.Mocker()
     def test_cancel_appointment_cancels_the_appointment(self, m):
         submission = SubmissionFactory.from_components(

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -32,12 +32,20 @@ class PluginTests(MockConfigMixin, TestCase):
             text=mock_response("getGovAvailableProductsResponse.xml"),
         )
 
-        products = self.plugin.get_available_products()
+        with self.subTest("without location ID"):
+            products = self.plugin.get_available_products()
 
-        self.assertEqual(len(products), 3)
-        self.assertEqual(products[0].identifier, "1")
-        self.assertEqual(products[0].code, "PASAAN")
-        self.assertEqual(products[0].name, "Paspoort aanvraag")
+            self.assertEqual(len(products), 3)
+            self.assertEqual(products[0].identifier, "1")
+            self.assertEqual(products[0].code, "PASAAN")
+            self.assertEqual(products[0].name, "Paspoort aanvraag")
+
+        with self.subTest("with location ID"):
+            # see ./mocks/getGovLocationsResponse.xml for the ID
+            products = self.plugin.get_available_products(location_id="1")
+
+            # plugin does not support filtering
+            self.assertEqual(len(products), 3)
 
     @requests_mock.Mocker()
     def test_get_available_product_products(self, m):

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -1,4 +1,3 @@
-import os
 from datetime import date, datetime
 
 from django.test import TestCase
@@ -6,37 +5,22 @@ from django.utils.translation import ugettext_lazy as _
 
 import requests_mock
 
-from stuf.tests.factories import SoapServiceFactory
-
 from ....base import (
     AppointmentClient,
     AppointmentDetails,
     AppointmentLocation,
     AppointmentProduct,
 )
-from ..models import JccConfig
 from ..plugin import JccAppointment
+from .utils import MockConfigMixin, mock_response
 
 
-def mock_response(filename):
-    filepath = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "mock", filename)
-    )
-    with open(filepath, "r") as f:
-        return f.read()
-
-
-class PluginTests(TestCase):
+class PluginTests(MockConfigMixin, TestCase):
     maxDiff = 1024
 
     @classmethod
     def setUpTestData(cls):
-        wsdl = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "mock/GenericGuidanceSystem2.wsdl")
-        )
-        config = JccConfig.get_solo()
-        config.service = SoapServiceFactory.create(url=wsdl)
-        config.save()
+        super().setUpTestData()
 
         cls.plugin = JccAppointment("jcc")
 

--- a/src/openforms/appointments/contrib/jcc/tests/utils.py
+++ b/src/openforms/appointments/contrib/jcc/tests/utils.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from openforms.utils.tests.cache import clear_caches
+from stuf.tests.factories import SoapServiceFactory
+
+from ....models import AppointmentsConfig
+from ..models import JccConfig
+
+MOCK_DIR = Path(__file__).parent.resolve() / "mock"
+
+
+def mock_response(filename: str):
+    full_path = MOCK_DIR / filename
+    return full_path.read_text()
+
+
+class MockConfigMixin:
+    extra_appointments_config = {}
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()  # type: ignore
+
+        wsdl = str(MOCK_DIR / "GenericGuidanceSystem2.wsdl")
+        cls.soap_service = SoapServiceFactory.create(url=wsdl)
+
+    def setUp(self):
+        super().setUp()  # type: ignore
+
+        self.addCleanup(clear_caches)  # type: ignore
+
+        main_config_patcher = patch(
+            "openforms.appointments.utils.AppointmentsConfig.get_solo",
+            return_value=AppointmentsConfig(
+                plugin="jcc", **self.extra_appointments_config
+            ),
+        )
+        main_config_patcher.start()
+        self.addCleanup(main_config_patcher.stop)  # type: ignore
+
+        jcc_config_patcher = patch(
+            "openforms.appointments.contrib.jcc.client.JccConfig.get_solo",
+            return_value=JccConfig(service=self.soap_service),
+        )
+        jcc_config_patcher.start()
+        self.addCleanup(jcc_config_patcher.stop)  # type: ignore

--- a/src/openforms/appointments/contrib/qmatic/tests/factories.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/factories.py
@@ -5,6 +5,7 @@ from zgw_consumers.models import Service
 from ..models import QmaticConfig
 
 
+# TODO: consilidate this in src/openforms/contrib or src/zgw_consumers_ext
 class ServiceFactory(factory.django.DjangoModelFactory):
     label = factory.Sequence(lambda n: f"API-{n}")
     api_root = factory.Sequence(lambda n: f"http://www.example{n}.com/api/v1/")

--- a/src/openforms/appointments/contrib/qmatic/tests/mock/limited_branches.json
+++ b/src/openforms/appointments/contrib/qmatic/tests/mock/limited_branches.json
@@ -1,0 +1,34 @@
+{
+    "notifications": [],
+    "branchList": [
+        {
+            "addressState": "Zuid Holland",
+            "phone": "010-1122334",
+            "addressCity": "Katwijk",
+            "fullTimeZone": "Europe/Amsterdam",
+            "timeZone": "Europe/Amsterdam",
+            "addressLine2": "Straat 1",
+            "addressLine1": null,
+            "updated": 1475589234069,
+            "created": 1475589234008,
+            "email": null,
+            "name": "Branch 2",
+            "publicId": "f7d0e4e45558de30c4772e4f1cc862",
+            "longitude": 4.436127618214371,
+            "branchPrefix": null,
+            "latitude": 52.202012993593705,
+            "addressCountry": "Netherlands",
+            "custom": null,
+            "addressZip": "2222 ZZ"
+        }
+    ],
+    "meta": {
+        "start": "",
+        "end": "",
+        "totalResults": 1,
+        "offset": null,
+        "limit": null,
+        "fields": "",
+        "arguments": {}
+    }
+}

--- a/src/openforms/appointments/contrib/qmatic/tests/mock/limited_services.json
+++ b/src/openforms/appointments/contrib/qmatic/tests/mock/limited_services.json
@@ -1,0 +1,25 @@
+{
+    "serviceList": [
+        {
+            "additionalCustomerDuration": 0,
+            "duration": 5,
+            "updated": 1475589228781,
+            "created": 1475589228595,
+            "name": "Service 02",
+            "publicId": "1e0c3d34acb5a4ad0133b2927959e896d",
+            "active": true,
+            "publicEnabled": true,
+            "custom": null
+        }
+    ],
+    "notifications": [],
+    "meta": {
+        "start": "",
+        "end": "",
+        "totalResults": 1,
+        "offset": null,
+        "limit": null,
+        "fields": "",
+        "arguments": {}
+    }
+}

--- a/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
@@ -7,12 +7,12 @@ from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
 
-from ...constants import AppointmentDetailsStatus
-from ...contrib.qmatic.client import QmaticException
-from ...contrib.qmatic.tests.factories import QmaticConfigFactory
-from ...contrib.qmatic.tests.test_plugin import mock_response
-from ...models import AppointmentsConfig
-from ...tests.factories import AppointmentInfoFactory
+from ....constants import AppointmentDetailsStatus
+from ....models import AppointmentsConfig
+from ....tests.factories import AppointmentInfoFactory
+from ..client import QmaticException
+from .factories import QmaticConfigFactory
+from .test_plugin import mock_response
 
 
 class ProductsListTests(SubmissionsMixin, TestCase):

--- a/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
@@ -19,16 +19,12 @@ from .test_plugin import mock_response
 
 
 class MockConfigMixin:
-    extra_appointments_config = {}
-
     def setUp(self):
         super().setUp()  # type: ignore
 
         patcher = patch(
             "openforms.appointments.utils.AppointmentsConfig.get_solo",
-            return_value=AppointmentsConfig(
-                plugin="qmatic", **self.extra_appointments_config
-            ),
+            return_value=AppointmentsConfig(plugin="qmatic"),
         )
         patcher.start()
         self.addCleanup(patcher.stop)  # type: ignore

--- a/src/openforms/appointments/contrib/qmatic/tests/utils.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/utils.py
@@ -2,10 +2,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 from openforms.utils.tests.cache import clear_caches
-from stuf.tests.factories import SoapServiceFactory
 
 from ....models import AppointmentsConfig
-from ..models import JccConfig
+from ..models import QmaticConfig
+from .factories import ServiceFactory
 
 MOCK_DIR = Path(__file__).parent.resolve() / "mock"
 
@@ -20,8 +20,7 @@ class MockConfigMixin:
     def setUpTestData(cls):
         super().setUpTestData()  # type: ignore
 
-        wsdl = str(MOCK_DIR / "GenericGuidanceSystem2.wsdl")
-        cls.soap_service = SoapServiceFactory.create(url=wsdl)
+        cls.service = ServiceFactory.create()
 
     def setUp(self):
         super().setUp()  # type: ignore
@@ -35,9 +34,11 @@ class MockConfigMixin:
         main_config_patcher.start()
         self.addCleanup(main_config_patcher.stop)  # type: ignore
 
+        qmatic_config = QmaticConfig(service=self.service)
+        self.api_root = qmatic_config.service.api_root
         jcc_config_patcher = patch(
-            "openforms.appointments.contrib.jcc.client.JccConfig.get_solo",
-            return_value=JccConfig(service=self.soap_service),
+            "openforms.appointments.contrib.qmatic.client.QmaticConfig.get_solo",
+            return_value=qmatic_config,
         )
         jcc_config_patcher.start()
         self.addCleanup(jcc_config_patcher.stop)  # type: ignore

--- a/src/openforms/appointments/tests/test_api_products.py
+++ b/src/openforms/appointments/tests/test_api_products.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.submissions.tests.mixins import SubmissionsMixin
+
+from ..models import AppointmentsConfig
+
+
+class ProductListTests(SubmissionsMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.submission = SubmissionFactory.create()
+        cls.endpoint = reverse("api:appointments-products-list")
+
+    @patch("openforms.appointments.api.views.get_plugin")
+    def test_list_products_with_fixed_location_in_config(self, mock_get_plugin):
+        mock_plugin = mock_get_plugin.return_value
+        config_patcher = patch(
+            "openforms.appointments.utils.AppointmentsConfig.get_solo",
+            return_value=AppointmentsConfig(
+                plugin="demo",
+                limit_to_location="some-location-id",
+            ),
+        )
+        config_patcher.start()
+        self.addCleanup(config_patcher.stop)  # type: ignore
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        mock_plugin.get_available_products.assert_called_once_with(
+            location_id="some-location-id"
+        )

--- a/src/openforms/appointments/tests/utils.py
+++ b/src/openforms/appointments/tests/utils.py
@@ -8,6 +8,7 @@ from ..contrib.jcc.models import JccConfig
 from ..models import AppointmentsConfig
 
 
+# FIXME: replace with proper mocks, see ../contrib/jcc/tests/utils.py
 def setup_jcc() -> None:
     appointments_config = AppointmentsConfig.get_solo()
     appointments_config.plugin = "jcc"


### PR DESCRIPTION
(Partially) closes #2471

Implemented getting all appointment locations (without any products provided) and filtering products based on location.

* Getting all locations is required to populate the options in the admin to hard-pin the location
* Filtering products based on a location is required to take the admin configuration into account