### PR TITLE
Fix radio field markup in Django templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
-        "@open-formulieren/design-tokens": "^0.33.0",
+        "@open-formulieren/design-tokens": "^0.39.0",
         "@open-formulieren/formio-builder": "^0.6.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^3.12.6",
@@ -4106,9 +4106,9 @@
       "dev": true
     },
     "node_modules/@open-formulieren/design-tokens": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.33.0.tgz",
-      "integrity": "sha512-Bnd+4ohH7kAxhomJUqBaJoy63NkAhgYcUbfOrLalstCZwesRjP/jzSA0kB5/Z+0hbGi5642n5QSXWizg7t2sbA=="
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.39.0.tgz",
+      "integrity": "sha512-tj8OzDBGilvdbJJVrOCkfQhIWClCoijqxYup1W0Sm612ernPXctJMldjSRDgDjNRqXRlXVD9kP3+6PjZiWhy4w=="
     },
     "node_modules/@open-formulieren/formio-builder": {
       "version": "0.6.0",
@@ -34610,9 +34610,9 @@
       "dev": true
     },
     "@open-formulieren/design-tokens": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.33.0.tgz",
-      "integrity": "sha512-Bnd+4ohH7kAxhomJUqBaJoy63NkAhgYcUbfOrLalstCZwesRjP/jzSA0kB5/Z+0hbGi5642n5QSXWizg7t2sbA=="
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.39.0.tgz",
+      "integrity": "sha512-tj8OzDBGilvdbJJVrOCkfQhIWClCoijqxYup1W0Sm612ernPXctJMldjSRDgDjNRqXRlXVD9kP3+6PjZiWhy4w=="
     },
     "@open-formulieren/formio-builder": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://maykinmedia.nl",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.33.0",
+    "@open-formulieren/design-tokens": "^0.39.0",
     "@open-formulieren/formio-builder": "^0.6.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^3.12.6",

--- a/src/openforms/scss/components/_form-choices.scss
+++ b/src/openforms/scss/components/_form-choices.scss
@@ -1,18 +1,21 @@
-@import 'microscope-sass/lib/bem';
+@use 'microscope-sass/lib/bem';
 @import 'microscope-sass/lib/typography';
 
-.openforms-form-choices {
-  @include modifier('inline') {
+.openforms-choice-list {
+  @include bem.modifier('inline') {
+    --of-utrecht-form-field-radio-margin-block-start: 0;
+
     display: flex;
     gap: 1em;
+    justify-content: space-between;
 
     @include mobile-only {
       display: block;
     }
 
-    @include element('choice') {
-      @include margin($margin: true, $value-mobile: $typography-margin-list);
-      width: 100%;
+    @include bem.element('choice') {
+      flex-basis: 100%;
+      flex-grow: 1;
     }
   }
 }

--- a/src/openforms/templates/includes/forms/field_wrapper.html
+++ b/src/openforms/templates/includes/forms/field_wrapper.html
@@ -1,20 +1,25 @@
 {# Takes a 'field' context argument, which should be an instance of a BoundField #}
-<div class="openforms-form-control openforms-form-control--{{ type|default:'textfield' }}  utrecht-form-field">
-    <div class="utrecht-form-field utrecht-form-field--openforms">
-        <p class="utrecht-paragraph utrecht-form-field__label">
-            <label for="{{ field.auto_id }}" class="utrecht-form-label">
-                {{ field.label }}
-            </label>
-        </p>
-        <div>
-            {{ field }}
+<div class="openforms-form-control openforms-form-control--{{ type|default:'textfield' }}">
+
+    {% if type == 'radio' %}
+        {% include "./radio.html" %}
+    {% else %}
+        <div class="utrecht-form-field utrecht-form-field--openforms">
+            <p class="utrecht-paragraph utrecht-form-field__label">
+                <label for="{{ field.auto_id }}" class="utrecht-form-label">
+                    {{ field.label }}
+                </label>
+            </p>
+            <div>
+                {{ field }}
+            </div>
+            {% if field.help_text %}
+            <div class="utrecht-form-field-description utrecht-form-field-description--openforms-helptext">
+                {{ field.help_text }}
+            </div>
+            {% endif %}
         </div>
-        {% if field.help_text %}
-        <div class="utrecht-form-field-description utrecht-form-field-description--openforms-helptext">
-            {{ field.help_text }}
-        </div>
-        {% endif %}
-    </div>
+    {% endif %}
 
     {# validation errors #}
     {% include "includes/forms/errorlist.html" with errors=field.errors only %}

--- a/src/openforms/templates/includes/forms/radio.html
+++ b/src/openforms/templates/includes/forms/radio.html
@@ -1,0 +1,26 @@
+<div class="utrecht-form-fieldset utrecht-form-fieldset--openforms">
+    <fieldset
+        {% if field.help_text %}aria-describedby="{{ field.auto_id }}"{% endif %}
+        role="radiogroup"
+        class="utrecht-form-fieldset__fieldset utrecht-form-fieldset--html-fieldset"
+    >
+        <legend class="
+            utrecht-form-fieldset__legend
+            utrecht-form-fieldset__legend--html-legend
+            utrecht-form-field__label">
+            <label class="utrecht-form-label utrecht-form-label--openforms-required">
+                {{ field.label }}
+            </label>
+        </legend>
+
+        {{ field }}
+
+        {% if field.help_text %}
+        <div id="{{ field.auto_id }}"
+             class="utrecht-form-field-description
+                    utrecht-form-field-description--openforms-helptext
+                    utrecht-form-field__description"
+        >{{ field.help_text }}</div>
+        {% endif %}
+    </fieldset>
+</div>

--- a/src/openforms/utils/templates/of_utils/widgets/radio.html
+++ b/src/openforms/utils/templates/of_utils/widgets/radio.html
@@ -1,8 +1,10 @@
-<div class="openforms-form-choices utrecht-form-fieldset__fieldset utrecht-form-fieldset__fieldset--html-fieldset {% if widget.inline %}openforms-form-choices--inline{% endif %}">
+<div class="openforms-choice-list {% if widget.inline %}openforms-choice-list--inline{% endif %}">
 {% for group, options, index in widget.optgroups %}
-    {% if group %}OPTGROUPS ARE NOT SUPPORTED{% endif %}
-    {% for option in options %}
-        {% include option.template_name with widget=option %}
-    {% endfor %}
+    <div class="openforms-choice-list__choice">
+        {% if group %}OPTGROUPS ARE NOT SUPPORTED{% endif %}
+        {% for option in options %}
+            {% include option.template_name with widget=option %}
+        {% endfor %}
+    </div>
 {% endfor %}
 </div>

--- a/src/openforms/utils/templates/of_utils/widgets/radio_option.html
+++ b/src/openforms/utils/templates/of_utils/widgets/radio_option.html
@@ -1,7 +1,8 @@
-<div class="openforms-form-choices__choice utrecht-form-field utrecht-form-field--radio">
+<div class="utrecht-form-field utrecht-form-field--radio utrecht-form-field--openforms">
     {% include "django/forms/widgets/input.html" %}
-    <div class="openforms-form-choices__checkmark"></div>
-    <label for="{{ widget.attrs.id }}" class="openforms-form-choices__label utrecht-form-label utrecht-form-label--radio">
-        {{ widget.label }}
-    </label>
+    <p class="utrecht-paragraph utrecht-form-field__label utrecht-form-field__label--radio">
+        <label for="{{ widget.attrs.id }}" class="utrecht-form-label utrecht-form-label--radio">
+            {{ widget.label }}
+        </label>
+    </p>
 </div>

--- a/src/openforms/utils/widgets.py
+++ b/src/openforms/utils/widgets.py
@@ -9,12 +9,25 @@ class OpenFormsRadioSelect(forms.RadioSelect):
         self._inline = kwargs.pop("inline", False)
         super().__init__(*args, **kwargs)
 
+    def create_option(self, *args, **kwargs):
+        attrs = kwargs.pop("attrs") or {}
+        attrs.update(
+            {
+                "class": " ".join(
+                    [
+                        "utrecht-radio-button",
+                        "utrecht-radio-button--html-input",
+                        "utrecht-form-field__input",
+                    ]
+                )
+            }
+        )
+        kwargs["attrs"] = attrs
+        return super().create_option(*args, **kwargs)
+
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context["widget"]["inline"] = self._inline
-        context["widget"]["attrs"].update(
-            {"class": "utrecht-radio-button utrecht-radio-button--html-input"}
-        )
         return context
 
 


### PR DESCRIPTION
Closes #3327
Closes #3207

Note that open-formulieren/open-forms-sdk#529 is required for the correct background styles of the radio options.