### PR TITLE
Add current_year static variable

### DIFF
--- a/src/openforms/variables/static_variables/static_variables.py
+++ b/src/openforms/variables/static_variables/static_variables.py
@@ -30,6 +30,16 @@ class Today(BaseStaticVariable):
         return timezone.localtime(now_utc).date()
 
 
+@register_static_variable("current_year")
+class CurrentYear(BaseStaticVariable):
+    name = _("Current year")
+    data_type = FormVariableDataTypes.int
+
+    def get_initial_value(self, submission: Optional[Submission] = None) -> int:
+        now_utc = timezone.now()
+        return timezone.localtime(now_utc).year
+
+
 @register_static_variable("environment")
 class Environment(BaseStaticVariable):
     name = _("Environment")

--- a/src/openforms/variables/tests/test_static_variables.py
+++ b/src/openforms/variables/tests/test_static_variables.py
@@ -29,6 +29,21 @@ class NowTests(TestCase):
         self.assertEqual(variable.initial_value, timezone.now())
 
 
+@freeze_time("2022-08-29T17:10:00+02:00")
+class CurrentYearTests(TestCase):
+    def test_with_submission(self):
+        submission = SubmissionFactory.build()
+
+        variable = _get_variable("current_year", submission=submission)
+
+        self.assertEqual(variable.initial_value, timezone.now().year)
+
+    def test_without_submission(self):
+        variable = _get_variable("current_year")
+
+        self.assertEqual(variable.initial_value, timezone.now().year)
+
+
 class EnvironmentTests(TestCase):
     def test_with_submission(self):
         submission = SubmissionFactory.build()


### PR DESCRIPTION
Closes #1889

Having current_year available as a variable solves the problem of
Haarlemmermeer of not being able to "block"/validate based on an integer
relative to the current year. They can adapt their current forms to use
this, so they won't need to change the forms on each January 1st
anymore.

I think the wish for a picker is a distraction from this core problem.
But should one really feel the need for a year picker, with this
`current_year` one can construct a one with a Select component with
variable options with an option expression like this:

```json
{
  "merge": [
    { "-": [{ "var": "current_year" }, 3] },
    { "-": [{ "var": "current_year" }, 2] },
    { "-": [{ "var": "current_year" }, 1] },
    { "var": "current_year" },
    { "+": [{ "var": "current_year" }, 1] },
    { "+": [{ "var": "current_year" }, 2] },
    { "+": [{ "var": "current_year" }, 3] }
  ]
}
```

This solution evades all kinds of combinations FormIO fun and
JavaScript's ill-conceived Date API.

PS: use `{{ current_year|stringformat: "d" }}` to diplay the value in templates
without thousands separator.
