### PR TITLE
:bug: [#3445] upped the map lat and long field decimal limit to 7

### DIFF
--- a/src/openforms/js/components/form/map.js
+++ b/src/openforms/js/components/form/map.js
@@ -92,6 +92,7 @@ const EDIT_FORM_TABS = {
               key: 'initialCenter.lat',
               type: 'number',
               requireDecimal: true,
+              decimalLimit: 7,
               validate: {
                 min: -90,
                 max: 90,
@@ -103,6 +104,7 @@ const EDIT_FORM_TABS = {
               key: 'initialCenter.lng',
               type: 'number',
               requireDecimal: true,
+              decimalLimit: 7,
               validate: {
                 min: -180,
                 max: 180,


### PR DESCRIPTION
fixes #3445 

added decimalLimit of 7 for the lat and long fields in the map.js