### PR TITLE
:truck: Move service factory to more general purpose location

### DIFF
--- a/src/openforms/appointments/contrib/qmatic/tests/factories.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/factories.py
@@ -1,18 +1,14 @@
 import factory
 from zgw_consumers.constants import APITypes
-from zgw_consumers.models import Service
+
+from zgw_consumers_ext.factories import ServiceFactory as _ServiceFactory
 
 from ..models import QmaticConfig
 
 
-# TODO: consolidate this in src/openforms/contrib or src/zgw_consumers_ext
-class ServiceFactory(factory.django.DjangoModelFactory):
-    label = factory.Sequence(lambda n: f"API-{n}")
+class ServiceFactory(_ServiceFactory):
     api_root = factory.Sequence(lambda n: f"http://www.example{n}.com/api/")
     api_type = APITypes.orc
-
-    class Meta:
-        model = Service
 
 
 class QmaticConfigFactory(factory.django.DjangoModelFactory):

--- a/src/openforms/contrib/bag/tests/base.py
+++ b/src/openforms/contrib/bag/tests/base.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from openforms.contrib.bag.models import BAGConfig
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 
 class BagTestMixin:

--- a/src/openforms/contrib/kvk/tests/base.py
+++ b/src/openforms/contrib/kvk/tests/base.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from openforms.contrib.kvk.models import KVKConfig
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 
 class KVKTestMixin:

--- a/src/openforms/formio/components/np_family_members/tests/test_family_members.py
+++ b/src/openforms/formio/components/np_family_members/tests/test_family_members.py
@@ -13,12 +13,12 @@ from zgw_consumers.test import mock_service_oas_get
 from openforms.authentication.constants import AuthAttribute
 from openforms.contrib.brp.models import BRPConfig
 from openforms.formio.service import get_dynamic_configuration
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.template import render_from_string
 from soap.constants import EndpointType
 from stuf.stuf_bg.models import StufBGConfig
 from stuf.tests.factories import StufServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ..constants import FamilyMembersDataAPIChoices
 from ..haal_centraal import get_np_children_haal_centraal

--- a/src/openforms/forms/tests/variables/test_viewset.py
+++ b/src/openforms/forms/tests/variables/test_viewset.py
@@ -21,7 +21,6 @@ from openforms.forms.tests.factories import (
     FormStepFactory,
     FormVariableFactory,
 )
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.variables.constants import (
     DataMappingTypes,
     FormVariableDataTypes,
@@ -30,6 +29,7 @@ from openforms.variables.constants import (
 )
 from openforms.variables.models import ServiceFetchConfiguration
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 
 @override_settings(LANGUAGE_CODE="en")

--- a/src/openforms/pre_requests/tests/test_clients.py
+++ b/src/openforms/pre_requests/tests/test_clients.py
@@ -5,8 +5,8 @@ from django.test import TestCase
 import requests_mock
 
 from openforms.prefill.contrib.haalcentraal.tests.utils import load_binary_mock
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.tests.factories import SubmissionFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ..base import PreRequestHookBase
 from ..clients import PreRequestClientContext

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_client.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_client.py
@@ -9,7 +9,7 @@ from zds_client.oas import schema_fetcher
 from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
 
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ..constants import HaalCentraalVersion
 from ..models import HaalCentraalConfig

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_co_sign.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_co_sign.py
@@ -8,8 +8,8 @@ from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
 
 from openforms.prefill.contrib.haalcentraal.constants import HaalCentraalVersion
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.tests.factories import SubmissionFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ....co_sign import add_co_sign_representation
 from ....models import PrefillConfig

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_config_check.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_config_check.py
@@ -10,7 +10,7 @@ from zgw_consumers.models import Service
 from zgw_consumers.test import mock_service_oas_get
 
 from openforms.plugins.exceptions import InvalidPluginConfiguration
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ....registry import register
 from ..constants import HaalCentraalVersion

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_models.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_models.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase
 
 from zgw_consumers.models import Service
 
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ..client import HaalCentraalClient, HaalCentraalV1Client, HaalCentraalV2Client
 from ..constants import Attributes, AttributesV2, HaalCentraalVersion

--- a/src/openforms/prefill/contrib/haalcentraal/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/haalcentraal/tests/test_plugin.py
@@ -11,8 +11,8 @@ from zgw_consumers.test import mock_service_oas_get
 
 from openforms.pre_requests.base import PreRequestHookBase
 from openforms.pre_requests.registry import Registry
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.tests.factories import SubmissionFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ....constants import IdentifierRoles
 from ....registry import register

--- a/src/openforms/prefill/tests/test_prefill_variables.py
+++ b/src/openforms/prefill/tests/test_prefill_variables.py
@@ -12,12 +12,12 @@ from openforms.formio.service import (
 from openforms.forms.models import FormVariable
 from openforms.forms.tests.factories import FormFactory, FormStepFactory
 from openforms.logging.models import TimelineLogProxy
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.constants import SubmissionValueVariableSources
 from openforms.submissions.tests.factories import (
     SubmissionFactory,
     SubmissionStepFactory,
 )
+from zgw_consumers_ext.factories import ServiceFactory
 
 from .. import prefill_variables
 from ..contrib.haalcentraal.models import HaalCentraalConfig

--- a/src/openforms/registrations/contrib/objects_api/tests/factories.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/factories.py
@@ -2,7 +2,7 @@ import factory
 from zgw_consumers.constants import APITypes
 
 from openforms.registrations.contrib.objects_api.models import ObjectsAPIConfig
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 
 class ObjectsAPIConfigFactory(factory.django.DjangoModelFactory):

--- a/src/openforms/registrations/contrib/zgw_apis/tests/factories.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/factories.py
@@ -1,34 +1,20 @@
 import factory
 from zgw_consumers.constants import APITypes
-from zgw_consumers.models import Service
 
 from ..models import ZGWApiGroupConfig
 
 
-class UriPathFaker(factory.Faker):
-    def __init__(self, **kwargs):
-        super().__init__("uri_path", **kwargs)
-
-    def generate(self, extra_kwargs=None):
-        uri_path = super().generate(extra_kwargs)
-        if not uri_path.endswith("/"):
-            return f"{uri_path}/"
-        return uri_path
-
-
-class ServiceFactory(factory.django.DjangoModelFactory):
-    api_root = UriPathFaker()
-
-    class Meta:
-        model = Service
-        django_get_or_create = ("api_root",)
-
-
 class ZGWApiGroupConfigFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: "ZGW API set %03d" % n)
-    zrc_service = factory.SubFactory(ServiceFactory, api_type=APITypes.zrc)
-    drc_service = factory.SubFactory(ServiceFactory, api_type=APITypes.drc)
-    ztc_service = factory.SubFactory(ServiceFactory, api_type=APITypes.ztc)
+    zrc_service = factory.SubFactory(
+        "zgw_consumers_ext.factories.ServiceFactory", api_type=APITypes.zrc
+    )
+    drc_service = factory.SubFactory(
+        "zgw_consumers_ext.factories.ServiceFactory", api_type=APITypes.drc
+    )
+    ztc_service = factory.SubFactory(
+        "zgw_consumers_ext.factories.ServiceFactory", api_type=APITypes.ztc
+    )
 
     class Meta:
         model = ZGWApiGroupConfig

--- a/src/openforms/services/tests/test_api_list.py
+++ b/src/openforms/services/tests/test_api_list.py
@@ -3,7 +3,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 
 class AccessControlTests(APITestCase):

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
@@ -13,11 +13,11 @@ from hypothesis import assume, example, given, strategies as st
 from zgw_consumers.constants import APITypes, AuthTypes
 
 from openforms.forms.tests.factories import FormVariableFactory
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.tests.utils import c_profile
 from openforms.variables.constants import DataMappingTypes
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 from openforms.variables.validators import HeaderValidator, ValidationError
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ...logic.service_fetching import perform_service_fetch
 

--- a/src/openforms/submissions/tests/test_variables/test_fetch_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_fetch_with_logic.py
@@ -8,8 +8,8 @@ from zgw_consumers.constants import APITypes, AuthTypes
 
 from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import FormLogicFactory
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ..factories import SubmissionFactory
 from ..mixins import SubmissionsMixin

--- a/src/openforms/tests/test_registrator_prefill.py
+++ b/src/openforms/tests/test_registrator_prefill.py
@@ -22,9 +22,9 @@ from openforms.prefill.contrib.haalcentraal.tests.utils import (
     load_binary_mock,
     load_json_mock,
 )
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
 from openforms.submissions.models import Submission
 from openforms.utils.urls import reverse_plus
+from zgw_consumers_ext.factories import ServiceFactory
 
 CONFIGURATION = {
     "display": "form",

--- a/src/openforms/variables/tests/factories.py
+++ b/src/openforms/variables/tests/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from openforms.registrations.contrib.zgw_apis.tests.factories import ServiceFactory
+from zgw_consumers_ext.factories import ServiceFactory
 
 from ..models import ServiceFetchConfiguration
 

--- a/src/zgw_consumers_ext/factories.py
+++ b/src/zgw_consumers_ext/factories.py
@@ -1,0 +1,22 @@
+import factory
+
+
+class UriPathFaker(factory.Faker):
+    def __init__(self, **kwargs):
+        super().__init__("uri_path", **kwargs)
+
+    def generate(self, extra_kwargs=None):
+        uri_path = super().generate(extra_kwargs)
+        # faker generates them without trailing slash, but let's make sure this stays true
+        # zgw_consumers.Service normalizes api_root to append missing trailing slashes
+        assert not uri_path.endswith("/")
+        return f"{uri_path}/"
+
+
+class ServiceFactory(factory.django.DjangoModelFactory):
+    label = factory.Sequence(lambda n: f"API-{n}")
+    api_root = UriPathFaker()
+
+    class Meta:
+        model = "zgw_consumers.Service"
+        django_get_or_create = ("api_root",)


### PR DESCRIPTION
We were now duplicating these factories in multiple places and importing them from weird places.