### PR TITLE
Upgrade to django-log-outgoing-requests 0.5.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -171,7 +171,7 @@ django-hijack==3.4.1
     # via -r requirements/base.in
 django-ipware==5.0.0
     # via django-axes
-django-log-outgoing-requests==0.4.0
+django-log-outgoing-requests==0.5.0
     # via -r requirements/base.in
 django-modeltranslation==0.18.11
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -287,7 +287,7 @@ django-ipware==5.0.0
     #   django-axes
 django-jenkins==0.110.0
     # via -r requirements/test-tools.in
-django-log-outgoing-requests==0.4.0
+django-log-outgoing-requests==0.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -322,7 +322,7 @@ django-jenkins==0.110.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-log-outgoing-requests==0.4.0
+django-log-outgoing-requests==0.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -247,7 +247,7 @@ django-ipware==5.0.0
     # via
     #   -r requirements/base.txt
     #   django-axes
-django-log-outgoing-requests==0.4.0
+django-log-outgoing-requests==0.5.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -462,7 +462,7 @@ LOGGING = {
             "handlers": ["project"] if not LOG_STDOUT else ["console"],
             "level": "DEBUG",
         },
-        "requests": {
+        "log_outgoing_requests": {
             "handlers": ["log_outgoing_requests", "save_outgoing_requests"]
             if LOG_REQUESTS
             else [],


### PR DESCRIPTION
Closes #3354

I checked that the reset-config task is picked up correctly, seems fine.

The changed logger name is a breaking change I made in 0.5.0.