### PR TITLE
🐛 Fix passing querystring params to service fetch

### DIFF
--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
@@ -222,7 +222,7 @@ class ServiceFetchConfigVariableBindingTests(SimpleTestCase):
             service_fetch_configuration=ServiceFetchConfigurationFactory.build(
                 service=self.service,
                 path="redirect-to",
-                query_params={"status_code": "{{code}}", "url": "{{url}}"},
+                query_params={"status_code": ["{{code}}"], "url": ["{{url}}"]},
             )
         )
 

--- a/src/openforms/variables/models.py
+++ b/src/openforms/variables/models.py
@@ -138,14 +138,17 @@ class ServiceFetchConfiguration(models.Model):
         escaped_for_path = {k: quote_plus(str(v)) for k, v in context.items()}
 
         query_params = {
-            param: render_from_string(
-                value,
-                # Explicitly cast values to strings to avoid localization
-                {k: str(v) for k, v in context.items()},
-                backend=sandbox_backend,
-                disable_autoescape=True,
-            )
-            for param, value in (self.query_params or {}).items()
+            param: [
+                render_from_string(
+                    value,
+                    # Explicitly cast values to strings to avoid localization
+                    {k: str(v) for k, v in context.items()},
+                    backend=sandbox_backend,
+                    disable_autoescape=True,
+                )
+                for value in (values if isinstance(values, list) else (values,))
+            ]
+            for param, values in (self.query_params or {}).items()
         }
 
         request_args = dict(


### PR DESCRIPTION
The serializer enforces qs params to have the form
`{'param': ["{{value}}"]}` but the template rendering code would send
this as:

https://example.com/api?param=["valueofvalueincontext"]

https://example.com/api?param="valueofvalueincontext"

There's a to be implemented test for the explode and form style OAS
variants of the spec. The httpbin OAS has no such endpoint.
