### PR TITLE
:recycle: Rename dataclasses to remove redundant prefix

### DIFF
--- a/src/openforms/appointments/api/fields.py
+++ b/src/openforms/appointments/api/fields.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 
-from ..base import AppointmentProduct
+from ..base import Product
 
 
 class ProductIDField(serializers.CharField):
@@ -10,9 +10,9 @@ class ProductIDField(serializers.CharField):
         kwargs.setdefault("label", _("product ID"))
         super().__init__(*args, **kwargs)
 
-    def run_validation(self, data) -> AppointmentProduct:
+    def run_validation(self, data) -> Product:
         """
         Normalize to dataclass instance.
         """
         value = super().run_validation(data)
-        return AppointmentProduct(identifier=value, code="", name="")
+        return Product(identifier=value, code="", name="")

--- a/src/openforms/appointments/api/views.py
+++ b/src/openforms/appointments/api/views.py
@@ -23,7 +23,7 @@ from openforms.submissions.api.permissions import (
 )
 from openforms.submissions.models import Submission
 
-from ..base import AppointmentLocation, AppointmentProduct
+from ..base import Location, Product
 from ..exceptions import AppointmentDeleteFailed, CancelAppointmentFailed
 from ..models import AppointmentsConfig
 from ..utils import delete_appointment_for_submission, get_plugin
@@ -103,7 +103,7 @@ class LocationsListView(ListMixin, APIView):
         if not is_valid:
             return []
 
-        product = AppointmentProduct(
+        product = Product(
             identifier=serializer.validated_data["product_id"], code="", name=""
         )
 
@@ -155,10 +155,10 @@ class DatesListView(ListMixin, APIView):
         if not is_valid:
             return []
 
-        product = AppointmentProduct(
+        product = Product(
             identifier=serializer.validated_data["product_id"], code="", name=""
         )
-        location = AppointmentLocation(
+        location = Location(
             identifier=serializer.validated_data["location_id"], name=""
         )
 
@@ -218,10 +218,10 @@ class TimesListView(ListMixin, APIView):
         if not is_valid:
             return []
 
-        product = AppointmentProduct(
+        product = Product(
             identifier=serializer.validated_data["product_id"], code="", name=""
         )
-        location = AppointmentLocation(
+        location = Location(
             identifier=serializer.validated_data["location_id"], name=""
         )
 

--- a/src/openforms/appointments/contrib/demo/plugin.py
+++ b/src/openforms/appointments/contrib/demo/plugin.py
@@ -5,12 +5,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 
 from openforms.formio.typing import Component
 
-from ...base import (
-    AppointmentDetails,
-    AppointmentLocation,
-    AppointmentProduct,
-    BasePlugin,
-)
+from ...base import AppointmentDetails, BasePlugin, Location, Product
 from ...registry import register
 
 
@@ -21,12 +16,12 @@ class DemoAppointment(BasePlugin):
 
     def get_available_products(self, current_products=None):
         return [
-            AppointmentProduct(identifier="1", name="Test product 1"),
-            AppointmentProduct(identifier="2", name="Test product 2"),
+            Product(identifier="1", name="Test product 1"),
+            Product(identifier="2", name="Test product 2"),
         ]
 
     def get_locations(self, products=None):
-        return [AppointmentLocation(identifier="1", name="Test location")]
+        return [Location(identifier="1", name="Test location")]
 
     def get_dates(self, products, location, start_at=None, end_at=None):
         return [timezone.localdate()]
@@ -38,7 +33,7 @@ class DemoAppointment(BasePlugin):
 
     def get_required_customer_fields(
         self,
-        products: list[AppointmentProduct],
+        products: list[Product],
     ) -> list[Component]:
         last_name: Component = {
             "type": "textfield",
@@ -47,7 +42,7 @@ class DemoAppointment(BasePlugin):
         }
         return [last_name]
 
-    def create_appointment(self, products, location, start_at, client, remarks=None):
+    def create_appointment(self, products, location, start_at, client, remarks=""):
         print(
             "Create appointment \n",
             f"products: {products}\n",
@@ -65,10 +60,10 @@ class DemoAppointment(BasePlugin):
         return AppointmentDetails(
             identifier=identifier,
             products=[
-                AppointmentProduct(identifier="1", name="Test product 1"),
-                AppointmentProduct(identifier="2", name="Test product 2"),
+                Product(identifier="1", name="Test product 1"),
+                Product(identifier="2", name="Test product 2"),
             ],
-            location=AppointmentLocation(identifier="1", name="Test location"),
+            location=Location(identifier="1", name="Test location"),
             start_at=datetime(2021, 1, 1, 12, 0),
             end_at=datetime(2021, 1, 1, 12, 15),
             remarks="Remarks",

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -10,12 +10,7 @@ from hypothesis import given, strategies as st
 from openforms.utils.tests.logging import disable_logging
 from stuf.tests.factories import SoapServiceFactory
 
-from ....base import (
-    AppointmentClient,
-    AppointmentDetails,
-    AppointmentLocation,
-    AppointmentProduct,
-)
+from ....base import AppointmentDetails, Customer, Location, Product
 from ....exceptions import AppointmentException
 from ..constants import FIELD_TO_FORMIO_COMPONENT, CustomerFields
 from ..plugin import JccAppointment
@@ -56,9 +51,7 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_get_available_product_products(self, m):
-        product = AppointmentProduct(
-            identifier="1", code="PASAAN", name="Paspoort aanvraag"
-        )
+        product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
 
         m.post(
             "http://example.com/soap11",
@@ -117,9 +110,7 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_get_locations(self, m):
-        product = AppointmentProduct(
-            identifier="1", code="PASAAN", name="Paspoort aanvraag"
-        )
+        product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
 
         m.post(
             "http://example.com/soap11",
@@ -133,10 +124,8 @@ class PluginTests(MockConfigMixin, TestCase):
         self.assertEqual(locations[0].name, "Maykin Media")
 
     def test_get_dates(self):
-        product = AppointmentProduct(
-            identifier="1", code="PASAAN", name="Paspoort aanvraag"
-        )
-        location = AppointmentLocation(identifier="1", name="Maykin Media")
+        product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
+        location = Location(identifier="1", name="Maykin Media")
 
         with requests_mock.mock() as m:
             m.post(
@@ -154,10 +143,8 @@ class PluginTests(MockConfigMixin, TestCase):
             )
 
     def test_get_times(self):
-        product = AppointmentProduct(
-            identifier="1", code="PASAAN", name="Paspoort aanvraag"
-        )
-        location = AppointmentLocation(identifier="1", name="Maykin Media")
+        product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
+        location = Location(identifier="1", name="Maykin Media")
         test_date = date(2021, 8, 23)
 
         with requests_mock.mock() as m:
@@ -176,9 +163,7 @@ class PluginTests(MockConfigMixin, TestCase):
             "http://example.com/soap11",
             text=mock_response("getRequiredClientFieldsResponse.xml"),
         )
-        product = AppointmentProduct(
-            identifier="1", code="PASAAN", name="Paspoort aanvraag"
-        )
+        product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
 
         fields = self.plugin.get_required_customer_fields([product])
 
@@ -215,11 +200,9 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_create_appointment(self, m):
-        product = AppointmentProduct(
-            identifier="1", code="PASAAN", name="Paspoort aanvraag"
-        )
-        location = AppointmentLocation(identifier="1", name="Maykin Media")
-        client = AppointmentClient(last_name="Doe", birthdate=date(1980, 1, 1))
+        product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
+        location = Location(identifier="1", name="Maykin Media")
+        client = Customer(last_name="Doe", birthdate=date(1980, 1, 1))
 
         m.post(
             "http://example.com/soap11",
@@ -319,7 +302,7 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=500, max_value=511))
     def test_get_locations_server_error(self, m, status_code):
         m.post(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
+        product = Product(identifier="k@pu77", name="Kaputt")
 
         locations = self.plugin.get_locations()
         self.assertEqual(locations, [])
@@ -330,7 +313,7 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @requests_mock.Mocker()
     def test_get_locations_unexpected_exception(self, m):
         m.post(requests_mock.ANY, exc=IOError("tubes are closed"))
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
+        product = Product(identifier="k@pu77", name="Kaputt")
 
         with self.assertRaises(AppointmentException):
             self.plugin.get_locations()
@@ -365,8 +348,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=500, max_value=511))
     def test_get_dates_server_error(self, m, status_code):
         m.post(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         dates = self.plugin.get_dates(products=[product], location=location)
 
@@ -375,8 +358,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @requests_mock.Mocker()
     def test_get_dates_unexpected_exception(self, m):
         m.post(requests_mock.ANY, exc=IOError("tubes are closed"))
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         with self.assertRaises(AppointmentException):
             self.plugin.get_dates(products=[product], location=location)
@@ -385,8 +368,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=500, max_value=511))
     def test_get_times_server_error(self, m, status_code):
         m.post(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         times = self.plugin.get_times(
             products=[product], location=location, day=date(2023, 6, 22)
@@ -397,8 +380,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @requests_mock.Mocker()
     def test_get_times_unexpected_exception(self, m):
         m.post(requests_mock.ANY, exc=IOError("tubes are closed"))
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         with self.assertRaises(AppointmentException):
             self.plugin.get_times(

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -9,12 +9,7 @@ from hypothesis import given, strategies as st
 from openforms.tests.utils import c_profile
 from openforms.utils.tests.logging import disable_logging
 
-from ....base import (
-    AppointmentClient,
-    AppointmentDetails,
-    AppointmentLocation,
-    AppointmentProduct,
-)
+from ....base import AppointmentDetails, Customer, Location, Product
 from ....exceptions import AppointmentException
 from ..constants import FIELD_TO_FORMIO_COMPONENT, CustomerFields
 from ..plugin import QmaticAppointment
@@ -62,7 +57,7 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_get_locations(self, m):
-        product = AppointmentProduct(
+        product = Product(
             identifier="54b3482204c11bedc8b0a7acbffa308", name="Service 01"
         )
 
@@ -92,10 +87,10 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_get_dates(self, m):
-        product = AppointmentProduct(
+        product = Product(
             identifier="54b3482204c11bedc8b0a7acbffa308", name="Service 01"
         )
-        location = AppointmentLocation(
+        location = Location(
             identifier="f364d92b7fa07a48c4ecc862de30c47", name="Branch 1"
         )
         day = date(2016, 12, 6)
@@ -115,10 +110,10 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_get_times(self, m):
-        product = AppointmentProduct(
+        product = Product(
             identifier="54b3482204c11bedc8b0a7acbffa308", name="Service 01"
         )
-        location = AppointmentLocation(
+        location = Location(
             identifier="f364d92b7fa07a48c4ecc862de30c47", name="Branch 1"
         )
         day = date(2016, 12, 6)
@@ -140,7 +135,7 @@ class PluginTests(MockConfigMixin, TestCase):
             CustomerFields.phone_number,
             CustomerFields.email,
         ]
-        product = AppointmentProduct(
+        product = Product(
             identifier="54b3482204c11bedc8b0a7acbffa308", name="Service 01"
         )
 
@@ -179,13 +174,13 @@ class PluginTests(MockConfigMixin, TestCase):
 
     @requests_mock.Mocker()
     def test_create_appointment(self, m):
-        product = AppointmentProduct(
+        product = Product(
             identifier="54b3482204c11bedc8b0a7acbffa308", name="Service 01"
         )
-        location = AppointmentLocation(
+        location = Location(
             identifier="f364d92b7fa07a48c4ecc862de30c47", name="Branch 1"
         )
-        client = AppointmentClient(last_name="Doe", birthdate=date(1980, 1, 1))
+        client = Customer(last_name="Doe", birthdate=date(1980, 1, 1))
         day = datetime(2016, 12, 6, 9, 0, 0)
 
         m.post(
@@ -313,8 +308,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=500, max_value=511))
     def test_get_dates_server_error(self, m, status_code):
         m.get(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         dates = self.plugin.get_dates(products=[product], location=location)
 
@@ -324,8 +319,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=400, max_value=499))
     def test_get_dates_client_error(self, m, status_code):
         m.get(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         dates = self.plugin.get_dates(products=[product], location=location)
 
@@ -334,8 +329,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @requests_mock.Mocker()
     def test_get_dates_unexpected_exception(self, m):
         m.get(requests_mock.ANY, exc=IOError("tubes are closed"))
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         with self.assertRaises(AppointmentException):
             self.plugin.get_dates(products=[product], location=location)
@@ -344,8 +339,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=500, max_value=511))
     def test_get_times_server_error(self, m, status_code):
         m.get(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         times = self.plugin.get_times(
             products=[product], location=location, day=date(2023, 6, 22)
@@ -358,8 +353,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @given(st.integers(min_value=400, max_value=499))
     def test_get_times_client_error(self, m, status_code):
         m.get(requests_mock.ANY, status_code=status_code)
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         times = self.plugin.get_times(
             products=[product], location=location, day=date(2023, 6, 22)
@@ -370,8 +365,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
     @requests_mock.Mocker()
     def test_get_times_unexpected_exception(self, m):
         m.get(requests_mock.ANY, exc=IOError("tubes are closed"))
-        product = AppointmentProduct(identifier="k@pu77", name="Kaputt")
-        location = AppointmentLocation(identifier="1", name="Bahamas")
+        product = Product(identifier="k@pu77", name="Kaputt")
+        location = Location(identifier="1", name="Bahamas")
 
         with self.assertRaises(AppointmentException):
             self.plugin.get_times(

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -14,7 +14,7 @@ from openforms.forms.models import Form, FormStep
 from openforms.logging import logevent
 from openforms.submissions.models import Submission
 
-from .base import AppointmentClient, AppointmentLocation, AppointmentProduct, BasePlugin
+from .base import BasePlugin, Customer, Location, Product
 from .constants import AppointmentDetailsStatus
 from .exceptions import (
     AppointmentCreateFailed,
@@ -117,15 +117,15 @@ def book_appointment_for_submission(submission: Submission) -> None:
             "No registration attempted because of incomplete information. "
         )
 
-    product = AppointmentProduct(
+    product = Product(
         identifier=appointment_data["productIDAndName"]["value"]["identifier"],
         name=appointment_data["productIDAndName"]["value"]["name"],
     )
-    location = AppointmentLocation(
+    location = Location(
         identifier=appointment_data["locationIDAndName"]["value"]["identifier"],
         name=appointment_data["locationIDAndName"]["value"]["name"],
     )
-    appointment_client = AppointmentClient(
+    appointment_client = Customer(
         last_name=appointment_data["clientLastName"]["value"],
         birthdate=datetime.strptime(
             appointment_data["clientDateOfBirth"]["value"], "%Y-%m-%d"

--- a/src/openforms/emails/tests/test_confirmation_email.py
+++ b/src/openforms/emails/tests/test_confirmation_email.py
@@ -15,9 +15,9 @@ from django.utils.translation import gettext as _
 
 from openforms.appointments.base import (
     AppointmentDetails,
-    AppointmentLocation,
-    AppointmentProduct,
     BasePlugin,
+    Location,
+    Product,
 )
 from openforms.appointments.constants import AppointmentDetailsStatus
 from openforms.appointments.contrib.demo.plugin import DemoAppointment
@@ -460,12 +460,12 @@ class PaymentConfirmationEmailTests(TestCase):
 class TestAppointmentPlugin(BasePlugin):
     def get_available_products(self, current_products=None):
         return [
-            AppointmentProduct(identifier="1", name="Test product 1"),
-            AppointmentProduct(identifier="2", name="Test product 2"),
+            Product(identifier="1", name="Test product 1"),
+            Product(identifier="2", name="Test product 2"),
         ]
 
     def get_locations(self, products):
-        return [AppointmentLocation(identifier="1", name="Test location")]
+        return [Location(identifier="1", name="Test location")]
 
     def get_dates(self, products, location, start_at=None, end_at=None):
         return [date(2021, 1, 1)]
@@ -486,10 +486,10 @@ class TestAppointmentPlugin(BasePlugin):
         return AppointmentDetails(
             identifier=identifier,
             products=[
-                AppointmentProduct(identifier="1", name="Test product 1 & 2"),
-                AppointmentProduct(identifier="2", name="Test product 3"),
+                Product(identifier="1", name="Test product 1 & 2"),
+                Product(identifier="2", name="Test product 3"),
             ],
-            location=AppointmentLocation(
+            location=Location(
                 identifier="1",
                 name="Test location",
                 city="Teststad",


### PR DESCRIPTION
This clears up the namespace for models that will have similar names.