### PR TITLE
Update confirmation email sending for new appointments

### DIFF
--- a/src/openforms/appointments/renderer.py
+++ b/src/openforms/appointments/renderer.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Iterator
 
 from openforms.formio.rendering.nodes import ComponentNodeBase
 from openforms.formio.service import FormioData, format_value
 from openforms.submissions.rendering import Renderer
+from openforms.typing import JSONValue
 
 from .service import get_appointment
 
@@ -23,12 +24,14 @@ class ContactDetailNode(ComponentNodeBase):
     data: FormioData
 
     @property
-    def value(self) -> Any:
-        assert "key" in self.component
+    def value(self) -> JSONValue:
+        assert (
+            "key" in self.component
+        )  # type guard due to TypedDict limitations in Py < 3.11
         return self.data[self.component["key"]]
 
     @property
-    def display_value(self) -> Any:
+    def display_value(self) -> str:
         return format_value(self.component, self.value, as_html=self.renderer.as_html)
 
     def get_children(self):

--- a/src/openforms/appointments/renderer.py
+++ b/src/openforms/appointments/renderer.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+from openforms.formio.rendering.nodes import ComponentNodeBase
+from openforms.formio.service import FormioData, format_value
+from openforms.submissions.rendering import Renderer
+
+from .service import get_appointment
+
+
+@dataclass
+class ContactDetailNode(ComponentNodeBase):
+    """
+    Rendering of a contact detail formio component.
+
+    Ideally we'd be able to share more logic with the
+    :class:`openforms.formio.rendering.nodes.ComponentNode`, but that is too tighly
+    coupled with ``FormStep`` and ``SubmissionStep`` Django models at the moment.
+
+    Therefore, this implementation is extremely minimal.
+    """
+
+    data: FormioData
+
+    @property
+    def value(self) -> Any:
+        assert "key" in self.component
+        return self.data[self.component["key"]]
+
+    @property
+    def display_value(self) -> Any:
+        return format_value(self.component, self.value, as_html=self.renderer.as_html)
+
+    def get_children(self):
+        return []
+
+    def render(self) -> str:
+        """
+        Output a simple key-value pair of label and value.
+        """
+        return f"{self.label}: {self.display_value}"
+
+
+class AppointmentRenderer(Renderer):
+    """
+    Custom renderer outputting the appointment contact details.
+    """
+
+    def get_children(self) -> Iterator[ContactDetailNode]:
+        appointment = get_appointment(self.submission)
+        if appointment is None:
+            return
+
+        data = FormioData(appointment.contact_details)
+        for component in appointment.contact_details_meta:
+            yield ContactDetailNode(renderer=self, component=component, data=data)

--- a/src/openforms/appointments/service.py
+++ b/src/openforms/appointments/service.py
@@ -1,0 +1,27 @@
+"""
+Public API of the appointments module.
+
+The exported names here may be used in other django apps and/or Open Forms modules.
+Anything else is considered private API.
+"""
+from openforms.submissions.models import Submission
+
+from .models import Appointment
+
+
+def get_email_confirmation_recipients(submission: Submission) -> list[str]:
+    """
+    Extract confirmation email recipient addresses, if relevant.
+
+    If the submission is for a form that is not a (new-style) appointment form, an
+    empty list is returned. The caller is expected to apply different logic to obtain
+    the e-mail addresses.
+    """
+    if not submission.form.is_appointment:
+        return []
+
+    appointment: Appointment | None = getattr(submission, "appointment", None)
+    if appointment is None:
+        return []
+
+    return appointment.extract_email_addresses()

--- a/src/openforms/appointments/service.py
+++ b/src/openforms/appointments/service.py
@@ -9,6 +9,13 @@ from openforms.submissions.models import Submission
 from .models import Appointment
 
 
+def get_appointment(submission: Submission) -> Appointment | None:
+    if not submission.form.is_appointment:
+        return None
+    appointment: Appointment | None = getattr(submission, "appointment", None)
+    return appointment
+
+
 def get_email_confirmation_recipients(submission: Submission) -> list[str]:
     """
     Extract confirmation email recipient addresses, if relevant.
@@ -17,11 +24,6 @@ def get_email_confirmation_recipients(submission: Submission) -> list[str]:
     empty list is returned. The caller is expected to apply different logic to obtain
     the e-mail addresses.
     """
-    if not submission.form.is_appointment:
+    if (appointment := get_appointment(submission)) is None:
         return []
-
-    appointment: Appointment | None = getattr(submission, "appointment", None)
-    if appointment is None:
-        return []
-
     return appointment.extract_email_addresses()

--- a/src/openforms/appointments/tests/factories.py
+++ b/src/openforms/appointments/tests/factories.py
@@ -5,6 +5,7 @@ import factory.fuzzy
 
 from openforms.submissions.tests.factories import SubmissionFactory
 
+from ..base import Product
 from ..constants import AppointmentDetailsStatus
 from ..models import AppointmentInfo
 
@@ -41,6 +42,28 @@ class AppointmentFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = "appointments.Appointment"
+
+    @factory.post_generation
+    def products(obj, create, extracted: list[Product], **kwargs):
+        if not create:
+            raise RuntimeError("You may only provide products with the create strategy")
+
+        for product in extracted:
+            AppointmentProductFactory.create(
+                appointment=obj,
+                product_id=product.identifier,
+                amount=product.amount,
+            )
+
+    @factory.post_generation
+    def appointment_info(obj, create, extracted, **kwargs):
+        if not create:
+            raise RuntimeError(
+                "You may only provide appointment info with the create strategy"
+            )
+        if not kwargs:
+            return
+        AppointmentInfoFactory.create(submission=obj.submission, **kwargs)
 
 
 class AppointmentProductFactory(factory.django.DjangoModelFactory):

--- a/src/openforms/appointments/tests/factories.py
+++ b/src/openforms/appointments/tests/factories.py
@@ -47,6 +47,8 @@ class AppointmentFactory(factory.django.DjangoModelFactory):
     def products(obj, create, extracted: list[Product], **kwargs):
         if not create:
             raise RuntimeError("You may only provide products with the create strategy")
+        if not extracted:
+            return
 
         for product in extracted:
             AppointmentProductFactory.create(

--- a/src/openforms/appointments/tests/test_confirmation_emails.py
+++ b/src/openforms/appointments/tests/test_confirmation_emails.py
@@ -71,7 +71,7 @@ class NoEmailPlugin(BasePlugin):
     def get_appointment_details(self, identifier: str) -> AppointmentDetails:
         return AppointmentDetails(
             identifier=identifier,
-            products=[Product(identifier="dummy", name="Dummy")],
+            products=[Product(identifier="dummy", name="Dummy", amount=2)],
             location=Location(
                 identifier="dummy",
                 name="Knowhere",
@@ -209,7 +209,7 @@ class AppointmentCreationConfirmationMailTests(HTMLAssertMixin, TestCase):
         assert isinstance(message_html, str)
 
         with self.subTest("Product name", type="plain text"):
-            self.assertIn("Dummy", message_text)
+            self.assertIn("Dummy (x2)", message_text)
 
         with self.subTest("Location name", type="plain text"):
             self.assertIn("Knowhere", message_text)
@@ -233,7 +233,7 @@ class AppointmentCreationConfirmationMailTests(HTMLAssertMixin, TestCase):
             self.assertIn("Email: austin@powers.net", message_text)
 
         with self.subTest("Product name", type="HTML"):
-            self.assertTagWithTextIn("td", "Dummy", message_html)
+            self.assertTagWithTextIn("td", "Dummy (x2)", message_html)
 
         with self.subTest("Location name", type="HTML"):
             self.assertIn("Knowhere", message_html)

--- a/src/openforms/appointments/tests/test_confirmation_emails.py
+++ b/src/openforms/appointments/tests/test_confirmation_emails.py
@@ -229,8 +229,8 @@ class AppointmentCreationConfirmationMailTests(HTMLAssertMixin, TestCase):
             self.assertNotIn(_("Summary"), message_text)
 
         with self.subTest("Contact details", type="plain text"):
-            self.assertIn("Last name:\nPowers", message_text)
-            self.assertIn("Email:\naustin@powers.net", message_text)
+            self.assertIn("Last name: Powers", message_text)
+            self.assertIn("Email: austin@powers.net", message_text)
 
         with self.subTest("Product name", type="HTML"):
             self.assertTagWithTextIn("td", "Dummy", message_html)

--- a/src/openforms/appointments/tests/test_confirmation_emails.py
+++ b/src/openforms/appointments/tests/test_confirmation_emails.py
@@ -1,0 +1,131 @@
+"""
+Test the generic confirmation e-mail sending for appointment forms.
+"""
+from datetime import date, datetime, time
+from unittest.mock import patch
+
+from django.core import mail
+from django.test import TestCase
+from django.utils import timezone
+
+from openforms.config.models import GlobalConfiguration
+from openforms.formio.typing import Component
+from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.submissions.utils import send_confirmation_email
+
+from ..base import AppointmentDetails, BasePlugin, Location, Product
+from ..registry import Registry
+from .factories import AppointmentFactory, AppointmentInfoFactory
+
+register = Registry()
+
+LAST_NAME: Component = {
+    "type": "textfield",
+    "key": "lastName",
+    "label": "Last name",
+    "validate": {
+        "required": True,
+        "maxLength": 20,
+    },
+}
+
+EMAIL: Component = {
+    "type": "email",
+    "key": "email",
+    "label": "Email",
+    "validate": {
+        "required": True,
+    },
+}
+
+
+@register("no-email")
+class NoEmailPlugin(BasePlugin):
+    def get_available_products(self, *args, **kwargs) -> list[Product]:
+        return [Product(identifier="dummy", name="Dummy")]
+
+    def get_locations(self, *args, **kwargs) -> list[Location]:
+        return [Location(identifier="dummy", name="Knowhere")]
+
+    def get_dates(self, *args, **kwargs):
+        return [date(2023, 8, 1)]
+
+    def get_times(self, *args, **kwargs):
+        return [
+            datetime.combine(day, time(12, 0), tzinfo=timezone.utc)
+            for day in self.get_dates()
+        ]
+
+    def get_required_customer_fields(self, *args, **kwargs) -> list[Component]:
+        return [LAST_NAME]
+
+    def create_appointment(self, *args, **kwargs):
+        return "dummy-identifier"
+
+    def delete_appointment(self, *args, **kwargs):
+        pass
+
+    def get_appointment_details(self, identifier: str) -> AppointmentDetails:
+        return AppointmentDetails(
+            identifier=identifier,
+            products=[Product(identifier="dummy", name="Dummy")],
+            location=Location(
+                identifier="dummy",
+                name="Knowhere",
+                city="Teststad",
+                postalcode="1234AB",
+            ),
+            start_at=datetime(2023, 8, 1, 12, 0).replace(tzinfo=timezone.utc),
+            end_at=datetime(2023, 8, 1, 12, 15).replace(tzinfo=timezone.utc),
+            remarks="Remarks",
+            other={"Some": "<h1>Data</h1>"},
+        )
+
+
+class AppointmentCreationConfirmationMailTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.config = GlobalConfiguration(
+            confirmation_email_content="{% summary %}\n{% appointment_information %}"
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = patch(
+            "openforms.emails.confirmation_emails.GlobalConfiguration.get_solo",
+            return_value=self.config,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_send_confirmation_mail_disabled(self):
+        appointment = AppointmentFactory.create(
+            submission__form__is_appointment_form=True,
+            submission__form__send_confirmation_email=False,
+            products=[Product(identifier="dummy", name="")],
+            appointment_info__registration_ok=True,
+            contact_details_meta=[LAST_NAME, EMAIL],
+            contact_details={"lastName": "Powers", "email": "austin@powers.net"},
+        )
+
+        send_confirmation_email(appointment.submission)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_no_available_email_address(self):
+        appointment = AppointmentFactory.create(
+            plugin="no-email",
+            submission__form__is_appointment_form=True,
+            submission__form__send_confirmation_email=True,
+            products=[Product(identifier="dummy", name="")],
+            appointment_info__registration_ok=True,
+            contact_details_meta=[LAST_NAME],
+            contact_details={"lastName": "Powers"},
+        )
+
+        send_confirmation_email(appointment.submission)
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -1207,7 +1207,7 @@ msgstr "Tijdstip wanneer de afspraakdetails zijn gemaakt "
 #: openforms/emails/templates/emails/templatetags/appointment_information.html:3
 #: openforms/emails/templates/emails/templatetags/appointment_information.txt:1
 msgid "Appointment information"
-msgstr "Afspraak informatie"
+msgstr "Afspraakinformatie"
 
 #: openforms/appointments/models.py:107 openforms/authentication/models.py:14
 msgid "plugin"

--- a/src/openforms/emails/confirmation_emails.py
+++ b/src/openforms/emails/confirmation_emails.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Tuple
+from typing import TYPE_CHECKING, Any, Dict
 
 from django.template.defaultfilters import date as date_filter
 from django.urls import reverse
@@ -19,12 +19,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_confirmation_email_templates(submission: "Submission") -> Tuple[str, str]:
+def get_confirmation_email_templates(submission: "Submission") -> tuple[str, str]:
     if not submission.form.send_confirmation_email:
         raise SkipConfirmationEmail("Confirmation e-mail sending is disabled.")
 
     with translation.override(submission.language_code):
         config = GlobalConfiguration.get_solo()
+        assert isinstance(config, GlobalConfiguration)
         if not hasattr(submission.form, "confirmation_email_template"):
             return config.confirmation_email_subject, config.confirmation_email_content
 

--- a/src/openforms/emails/templates/emails/templatetags/appointment_information.html
+++ b/src/openforms/emails/templates/emails/templatetags/appointment_information.html
@@ -22,7 +22,7 @@
         <tr>
             <td width="25%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;">{% trans "Date and time" %}</td>
             <td width="75%" style="padding: 4px 10px 4px 0; text-align: left;">
-                {{ appointment.start_at.date }}, {{ appointment.start_at.time }}{% if appointment.end_at %} - {{ appointment.end_at.time }}{% endif %}
+                {{ appointment.start_at|date }}, {{ appointment.start_at|time }}{% if appointment.end_at %} - {{ appointment.end_at|time }}{% endif %}
             </td>
         </tr>
         <tr>

--- a/src/openforms/emails/templates/emails/templatetags/appointment_information.html
+++ b/src/openforms/emails/templates/emails/templatetags/appointment_information.html
@@ -7,7 +7,7 @@
             <td width="25%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;">{% trans "Products" %}</td>
             <td width="75%" style="padding: 4px 10px 4px 0; text-align: left;">
                 {% for product in appointment.products %}
-                    {{ product.name }}{% if not forloop.last %}<br />{% endif %}
+                    {{ product.name }}{% if product.amount > 1 %} (x{{ product.amount }}){% endif %}{% if not forloop.last %}<br />{% endif %}
                 {% endfor %}
             </td>
         </tr>

--- a/src/openforms/emails/templates/emails/templatetags/appointment_information.html
+++ b/src/openforms/emails/templates/emails/templatetags/appointment_information.html
@@ -41,6 +41,17 @@
         {% endif %}
     </table>
 
+    <h2 style="margin: 1em 0; font-size: 1.3em;">{% trans "Your contact details" %}</h2>
+
+    <table style="width: 100%; border: none; border-collapse: collapse;" cellpadding="0" cellspacing="0" width="100%">
+        {% for node in appointment_renderer.get_children %}
+        <tr>
+            <td width="25%" valign="top" style="padding: 4px 10px 4px 0; text-align: left;">{{ node.label }}</td>
+            <td width="75%" style="padding: 4px 10px 4px 0; text-align: left;">{{ node.display_value }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+
     <p>
         {% trans "If you want to cancel or change your appointment, you can do so below." %}
     </p>

--- a/src/openforms/emails/templates/emails/templatetags/appointment_information.txt
+++ b/src/openforms/emails/templates/emails/templatetags/appointment_information.txt
@@ -9,7 +9,7 @@
 {{ appointment.location.postalcode }} {{ appointment.location.city }}{% endif %}
 
 {% trans "Date and time" %}:
-{{ appointment.start_at.date|date }}, {{ appointment.start_at.time|time }}{% if appointment.end_at %} - {{ appointment.end_at.time|time }}{% endif %}
+{{ appointment.start_at|date }}, {{ appointment.start_at|time }}{% if appointment.end_at %} - {{ appointment.end_at|time }}{% endif %}
 
 {% trans "Remarks" %}:
 {{ appointment.remarks }}

--- a/src/openforms/emails/templates/emails/templatetags/appointment_information.txt
+++ b/src/openforms/emails/templates/emails/templatetags/appointment_information.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% autoescape off %}{% if appointment %}{% trans "Appointment information" %}
 
 {% trans "Products" %}:{% for product in appointment.products %}
-- {{ product.name }}{% endfor %}
+- {{ product.name }}{% if product.amount > 1 %} (x{{ product.amount }}){% endif %}{% endfor %}
 
 {% trans "Location" %}:
 {{ appointment.location.name }}{% if appointment.location.address %}

--- a/src/openforms/emails/templates/emails/templatetags/appointment_information.txt
+++ b/src/openforms/emails/templates/emails/templatetags/appointment_information.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% trans "Appointment information" %}
+{% load i18n %}{% autoescape off %}{% if appointment %}{% trans "Appointment information" %}
 
 {% trans "Products" %}:{% for product in appointment.products %}
 - {{ product.name }}{% endfor %}
@@ -11,6 +11,9 @@
 {% trans "Date and time" %}:
 {{ appointment.start_at|date }}, {{ appointment.start_at|time }}{% if appointment.end_at %} - {{ appointment.end_at|time }}{% endif %}
 
+{% if appointment_renderer.has_children %}{% trans "Your contact details" %}:{% for node in appointment_renderer.get_children %}
+- {{ node.label }}: {{ node.display_value }}{% endfor %}{% endif %}
+
 {% trans "Remarks" %}:
 {{ appointment.remarks }}
 
@@ -20,4 +23,4 @@
 
 {% trans "If you want to cancel or change your appointment, you can do so below." %}
 {% trans "Cancel appointment" %}: {{ appointment_cancel_link }}
-{% trans "Change appointment" %}: {{ appointment_change_link }}{% endautoescape %}
+{% trans "Change appointment" %}: {{ appointment_change_link }}{% endif %}{% endautoescape %}

--- a/src/openforms/emails/templatetags/appointments.py
+++ b/src/openforms/emails/templatetags/appointments.py
@@ -2,7 +2,9 @@ from django import template
 from django.template.loader import render_to_string
 
 from openforms.appointments.models import Appointment
+from openforms.appointments.renderer import AppointmentRenderer
 from openforms.appointments.utils import get_plugin
+from openforms.submissions.rendering.constants import RenderModes
 
 register = template.Library()
 
@@ -13,7 +15,7 @@ def appointment_information(context):
     if not (appointment_id := context.get("_appointment_id")):
         return ""
 
-    if context.get("rendering_text"):
+    if as_text := context.get("rendering_text", False):
         template_name = "emails/templatetags/appointment_information.txt"
     else:
         template_name = "emails/templatetags/appointment_information.html"
@@ -27,6 +29,11 @@ def appointment_information(context):
 
     tag_context = {
         "appointment": plugin.get_appointment_details(appointment_id),
+        "appointment_renderer": AppointmentRenderer(
+            submission=submission,
+            mode=RenderModes.confirmation_email,
+            as_html=not as_text,
+        ),
         "appointment_cancel_link": plugin.get_cancel_link(context["_submission"]),
         "appointment_change_link": plugin.get_change_link(context["_submission"]),
     }

--- a/src/openforms/emails/templatetags/form_summary.py
+++ b/src/openforms/emails/templatetags/form_summary.py
@@ -1,6 +1,7 @@
 from django import template
 from django.template.loader import get_template
 
+from openforms.appointments.service import get_appointment
 from openforms.formio.rendering.default import (
     EditGridGroupNode,
     EditGridNode,
@@ -14,9 +15,14 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def summary(context):
-    as_text = context.get("rendering_text")
+    submission = context["_submission"]
+    # if it's a new-style appointment submission, there are no steps or summary to render
+    if get_appointment(submission) is not None:
+        return ""
+
+    as_text = context.get("rendering_text", False)
     renderer = Renderer(
-        submission=context["_submission"],
+        submission=submission,
         mode=RenderModes.confirmation_email,
         as_html=not as_text,
     )

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -92,7 +92,7 @@ class ComponentRegistry(BaseRegistry):
             return value
         return normalizer(component, value)
 
-    def format(self, component: Component, value: Any, as_html=False):
+    def format(self, component: Component, value: Any, as_html=False) -> str:
         """
         Format a given value in the appropriate way for the specified component.
 

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -645,7 +645,14 @@ class Submission(models.Model):
             self._merged_attachments = self.get_attachments().as_form_dict()
         return self._merged_attachments
 
-    def get_email_confirmation_recipients(self, submitted_data: dict) -> List[str]:
+    def get_email_confirmation_recipients(self, submitted_data: dict) -> list[str]:
+        from openforms.appointments.service import get_email_confirmation_recipients
+
+        # first check if there are any recipients because it's an e-mail form, as that
+        # shortcuts the formio component checking (there aren't any)
+        if emails := get_email_confirmation_recipients(self):
+            return emails
+
         recipient_emails = set()
         for key in self.form.get_keys_for_email_confirmation():
             value = submitted_data.get(key)


### PR DESCRIPTION
Closes #3321

- The form summary rendering is now empty for appointment forms (there are no steps or formio forms to render)
- The contact details submitted (dynamic, depending on the selected product(s)) are now included
- The setting to not send a confirmation email is respected
- Restructured some code to move more responsibility into the appointments app/module