### PR TITLE
Support passing already selected product IDs in products list endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -360,6 +360,17 @@ paths:
       operationId: appointments_products_list
       description: List all products a user can choose when making an appointment.
       summary: List available products
+      parameters:
+      - in: query
+        name: product_id
+        schema:
+          type: array
+          items:
+            type: string
+          minLength: 1
+        description: ID of the product, repeat for multiple products.
+        explode: true
+        style: form
       tags:
       - appointments
       responses:

--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -59,6 +59,18 @@ class ProductSerializer(serializers.Serializer):
         ref_name = "AppointmentProduct"
 
 
+class ProductInputSerializer(serializers.Serializer):
+    product_id = serializers.ListField(
+        child=ProductIDField(help_text=_("ID of a selected product.")),
+        label=_("Product IDs"),
+        help_text=_(
+            "One or more product IDs already selected, which may limit the collection "
+            "of additional products to select."
+        ),
+        required=False,
+    )
+
+
 class LocationSerializer(serializers.Serializer):
     identifier = serializers.CharField(
         label=_("identifier"), help_text=_("ID of the location")

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class Product:
     identifier: str
     name: str
-    code: str | None = None
+    code: str = ""
     amount: int = 1
 
     def __str__(self):

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -69,6 +69,8 @@ class PluginTests(MockConfigMixin, TestCase):
         self.assertEqual(other_products[0].identifier, "5")
         self.assertEqual(other_products[0].code, "RIJAAN")
         self.assertEqual(other_products[0].name, "Rijbewijs aanvraag (Drivers license)")
+        body = m.last_request.text
+        self.assertIn("getGovAvailableProductsByProductRequest", body)
 
     @requests_mock.Mocker()
     def test_get_all_locations(self, m):

--- a/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
@@ -41,7 +41,7 @@ class ProductsListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
         products = response.json()
         self.assertEqual(len(products), 2)
         self.assertEqual(products[0]["identifier"], "54b3482204c11bedc8b0a7acbffa308")
-        self.assertEqual(products[0]["code"], None)
+        self.assertEqual(products[0]["code"], "")
         self.assertEqual(products[0]["name"], "Service 01")
 
     def test_get_products_returns_403_when_no_active_sessions(self):

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -39,7 +39,7 @@ class PluginTests(MockConfigMixin, TestCase):
 
             self.assertEqual(len(products), 2)
             self.assertEqual(products[0].identifier, "54b3482204c11bedc8b0a7acbffa308")
-            self.assertEqual(products[0].code, None)
+            self.assertEqual(products[0].code, "")
             self.assertEqual(products[0].name, "Service 01")
 
         with self.subTest("with location ID"):

--- a/src/openforms/appointments/tests/test_api_products.py
+++ b/src/openforms/appointments/tests/test_api_products.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
 
+from ..base import Product
 from ..models import AppointmentsConfig
 
 
@@ -37,3 +38,33 @@ class ProductListTests(SubmissionsMixin, APITestCase):
         mock_plugin.get_available_products.assert_called_once_with(
             location_id="some-location-id"
         )
+
+    @patch("openforms.appointments.api.views.get_plugin")
+    def test_list_products_with_existing_product(self, mock_get_plugin):
+        mock_plugin = mock_get_plugin.return_value
+        config_patcher = patch(
+            "openforms.appointments.utils.AppointmentsConfig.get_solo",
+            return_value=AppointmentsConfig(plugin="demo"),
+        )
+        config_patcher.start()
+        self.addCleanup(config_patcher.stop)
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(self.endpoint, {"product_id": ["123", "456"]})
+
+        self.assertEqual(response.status_code, 200)
+        mock_plugin.get_available_products.assert_called_once_with(
+            current_products=[
+                Product(identifier="123", name=""),
+                Product(identifier="456", name=""),
+            ]
+        )
+
+    def test_list_products_with_existing_product_invalid_query_param(self):
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(self.endpoint, {"product_id": [""]})
+
+        # XXX in 3.0, this will become HTTP 400
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])


### PR DESCRIPTION
Partly closes #3332

Passing the IDs of the products allows the plugin to retrieve other products in that context, as certain products can not be selected in combination with other products.

Backend aspect - SDK needs to take the selected products into account.