### PR TITLE
♻[#3416] Refactor rendering appointment data

### DIFF
--- a/src/openforms/appointments/renderer.py
+++ b/src/openforms/appointments/renderer.py
@@ -7,8 +7,7 @@ from openforms.formio.rendering.nodes import ComponentNode
 from openforms.formio.typing import Component
 from openforms.submissions.rendering import Renderer
 
-from .service import get_appointment
-from .utils import get_plugin
+from .utils import get_appointment, get_plugin
 
 
 class AppointmentRenderer(Renderer):
@@ -33,7 +32,7 @@ class AppointmentRenderer(Renderer):
             yield from child_node
 
     def __str__(self) -> SafeString:
-        # Like a Django Form renderer, render to the default representation
+        # Like a Django Form renderer, render to the requested representation
 
         if (
             not (appointment := get_appointment(self.submission))

--- a/src/openforms/appointments/service.py
+++ b/src/openforms/appointments/service.py
@@ -6,14 +6,15 @@ Anything else is considered private API.
 """
 from openforms.submissions.models import Submission
 
-from .models import Appointment
+from .renderer import AppointmentRenderer
+from .utils import get_appointment, get_plugin
 
-
-def get_appointment(submission: Submission) -> Appointment | None:
-    if not submission.form.is_appointment:
-        return None
-    appointment: Appointment | None = getattr(submission, "appointment", None)
-    return appointment
+__all__ = [
+    "AppointmentRenderer",
+    "get_appointment",
+    "get_email_confirmation_recipients",
+    "get_plugin",
+]
 
 
 def get_email_confirmation_recipients(submission: Submission) -> list[str]:

--- a/src/openforms/appointments/templates/appointments/appointment__pdf.html
+++ b/src/openforms/appointments/templates/appointments/appointment__pdf.html
@@ -1,0 +1,61 @@
+{% load i18n %}
+<section class="appointment">
+<h2>{% trans "Appointment information" %}</h2>
+
+<table>
+  <tr class="appointment__products">
+    <td>
+      {% trans "Products" %}
+    </td>
+    <td>
+      {% for product in appointment.products %} {{ product.name }}{% if product.amount > 1 %} (x{{
+      product.amount }}){% endif %}{% if not forloop.last %}<br />{% endif %} {% endfor %}
+    </td>
+  </tr>
+  <tr class="appointment__location">
+    <td>
+      {% trans "Location" %}
+    </td>
+    <td>
+      {{ appointment.location.name }} {% if appointment.location.address %}<br />{{
+      appointment.location.address }}{% endif %} {% if appointment.location.city %}<br />{{
+      appointment.location.postalcode }} {{ appointment.location.city }}{% endif %}
+    </td>
+  </tr>
+  <tr class="appointment__datetime">
+    <td>
+      {% trans "Date and time" %}
+    </td>
+    <td>
+      {{ appointment.start_at|date }}, {{ appointment.start_at|time }}{% if appointment.end_at %} -
+      {{ appointment.end_at|time }}{% endif %}
+    </td>
+  </tr>
+  <tr class="appointment__remarks">
+    <td>
+      {% trans "Remarks" %}
+    </td>
+    <td>
+      {{ appointment.remarks|linebreaksbr }}
+    </td>
+  </tr>
+  {% if appointment.other %} {% for key, value in appointment.other.items %}
+  <tr class="appointment__{{key}}">
+    <td>{{ key }}</td>
+    <td>{{ value }}</td>
+  </tr>
+  {% endfor %} {% endif %}
+</table>
+
+<h2>{% trans "Your contact details" %}</h2>
+
+<table class="appointment__contact_details">
+  {% for node in contact_details %}
+  <tr>
+    <td>{{ node.label }}</td>
+    <td>{{ node.display_value }}</td>
+  </tr>
+  {% endfor %}
+</table>
+
+</section>

--- a/src/openforms/appointments/templates/appointments/appointment__pdf.html
+++ b/src/openforms/appointments/templates/appointments/appointment__pdf.html
@@ -1,61 +1,60 @@
 {% load i18n %}
 <section class="appointment">
-<h2>{% trans "Appointment information" %}</h2>
+<h2 class="subtitle">{% trans "Appointment information" %}</h2>
 
-<table>
-  <tr class="appointment__products">
-    <td>
+<div>
+  <div class="submission-step-row">
+    <div class="submission-step-row__label">
       {% trans "Products" %}
-    </td>
-    <td>
+    </div>
+    <div class="submission-step-row__value">
       {% for product in appointment.products %} {{ product.name }}{% if product.amount > 1 %} (x{{
       product.amount }}){% endif %}{% if not forloop.last %}<br />{% endif %} {% endfor %}
-    </td>
-  </tr>
-  <tr class="appointment__location">
-    <td>
+    </div>
+  </div>
+  <div class="submission-step-row">
+    <div class="submission-step-row__label">
       {% trans "Location" %}
-    </td>
-    <td>
+    </div>
+    <div class="submission-step-row__value">
       {{ appointment.location.name }} {% if appointment.location.address %}<br />{{
       appointment.location.address }}{% endif %} {% if appointment.location.city %}<br />{{
       appointment.location.postalcode }} {{ appointment.location.city }}{% endif %}
-    </td>
-  </tr>
-  <tr class="appointment__datetime">
-    <td>
+    </div>
+  </div>
+  <div class="submission-step-row">
+    <div class="submission-step-row__label">
       {% trans "Date and time" %}
-    </td>
-    <td>
+    </div>
+    <div class="submission-step-row__value">
       {{ appointment.start_at|date }}, {{ appointment.start_at|time }}{% if appointment.end_at %} -
       {{ appointment.end_at|time }}{% endif %}
-    </td>
-  </tr>
-  <tr class="appointment__remarks">
-    <td>
+    </div>
+  </div>
+  <div class="submission-step-row">
+    <div class="submission-step-row__label">
       {% trans "Remarks" %}
-    </td>
-    <td>
+    </div>
+    <div class="submission-step-row__value">
       {{ appointment.remarks|linebreaksbr }}
-    </td>
-  </tr>
+    </div>
+  </div>
   {% if appointment.other %} {% for key, value in appointment.other.items %}
-  <tr class="appointment__{{key}}">
-    <td>{{ key }}</td>
-    <td>{{ value }}</td>
-  </tr>
+  <div class="submission-step-row">
+    <div class="submission-step-row__label">{{ key }}</div>
+    <div class="submission-step-row__value">{{ value }}</div>
+  </div>
   {% endfor %} {% endif %}
-</table>
+</div>
 
-<h2>{% trans "Your contact details" %}</h2>
-
-<table class="appointment__contact_details">
+<h2 class="subtitle">{% trans "Your contact details" %}</h2>
+<div class="submission-step">
   {% for node in contact_details %}
-  <tr>
-    <td>{{ node.label }}</td>
-    <td>{{ node.display_value }}</td>
-  </tr>
+  <div class="submission-step-row">
+    <div class="submission-step-row__label">{{ node.label }}</div>
+    <div class="submission-step-row__value">{{ node.display_value }}</div>
+  </div>
   {% endfor %}
-</table>
+</div>
 
 </section>

--- a/src/openforms/appointments/tests/test_confirmation_emails.py
+++ b/src/openforms/appointments/tests/test_confirmation_emails.py
@@ -30,6 +30,7 @@ LAST_NAME: Component = {
         "required": True,
         "maxLength": 20,
     },
+    "showInEmail": True,
 }
 
 EMAIL: Component = {
@@ -39,6 +40,7 @@ EMAIL: Component = {
     "validate": {
         "required": True,
     },
+    "showInEmail": True,
 }
 
 

--- a/src/openforms/appointments/tests/test_pdf.py
+++ b/src/openforms/appointments/tests/test_pdf.py
@@ -1,0 +1,57 @@
+from django.test import RequestFactory, TestCase, override_settings
+
+from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.submissions.dev_views import SubmissionPDFTestView
+from openforms.submissions.tests.factories import SubmissionFactory
+
+from .factories import AppointmentFactory, AppointmentProductFactory
+
+
+class PDFGenerationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        appointment = AppointmentFactory.create(
+            plugin="demo",
+            submission__language_code="nl",
+            submission__registration_success=True,
+            submission__with_report=True,
+            appointment_info__registration_ok=True,
+            location__identifier="1",
+        )
+        AppointmentProductFactory.create(
+            appointment=appointment, product_id="1", amount=1
+        )
+        cls.submission = appointment.submission
+
+    def test_appointment_info_is_included(self):
+        # NB the demo plugin appointment info is hardcoded in the plugin
+        html = self.submission.report.generate_submission_report_pdf()
+
+        self.assertIn("Afspraakinformatie", html)
+        self.assertIn("Test product 1", html)
+        self.assertIn("Test location", html)
+        self.assertIn("Datum en tijd", html)
+
+    @override_settings(DEBUG=True)
+    def test_appointment_info_is_included_in_submission_pdf_test_view(self):
+        # We're too late for django.urls.reverse to work; use the view
+        view = SubmissionPDFTestView.as_view()
+        request = RequestFactory().get("/foo")
+        request.user = SuperUserFactory()
+        response = view(request, pk=self.submission.id)
+
+        self.assertContains(response, "Afspraakinformatie")
+        self.assertContains(response, "Test product 1")
+        self.assertContains(response, "Test location")
+        self.assertContains(response, "Datum en tijd")
+
+    def test_submission_without_appointment_shows_no_appointment_info(self):
+        submission = SubmissionFactory.create(
+            language_code="nl",
+            registration_success=True,
+            with_report=True,
+        )
+        html = submission.report.generate_submission_report_pdf()
+
+        self.assertNotIn("Afspraakinformatie", html)

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -309,3 +309,10 @@ def get_confirmation_mail_suffix(submission: Submission) -> str:
         return ""
 
     return _("(updated)")
+
+
+def get_appointment(submission: Submission) -> Appointment | None:
+    if not submission.form.is_appointment:
+        return None
+    appointment: Appointment | None = getattr(submission, "appointment", None)
+    return appointment

--- a/src/openforms/emails/templatetags/appointments.py
+++ b/src/openforms/emails/templatetags/appointments.py
@@ -1,9 +1,11 @@
 from django import template
 from django.template.loader import render_to_string
 
-from openforms.appointments.models import Appointment
-from openforms.appointments.renderer import AppointmentRenderer
-from openforms.appointments.utils import get_plugin
+from openforms.appointments.service import (
+    AppointmentRenderer,
+    get_appointment,
+    get_plugin,
+)
 from openforms.submissions.rendering.constants import RenderModes
 
 register = template.Library()
@@ -22,7 +24,7 @@ def appointment_information(context):
 
     # check for new style appointments
     submission = context["_submission"]
-    appointment: Appointment | None = getattr(submission, "appointment", None)
+    appointment = get_appointment(submission)
     plugin_id = appointment.plugin if appointment else ""
 
     plugin = get_plugin(plugin=plugin_id)

--- a/src/openforms/submissions/models/submission_report.py
+++ b/src/openforms/submissions/models/submission_report.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy as _, override
 from celery.result import AsyncResult
 from privates.fields import PrivateMediaFileField
 
-from openforms.appointments.models import AppointmentInfo
 from openforms.utils.pdf import render_to_pdf
 
 from ..report import Report

--- a/src/openforms/submissions/models/submission_report.py
+++ b/src/openforms/submissions/models/submission_report.py
@@ -66,21 +66,12 @@ class SubmissionReport(models.Model):
         :return: string with the HTML used for the PDF generation, so that contents
           can be tested.
         """
-        try:
-            appointment_id = self.submission.appointment_info.appointment_id
-        except AppointmentInfo.DoesNotExist:
-            appointment_id = None
 
         with override(self.submission.language_code):
             form = self.submission.form
             html_report, pdf_report = render_to_pdf(
                 "report/submission_report.html",
-                context={
-                    "report": Report(self.submission),
-                    # appointment_information tag needs _submission and _appointment_id
-                    "_submission": self.submission,
-                    "_appointment_id": appointment_id,
-                },
+                context={"report": Report(self.submission)},
             )
             self.content = ContentFile(
                 content=pdf_report,

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -80,7 +80,7 @@ class Report:
 
     @property
     def appointment(self):
-        from openforms.appointments.renderer import AppointmentRenderer
+        from openforms.appointments.service import AppointmentRenderer
 
         return AppointmentRenderer(
             submission=self.renderer.submission,

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -77,3 +77,13 @@ class Report:
         # has been applied by ``Template.render``
         content = self.submission.render_confirmation_page()
         return content
+
+    @property
+    def appointment(self):
+        from openforms.appointments.renderer import AppointmentRenderer
+
+        return AppointmentRenderer(
+            submission=self.renderer.submission,
+            mode=self.renderer.mode,
+            as_html=self.renderer.as_html,
+        )

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -94,9 +94,7 @@
             </section>
             {% endif %}
 
-            {% if report.submission.form.is_appointment %}
-            <section>{% appointment_information %}</section>
-            {% endif %}
+            {{ report.appointment }}
 
             {% if report.submission.form.include_confirmation_page_content_in_pdf %}
                 <section>

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -8,11 +8,6 @@ from privates.test import temp_private_root
 from pyquery import PyQuery as pq
 from testfixtures import LogCapture
 
-from openforms.appointments.tests.factories import (
-    AppointmentFactory,
-    AppointmentProductFactory,
-)
-
 from ..models import SubmissionReport
 from ..tasks.pdf import generate_submission_report
 from .factories import SubmissionFactory, SubmissionReportFactory
@@ -237,26 +232,6 @@ class SubmissionReportGenerationTests(TestCase):
         reference_node = doc(".metadata").children()[1]
 
         self.assertEqual(reference_node.text, "Your reference is: OF-12345")
-
-    def test_appointment_info_is_included(self):
-        # NB the demo plugin appointment info is hardcoded in the plugin
-        appointment = AppointmentFactory.create(
-            plugin="demo",
-            submission__language_code="nl",
-            submission__with_report=True,
-            appointment_info__registration_ok=True,
-            location__identifier="1",
-        )
-        AppointmentProductFactory.create(
-            appointment=appointment, product_id="1", amount=1
-        )
-        submission = appointment.submission
-
-        html = submission.report.generate_submission_report_pdf()
-
-        self.assertIn("Test product 1", html)
-        self.assertIn("Test location", html)
-        self.assertIn("Datum en tijd", html)
 
 
 @temp_private_root()


### PR DESCRIPTION
Closes #3416

The idea is that a renderer should behave a like a Django Form does.
i.e. render the default representation when used as `{{ appointment }}`

No effort has been put (yet) into the getattr side of that API.
So within the submission_report template you can't access the
appointment attributes, the way you can access Django form fields.
