### PR TITLE
:sparkles: [#2174] added api call for the pdok locatie server reverse lookup

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -2931,6 +2931,85 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+  /api/v2/geo/latlng-search:
+    get:
+      operationId: geo_latlng_search_retrieve
+      description: Get the closest address name based on the given longitude and latitude.
+      summary: Get an adress based on coordinates
+      parameters:
+      - in: query
+        name: lat
+        schema:
+          type: number
+          format: float
+        description: The latitude of the location, in decimal degrees.
+        required: true
+      - in: query
+        name: lng
+        schema:
+          type: number
+          format: float
+        description: The longitude of the location, in decimal degrees.
+        required: true
+      tags:
+      - geo
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LatLngSearchResult'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
+        '204':
+          description: No response body
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/i18n/formio/{language}:
     get:
       operationId: i18n_formio_retrieve
@@ -7474,6 +7553,14 @@ components:
       required:
       - current
       - languages
+    LatLngSearchResult:
+      type: object
+      properties:
+        label:
+          type: string
+          title: Closest address
+      required:
+      - label
     LatitudeLongitude:
       type: object
       properties:

--- a/src/openforms/contrib/kadaster/api/serializers.py
+++ b/src/openforms/contrib/kadaster/api/serializers.py
@@ -1,3 +1,4 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -28,3 +29,22 @@ class AddressSearchResultSerializer(serializers.Serializer):
         ),
         allow_null=True,
     )
+
+
+class LatLngSearchInputSerializer(serializers.Serializer):
+    lat = serializers.FloatField(
+        label=_("Latitude"),
+        help_text=_("Latitude, in decimal degrees."),
+        required=True,
+        validators=[MinValueValidator(-90.0), MaxValueValidator(90.0)],
+    )
+    lng = serializers.FloatField(
+        label=_("Longitude"),
+        help_text=_("Longitude, in decimal degrees."),
+        required=True,
+        validators=[MinValueValidator(-180.0), MaxValueValidator(180.0)],
+    )
+
+
+class LatLngSearchResultSerializer(serializers.Serializer):
+    label = serializers.CharField(label=_("Closest address"))

--- a/src/openforms/contrib/kadaster/api/urls.py
+++ b/src/openforms/contrib/kadaster/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import AddressSearchView
+from .views import AddressSearchView, LatLngSearchView
 
 app_name = "geo"
 
@@ -9,5 +9,10 @@ urlpatterns = [
         "address-search",
         AddressSearchView.as_view(),
         name="address-search",
+    ),
+    path(
+        "latlng-search",
+        LatLngSearchView.as_view(),
+        name="latlng-search",
     ),
 ]

--- a/src/openforms/contrib/kadaster/api/views.py
+++ b/src/openforms/contrib/kadaster/api/views.py
@@ -8,6 +8,8 @@ import requests
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.views import APIView
 from zds_client import ClientError
 
@@ -16,10 +18,79 @@ from openforms.api.views.mixins import ListMixin
 from openforms.submissions.api.permissions import AnyActiveSubmissionPermission
 
 from ..models import KadasterApiConfig
-from ..search import free_address_search
-from .serializers import AddressSearchResultSerializer
+from ..search import free_address_search, reverse_address_search
+from .serializers import (
+    AddressSearchResultSerializer,
+    LatLngSearchInputSerializer,
+    LatLngSearchResultSerializer,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@extend_schema(
+    summary=_("Get an adress based on coordinates"),
+    description=_(
+        "Get the closest address name based on the given longitude and latitude."
+    ),
+    parameters=[
+        OpenApiParameter(
+            "lat",
+            OpenApiTypes.FLOAT,
+            OpenApiParameter.QUERY,
+            description=_("The latitude of the location, in decimal degrees."),
+            required=True,
+        ),
+        OpenApiParameter(
+            "lng",
+            OpenApiTypes.FLOAT,
+            OpenApiParameter.QUERY,
+            description=_("The longitude of the location, in decimal degrees."),
+            required=True,
+        ),
+    ],
+    responses={
+        200: LatLngSearchResultSerializer,
+        204: None,
+        status.HTTP_400_BAD_REQUEST: ValidationErrorSerializer,
+        status.HTTP_403_FORBIDDEN: ExceptionSerializer,
+    },
+)
+class LatLngSearchView(APIView):
+    authentication_classes = ()
+    permission_classes = [AnyActiveSubmissionPermission]
+
+    def get(self, request: Request):
+        config = KadasterApiConfig.get_solo()
+        assert isinstance(config, KadasterApiConfig)
+
+        input_serializer = LatLngSearchInputSerializer(data=request.GET)
+        input_serializer.is_valid(raise_exception=True)
+
+        lat = input_serializer.validated_data["lat"]
+        lng = input_serializer.validated_data["lng"]
+        client = config.get_client()
+        try:
+            bag_response = reverse_address_search(client, lat, lng)
+        except (ClientError, requests.RequestException):
+            logger.exception(
+                "Couldn't retrieve locatieserver reverse lookup data",
+                extra={"lat": lat, "lng": lng},
+            )
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        if not (
+            (response := bag_response.get("response"))
+            and (docs := response.get("docs"))
+            and (weergavenaam := docs[0].get("weergavenaam"))
+        ):
+            # no response with docs: return empty
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        serializer = LatLngSearchResultSerializer(
+            instance={"label": weergavenaam}, context={"request": request}
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 @extend_schema(

--- a/src/openforms/contrib/kadaster/search.py
+++ b/src/openforms/contrib/kadaster/search.py
@@ -9,3 +9,18 @@ def free_address_search(client: PreRequestZGWClient, query: str):
         url="v3_1/free",
         request_kwargs={"params": {"q": query}},
     )
+
+
+def reverse_address_search(client: PreRequestZGWClient, lat: float, lng: float):
+    # using retrieve rather than list so we can provide the URL explicitly -
+    # we don't have much guarantees about the operationId
+    return client.retrieve(
+        resource="reverse",
+        url="v3_1/reverse",
+        request_kwargs={
+            "params": {
+                "lat": lat,
+                "lon": lng,
+            }
+        },
+    )

--- a/src/openforms/contrib/kadaster/tests/test_api_latlng_search.py
+++ b/src/openforms/contrib/kadaster/tests/test_api_latlng_search.py
@@ -1,0 +1,262 @@
+from unittest.mock import patch
+
+from django.test import override_settings
+
+import requests
+import requests_mock
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+from zgw_consumers.test import mock_service_oas_get
+
+from openforms.appointments.contrib.qmatic.tests.factories import ServiceFactory
+from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.submissions.tests.mixins import SubmissionsMixin
+
+from ..models import KadasterApiConfig
+
+
+@override_settings(LANGUAGE_CODE="en")
+class AddressSearchApiTests(SubmissionsMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.submission = SubmissionFactory.create()
+
+        cls.kadaster_service = ServiceFactory.build(
+            api_root="https://kadaster/",
+            oas="https://kadaster/api/schema/openapi.yaml",
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        self.config = KadasterApiConfig(search_service=self.kadaster_service)
+        config_patcher = patch(
+            "openforms.contrib.kadaster.api.views.KadasterApiConfig.get_solo",
+            return_value=self.config,
+        )
+        self.config_mock = config_patcher.start()
+        self.addCleanup(config_patcher.stop)
+
+    @requests_mock.Mocker()
+    def test_call_with_query_parameter_utrecht(self, m):
+        mock_service_oas_get(
+            m,
+            url="https://kadaster/",
+            service="locatieserver_openapi",
+            oas_url="https://kadaster/api/schema/openapi.yaml",
+        )
+        m.get(
+            "https://kadaster/v3_1/reverse",
+            status_code=200,
+            json={
+                "response": {
+                    "numFound": 1,
+                    "start": 0,
+                    "maxScore": 7.2816563,
+                    "numFoundExact": True,
+                    "docs": [
+                        {
+                            "type": "adres",
+                            "weergavenaam": "Gemeente Utrecht",
+                            "id": "adr-eebf5ada9e3af187be3704b2b01d4dec",
+                            "score": 7.2816563,
+                            "afstand": 7307439.14,
+                        },
+                    ],
+                }
+            },
+        )
+
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798", "lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(
+            body,
+            {
+                "label": "Gemeente Utrecht",
+            },
+        )
+
+    def test_call_with_no_active_submission(self):
+        url = reverse("api:geo:latlng-search")
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_call_with_no_query_parameter(self):
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        errors = response.json()["invalidParams"]
+
+        self.assertEqual(len(errors), 2)
+        codes = {error["code"] for error in errors}
+        self.assertEqual(codes, {"required"})
+        names = {error["name"] for error in errors}
+        self.assertEqual(names, {"lat", "lng"})
+
+    def test_call_with_no_lat_parameter(self):
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        errors = response.json()["invalidParams"]
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "required")
+        self.assertEqual(errors[0]["name"], "lat")
+
+    def test_call_with_no_lng_parameter(self):
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        errors = response.json()["invalidParams"]
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "required")
+        self.assertEqual(errors[0]["name"], "lng")
+
+    @requests_mock.Mocker()
+    def test_call_with_api_get_bag_response_exception(self, m):
+        mock_service_oas_get(
+            m,
+            url="https://kadaster/",
+            service="locatieserver_openapi",
+            oas_url="https://kadaster/api/schema/openapi.yaml",
+        )
+        m.get(
+            "https://kadaster/v3_1/reverse",
+            exc=requests.RequestException,
+        )
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798", "lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @requests_mock.Mocker()
+    def test_call_with_api_return_something_other_then_200(self, m):
+        mock_service_oas_get(
+            m,
+            url="https://kadaster/",
+            service="locatieserver_openapi",
+            oas_url="https://kadaster/api/schema/openapi.yaml",
+        )
+        m.get(
+            "https://kadaster/v3_1/reverse",
+            status_code=400,
+            json={
+                "error": {
+                    "code": 400,
+                    "metadata": ["error-class"],
+                    "msg": "undefined field",
+                }
+            },
+        )
+
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798", "lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @requests_mock.Mocker()
+    def test_call_with_api_return_data_not_having_response(self, m):
+        mock_service_oas_get(
+            m,
+            url="https://kadaster/",
+            service="locatieserver_openapi",
+            oas_url="https://kadaster/api/schema/openapi.yaml",
+        )
+        m.get("https://kadaster/v3_1/reverse", status_code=200, json={})
+
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798", "lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @requests_mock.Mocker()
+    def test_call_with_api_return_data_not_having_docs(self, m):
+        mock_service_oas_get(
+            m,
+            url="https://kadaster/",
+            service="locatieserver_openapi",
+            oas_url="https://kadaster/api/schema/openapi.yaml",
+        )
+        m.get(
+            "https://kadaster/v3_1/reverse",
+            status_code=200,
+            json={
+                "response": {
+                    "numFound": 0,
+                    "start": 0,
+                    "maxScore": None,
+                    "numFoundExact": False,
+                }
+            },
+        )
+
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798", "lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @requests_mock.Mocker()
+    def test_call_with_api_return_data_not_having_weergavenaam(self, m):
+        mock_service_oas_get(
+            m,
+            url="https://kadaster/",
+            service="locatieserver_openapi",
+            oas_url="https://kadaster/api/schema/openapi.yaml",
+        )
+        m.get(
+            "https://kadaster/v3_1/reverse",
+            status_code=200,
+            json={
+                "response": {
+                    "numFound": 1,
+                    "start": 0,
+                    "maxScore": 7.2816563,
+                    "numFoundExact": True,
+                    "docs": [
+                        {
+                            "type": "adres",
+                            "id": "adr-eebf5ada9e3af187be3704b2b01d4dec",
+                            "score": 7.2816563,
+                            "afstand": 7307439.14,
+                        },
+                    ],
+                }
+            },
+        )
+
+        url = reverse("api:geo:latlng-search")
+        self._add_submission_to_session(self.submission)
+
+        response = self.client.get(url, {"lat": "52.09113798", "lng": "5.0747543"})
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
fixes #2174 

- Added api call that returns location name based on the latitude and longitude
- Added unit tests to test the correct behavior for the newly added api call