### PR TITLE
Make the base registry class a generic type

### DIFF
--- a/src/openforms/appointments/registry.py
+++ b/src/openforms/appointments/registry.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 from openforms.plugins.registry import BaseRegistry
 
+if TYPE_CHECKING:  # pragma: no cover
+    from .base import BasePlugin  # noqa: F401
 
-class Registry(BaseRegistry):
+
+class Registry(BaseRegistry["BasePlugin"]):
     """
     A registry for appointments module plugins.
     """

--- a/src/openforms/authentication/base.py
+++ b/src/openforms/authentication/base.py
@@ -98,11 +98,11 @@ class BasePlugin(AbstractBasePlugin):
         """
         pass
 
-    def get_login_info(self, request: HttpRequest, form: Form) -> LoginInfo:
+    def get_login_info(self, request: HttpRequest, form: Form | None) -> LoginInfo:
         info = LoginInfo(
             self.identifier,
             self.get_label(),
-            url=self.get_start_url(request, form),
+            url=self.get_start_url(request, form) if form else "",
             logo=self.get_logo(request),
             is_for_gemachtigde=self.is_for_gemachtigde,
         )

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from django.http import HttpRequest
@@ -8,6 +9,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from openforms.forms.models import Form
 
     from .base import BasePlugin, LoginInfo  # noqa: F401
+
+logger = logging.getLogger(__name__)
 
 
 def _iter_plugin_ids(form: Optional["Form"], registry: "Registry") -> Iterator[str]:
@@ -31,6 +34,11 @@ class Registry(BaseRegistry["BasePlugin"]):
         options = list()
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:
+                logger.warning(
+                    "Plugin %s not found in registry, ignoring it.",
+                    plugin_id,
+                    extra={"plugin_id": plugin_id, "form": form.pk if form else None},
+                )
                 continue
             plugin = self._registry[plugin_id]
             info = plugin.get_login_info(request, form)

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -1,28 +1,40 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from django.http import HttpRequest
 
 from openforms.plugins.registry import BaseRegistry
 
-if TYPE_CHECKING:
-    from .base import LoginInfo  # pragma: nocover
+if TYPE_CHECKING:  # pragma: no cover
+    from openforms.forms.models import Form
+
+    from .base import BasePlugin, LoginInfo  # noqa: F401
 
 
-class Registry(BaseRegistry):
+def _iter_plugin_ids(form: Optional["Form"], registry: "Registry") -> Iterator[str]:
+    if form is not None:
+        yield from form.authentication_backends
+    else:
+        for plugin in registry.iter_enabled_plugins():
+            yield plugin.identifier
+
+
+class Registry(BaseRegistry["BasePlugin"]):
     """
     A registry for the authentication module plugins.
     """
 
     module = "authentication"
 
-    def get_options(self, request: HttpRequest, form=None) -> List["LoginInfo"]:
+    def get_options(
+        self, request: HttpRequest, form: Optional["Form"] = None
+    ) -> List["LoginInfo"]:
         options = list()
-        plugins = form.authentication_backends if form else self.iter_enabled_plugins()
-        for plugin_id in plugins:
-            if plugin_id in self._registry:
-                plugin = self._registry[plugin_id]
-                info = plugin.get_login_info(request, form)
-                options.append(info)
+        for plugin_id in _iter_plugin_ids(form, self):
+            if plugin_id not in self._registry:
+                continue
+            plugin = self._registry[plugin_id]
+            info = plugin.get_login_info(request, form)
+            options.append(info)
         return options
 
 

--- a/src/openforms/dmn/registry.py
+++ b/src/openforms/dmn/registry.py
@@ -1,7 +1,9 @@
 from openforms.plugins.registry import BaseRegistry
 
+from .base import BasePlugin
 
-class Registry(BaseRegistry):
+
+class Registry(BaseRegistry[BasePlugin]):
     """
     A registry for decision modelling/evaluation module plugins.
     """

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -78,7 +78,7 @@ class BasePlugin(AbstractBasePlugin):
         ...
 
 
-class ComponentRegistry(BaseRegistry):
+class ComponentRegistry(BaseRegistry[BasePlugin]):
     module = "formio_components"
 
     def normalize(self, component: Component, value: Any) -> Any:

--- a/src/openforms/formio/rendering/registry.py
+++ b/src/openforms/formio/rendering/registry.py
@@ -1,19 +1,23 @@
-from typing import Type
+from typing import Callable, TypeAlias
 
 from openforms.plugins.registry import BaseRegistry
 
 from .nodes import ComponentNode
 
+TComponentNode: TypeAlias = type[ComponentNode]
+
 
 class Registry(BaseRegistry):
     module = "formio"
 
-    def __call__(self, unique_identifier: str, *args, **kwargs) -> callable:
+    def __call__(
+        self, unique_identifier: str, *args, **kwargs
+    ) -> Callable[[TComponentNode], TComponentNode]:
         """
         Overridden from base class because we register classes instead of instances.
         """
 
-        def decorator(klass: Type[ComponentNode]) -> Type[ComponentNode]:
+        def decorator(klass: TComponentNode) -> TComponentNode:
             if unique_identifier in self._registry:
                 raise ValueError(
                     f"The unique identifier '{unique_identifier}' is already present "
@@ -26,7 +30,7 @@ class Registry(BaseRegistry):
 
         return decorator
 
-    def __getitem__(self, key: str) -> Type[ComponentNode]:
+    def __getitem__(self, key: str) -> TComponentNode:
         try:
             return self._registry[key]
         except KeyError:

--- a/src/openforms/forms/validation/registry.py
+++ b/src/openforms/forms/validation/registry.py
@@ -1,7 +1,9 @@
 from openforms.plugins.registry import BaseRegistry
 
+from .base import BaseValidator
 
-class FormioValidationRegistry(BaseRegistry):
+
+class FormioValidationRegistry(BaseRegistry[BaseValidator]):
     pass
 
 

--- a/src/openforms/payments/base.py
+++ b/src/openforms/payments/base.py
@@ -11,9 +11,7 @@ from openforms.utils.urls import reverse_plus
 
 from .constants import PaymentRequestType
 
-if TYPE_CHECKING:  # pragma: nocover
-    from openforms.forms.models import Form
-
+if TYPE_CHECKING:  # pragma: no cover
     from .models import Submission, SubmissionPayment
 
 
@@ -27,7 +25,7 @@ class APIInfo:
 class PaymentInfo:
     type: str = PaymentRequestType.get
     url: str = ""
-    data: Mapping[str, str] = None
+    data: Mapping[str, str] | None = None
 
 
 class EmptyOptions(JsonSchemaSerializerMixin, serializers.Serializer):
@@ -79,9 +77,6 @@ class BasePlugin(AbstractBasePlugin):
             request=request,
         )
 
-    def get_api_info(self, request: HttpRequest, form: "Form") -> APIInfo:
-        info = APIInfo(
-            self.identifier,
-            self.get_label(),
-        )
+    def get_api_info(self, request: HttpRequest) -> APIInfo:
+        info = APIInfo(self.identifier, str(self.get_label()))
         return info

--- a/src/openforms/payments/tests/test_registry.py
+++ b/src/openforms/payments/tests/test_registry.py
@@ -77,7 +77,7 @@ class RegistryTests(TestCase):
         form = step.form
         self.assertEqual(form.payment_backend, "plugin1")
 
-        options = register.get_options(request, form)
+        options = register.get_options(request)
         self.assertEqual(len(options), 1)
 
         option = options[0]

--- a/src/openforms/plugins/tests/test_registry.py
+++ b/src/openforms/plugins/tests/test_registry.py
@@ -9,7 +9,7 @@ from ..plugin import AbstractBasePlugin
 from ..registry import BaseRegistry
 
 
-class Registry1(BaseRegistry):
+class Registry1(BaseRegistry[AbstractBasePlugin]):
     module = "test"
 
 
@@ -26,7 +26,7 @@ class TestPlugin2(AbstractBasePlugin):
     verbose_name = "Test2"
 
 
-class Registry2(BaseRegistry):
+class Registry2(BaseRegistry[AbstractBasePlugin]):
     module = "test2"
 
 

--- a/src/openforms/pre_requests/base.py
+++ b/src/openforms/pre_requests/base.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING
 
-from .clients import PreRequestClientContext
+from openforms.plugins.plugin import AbstractBasePlugin
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .clients import PreRequestClientContext
 
 
 @dataclass
-class PreRequestHookBase(ABC):
+class PreRequestHookBase(ABC, AbstractBasePlugin):
     identifier: str
 
     @abstractmethod
@@ -15,6 +20,6 @@ class PreRequestHookBase(ABC):
         method: str,
         url: str,
         kwargs: dict,
-        context: Optional[PreRequestClientContext] = None,
+        context: PreRequestClientContext | None = None,
     ) -> None:
         raise NotImplementedError()  # pragma: nocover

--- a/src/openforms/pre_requests/registry.py
+++ b/src/openforms/pre_requests/registry.py
@@ -1,7 +1,9 @@
 from openforms.plugins.registry import BaseRegistry
 
+from .base import PreRequestHookBase
 
-class Registry(BaseRegistry):
+
+class Registry(BaseRegistry[PreRequestHookBase]):
     """
     A registry for pre-request hooks.
     """

--- a/src/openforms/prefill/registry.py
+++ b/src/openforms/prefill/registry.py
@@ -1,7 +1,9 @@
 from openforms.plugins.registry import BaseRegistry
 
+from .base import BasePlugin
 
-class Registry(BaseRegistry):
+
+class Registry(BaseRegistry[BasePlugin]):
     """
     A registry for the prefill module plugins.
     """

--- a/src/openforms/registrations/registry.py
+++ b/src/openforms/registrations/registry.py
@@ -1,7 +1,9 @@
 from openforms.plugins.registry import BaseRegistry
 
+from .base import BasePlugin
 
-class Registry(BaseRegistry):
+
+class Registry(BaseRegistry[BasePlugin]):
     """
     A registry for registrations module plugins.
     """

--- a/src/openforms/variables/base.py
+++ b/src/openforms/variables/base.py
@@ -3,11 +3,12 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from openforms.forms.models import FormVariable
+from openforms.plugins.plugin import AbstractBasePlugin
 from openforms.submissions.models import Submission
 
 
 @dataclass
-class BaseStaticVariable(ABC):
+class BaseStaticVariable(ABC, AbstractBasePlugin):
     identifier: str
     name: str = field(init=False)
     data_type: str = field(init=False)

--- a/src/openforms/variables/registry.py
+++ b/src/openforms/variables/registry.py
@@ -1,7 +1,9 @@
 from openforms.plugins.registry import BaseRegistry
 
+from .base import BaseStaticVariable
 
-class Registry(BaseRegistry):
+
+class Registry(BaseRegistry[BaseStaticVariable]):
     """
     A registry for static variables.
     """


### PR DESCRIPTION
This uncovered a couple of bugs too where plugins were being yielded rather than their identifiers.