### PR TITLE
:ambulance: Replace HEAD calls with GET for OIDC auth endpoint

### DIFF
--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid/test_auth_procedure.py
@@ -68,7 +68,7 @@ class DigiDOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -120,7 +120,7 @@ class DigiDOIDCTests(TestCase):
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=500,
             )
@@ -231,7 +231,7 @@ class DigiDOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -300,7 +300,7 @@ class DigiDOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid_machtigen/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid_machtigen/test_auth_procedure.py
@@ -74,7 +74,7 @@ class DigiDMachtigenOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -122,7 +122,7 @@ class DigiDMachtigenOIDCTests(TestCase):
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=500,
             )
@@ -227,7 +227,7 @@ class DigiDMachtigenOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -296,7 +296,7 @@ class DigiDMachtigenOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning/test_auth_procedure.py
@@ -70,7 +70,7 @@ class eHerkenningOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -122,7 +122,7 @@ class eHerkenningOIDCTests(TestCase):
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=500,
             )
@@ -238,7 +238,7 @@ class eHerkenningOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -309,7 +309,7 @@ class eHerkenningOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning_bewindvoering/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning_bewindvoering/test_auth_procedure.py
@@ -82,7 +82,7 @@ class EHerkenningBewindvoeringOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -138,7 +138,7 @@ class EHerkenningBewindvoeringOIDCTests(TestCase):
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=500,
             )
@@ -260,7 +260,7 @@ class EHerkenningBewindvoeringOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -336,7 +336,7 @@ class EHerkenningBewindvoeringOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
@@ -40,7 +40,7 @@ class OIDCAuthenticationRequestView(_OIDCAuthenticationRequestView):
 
         try:
             # Verify that the identity provider endpoint can be reached
-            response = requests.head(self.OIDC_OP_AUTH_ENDPOINT)
+            response = requests.get(self.OIDC_OP_AUTH_ENDPOINT)
             if response.status_code > 400:
                 response.raise_for_status()
         except Exception as e:

--- a/src/openforms/authentication/contrib/org_oidc/tests/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/org_oidc/tests/test_auth_procedure.py
@@ -79,7 +79,7 @@ class OrgOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )
@@ -131,7 +131,7 @@ class OrgOIDCTests(TestCase):
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=500,
             )
@@ -232,7 +232,7 @@ class OrgOIDCTests(TestCase):
         self.assertEqual(query_params["next"], form_url)
 
         with requests_mock.Mocker() as m:
-            m.head(
+            m.get(
                 "http://provider.com/auth/realms/master/protocol/openid-connect/auth",
                 status_code=200,
             )

--- a/src/openforms/authentication/contrib/org_oidc/views.py
+++ b/src/openforms/authentication/contrib/org_oidc/views.py
@@ -31,7 +31,7 @@ class OIDCAuthenticationRequestView(SoloConfigMixin, _OIDCAuthenticationRequestV
 
         try:
             # Verify that the identity provider endpoint can be reached
-            response = requests.head(self.OIDC_OP_AUTH_ENDPOINT)
+            response = requests.get(self.OIDC_OP_AUTH_ENDPOINT)
             if response.status_code > 400:
                 response.raise_for_status()
         except Exception as e:


### PR DESCRIPTION
The OpenID Connect standard prescribes nothing about having to support HEAD requests, so we can't be certain that all OIDC providers support this, nor can we make a reasonable demand to support this at the infrastructure level.

This replaces the HEAD requests with a GET, which should be guaranteed to work.