### PR TITLE
:sparkles: [#3187] prevent selecting duplicate form definitions

### DIFF
--- a/src/openforms/js/components/admin/form_design/NewStepFormDefinitionPicker.js
+++ b/src/openforms/js/components/admin/form_design/NewStepFormDefinitionPicker.js
@@ -21,7 +21,7 @@ const NewStepFormDefinitionPicker = ({onReplace}) => {
   const [validationErrors, setValidationErrors] = useState([]);
 
   const formDefinitionChoices = formDefinitions
-    .filter(fd => fd.isReusable)
+    .filter(fd => fd.isReusable && !formContext.formSteps.some(fc => fc.isReusable && fc.formDefinition === fd.url))
     .map(fd => [fd.url, fd.internalName || fd.name])
     .sort((a, b) => a[1].localeCompare(b[1]));
 

--- a/src/openforms/js/components/admin/form_design/NewStepFormDefinitionPicker.js
+++ b/src/openforms/js/components/admin/form_design/NewStepFormDefinitionPicker.js
@@ -21,7 +21,11 @@ const NewStepFormDefinitionPicker = ({onReplace}) => {
   const [validationErrors, setValidationErrors] = useState([]);
 
   const formDefinitionChoices = formDefinitions
-    .filter(fd => fd.isReusable && !formContext.formSteps.some(fc => fc.isReusable && fc.formDefinition === fd.url))
+    .filter(
+      fd =>
+        fd.isReusable &&
+        !formContext.formSteps.some(fc => fc.isReusable && fc.formDefinition === fd.url)
+    )
     .map(fd => [fd.url, fd.internalName || fd.name])
     .sort((a, b) => a[1].localeCompare(b[1]));
 


### PR DESCRIPTION
fixes #3187 

- added line of code in the filtering of the selectbox options to filterout selected form definitions
- added playwright tests