### PR TITLE
[#3130] Fix copying form definitions with long names

### DIFF
--- a/src/openforms/forms/models/form_definition.py
+++ b/src/openforms/forms/models/form_definition.py
@@ -15,7 +15,7 @@ from django.utils.translation import gettext_lazy as _
 from autoslug import AutoSlugField
 
 from openforms.formio.utils import iter_components
-from openforms.utils.helpers import truncate_str_if_needed
+from openforms.utils.helpers import get_charfield_max_length, truncate_str_if_needed
 
 from ..models import Form
 from ..tasks import detect_formiojs_configuration_snake_case
@@ -103,9 +103,6 @@ class FormDefinition(models.Model):
             callback = partial(detect_formiojs_configuration_snake_case.delay, self.id)
         transaction.on_commit(callback)
 
-    def get_charfield_max_length(self, field_name: str) -> int:
-        return self._meta.get_field(field_name).max_length
-
     @transaction.atomic
     def copy(self):
         copy = deepcopy(self)
@@ -121,12 +118,12 @@ class FormDefinition(models.Model):
 
         # truncate name and internal name if needed
         copy.name = truncate_str_if_needed(
-            self.name, copy.name, self.get_charfield_max_length("name")
+            self.name, copy.name, get_charfield_max_length(self, "name")
         )
         copy.internal_name = truncate_str_if_needed(
             self.internal_name,
             copy.internal_name,
-            self.get_charfield_max_length("internal_name"),
+            get_charfield_max_length(self, "internal_name"),
         )
 
         copy.save()

--- a/src/openforms/forms/tests/test_formdefinition_admin.py
+++ b/src/openforms/forms/tests/test_formdefinition_admin.py
@@ -48,7 +48,7 @@ class FormDefinitionAdminTests(WebTest):
         form["_selected_action"].checked = True
         response = form.submit("submit", value="0")
 
-        form_definition_copy = FormDefinition.objects.last()
+        form_definition_copy = FormDefinition.objects.order_by("pk").last()
 
         self.assertEqual(FormDefinition.objects.count(), 2)
         self.assertRedirects(response, reverse("admin:forms_formdefinition_changelist"))

--- a/src/openforms/forms/tests/test_formdefinition_admin.py
+++ b/src/openforms/forms/tests/test_formdefinition_admin.py
@@ -1,9 +1,13 @@
+from django.test import override_settings
 from django.urls import reverse
 
 from django_webtest import WebTest
 
 from openforms.accounts.tests.factories import StaffUserFactory, SuperUserFactory
 from openforms.tests.utils import disable_2fa
+
+from ..models.form_definition import FormDefinition
+from .factories import FormDefinitionFactory
 
 
 @disable_2fa
@@ -26,3 +30,33 @@ class FormDefinitionAdminTests(WebTest):
         response = self.app.get(url, user=user)
 
         self.assertEqual(response.status_code, 200)
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_copy_with_long_names_succeeds(self):
+        user = SuperUserFactory.create()
+        FormDefinitionFactory.create(
+            name="This is a really long long name for formdefinition",
+            internal_name="This is a really long long name for formdefinition",
+        )
+
+        self.assertEqual(FormDefinition.objects.count(), 1)
+
+        url = reverse("admin:forms_formdefinition_changelist")
+        response = self.app.get(url, user=user)
+        form = response.forms["changelist-form"]
+        form["action"] = "make_copies"
+        form["_selected_action"].checked = True
+        response = form.submit("submit", value="0")
+
+        form_definition_copy = FormDefinition.objects.last()
+
+        self.assertEqual(FormDefinition.objects.count(), 2)
+        self.assertRedirects(response, reverse("admin:forms_formdefinition_changelist"))
+        self.assertEqual(
+            form_definition_copy.name,
+            "This is a really long long name for formde\u2026 (copy)",
+        )
+        self.assertEqual(
+            form_definition_copy.internal_name,
+            "This is a really long long name for formde\u2026 (copy)",
+        )

--- a/src/openforms/utils/helpers.py
+++ b/src/openforms/utils/helpers.py
@@ -1,0 +1,12 @@
+def truncate_str_if_needed(original_str: str, new_str: str, max_length: int) -> str:
+    """
+    Given the original string and the new string, return either the original one if
+    it doesn't exceed the given max length, or the new one truncated and by adding
+    the ellipsis to the original one.
+    """
+    if len(new_str) <= max_length:
+        return new_str
+
+    new_str_length = len(new_str) - len(original_str)
+    str_max_length = max_length - new_str_length
+    return original_str[: str_max_length - 1] + "\u2026" + new_str[-new_str_length:]

--- a/src/openforms/utils/helpers.py
+++ b/src/openforms/utils/helpers.py
@@ -1,3 +1,12 @@
+from django.db import models
+
+
+def get_charfield_max_length(
+    model_or_instance: models.Model | type[models.Model], field_name: str
+) -> int:
+    return model_or_instance._meta.get_field(field_name).max_length
+
+
 def truncate_str_if_needed(original_str: str, new_str: str, max_length: int) -> str:
     """
     Given the original string and the new string, return either the original one if

--- a/src/openforms/utils/tests/test_helpers.py
+++ b/src/openforms/utils/tests/test_helpers.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from ..helpers import truncate_str_if_needed
+
+
+class TruncateStrTests(TestCase):
+    def test_str_is_truncated_when_max_length_exceeded(self):
+        original_str = "This is the initial text"
+        added_str = "This is the initial text (added text)"
+        max_chars = 30
+
+        result = truncate_str_if_needed(original_str, added_str, max_chars)
+
+        self.assertEqual(result, "This is the init\u2026 (added text)")
+
+    def test_not_trucated_str_is_returned_when_max_length_not_exceeded(self):
+        original_str = "This is the text"
+        added_str = "This is the text (added text)"
+        max_chars = 30
+
+        result = truncate_str_if_needed(original_str, added_str, max_chars)
+
+        self.assertEqual(result, "This is the text (added text)")


### PR DESCRIPTION
Fixes #3130 