### PR TITLE
:art: Fix test isolation issue and clean up test code

### DIFF
--- a/src/openforms/formio/components/np_family_members/haal_centraal.py
+++ b/src/openforms/formio/components/np_family_members/haal_centraal.py
@@ -4,7 +4,11 @@ from openforms.contrib.brp.models import BRPConfig
 
 
 def get_np_children_haal_centraal(bsn: str) -> List[Tuple[str, str]]:
+    # XXX: check the usage of this component in production, perhaps we can deprecate and
+    # remove it instead.
+    # otherwise: make Haal Centraal v2 compatible
     config = BRPConfig.get_solo()
+    assert isinstance(config, BRPConfig)
     client = config.get_client()
 
     # actual operation ID from standard! but Open Personen has the wrong one

--- a/src/openforms/formio/components/np_family_members/stuf_bg.py
+++ b/src/openforms/formio/components/np_family_members/stuf_bg.py
@@ -5,6 +5,7 @@ from stuf.stuf_bg.models import StufBGConfig
 
 def get_np_children_stuf_bg(bsn: str) -> List[Tuple[str, str]]:
     config = StufBGConfig.get_solo()
+    assert isinstance(config, StufBGConfig)
     client = config.get_client()
 
     attributes = [

--- a/src/openforms/formio/components/np_family_members/tests/test_family_members.py
+++ b/src/openforms/formio/components/np_family_members/tests/test_family_members.py
@@ -1,20 +1,21 @@
 import json
-import os
+from pathlib import Path
 from unittest.mock import patch
 
-from django.template import Context, Template
 from django.test import TestCase
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
 import requests_mock
+from zds_client.oas import schema_fetcher
+from zgw_consumers.test import mock_service_oas_get
 
 from openforms.authentication.constants import AuthAttribute
 from openforms.contrib.brp.models import BRPConfig
 from openforms.formio.service import get_dynamic_configuration
-from openforms.prefill.contrib.haalcentraal.tests.utils import load_binary_mock
 from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.template import render_from_string
 from stuf.constants import EndpointType
 from stuf.stuf_bg.models import StufBGConfig
 from stuf.tests.factories import StufServiceFactory
@@ -24,8 +25,17 @@ from ..haal_centraal import get_np_children_haal_centraal
 from ..models import FamilyMembersTypeConfig
 from ..stuf_bg import get_np_children_stuf_bg
 
+TEST_FILES = Path(__file__).parent.resolve() / "responses"
+
 
 class FamilyMembersCustomFieldTypeTest(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        # ensure the schema cache is cleared before and after each test
+        schema_fetcher.cache.clear()
+        self.addCleanup(schema_fetcher.cache.clear)
+
     @patch(
         "openforms.formio.components.custom.get_np_children_haal_centraal",
         return_value=[("222333444", "Billy Doe"), ("333444555", "Jane Doe")],
@@ -43,18 +53,21 @@ class FamilyMembersCustomFieldTypeTest(TestCase):
             auth_info__attribute=AuthAttribute.bsn,
             auth_info__value="111222333",
         )
-        config = FamilyMembersTypeConfig.get_solo()
-        config.data_api = FamilyMembersDataAPIChoices.haal_centraal
-        config.save()
         formio_wrapper = (
             submission.submissionstep_set.get().form_step.form_definition.configuration_wrapper
         )
 
-        updated_config_wrapper = get_dynamic_configuration(
-            formio_wrapper,
-            request=None,
-            submission=submission,
-        )
+        with patch(
+            "openforms.formio.components.custom.FamilyMembersTypeConfig.get_solo",
+            return_value=FamilyMembersTypeConfig(
+                data_api=FamilyMembersDataAPIChoices.haal_centraal
+            ),
+        ):
+            updated_config_wrapper = get_dynamic_configuration(
+                formio_wrapper,
+                request=None,
+                submission=submission,
+            )
 
         rewritten_component = updated_config_wrapper["npFamilyMembers"]
         self.assertEqual("selectboxes", rewritten_component["type"])
@@ -71,28 +84,21 @@ class FamilyMembersCustomFieldTypeTest(TestCase):
             {"value": "333444555", "label": "Jane Doe"},
         )
 
-    def test_get_children_haal_centraal(self):
-        test_files = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "responses"
-        )
-
-        response_file = open(os.path.join(test_files, "op_2_children.json"), "r")
-        json_response = json.load(response_file)
-        response_file.close()
-
-        config = BRPConfig.get_solo()
-        haal_centraal_service = ServiceFactory(
+    @patch(
+        "openforms.formio.components.np_family_members.haal_centraal.BRPConfig.get_solo"
+    )
+    def test_get_children_haal_centraal(self, mock_brp_config_get_solo):
+        service = ServiceFactory.build(
             api_root="https://personen/api/",
             oas="https://personen/api/schema/openapi.yaml",
         )
-        config.brp_service = haal_centraal_service
-        config.save()
+        mock_brp_config_get_solo.return_value = BRPConfig(brp_service=service)
+        with (TEST_FILES / "op_2_children.json").open("r") as infile:
+            json_response = json.load(infile)
 
         with requests_mock.Mocker() as m:
-            m.get(
-                "https://personen/api/schema/openapi.yaml?v=3",
-                status_code=200,
-                content=load_binary_mock("personen.yaml"),
+            mock_service_oas_get(
+                m, url=service.api_root, service="personen", oas_url=service.oas
             )
             m.get(
                 "https://personen/api/ingeschrevenpersonen/111222333/kinderen",
@@ -106,28 +112,21 @@ class FamilyMembersCustomFieldTypeTest(TestCase):
             self.assertEqual(("456789123", "Bolly van Doe"), kids_choices[0])
             self.assertEqual(("789123456", "Billy van Doe"), kids_choices[1])
 
-    def test_get_children_stuf_bg(self):
-        test_files = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "responses"
+    @patch(
+        "openforms.formio.components.np_family_members.stuf_bg.StufBGConfig.get_solo"
+    )
+    def test_get_children_stuf_bg(self, mock_stufbg_config_get_solo):
+        stuf_bg_service = StufServiceFactory.build()
+        mock_stufbg_config_get_solo.return_value = StufBGConfig(service=stuf_bg_service)
+        soap_response_template = (TEST_FILES / "stuf_bg_2_children.xml").read_text()
+        response_content = render_from_string(soap_response_template, {}).encode(
+            "utf-8"
         )
-
-        soap_response_template_file = open(
-            os.path.join(test_files, "stuf_bg_2_children.xml"), "r"
-        )
-        soap_response_template = soap_response_template_file.read()
-        soap_response_template_file.close()
-
-        stuf_bg_service = StufServiceFactory.create()
-        config = StufBGConfig.get_solo()
-        config.service = stuf_bg_service
-        config.save()
 
         with requests_mock.Mocker() as m:
             m.post(
                 stuf_bg_service.get_endpoint(type=EndpointType.vrije_berichten),
-                content=Template(soap_response_template)
-                .render(Context({}))
-                .encode("utf-8"),
+                content=response_content,
             )
 
             kids_choices = get_np_children_stuf_bg(bsn="111222333")

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_client.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_client.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 
 import requests_mock
 from glom import glom
+from zds_client.oas import schema_fetcher
 from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
 
@@ -58,6 +59,10 @@ class HaalCentraalFindPersonTests:
             oas_url=self.service.oas,
         )
         self.addCleanup(self.requests_mock.stop)  # type: ignore
+
+        # ensure the schema cache is cleared before and after each test
+        schema_fetcher.cache.clear()
+        self.addCleanup(schema_fetcher.cache.clear)  # type: ignore
 
     def test_find_person_succesfully(self):
         attributes = self.config.get_attributes()

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_plugin.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase, TestCase
 
 import requests_mock
 from glom import glom
+from zds_client.oas import schema_fetcher
 from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
 
@@ -88,6 +89,10 @@ class HaalCentraalPluginTests:
             oas_url=self.service.oas,
         )
         self.addCleanup(self.requests_mock.stop)  # type: ignore
+
+        # ensure the schema cache is cleared before and after each test
+        schema_fetcher.cache.clear()
+        self.addCleanup(schema_fetcher.cache.clear)  # type: ignore
 
     def test_get_available_attributes(self):
         attributes = HaalCentraalPrefill.get_available_attributes()


### PR DESCRIPTION
I noticed test failures again via #3167 and managed to reproduce it locally.

* Ensure the zds client oas cache is cleared between tests
* Update tests to use unittest.mock approach for django-solo models
* Replace old-style file handling with pathlib for mock data