### PR TITLE
:pushpin: Unpin Python from 3.10.9 to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: maykinmedia/setup-django-backend@v1
         with:
           apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client'
-          python-version: '3.10.9'
+          python-version: '3.10'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
           setup-node: 'yes'
@@ -133,7 +133,7 @@ jobs:
         uses: maykinmedia/setup-django-backend@v1
         with:
           apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client'
-          python-version: '3.10.9'
+          python-version: '3.10'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
           setup-node: 'yes'
@@ -206,7 +206,7 @@ jobs:
         uses: maykinmedia/setup-django-backend@v1
         with:
           apt-packages: 'libxml2-dev libxmlsec1-dev libxmlsec1-openssl gettext postgresql-client'
-          python-version: '3.10.9'
+          python-version: '3.10'
           optimize-postgres: 'yes'
           pg-service: 'postgres'
           setup-node: 'yes'

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM openformulieren/open-forms-sdk:${SDK_RELEASE} as sdk-image
 
 # Stage 1 - Backend build environment
 # includes compilers and build tooling to create the environment
-FROM python:3.10.9-slim-bullseye AS backend-build
+FROM python:3.10-slim-bullseye AS backend-build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
@@ -61,7 +61,7 @@ COPY ./src /app/src
 RUN npm run build
 
 # Stage 3 - Build docker image suitable for production
-FROM python:3.10.9-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 # Stage 3.1 - Set up the needed production dependencies
 # install all the dependencies for GeoDjango


### PR DESCRIPTION
This was originally pinned due to a threading shutdown bug in CPython, see #2748. Since then Python 3.10.11 and 3.10.12 have been released, containing security fixes.

Not specifying the patch version in docker images and CI pipelines grabs the latest patch version for the minor version, which gives us the latest bug fixes 'for free'. This is preferrable over the risk of new bugs breaking our application like in #2748.