### PR TITLE
:arrow_up: Upgrade to django-autoslug 1.9.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -134,7 +134,7 @@ django-appconf==1.0.4
     #   django-cookie-consent
     #   django-log-outgoing-requests
     #   django-timeline-logger
-django-autoslug==1.9.8
+django-autoslug==1.9.9
     # via -r requirements/base.in
 django-axes==5.31.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -213,7 +213,7 @@ django-appconf==1.0.4
     #   django-cookie-consent
     #   django-log-outgoing-requests
     #   django-timeline-logger
-django-autoslug==1.9.8
+django-autoslug==1.9.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -242,7 +242,7 @@ django-appconf==1.0.4
     #   django-cookie-consent
     #   django-log-outgoing-requests
     #   django-timeline-logger
-django-autoslug==1.9.8
+django-autoslug==1.9.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -177,7 +177,7 @@ django-appconf==1.0.4
     #   django-cookie-consent
     #   django-log-outgoing-requests
     #   django-timeline-logger
-django-autoslug==1.9.8
+django-autoslug==1.9.9
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt


### PR DESCRIPTION
This version supports Django 4.2. Thanks to @ErhanCitil for doing the research.