### PR TITLE
Bump to django-yubin 2.0.1

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -66,7 +66,7 @@ django-csp-reports
 mail-cleaner
 
 # API libraries
-djangorestframework~=3.13.0
+djangorestframework
 drf-nested-routers
 djangorestframework-camel-case
 django-filter

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -213,7 +213,7 @@ django-tinymce==3.6.1
     # via -r requirements/base.in
 django-treebeard==4.7
     # via -r requirements/base.in
-django-yubin==2.0.0
+django-yubin==2.0.1
     # via -r requirements/base.in
 djangorestframework==3.14.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -363,7 +363,7 @@ django-treebeard==4.7
     #   -r requirements/base.txt
 django-webtest==1.9.7
     # via -r requirements/test-tools.in
-django-yubin==2.0.0
+django-yubin==2.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -404,7 +404,7 @@ django-webtest==1.9.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-yubin==2.0.0
+django-yubin==2.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -315,7 +315,7 @@ django-treebeard==4.7
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-yubin==2.0.0
+django-yubin==2.0.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt


### PR DESCRIPTION
Django yubin before 2.0.1 would discard custom headers and incorrectly reconstruct message attachments, as well as losing other headers like the Reply-To value.

See APSL/django-yubin#66 for details.Django yubin before 2.0.1 would discard custom headers and incorrectly reconstruct message attachments, as well as losing other headers like the Reply-To value.

See APSL/django-yubin#66 for details.

Ideally we would backport this, but due to the breaking changes in 2.0 this is not easily done.