### PR TITLE
:label: Refactor formio types in backend

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -9,15 +9,11 @@ from openforms.submissions.models import Submission
 from openforms.typing import DataMapping
 from openforms.utils.date import format_date_value
 
-from ..dynamic_config.date import (
-    FormioDateComponent,
-    FormioDatetimeComponent,
-    mutate as mutate_min_max_validation,
-)
+from ..dynamic_config.date import mutate as mutate_min_max_validation
 from ..formatters.custom import DateFormatter, DateTimeFormatter, MapFormatter
 from ..formatters.formio import DefaultFormatter, TextFieldFormatter
 from ..registry import BasePlugin, register
-from ..typing import Component
+from ..typing import Component, DateComponent, DatetimeComponent
 from ..utils import conform_to_mask
 from .np_family_members.constants import FamilyMembersDataAPIChoices
 from .np_family_members.haal_centraal import get_np_children_haal_centraal
@@ -32,11 +28,11 @@ class Date(BasePlugin):
     formatter = DateFormatter
 
     @staticmethod
-    def normalizer(component: FormioDateComponent, value: str) -> str:
+    def normalizer(component: DateComponent, value: str) -> str:
         return format_date_value(value)
 
     def mutate_config_dynamically(
-        self, component: FormioDateComponent, submission: Submission, data: DataMapping
+        self, component: DateComponent, submission: Submission, data: DataMapping
     ) -> None:
         """
         Implement the behaviour for our custom date component options.
@@ -53,7 +49,7 @@ class Datetime(BasePlugin):
 
     def mutate_config_dynamically(
         self,
-        component: FormioDatetimeComponent,
+        component: DatetimeComponent,
         submission: Submission,
         data: DataMapping,
     ) -> None:

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -4,7 +4,7 @@ Implement backend functionality for core Formio (built-in) component types.
 Custom component types (defined by us or third parties) need to be organized in the
 adjacent custom.py module.
 """
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING
 
 from rest_framework.request import Request
 from rest_framework.reverse import reverse
@@ -34,7 +34,7 @@ from ..formatters.formio import (
     TimeFormatter,
 )
 from ..registry import BasePlugin, register
-from ..typing import Component
+from ..typing import Component, ContentComponent, FileComponent, RadioComponent
 
 if TYPE_CHECKING:  # pragma: nocover
     from openforms.submissions.models import Submission
@@ -67,18 +67,6 @@ class Time(BasePlugin):
 @register("phoneNumber")
 class PhoneNumber(BasePlugin):
     formatter = PhoneNumberFormatter
-
-
-class FileConfig(TypedDict):
-    allowedTypesLabels: list[str]
-
-
-class FileComponent(Component):
-    storage: Literal["url"]
-    url: str
-    useConfigFiletypes: bool
-    filePattern: str
-    file: FileConfig
 
 
 @register("file")
@@ -161,7 +149,7 @@ class Radio(BasePlugin):
     formatter = RadioFormatter
 
     def mutate_config_dynamically(
-        self, component: Component, submission: "Submission", data: DataMapping
+        self, component: RadioComponent, submission: "Submission", data: DataMapping
     ) -> None:
         add_options_to_config(component, data, submission)
 
@@ -169,10 +157,6 @@ class Radio(BasePlugin):
 @register("signature")
 class Signature(BasePlugin):
     formatter = SignatureFormatter
-
-
-class ContentComponent(Component):
-    html: str
 
 
 @register("content")

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -11,9 +11,8 @@ from rest_framework.test import APIRequestFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.variables.service import get_static_variables
 
-from ...dynamic_config.date import FormioDateComponent
 from ...service import FormioConfigurationWrapper, get_dynamic_configuration
-from ...typing import Component
+from ...typing import DateComponent
 
 request_factory = APIRequestFactory()
 
@@ -21,8 +20,8 @@ request_factory = APIRequestFactory()
 class DynamicDateConfigurationTests(SimpleTestCase):
     @staticmethod
     def _get_dynamic_config(
-        component: Component, variables: Dict[str, Any]
-    ) -> FormioDateComponent:
+        component: DateComponent, variables: Dict[str, Any]
+    ) -> DateComponent:
         config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")
         submission = SubmissionFactory.build()

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -10,9 +10,8 @@ from rest_framework.test import APIRequestFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.variables.service import get_static_variables
 
-from ...dynamic_config.date import FormioDateComponent
 from ...service import FormioConfigurationWrapper, get_dynamic_configuration
-from ...typing import Component
+from ...typing import DatetimeComponent
 
 request_factory = APIRequestFactory()
 
@@ -21,8 +20,8 @@ request_factory = APIRequestFactory()
 class DynamicDatetimeConfigurationTests(SimpleTestCase):
     @staticmethod
     def _get_dynamic_config(
-        component: Component, variables: Dict[str, Any]
-    ) -> FormioDateComponent:
+        component: DatetimeComponent, variables: Dict[str, Any]
+    ) -> DatetimeComponent:
         config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")
         submission = SubmissionFactory.build()

--- a/src/openforms/formio/typing/__init__.py
+++ b/src/openforms/formio/typing/__init__.py
@@ -1,0 +1,22 @@
+"""
+Type definitions to be used in type hints for Formio structures.
+
+Formio components are JSON blobs adhering to a formio-specific schema. We define
+(subsets) of these schema's to make it easier to reason about the code operating on
+(parts of) the schema.
+"""
+
+from .base import Component, OptionDict
+from .custom import CosignComponent, DateComponent
+from .vanilla import ContentComponent, DatetimeComponent, FileComponent, RadioComponent
+
+__all__ = [
+    "Component",
+    "OptionDict",
+    "ContentComponent",
+    "FileComponent",
+    "RadioComponent",
+    "DatetimeComponent",
+    "CosignComponent",
+    "DateComponent",
+]

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -1,14 +1,28 @@
 """
-Type definitions to be used in type hints for Formio structures.
+Base types for more specific component types.
 
-Formio components are JSON blobs adhering to a formio-specific schema. We define
-(subsets) of these schema's to make it easier to reason about the code operating on
-(parts of) the schema.
+These are common ancestors for all specific component types.
 """
-# TODO: on python 3.11+ we can use typing.NotRequired to mark keys that may be absent
+
+# TODO: on python 3.11+ we can use typing.NotRequired to mark keys that may be absent.
+# For now at least, we use total=False.
+
 from typing import TypedDict
 
 from openforms.typing import JSONValue
+
+from .dates import DateConstraintConfiguration
+
+
+class Validate(TypedDict, total=False):
+    required: bool
+    maxLength: int
+
+
+class OpenFormsConfig(TypedDict, total=False):
+    widget: str
+    minDate: DateConstraintConfiguration | None
+    maxDate: DateConstraintConfiguration | None
 
 
 class OptionDict(TypedDict):
@@ -28,7 +42,7 @@ class PrefillConfiguration(TypedDict):
     attribute: str
 
 
-class Component(TypedDict):
+class Component(TypedDict, total=False):
     """
     A formio component definition.
 
@@ -40,6 +54,8 @@ class Component(TypedDict):
 
     * we don't run mypy (yet) and type hints are used as just hints/documentation
     * NotRequired is only available in typing_extensions and Python 3.11+
+    * The ``total=False`` matches Form.io's own typescript types where (almost) every
+      property can be absent.
     """
 
     type: str
@@ -48,8 +64,7 @@ class Component(TypedDict):
     multiple: bool
     hidden: bool
     defaultValue: JSONValue
+    validate: Validate
     prefill: PrefillConfiguration
-
-
-class CosignComponent(Component):
-    authPlugin: str
+    openForms: OpenFormsConfig
+    autocomplete: str

--- a/src/openforms/formio/typing/custom.py
+++ b/src/openforms/formio/typing/custom.py
@@ -1,0 +1,10 @@
+from .base import Component
+from .dates import DatePickerConfig
+
+
+class CosignComponent(Component):
+    authPlugin: str
+
+
+class DateComponent(Component):
+    datePicker: DatePickerConfig | None

--- a/src/openforms/formio/typing/dates.py
+++ b/src/openforms/formio/typing/dates.py
@@ -1,0 +1,23 @@
+"""
+Types for our date/datetime validation extension.
+"""
+from typing import Literal, TypedDict
+
+
+class DateConstraintDelta(TypedDict):
+    years: int | None
+    months: int | None
+    days: int | None
+
+
+class DateConstraintConfiguration(TypedDict):
+    mode: Literal["", "fixedValue", "future", "past", "relativeToVariable"]
+    includeToday: bool | None
+    variable: str | None
+    delta: DateConstraintDelta | None
+    operator: Literal["add", "subtract"] | None
+
+
+class DatePickerConfig(TypedDict):
+    minDate: str | None
+    maxDate: str | None

--- a/src/openforms/formio/typing/vanilla.py
+++ b/src/openforms/formio/typing/vanilla.py
@@ -1,0 +1,28 @@
+from typing import Literal, TypedDict
+
+from .base import Component, OptionDict
+from .dates import DatePickerConfig
+
+
+class FileConfig(TypedDict):
+    allowedTypesLabels: list[str]
+
+
+class FileComponent(Component):
+    storage: Literal["url"]
+    url: str
+    useConfigFiletypes: bool
+    filePattern: str
+    file: FileConfig
+
+
+class RadioComponent(Component):
+    values: list[OptionDict]
+
+
+class ContentComponent(Component):
+    html: str
+
+
+class DatetimeComponent(Component):
+    datePicker: DatePickerConfig | None


### PR DESCRIPTION
The Form.io base component type is now more realistic with the totality set to False, meaning that any key in the dict may be absent. This matches Form.io's own typescript definitions.

Additionally, the types are centralized in a typing package where (relative) imports don't cause circular import issues - they are now truly standalone. The runtime code that had type definitions now imports them from the top-level entry point.

This change allows us to more strictly type individual component types, while having the type checker help accounting for possible Form.io JSON weirdness.

Needed for the #3139 PR which makes use of these types.