### PR TITLE
Fixed hidden file field triggering validation

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import {Utils as FormioUtils} from 'formiojs';
 import {defineMessage} from 'react-intl';
 
+import {getComponentEmptyValue} from 'components/utils';
+
 import {COMPONENT_DATATYPES, VARIABLE_SOURCES} from './constants';
 
 const getComponentDatatype = component => {
@@ -210,7 +212,7 @@ const getDefaultValue = component => {
   if (component.hasOwnProperty('defaultValue') && component.defaultValue !== null)
     return component.defaultValue;
 
-  return null;
+  return getComponentEmptyValue(component);
 };
 
 const variableHasErrors = variable => !!Object.entries(variable.errors || {}).length;

--- a/src/openforms/js/components/utils.js
+++ b/src/openforms/js/components/utils.js
@@ -1,0 +1,8 @@
+import {Formio} from 'formiojs';
+
+const getComponentEmptyValue = component => {
+  const componentInstance = Formio.Components.create(component);
+  return componentInstance.emptyValue;
+};
+
+export {getComponentEmptyValue};


### PR DESCRIPTION
Closes #3128

See description in https://github.com/open-formulieren/open-forms/issues/3128#issuecomment-1598864509

Basically:

* Frontend code set `defaultValue: null` for file field
* This is stored in the `FormVariable.initial_value` as `None`
* Logic check compares that the expected default value for file field (`[]`) != `None`
* Logic check emits `data: {"fileField": []}` to correct this
* which triggered the client-side form.io validation

Backporting #2436 fixes the client-side admin code, which results in the correct `FormVariable.initial_value` and makes the problem go away.