### PR TITLE
Refactor formio/appointment render nodes

### DIFF
--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -46,7 +46,7 @@ class ComponentNode(Node):
     json_renderer_path: Path | None = None  # Special data path used by the JSON rendering in openforms/formio/rendering/nodes.py #TODO Refactor?
     configuration_path: str = ""  # Path in the configuration tree, matching the path obtained with openforms/formio/utils.py `flatten_by_path`
     parent_node: Node | None = None
-    translate_function: Callable[[str], str] | None = None
+    translate: Callable[[str], str] | None = None
 
     @staticmethod
     def build_node(
@@ -58,7 +58,7 @@ class ComponentNode(Node):
         configuration_path: str = "",
         depth: int = 0,
         parent_node: Node | None = None,
-        translate_function: Callable[[str], str] | None = None,
+        translate: Callable[[str], str] | None = None,
     ) -> "ComponentNode":
         """
         Instantiate the most specific node type for a given component type.
@@ -76,7 +76,7 @@ class ComponentNode(Node):
             json_renderer_path=json_renderer_path,
             configuration_path=configuration_path,
             parent_node=parent_node,
-            translate_function=translate_function,
+            translate=translate,
         )
         return nested_node
 
@@ -84,8 +84,8 @@ class ComponentNode(Node):
         # Value Formatters have no access to the translations; run all our
         # labels through the translations, before further processing of logic
         # etc.
-        if self.translate_function:
-            self.apply_to_labels(self.translate_function)
+        if self.translate:
+            self.apply_to_labels(self.translate)
 
     @property
     def is_visible(self) -> bool:
@@ -157,6 +157,7 @@ class ComponentNode(Node):
 
     @property
     def key(self):
+        assert "key" in self.component
         return self.component["key"]
 
     @property
@@ -172,9 +173,10 @@ class ComponentNode(Node):
         """
         Obtain the (human-readable) label for the Formio component.
         """
+        assert "key" in self.component
         if self.mode == RenderModes.export:
-            return self.component.get("key") or "KEY_MISSING"
-        return self.component.get("label") or self.component.get("key", "")
+            return self.component["key"]
+        return self.component.get("label") or self.component["key"]
 
     @property
     def value(self) -> Any:
@@ -309,6 +311,6 @@ class FormioNode(Node):
                 component=component,
                 renderer=self.renderer,
                 configuration_path=configuration_path,
-                translate_function=do_translate,
+                translate=do_translate,
             )
             yield from child_node

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -37,33 +37,8 @@ class RenderConfiguration:
 
 
 @dataclass
-class ComponentNodeBase(Node):
+class ComponentNode(Node):
     component: Component
-
-    @property
-    def label(self) -> str:
-        """
-        Obtain the (human-readable) label for the Formio component.
-        """
-        if self.mode == RenderModes.export:
-            return self.component.get("key") or "KEY_MISSING"
-        return self.component.get("label") or self.component.get("key", "")
-
-    @property
-    def key(self):
-        return self.component["key"]
-
-    @property
-    def key_as_path(self) -> Path:
-        """
-        See https://glom.readthedocs.io/en/latest/api.html?highlight=Path#glom.Path
-        Using Path("a.b") in glom will not use the nested path, but will look for a key "a.b"
-        """
-        return Path.from_text(self.key)
-
-
-@dataclass
-class ComponentNode(ComponentNodeBase):
     step_data: DataMapping  # XXX refactor to FormioData
     depth: int = 0
     is_layout = False
@@ -179,6 +154,27 @@ class ComponentNode(ComponentNodeBase):
             render_configuration.key, render_configuration.default
         )
         return should_render
+
+    @property
+    def key(self):
+        return self.component["key"]
+
+    @property
+    def key_as_path(self) -> Path:
+        """
+        See https://glom.readthedocs.io/en/latest/api.html?highlight=Path#glom.Path
+        Using Path("a.b") in glom will not use the nested path, but will look for a key "a.b"
+        """
+        return Path.from_text(self.key)
+
+    @property
+    def label(self) -> str:
+        """
+        Obtain the (human-readable) label for the Formio component.
+        """
+        if self.mode == RenderModes.export:
+            return self.component.get("key") or "KEY_MISSING"
+        return self.component.get("label") or self.component.get("key", "")
 
     @property
     def value(self) -> Any:

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -250,7 +250,7 @@ class FormNodeTests(TestCase):
         assert component["key"] == "input1"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertIsInstance(component_node, ComponentNode)
@@ -280,7 +280,7 @@ class FormNodeTests(TestCase):
 
         with patch("openforms.formio.rendering.registry.register", new=register):
             component_node = ComponentNode.build_node(
-                step=self.step, component=component, renderer=renderer
+                step_data=self.step.data, component=component, renderer=renderer
             )
 
         self.assertIsInstance(component_node, TextFieldNode)
@@ -297,7 +297,7 @@ class FormNodeTests(TestCase):
             assert component["hidden"]
 
             component_node = ComponentNode.build_node(
-                step=self.step, component=component, renderer=renderer
+                step_data=self.step.data, component=component, renderer=renderer
             )
 
             nodelist = list(component_node)
@@ -315,7 +315,7 @@ class FormNodeTests(TestCase):
 
             with patch("openforms.formio.rendering.registry.register", new=register):
                 component_node = ComponentNode.build_node(
-                    step=self.step, component=fieldset, renderer=renderer
+                    step_data=self.step.data, component=fieldset, renderer=renderer
                 )
 
                 nodelist = list(component_node)
@@ -331,7 +331,7 @@ class FormNodeTests(TestCase):
             "components"
         ]:
             component_node = ComponentNode.build_node(
-                step=self.step, component=component, renderer=renderer
+                step_data=self.step.data, component=component, renderer=renderer
             )
             nodelist += list(component_node)
 
@@ -375,7 +375,7 @@ class FormNodeTests(TestCase):
                 "components"
             ]:
                 component_node = ComponentNode.build_node(
-                    step=self.step, component=component, renderer=renderer
+                    step_data=self.step.data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 
@@ -407,7 +407,7 @@ class FormNodeTests(TestCase):
                 "components"
             ]:
                 component_node = ComponentNode.build_node(
-                    step=self.step, component=component, renderer=renderer
+                    step_data=self.step.data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 
@@ -441,7 +441,7 @@ class FormNodeTests(TestCase):
                 "components"
             ]:
                 component_node = ComponentNode.build_node(
-                    step=self.step, component=component, renderer=renderer
+                    step_data=self.step.data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -206,7 +206,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "fieldset"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -219,7 +219,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "fieldset"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertTrue(component_node.is_visible)
@@ -235,7 +235,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "fieldset"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -253,7 +253,7 @@ class FormNodeTests(TestCase):
         }
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertEqual(component_node.label, "")
@@ -265,7 +265,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "columns"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -278,7 +278,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "columns"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertTrue(component_node.is_visible)
@@ -294,7 +294,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "columns"
 
         component_node = ComponentNode.build_node(
-            step=self.step, component=component, renderer=renderer
+            step_data=self.step.data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -309,7 +309,7 @@ class FormNodeTests(TestCase):
                 renderer = Renderer(self.submission, mode=render_mode, as_html=False)
 
                 component_node = ComponentNode.build_node(
-                    step=self.step, component=component, renderer=renderer
+                    step_data=self.step.data, component=component, renderer=renderer
                 )
 
                 self.assertEqual(component_node.label, "")
@@ -348,7 +348,7 @@ class FormNodeTests(TestCase):
             with self.subTest(render_mode=render_mode):
                 renderer = Renderer(submission, mode=render_mode, as_html=False)
                 component_node = ComponentNode.build_node(
-                    step=step, component=component, renderer=renderer
+                    step_data=step.data, component=component, renderer=renderer
                 )
 
                 self.assertEqual(component_node.is_visible, is_visible)
@@ -356,7 +356,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=True)
             component_node = ComponentNode.build_node(
-                step=step, component=component, renderer=renderer
+                step_data=step.data, component=component, renderer=renderer
             )
 
             self.assertEqual(
@@ -366,7 +366,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=False):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=False)
             component_node = ComponentNode.build_node(
-                step=step, component=component, renderer=renderer
+                step_data=step.data, component=component, renderer=renderer
             )
 
             self.assertEqual(component_node.value, "WYSIWYG with markup")
@@ -404,7 +404,7 @@ class FormNodeTests(TestCase):
             with self.subTest(render_mode=render_mode):
                 renderer = Renderer(submission, mode=render_mode, as_html=False)
                 component_node = ComponentNode.build_node(
-                    step=step, component=component, renderer=renderer
+                    step_data=step.data, component=component, renderer=renderer
                 )
 
                 self.assertEqual(component_node.is_visible, is_visible)
@@ -412,7 +412,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=True)
             component_node = ComponentNode.build_node(
-                step=step, component=component, renderer=renderer
+                step_data=step.data, component=component, renderer=renderer
             )
 
             self.assertEqual(
@@ -422,7 +422,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=False):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=False)
             component_node = ComponentNode.build_node(
-                step=step, component=component, renderer=renderer
+                step_data=step.data, component=component, renderer=renderer
             )
 
             self.assertEqual(component_node.value, "WYSIWYG with markup")
@@ -477,7 +477,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step=step,
+                step_data=step.data,
                 component=component,
                 configuration_path="components.0",
                 renderer=renderer,
@@ -496,7 +496,7 @@ class FormNodeTests(TestCase):
                 submission, mode=RenderModes.registration, as_html=False
             )
             component_node = ComponentNode.build_node(
-                step=step,
+                step_data=step.data,
                 component=component,
                 configuration_path="components.0",
                 renderer=renderer,
@@ -646,7 +646,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             repeating_group_node = ComponentNode.build_node(
-                step=step,
+                step_data=step.data,
                 component=components[0],
                 renderer=renderer,
                 configuration_path="components.0",
@@ -685,7 +685,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             nested_file_node = ComponentNode.build_node(
-                step=step,
+                step_data=step.data,
                 component=components[1],
                 renderer=renderer,
                 configuration_path="components.1",
@@ -799,7 +799,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             repeating_group_node = ComponentNode.build_node(
-                step=step,
+                step_data=step.data,
                 component=components[0],
                 configuration_path="components.0",
                 renderer=renderer,
@@ -824,7 +824,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             outside_file_node = ComponentNode.build_node(
-                step=step,
+                step_data=step.data,
                 component=components[1],
                 configuration_path="components.1",
                 renderer=renderer,
@@ -949,7 +949,7 @@ class FormNodeTests(TestCase):
 
         renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
         repeating_group_node = ComponentNode.build_node(
-            step=step,
+            step_data=step.data,
             component=components[0],
             configuration_path="components.0",
             renderer=renderer,
@@ -999,7 +999,7 @@ class FormNodeTests(TestCase):
         )
         renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
         component_node = ComponentNode.build_node(
-            step=step, component=component, renderer=renderer
+            step_data=step.data, component=component, renderer=renderer
         )
         link = component_node.render()
         self.assertEqual(link, "My File: ")
@@ -1037,7 +1037,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step=submission_step, component=component, renderer=renderer
+                step_data=submission_step.data, component=component, renderer=renderer
             )
             nodelist = list(component_node)
 
@@ -1084,7 +1084,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step=submission_step, component=component, renderer=renderer
+                step_data=submission_step.data, component=component, renderer=renderer
             )
             nodelist = list(component_node)
 
@@ -1163,7 +1163,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step=submission_step, component=component, renderer=renderer
+                step_data=submission_step.data, component=component, renderer=renderer
             )
             nodelist = list(component_node)
 

--- a/src/openforms/formio/typing/__init__.py
+++ b/src/openforms/formio/typing/__init__.py
@@ -8,7 +8,14 @@ Formio components are JSON blobs adhering to a formio-specific schema. We define
 
 from .base import Component, OptionDict
 from .custom import CosignComponent, DateComponent
-from .vanilla import ContentComponent, DatetimeComponent, FileComponent, RadioComponent
+from .vanilla import (
+    Column,
+    ColumnsComponent,
+    ContentComponent,
+    DatetimeComponent,
+    FileComponent,
+    RadioComponent,
+)
 
 __all__ = [
     "Component",
@@ -16,6 +23,8 @@ __all__ = [
     "ContentComponent",
     "FileComponent",
     "RadioComponent",
+    "Column",
+    "ColumnsComponent",
     "DatetimeComponent",
     "CosignComponent",
     "DateComponent",

--- a/src/openforms/formio/typing/vanilla.py
+++ b/src/openforms/formio/typing/vanilla.py
@@ -26,3 +26,11 @@ class ContentComponent(Component):
 
 class DatetimeComponent(Component):
     datePicker: DatePickerConfig | None
+
+
+class Column(TypedDict):
+    components: list[Component]
+
+
+class ColumnsComponent(Component):
+    columns: list[Column]

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from frozendict import frozendict
 
 from openforms.forms.models import FormDefinition, FormStep
+from openforms.typing import DataMapping
 
 
 def _make_frozen(obj):
@@ -202,7 +203,7 @@ class SubmissionStep(models.Model):
         self.save()
 
     @property
-    def data(self) -> dict:
+    def data(self) -> DataMapping:
         values_state = self.submission.load_submission_value_variables_state()
         # This is used in the evaluate_form_logic function, which only returns the data that has been changed to the
         # frontend.

--- a/src/openforms/submissions/rendering/base.py
+++ b/src/openforms/submissions/rendering/base.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator
 
+from .constants import RenderModes
+
 if TYPE_CHECKING:
     from .renderer import Renderer  # pragma: nocover
 
@@ -18,7 +20,7 @@ class Node(ABC):
     renderer: "Renderer"
 
     @property
-    def mode(self) -> str:
+    def mode(self) -> RenderModes:
         return self.renderer.mode
 
     @property

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -14,7 +14,7 @@ from openforms.variables.rendering.nodes import VariablesNode
 from ..form_logic import evaluate_form_logic
 from ..models import Submission
 from .base import Node
-from .constants import RenderModes  # noqa
+from .constants import RenderModes
 from .nodes import FormNode, SubmissionStepNode
 from .utils import get_request
 
@@ -31,7 +31,7 @@ class Renderer:
 
     # render context, passed to all underlying nodes
     submission: Submission
-    mode: str
+    mode: RenderModes
     as_html: bool
 
     def __post_init__(self):


### PR DESCRIPTION
Closes #3406

The Formio `ComponentNode` essentially only required access to a `SubmissionStep` instance to read the data/values for each component. So, the data (and translation machinery) has been lifted up to the parent that is responsible for yielding `ComponentNode`'s so that the dependency on `SubmissionStep` can be removed.

This in turn makes it possible for the appointment data renderer class to re-use the `ComponentNode` for the contact details data, which is recorded as formio component definitions and stored in a similar way, but crucially does not make any use of `FormStep` or `SubmissionStep`.

Finally - my editor was showing many red squiggly lines so I tweaked the type hints in `openforms.formio.utils` a bit. It's definitely not complete yet, but I think it's more correct than what we had.

I'd like to test our extensive test suite so that these kind of refactors are possible without worrying about breaking everything.