### PR TITLE
🩹 Fix storybook build

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,10 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
-  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: [
+    '../src/openforms/js/**/*.stories.mdx',
+    '../src/openforms/js/**/*.stories.@(js|jsx|ts|tsx)',
+  ],
   staticDirs: [
     {from: '../static/admin', to: 'static/admin'},
     {from: '../static/fonts', to: 'static/fonts'},


### PR DESCRIPTION
Sets more specific path glob pattern to find stories, mine was picking
up sdk stories that somehow found their way into my sdk build.
