### PR TITLE
Fixed race condition between celery worker and DB transaction

### DIFF
--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.core.files.temp import NamedTemporaryFile
 from django.core.files.uploadedfile import UploadedFile
+from django.db import transaction
 from django.urls import Resolver404, resolve
 from django.utils.translation import gettext as _
 
@@ -255,7 +256,9 @@ def attach_uploads_to_submission_step(submission_step: SubmissionStep) -> list:
         if created and resize_apply and resize_size:
             # NOTE there is a possible race-condition if user completes a submission before this resize task is done
             # see https://github.com/open-formulieren/open-forms/issues/507
-            resize_submission_attachment.delay(attachment.id, resize_size)
+            transaction.on_commit(
+                lambda: resize_submission_attachment.delay(attachment.id, resize_size)
+            )
 
     return result
 

--- a/src/openforms/submissions/tests/test_submission_attachment.py
+++ b/src/openforms/submissions/tests/test_submission_attachment.py
@@ -1006,7 +1006,8 @@ class SubmissionAttachmentTest(TestCase):
         )
 
         # test attaching the file
-        result = attach_uploads_to_submission_step(submission_step)
+        with self.captureOnCommitCallbacks(execute=True):
+            result = attach_uploads_to_submission_step(submission_step)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][1], True)  # created new


### PR DESCRIPTION
Fixes #3302

Prevent the celery worker from picking up the attachment image resize task before the DB transaction is committed. Celery workers run in different processes and thus different database transactions. The database record must be committed before the worker can look it up to start processing.