### PR TITLE
Correctly report product amount when fetching JCC appointment details

### DIFF
--- a/src/openforms/appointments/contrib/jcc/plugin.py
+++ b/src/openforms/appointments/contrib/jcc/plugin.py
@@ -360,7 +360,7 @@ class JccAppointment(BasePlugin):
             for product_id, count in product_ids.items():
                 _product = client.service.getGovProductDetails(productID=product_id)
                 product = Product(
-                    identifier=product_id, name=_product.description, amount=count
+                    identifier=product_id, name=_product.description or "", amount=count
                 )
                 app_products.append(product)
 

--- a/src/openforms/appointments/contrib/jcc/plugin.py
+++ b/src/openforms/appointments/contrib/jcc/plugin.py
@@ -319,7 +319,9 @@ class JccAppointment(BasePlugin):
                 },
             )
             raise error
-        except (ZeepError, RequestException, KeyError) as e:
+        except Exception as e:
+            if isinstance(e, AppointmentCreateFailed):
+                raise e
             raise AppointmentCreateFailed(
                 "Unexpected appointment create failure"
             ) from e

--- a/src/openforms/appointments/contrib/jcc/plugin.py
+++ b/src/openforms/appointments/contrib/jcc/plugin.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from collections import Counter
 from contextlib import contextmanager
 from datetime import date, datetime
 from functools import wraps
@@ -353,10 +354,13 @@ class JccAppointment(BasePlugin):
             qrcode = client.service.GetAppointmentQRCodeText(appID=identifier)
 
             app_products = []
-            for pid in details.productID.split(","):
-                product = client.service.getGovProductDetails(productID=pid)
-
-                app_products.append(Product(identifier=pid, name=product.description))
+            product_ids = Counter(details.productID.split(","))
+            for product_id, count in product_ids.items():
+                _product = client.service.getGovProductDetails(productID=product_id)
+                product = Product(
+                    identifier=product_id, name=_product.description, amount=count
+                )
+                app_products.append(product)
 
             qrcode_base64 = create_base64_qrcode(qrcode)
 

--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovAppointmentDetailsMultipleProductsResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovAppointmentDetailsMultipleProductsResponse.xml
@@ -1,0 +1,27 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <getGovAppointmentDetailsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <appointment xmlns="">
+            <productID>1,2,1</productID>
+            <clientLastName>Doe</clientLastName>
+            <clientSex>M</clientSex>
+            <clientDateOfBirth>1980-01-01</clientDateOfBirth>
+            <clientInitials>John</clientInitials>
+            <clientAddress>Straat 1</clientAddress>
+            <clientPostalCode>1111 AA</clientPostalCode>
+            <clientCity>Stad</clientCity>
+            <clientCountry>Nederland</clientCountry>
+            <clientTel>06123456789</clientTel>
+            <clientMail>john.doe@example.com</clientMail>
+            <locationID>1</locationID>
+            <appStartTime>2021-08-30T15:00:00</appStartTime>
+            <appEndTime>2021-08-30T15:15:00</appEndTime>
+            <appointmentDesc>Dit is een testafspraak
+
+Bvd,
+John</appointmentDesc>
+            <isClientVerified>false</isClientVerified>
+         </appointment>
+      </getGovAppointmentDetailsResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovProductDetailsNoDescriptionResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovProductDetailsNoDescriptionResponse.xml
@@ -1,0 +1,9 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <getGovProductDetailsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <out xmlns="">
+            <appDuration>10</appDuration>
+         </out>
+      </getGovProductDetailsResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -416,6 +416,41 @@ class PluginTests(MockConfigMixin, TestCase):
         )
 
     @requests_mock.Mocker()
+    def test_get_appointment_details_no_product_description(self, m):
+        identifier = "1234567890"
+
+        m.post(
+            "http://example.com/soap11",
+            text=mock_response("getGovAppointmentDetailsResponse.xml"),
+            additional_matcher=lambda req: "getGovAppointmentDetailsRequest"
+            in req.text,
+        )
+        m.post(
+            "http://example.com/soap11",
+            text=mock_response("getGovLocationDetailsResponse.xml"),
+            additional_matcher=lambda req: "getGovLocationDetailsRequest" in req.text,
+        )
+        m.post(
+            "http://example.com/soap11",
+            text=mock_response("GetAppointmentQRCodeTextResponse.xml"),
+            additional_matcher=lambda req: "GetAppointmentQRCodeTextRequest"
+            in req.text,
+        )
+        m.post(
+            "http://example.com/soap11",
+            text=mock_response("getGovProductDetailsNoDescriptionResponse.xml"),
+            additional_matcher=lambda req: "getGovProductDetailsRequest" in req.text,
+        )
+
+        result = self.plugin.get_appointment_details(identifier)
+
+        self.assertEqual(type(result), AppointmentDetails)
+
+        self.assertEqual(len(result.products), 1)
+        self.assertEqual(result.identifier, identifier)
+        self.assertEqual(result.products[0].name, "")
+
+    @requests_mock.Mocker()
     def test_get_appointment_details_multiple_products(self, m):
         identifier = "1234567890"
         m.post(

--- a/src/openforms/appointments/core.py
+++ b/src/openforms/appointments/core.py
@@ -4,6 +4,8 @@ Core implementation of the generic API.
 This module is the follow-up to the bulk of functionality in utils.py, which is doing
 way too much but can't be easily refactored without breaking existing functionality.
 """
+import logging
+
 from django.utils.translation import gettext_lazy as _
 
 import elasticapm
@@ -23,6 +25,8 @@ from .registry import register
 from .utils import cancel_previous_submission_appointment
 
 __all__ = ["book_for_submission"]
+
+logger = logging.getLogger(__name__)
 
 
 def _get_plugin(appointment: Appointment) -> BasePlugin:
@@ -95,6 +99,7 @@ def book_for_submission(submission: Submission) -> str:
     try:
         appointment_id = book(appointment)
     except AppointmentCreateFailed as e:
+        logger.error("Appointment creation failed", exc_info=e)
         # This is displayed to the end-user!
         error_information = _(
             "A technical error occurred while we tried to book your appointment. "

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -158,6 +158,7 @@ def book_appointment_for_submission(submission: Submission) -> None:
         )
         logevent.appointment_register_success(appointment_info, plugin)
     except AppointmentCreateFailed as e:
+        logger.error("Appointment creation failed", exc_info=e)
         # This is displayed to the end-user!
         error_information = _(
             "A technical error occurred while we tried to book your appointment. "


### PR DESCRIPTION
Depends on #3330, related to #3321

Ensure that we correctly interpret the product count when retrieving appointment details from JCC.

Implemented based on documentation, as I'm still waiting for support/help from JCC to figure out the appointment booking issues.