### PR TITLE
:arrow_up: [#3103] -- bump django-digig-eherkenning to 0.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,7 +78,7 @@ cssselect2==0.4.1
     # via
     #   cairosvg
     #   weasyprint
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/base.in
     #   cairosvg
@@ -153,7 +153,7 @@ django-csp-reports==1.8.1
     # via -r requirements/base.in
 django-decorator-include==3.0
     # via -r requirements/base.in
-django-digid-eherkenning==0.6.0
+django-digid-eherkenning==0.8.0
     # via -r requirements/base.in
 django-filter==2.4.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -147,7 +147,7 @@ cssselect2==0.4.1
     #   -r requirements/base.txt
     #   cairosvg
     #   weasyprint
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -250,7 +250,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.6.0
+django-digid-eherkenning==0.8.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -172,7 +172,7 @@ cssselect2==0.4.1
     #   weasyprint
 ddt-api-calls==0.3.2
     # via -r requirements/dev.in
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -281,7 +281,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.6.0
+django-digid-eherkenning==0.8.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -113,7 +113,7 @@ cssselect2==0.4.1
     #   -r requirements/base.txt
     #   cairosvg
     #   weasyprint
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -215,7 +215,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-digid-eherkenning==0.6.0
+django-digid-eherkenning==0.8.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt


### PR DESCRIPTION
Closes #3103

This version prepends the XML declaration as part of metadata generation.