### PR TITLE
[#3223] Translate name when copying a form or a formdefinition

### DIFF
--- a/src/openforms/forms/tests/test_form_admin.py
+++ b/src/openforms/forms/tests/test_form_admin.py
@@ -1,3 +1,4 @@
+from django.test import override_settings
 from django.urls import reverse
 
 from django_webtest import WebTest
@@ -104,3 +105,18 @@ class FormAdminTests(FormListAjaxMixin, WebTest):
 
         form.refresh_from_db()
         self.assertTrue(form._is_deleted)
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_copy_saves_translated_name_for_all_the_languages(self):
+        form = FormFactory.create(
+            name="A name for the form",
+            name_nl="A Dutch name for the form",
+            name_en="A name for the form",
+        )
+        form.copy()
+
+        form_copy = Form.objects.order_by("pk").last()
+
+        self.assertEqual(form_copy.name, "A name for the form (copy)")
+        self.assertEqual(form_copy.name_en, "A name for the form (copy)")
+        self.assertEqual(form_copy.name_nl, "A Dutch name for the form (kopie)")

--- a/src/openforms/forms/tests/test_formdefinition_admin.py
+++ b/src/openforms/forms/tests/test_formdefinition_admin.py
@@ -60,3 +60,22 @@ class FormDefinitionAdminTests(WebTest):
             form_definition_copy.internal_name,
             "This is a really long long name for formde\u2026 (copy)",
         )
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_copy_saves_translated_name_for_all_the_languages(self):
+        form_definition = FormDefinitionFactory.create(
+            name="A name for formdefinition",
+            name_nl="A Dutch name for the formdefinition",
+            name_en="A name for formdefinition",
+        )
+        form_definition.copy()
+
+        form_definition_copy = FormDefinition.objects.order_by("pk").last()
+
+        self.assertEqual(form_definition_copy.name, "A name for formdefinition (copy)")
+        self.assertEqual(
+            form_definition_copy.name_en, "A name for formdefinition (copy)"
+        )
+        self.assertEqual(
+            form_definition_copy.name_nl, "A Dutch name for the formdefinition (kopie)"
+        )


### PR DESCRIPTION
Fixes #3223 