### PR TITLE
Support multi product / multi customer appointments in Qmatic

### DIFF
--- a/src/openforms/appointments/contrib/qmatic/client.py
+++ b/src/openforms/appointments/contrib/qmatic/client.py
@@ -190,7 +190,7 @@ class QmaticClient(Session):
         self, location_id: str, service_ids: list[str], day: date, num_customers: int
     ) -> list[datetime]:
         """
-        Get list of available dates for multiple services and customers.
+        Get list of available times for multiple services and customers.
 
         ``num_customers`` is the total number of customers, which affects the
         appointment duration in Qmatic (using

--- a/src/openforms/appointments/contrib/qmatic/plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/plugin.py
@@ -301,11 +301,6 @@ class QmaticAppointment(BasePlugin[CustomerFields]):
         client: _CustomerDetails | Customer,
         remarks: str = "",
     ) -> str | None:
-        warnings.warn(
-            "The QMatic plugin is deprecated and will be removed in Open Forms 3.0",
-            DeprecationWarning,
-        )
-
         qmatic_client = QmaticClient()
         if len(products) != 1:
             logger.warning(

--- a/src/openforms/appointments/contrib/qmatic/plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/plugin.py
@@ -245,7 +245,7 @@ class QmaticAppointment(BasePlugin[CustomerFields]):
         From the documentation:
 
             numberOfCustomers will be used on all services when calculating the
-            appointment duration For example, a service with Duration of 10 minutes and
+            appointment duration. For example, a service with Duration of 10 minutes and
             additionalCustomerDuration of 5 minutes will result in an appointment
             duration of 50 when minutes for 4 customers and 2 services.
 

--- a/src/openforms/appointments/contrib/qmatic/plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/plugin.py
@@ -317,7 +317,8 @@ class QmaticAppointment(BasePlugin[CustomerFields]):
         start_at: datetime,
         client: _CustomerDetails | Customer,
         remarks: str = "",
-    ) -> str | None:
+    ) -> str:
+        assert products, "Can't book for empty products"
         customer = normalize_customer_details(client)
 
         product_names = ", ".join(sorted({product.name for product in products}))

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/CreateAppointmentTests/CreateAppointmentTests.test_create_appointment_multi_product_multi_customer.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/CreateAppointmentTests/CreateAppointmentTests.test_create_appointment_multi_product_multi_customer.yaml
@@ -1,0 +1,622 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services/groups;servicePublicId=INT_Achternaam_gebruiken
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOWYX2/TMBTFv4rl5z7Aw176RtmACQTVKLy0k+XEN6kbx578J5s27btznbVNXMo0
+        JEBsfqps/1LFR+ceX2d5Rx3YTpbg6HR5R69CoWR5LuiUnn9esDfl2oPVnLeshsIG2YCmE6p5C0gM
+        q2S8KoLlXhpNp69fTSgXQsYRV2+D86YFe5qsl/0s/tvdilpw5RpEUHCmeaFArOjU2wCTFS25LkH9
+        NA0tl8rheEVXFMdr6c7FMNTGg3snQYnhyYorFx+VujILuPEDvVUi7s5brp3qXzP++/Lynt5PUnkE
+        aC89SO8azq0fZDmyMkhy8rgiJ89YEPTL7OsgwzfpvYXGgSJFsDVYJTcNEOe5FoRz3VleZ+SXU1OG
+        Fo3Bmmu58cxUWFG4EzUuqB1DeoaYioyYHDx0ITcF4N7doMl4KgcJ5txdGTPOk9HM00vlbysAN+Wa
+        6xrOIvZPhPkOtlHcSl0z02KyYCnVIDBEBqUGhGwRskeeLt0zDpk+gy/mR0N4xp10FmrpfNwpkDlY
+        Z/TvZcsz16YDuw7yFg2SmGY7F0+lGrqMDqVZn6ys45pJzVTcO7uVm9GR9EAQJIjUpCfIlsghjWcB
+        GzmtsGVxzO5OIsyfa+mwpsZn94gke5Ik5MhTL7fMsJxi4jC8FlhW7EVJ6i0CJAIkAfKouZhD3mBf
+        By0WHb43uqVLEmnxsNrGSDogcqi5KND845dxA2QbAGu0X0NVHQrxkr3yIUjXoRlwz/hr66B14pRf
+        rufikxl4juHKOmyQ8YFehW0LOD7Deogch3LofT5BzZXER1AqbNuFhwZSJ40IckDk4KX3HBGPqatU
+        f8GomDK1hOgUF0+rJhErpeM9/Sidg3C7y2lfgayzAK0Alai1Q/r6IymSRUu0C6kaWsA7KRSgeJ/Z
+        Sf+4DanjUA4hdWAlFeLn5UetlCD/z7eRP6rR5f3lD3WWOsGlFwAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '723'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times;servicePublicId=INT_Achternaam_gebruiken;servicePublicId=Betalen_gemeentebelastingen;numberOfCustomers=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD3TsW7CMBSF4VepPGdI7rXVNlvbiaWtqm4oQk64oVZtR4qdLoh3r0MOTOYHn48M
+        cFbZBUmq3av6qeVaVdfTbKe+9nPb3E6znYQmNKMZfdvptZt6268nmtCEZjSjNfq2N2hz7aata5zo
+        Bt2gCU1oRjNaozXaoDef4BN8gk/wCT7BJ/gEn+ATfIJP8Bk+w2f4DJ/hM3yGz/AZPsNn+Axfw9fw
+        NXwNX8PX8DV8Dd9gb7A32BvsDfYGe4O9ue81ujxfV6kg2ar2rFK2c1atKp9JPG4v8pSt/5K0+Fx+
+        hI+mUtM4JinX4uJ9pbwL7h6jE39M29DOpyVIXFdnFZfQy/wxvi0pT0Hm9c6+6cq1JPOfG+Rz6b0b
+        duuX7nfv34eX4SfLHK0Nh5P08+J+JVYPr+VBvcTyVpBCSy/epuziSWKnLpdKxSm70Q02uymu/5nu
+        8g8NUH/gQAMAAA==
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '352'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 14:03:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"title": "Open Formulieren: Achternaam gebruiken, Betalen gemeentebelastingen",
+      "customers": [{"email": "automated-test@example.com", "lastName": "TEST (automated)"},
+      {"email": "automated-test@example.com", "lastName": "TEST (automated)"}], "services":
+      [{"publicId": "INT_Achternaam_gebruiken"}, {"publicId": "Betalen_gemeentebelastingen"}],
+      "notes": "AUTOMATED TEST APPOINTMENT - can safely be removed."}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '406'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times/08:30/book
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1WTW/cNhD9KwJ7adH1lqRIStxTHMcBjCa2gWwRINkgoMiRlw0lGVrKcGD4v2e4
+        3i/ZSdAG6CE9iIBIznDmzXtD3pG2i7AiM3L81/zi9fH89EU2P30zz44vLy/OzuevT8/n2VFmTZut
+        TA3hc1ZB1kPT3YCbkgnpYdUNvQUyuyN2WMWuQVd3C2K70PULMluQX3JTFsYtyGRBoDE+rGcX5B6t
+        W9OgJWGrCFnwf7cZI/cTYnswERyZMaUF1TIvtRD5ZOe/HUKYkFU0fURjTnl+RPURLedUzXI6o3RK
+        Kf0dP5qOGJoK+ov6ZG0MPabK0Rj6G29T3u/viBt6E33X4oF0Qq6HKnh72poqpBhiP8CEGOd82mLC
+        1s+LkdE+ZFFIVWhNqRByMoIEobJLcEOAjfPFxjuiZVoL4cn0Gq7VBi/8X/rVmdv/riv30kNwe8va
+        hFUy9W3dzeE27ndvUk6Qx960q7AOP3l//+GgFsd2GaFvjWmyK6j6wX+CFleNjf4GtnAM126TrswF
+        logpVubFFrszXCDInY97Xx/3vu4nh4jLHwB8jLcohdBFwVVOf0a8n0M0AVoEuwFoI1QQzCr69uof
+        wk75CPaNu49fc3f/YUKijyEde3GNZ77s+mYIHnpoZ9nXCj/Jvh9ehYnZZdI+1gvxXp10Qxv7z1uN
+        bmbf+eskVK5E9vw1GVdPClaUNJe8nJAEURwcxif5lJaS57jKi7zIuXos/+gbeNe1KZfToe+u4Y/j
+        BttI70xDdge/iXjO1uJ6+bCdiYwWdF+BP09O9havfAssTXbtNHvrwxJC45GFBhsgH2/jW8c1jvPv
+        hjMuHKNScy7HeqmZrg2nOa2ckrkTXFvBkdac6sooap2tcJQ1qw0rjZZWuIJXXFLDcFaWu2pc9lD7
+        221sa0qj+8TPZwG8S5poMaqjm67rq6G/mrZhn9eJj1g88upgIy6Grr3aFEZMc51rJcpS56xQlGG/
+        NiG8MJ+3WiBV6OwnZMhuAt086dNSPurTD9V9E7r4CtqruNwmYPd9+/23aJYoef5QzPXd9asZ0CYh
+        /hsZk3Dj8+kFwxR/8HOGJO+T7Lo21RRvmeb6MPpizsSM5jOqp0zn4+h3oN+ulRRSYUdCGPExUeKi
+        fu77g2SxQaDKDg5+svWtj8tuWG/ZrUKAr8bL6LfirX2/hWwkjlEYZw4HX2N/2C5sFJN+sm8jvdHQ
+        g4nfOLHr9ne+vo0foTISUw8xGXTtZYfSSGR0UJshxEMZbWLeq8dJXSgrTEm1pVpxW1RCKlPTUlf4
+        drDKuQryqhS0qFSeV7XEqYKZUgqNtXdkr5RdRkfY7eMzuEVAA0xt1zyWSYoi3Wb/GSm5VP+alLzg
+        PxUpD+L9v5FSlTllwCoqFROyrkqlLYhKm1IgSUtKSyOlLlXOpFLOFKYytVKG8xxbemn4j5Pyw+GV
+        M35EH8RXaCa1Y4qW4EonMT4KuZDUaVdSB9rl3EkcgBea1viulWA1o7yiFngtNFk/wuOQntT0/guo
+        ZwmXSgwAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1147'
+      Content-Security-Policy:
+      - script-src 'self' 'unsafe-inline' 'unsafe-eval';
+      Content-Type:
+      - application/text;charset=UTF-8
+      Date:
+      - Thu, 07 Sep 2023 14:03:11 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Set-Cookie:
+      - JSESSIONID=node01qy53s225i26rpmk2uosihety26.node0; Path=/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times/08:30;
+        Domain=apigateway1.lv.nl
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/appointments/79159d1608ed8d5b860e3450d9d80de9d32d5d32e2790f7565ec9102b0ce2f49
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Date:
+      - Thu, 07 Sep 2023 14:03:11 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/CreateAppointmentTests/CreateAppointmentTests.test_create_appointment_single_product_single_customer.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/CreateAppointmentTests/CreateAppointmentTests.test_create_appointment_single_product_single_customer.yaml
@@ -1,0 +1,467 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 13:58:22 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 13:58:22 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 13:58:22 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times;servicePublicId=INT_Achternaam_gebruiken
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD3TvW6DQBBF4XfZmgJmZpWYLmWaKIrSWZaF8eKswo8ESxrL7x4wx64uR7CfKODq
+        UuzC5Mq9y19LzV12X7+t0XbvXVnkLC200EorbfTjvF+7yDdnXb+t0EIrrbTRRj8cf++izHOWLuiC
+        FlpopZU22mhPb77gC77gC77gC77gC77gC77gC77iK77iK77iK77iK77iK77iK77hG77hG77hG77h
+        G77hexyP43E8jsfxOB7H4/inY/TynofMdSFVrry6KVVjcqVb7oX+vF2kIVXtV5jmNi0f6csuc0PT
+        TGF5rJ/bNnNt7OIzmhja87QdrMbL3IV+PbXIYfyLdficT22s31d6//7xfXyrf1IY+6rqjpdwGuf4
+        G/qDu90y1w8pNrGuUhz69ec43P4B4OTKRSkDAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '314'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 13:58:22 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 13:58:22 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"title": "Open Formulieren: Achternaam gebruiken", "customers": [{"email":
+      "automated-test@example.com", "lastName": "TEST (automated)"}], "services":
+      [{"publicId": "INT_Achternaam_gebruiken"}], "notes": "AUTOMATED TEST APPOINTMENT
+      - can safely be removed."}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '259'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times/08:30/book
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1V227jNhD9FYF9aVHHJSlSFz9tNskCQXMD4mKBjRcLiqRidinKoKkgQZB/36Ei
+        W1bS9EECRHKGZ86cM3pGrg16ixbo+J/l9eXx8uw0WZ7dLpPjm5vr86vl5dnVMjlKpHDJVtTaPiWV
+        Trxu2get5miGvN62nZcaLZ6R7LahbSDV8wrJ1rZ+hRYr9FsqilyoFZqtkG6Esf3qCr1AtBMNRCKy
+        DTqx5l+XEPQyQ9JrEbRCC5KVDJecYEZoPtvnd521M7QNwgcIppimR7g8wsUSZ4sULzCeY4z/hAfH
+        K7qm0v66PumDtYdSCQRr/2BkrPvuGanOi2BaBzt4hjZdZY08c6KyEUPwnZ4hoZSJR4Td5TmdBI2Q
+        Wc6zvCwxZozPJpQAVXKtVWf1kHw1ZAe2hJPavlvu6doOfMH32mzP1fjZd+6L0VaNkbWw2xhqXN0u
+        9WMYTw8lR8qDF25re/gx+933g14cy3XQ3gnRJPe68p35qR3sChnMg97R0W3UUC5PGbSIZKRI8x13
+        57CBQDs/xlw/xlwv32comGDjZdcb7ZIvrW86a7TXbpF8cH0FiOU6igw6AURuT9rOBf+0E8Ow+s1s
+        oiJoxpLPl2jSFsYZyQucclrMUKw9dAogcDrHBacpjxJL85Rmb3UWTKO/tS7CPet8u9F/HTegV69E
+        g/YX3wa4ZxexWb8eJyzBOR6p/fvkZIy4ME6TuNi6efLV2LW2jQF9CXAanR6ju8Q1vJf/C2faGIJ5
+        SSmfNqYmZS0oTnGlMp4qRkvJaJ5TistKZFgqWcGb16QWpBAll0zltKIcCwKrvNh348br2jzusPVa
+        hfRReJ+sNiqK3QGqo4e29VXn7+fOjnWdmADNQxcHB2HTtu5+aAybp2VaZqwoypTkGSYwGIS1p+Jp
+        J3JU2Vb+NO5+vwBp3g0E9nYgvHb31rbhQrv7sN4VIMcBcfeRzKzYhqvXZvZD8nfRQUxk/A80FeGQ
+        8/0kw6R4zXPuoGvRVq2LPYVx1mwO0edLki54saBsjlM2Rb8n/bE3i42NnRhhoscoiev6s/EHxYLz
+        tQsHF787+tWEddv1R/a72ur/xEvwR3hr43eUTcwxgXGu4GVqGAG7jcEx8SP5mOnBQ68hZkgi+7l2
+        1Y/9N6xMzOR1iAGtu2nBGlGMSteis+HQRgPm0T2E8SpjVKU5qSohU1LQkuksw2mOq5wWSpei4lqK
+        THLFclaUquSUFzirGBVphUan7Cs6gjEePulHINTquWybtzaJKOLYHN09/hh5OcFHCS8oXESYZkIS
+        +A1lXEpBi7yWMOhqokmFYS8TdZ7ngDHFaZHJQhBcC0UI6n+soQMXUPzyC9AarjseCAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1020'
+      Content-Security-Policy:
+      - script-src 'self' 'unsafe-inline' 'unsafe-eval';
+      Content-Type:
+      - application/text;charset=UTF-8
+      Date:
+      - Thu, 07 Sep 2023 13:58:26 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Set-Cookie:
+      - JSESSIONID=node079ay4exhboepubjzf1n93fw225.node0; Path=/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times/08:30;
+        Domain=apigateway1.lv.nl
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 202
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: DELETE
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/appointments/215822a314e4ac100465cca287fc085f1e1b04e46af777c5d30386c8a10fad11
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Date:
+      - Thu, 07 Sep 2023 13:58:26 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableDatesTests/ListAvailableDatesTests.test_listing_dates_single_product_multiple_customers.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableDatesTests/ListAvailableDatesTests.test_listing_dates_single_product_multiple_customers.yaml
@@ -1,0 +1,400 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:50:09 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:50:09 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:50:09 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates;servicePublicId=INT_Achternaam_gebruiken;numberOfCustomers=998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD2NsQ6DMAxE/8Vzho6FrWJiaauqG0LIBIdaTRwpcbog/r1QpG53p3d3CwRShHqB
+        rJgUagADJNMhNCr6B+XiNUN9MhCdy7RRUrw34Dnw3zgmP+Wjh2kugWQvLSAljJRurilZY6C0M11V
+        nfsNzJQ+bOleRs+23V+79vocLvallAQxDDONqfCbpId1NTCh0jbQ9QYkKju2qBzlF61fWf34e80A
+        AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '173'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:50:09 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:54:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates;servicePublicId=INT_Achternaam_gebruiken;numberOfCustomers=998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD2NsQ6DMAxE/8Vzho6FrWJiaauqG0LIBIdaTRwpcbog/r1QpG53p3d3CwRShHqB
+        rJgUagADJNMhNCr6B+XiNUN9MhCdy7RRUrw34Dnw3zgmP+Wjh2kugWQvLSAljJRurilZY6C0M11V
+        nfsNzJQ+bOleRs+23V+79vocLvallAQxDDONqfCbpId1NTCh0jbQ9QYkKju2qBzlF61fWf34e80A
+        AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '173'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:54:07 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableDatesTests/ListAvailableDatesTests.test_listing_dates_single_product_single_customer.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableDatesTests/ListAvailableDatesTests.test_listing_dates_single_product_single_customer.yaml
@@ -1,0 +1,285 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:48:16 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:48:16 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:48:16 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates;servicePublicId=INT_Achternaam_gebruiken
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAG2UQWuDQBCF/8ucFXbGJm289ZhLKSW3IGFj1nTJuoKuvQT/e50GAmUfeNCPneXx
+        PsY79S5Zqu80JTsmqokKcvHyeElDsuHLTXNIE9XbTUFD101uPRbnEAoKvvfPj867cJkeg3a8zr2L
+        OrXe7MYf37rP+Rx8u9erj/uPw+m9/U5ujNb2p6s7j7O/udjQshR0scmtk0cSI1VpdqV5PRhT/z3r
+        5U/6higzpAJpBekLpBtIcYYdomIghXkF5hWYQbaQws4E5pU8L5vS5BmU5p0pzTtTmudVmudVCjNw
+        3pnSvDOlMC9wrBRm4LwzpXlnSmFe4FgpzCCwM+BYKcwLHK+0ghkq0BmXBlPQJEPzDG0y2liloEmG
+        5hmaZ2iT0cYqBU0yNM/QPEObjDZWKewMmWdonqFNRhurFHaGzAt0LHBjBW6s/HPcFBSH5Dvf2uSH
+        qP/pZvkFkUhit0cGAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '356'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 09:48:16 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableDatesTests/ListAvailableDatesTests.test_multiple_products_multiple_customers.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableDatesTests/ListAvailableDatesTests.test_multiple_products_multiple_customers.yaml
@@ -1,0 +1,435 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 10:06:45 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 10:06:45 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 10:06:45 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services/groups;servicePublicId=INT_Achternaam_gebruiken
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOWYX2/TMBTFv4rl5z7Aw176RtmACQTVKLy0k+XEN6kbx578J5s27btznbVNXMo0
+        JEBsfqps/1LFR+ceX2d5Rx3YTpbg6HR5R69CoWR5LuiUnn9esDfl2oPVnLeshsIG2YCmE6p5C0gM
+        q2S8KoLlXhpNp69fTSgXQsYRV2+D86YFe5qsl/0s/tvdilpw5RpEUHCmeaFArOjU2wCTFS25LkH9
+        NA0tl8rheEVXFMdr6c7FMNTGg3snQYnhyYorFx+VujILuPEDvVUi7s5brp3qXzP++/Lynt5PUnkE
+        aC89SO8azq0fZDmyMkhy8rgiJ89YEPTL7OsgwzfpvYXGgSJFsDVYJTcNEOe5FoRz3VleZ+SXU1OG
+        Fo3Bmmu58cxUWFG4EzUuqB1DeoaYioyYHDx0ITcF4N7doMl4KgcJ5txdGTPOk9HM00vlbysAN+Wa
+        6xrOIvZPhPkOtlHcSl0z02KyYCnVIDBEBqUGhGwRskeeLt0zDpk+gy/mR0N4xp10FmrpfNwpkDlY
+        Z/TvZcsz16YDuw7yFg2SmGY7F0+lGrqMDqVZn6ys45pJzVTcO7uVm9GR9EAQJIjUpCfIlsghjWcB
+        GzmtsGVxzO5OIsyfa+mwpsZn94gke5Ik5MhTL7fMsJxi4jC8FlhW7EVJ6i0CJAIkAfKouZhD3mBf
+        By0WHb43uqVLEmnxsNrGSDogcqi5KND845dxA2QbAGu0X0NVHQrxkr3yIUjXoRlwz/hr66B14pRf
+        rufikxl4juHKOmyQ8YFehW0LOD7Deogch3LofT5BzZXER1AqbNuFhwZSJ40IckDk4KX3HBGPqatU
+        f8GomDK1hOgUF0+rJhErpeM9/Sidg3C7y2lfgayzAK0Alai1Q/r6IymSRUu0C6kaWsA7KRSgeJ/Z
+        Sf+4DanjUA4hdWAlFeLn5UetlCD/z7eRP6rR5f3lD3WWOsGlFwAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '723'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 10:06:45 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 10:06:45 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates;servicePublicId=INT_Achternaam_gebruiken;servicePublicId=Betalen_gemeentebelastingen;numberOfCustomers=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAG2Uy2rDMBBFf6VobYNGbtI2u7arbNpSsgsmyM44FZVlsORuQv69mgYCRRe8sA96
+        XO5hfFYjJ6s2ZxWTnZPaKFUpDsfrS5qS9Z8cF5+i2qxXlZqGIXJeFhbvK+Xd6G4fg2N/jNeNdj4t
+        IwfZdVZhGTue34fXJaZp5FnW7KnNyyLPP67nj6Xzrt/Kpfvt2+7w3H8lnoO14+HE3by4bw7V3UsO
+        6jlkNHI+mjv2NiYXThxadblU6mgT57P3ymjT1Pqp1g87rTd/T77sRh8RJYLUQNpAeg/pClKc4QlR
+        oyGFeQ3Ma2AGs4YUdmZgXlPmJV3rMoPQsjOhZWdCy7xCy7xCYQYqOxNadiYU5gWOhcIMVHYmtOxM
+        KMwLHAuFGQzsDDgWCvMCx5k2MEMDOqNaYwqaJGieoE1CEysUNEnQPEHzBG0SmlihoEmC5gmaJ2iT
+        0MQKhZ0h8wTNE7RJaGKFws6QeQMdGzixBk6s+ee4rVSYkhtcb5Obgvyn28svxeTDsn4GAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '395'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 10:06:46 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableTimesTests/ListAvailableTimesTests.test_listing_times_single_product_multiple_customers.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableTimesTests/ListAvailableTimesTests.test_listing_times_single_product_multiple_customers.yaml
@@ -1,0 +1,400 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:28 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:28 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times;servicePublicId=INT_Achternaam_gebruiken;numberOfCustomers=998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD2PMQuDMBCF/8vNGTpWt+Lk0pbSTURivNijyQUuly7if69W6PYefB+Pt4BSxAx1
+        1xuIqBbqBbJaUagBDCBPR9CkNjwwl6AbfTKQvM+4UVxCMBAo0r94wjDlw7Myl4i8SwtwiSPKzTcl
+        a4ooO9NV1bnfwIzyIYf3MgZy7b7atdfncHEvRWFr4zDjKIXeyD2sqwFOSp6cVUr8O7B+AREXvB/N
+        AAAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '174'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times;servicePublicId=INT_Achternaam_gebruiken;numberOfCustomers=998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD2PMQuDMBCF/8vNGTpWt+Lk0pbSTURivNijyQUuly7if69W6PYefB+Pt4BSxAx1
+        1xuIqBbqBbJaUagBDCBPR9CkNjwwl6AbfTKQvM+4UVxCMBAo0r94wjDlw7Myl4i8SwtwiSPKzTcl
+        a4ooO9NV1bnfwIzyIYf3MgZy7b7atdfncHEvRWFr4zDjKIXeyD2sqwFOSp6cVUr8O7B+AREXvB/N
+        AAAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '174'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableTimesTests/ListAvailableTimesTests.test_listing_times_single_product_single_customer.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableTimesTests/ListAvailableTimesTests.test_listing_times_single_product_single_customer.yaml
@@ -1,0 +1,284 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times;servicePublicId=INT_Achternaam_gebruiken
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD3TvW6DQBBF4XfZmgJmZpWYLmWaKIrSWZaF8eKswo8ESxrL7x4wx64uR7CfKODq
+        UuzC5Mq9y19LzV12X7+t0XbvXVnkLC200EorbfTjvF+7yDdnXb+t0EIrrbTRRj8cf++izHOWLuiC
+        FlpopZU22mhPb77gC77gC77gC77gC77gC77gC77iK77iK77iK77iK77iK77iK77hG77hG77hG77h
+        G77hexyP43E8jsfxOB7H4/inY/TynofMdSFVrry6KVVjcqVb7oX+vF2kIVXtV5jmNi0f6csuc0PT
+        TGF5rJ/bNnNt7OIzmhja87QdrMbL3IV+PbXIYfyLdficT22s31d6//7xfXyrf1IY+6rqjpdwGuf4
+        G/qDu90y1w8pNrGuUhz69ec43P4B4OTKRSkDAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '314'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableTimesTests/ListAvailableTimesTests.test_multiple_products_multiple_customers.yaml
+++ b/src/openforms/appointments/contrib/qmatic/tests/data/vcr_cassettes/ListAvailableTimesTests/ListAvailableTimesTests.test_multiple_products_multiple_customers.yaml
@@ -1,0 +1,435 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAM2YbW/URhDHv8rJr9N0dnb2Ka/aokqlQIuAEgnEi32YTSzufJHPh1pF+e4dcwRy
+        OFCSBis66XTeJ+/65//Mf+68SX3s8unjdjM0R6/Pm1hKz5vNg/W2G/p/mqPmDy7cL2NXmoPLzlft
+        mXQgWlr88kSac89x4NIcKXIWLdigrFUHzTIO7bAt3Bx12+VSxm03w3p1eTW0K3617qS3+XXbr8/4
+        x59Xm4H7ElefbvV8kJUvZ5ydvh++u+jiapz6O29Prmztcduxur4ZpfnRujtcHLfLU16u2i4uY+wW
+        KMOqLPniq/vZnpVPZwyOggLyIHvapmWbH0pHY9BmwsAlVQyUomLEbHy0EDUlrz1GrdBkUAFBgQGb
+        o0o6MNdqQqhylx2Mpz3X9u/Lg/IqtsvLi0s87TCyecxt2eRT7nZ7XK67kysP/OJginNvlfccP6DZ
+        R4gqKO31jAgXZ/26bPPA3RTmi1N5BhOYuzVuSA6dJqcM7ZMb5AaMkF2AnLEEB0Ej2+w5srEMrJ11
+        BpNP4ASfilXXrGsKRaNSbG9Mbtd0K17X644MKedBG/RXoRk8BG9QS6+c3Gm0d4awUbQAB81HjI8e
+        PJii+5Lg/i9Ko4lEQgHRuD2UVYUaETSkYo0uokfRpHOIEJIoMZec5NtUVaPyMZhMxWFCA1FJq/Ff
+        R9m0XV3/tLwiux/erdd92vYnh92y+XZ90qEOOljyPmjlLKjbitVZYwR7wDCPWIXyPFJ9fzAXLOqp
+        VCHVEqozwAlQMWmXArhSjDfssqg1ckjAonYbPKOnlKqP3rIr30+qt8yU8pmH3FPZ2km/5rMptS90
+        3WHG9N569ArVHkxUFFxNIsNqEjplK0AipZ1jykmBDjVkdi54GecYORgbQsk6M4aI+h5lTG0JtYaZ
+        Uc6VNe2ITik7lWJ2JmVJg8kY49n7kmy24BXYkpJWHqwWh6Mi15woO1G0t6VCFOxzZs1rAqcJJoBB
+        onmYPePMZ0PLU1DX99w2bO6OpWGflc4ei5XUSEAOPYCNYkhtrBVtrWCKFxszchaEo8hy1uJx4xhL
+        S1E5zqG0LwbQCTxPlrSX9DAm/zngPef+XSuUZKeLlx8S/hTkf48aI+pv3HO3GfoYh8VNA6k3EmMc
+        BmtpD683FbUDNqFUVSw4lZlIYil41CzlWKwSgCkUDJoYkOTJgTUu5yieMN7cwDZXzvfdciNKHJmH
+        71/HL6c4J413ng8N7quUc7Q6GkOSTbTWSbyNrpUNURT3ygYxAqIOWKQKKd4pEGtTjEFjc02K7k0+
+        1ADaaocz5UMhNVMmHA/mQiA1zYSis1i0lmKrgpWCbIzEkl1scmSqBFHpswpJkl9xUp9olULyqkjp
+        Ye6bKUUcX8w5yB0/+XPKa9J458Jz3uwBpGQ8cCyKWVOolNXoahxJkUijGI04HJOj6DNqqjV7KSEj
+        p6KjjU4bdW+EJ0bUeXIwU9wUUrNZUOFgpVqaCo+jI6kMRGZBaj0xBeJmgghLQzJkpUYsSZA5D96L
+        7/QhBCCQoeJyvqPwPgP87dojnMmRHnP38Brxcf92wd3iYfd2vfoc6l0LMWi/b2QAvBQJ2SUp3xmU
+        EUPrIgSvMQTHPmeSqQWz5yTcvZc3vUiUjbqKw6nO3SMhkpKKkGYyqCPL+ZSojLH+OiWGhJWSQu+T
+        tQmM8KoZbCIXpfjwKhU3/kWpEwRTpBRRninZQvrm1uV6Jb45aFY8xObovNkMsR9kZ7KywN39GNZD
+        XD7jzXY5bMbTHDTrWjc8fFyuXbUfL2rLy7LZTYz9yVbUMM46v7iQx74e2tpmIbvupO31m4t/AfMv
+        tzJKGQAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1374'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:29 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAN1by27bOBT9FUGrGcAFRIl6ZTdpO9NgimmQdrppCoGWr206smSQlFMkyL/PpSw/
+        ZDuRmkoLziaJbPJIOrw898U82ktQzL54tKViQtkXtj2yIZ9s/lCFYtkNyDJT0r7w4pFdTKcScFhe
+        ZtnIzviS7y6mHLKJ3ExkYlYuIdezHp+eRrYEseYpfOQSh397tCelYIoXuX1BnJG9KscZT9/nbJwB
+        3lmJEhBiMuF6CMvellIVSxDvGpNSAUzp4YSGfhDGseNQ6uPn1Wh8jMdbW4BM5zApM6jBb2v0Wztl
+        eQrZycewZDyTeH1r39p4PefyarK/zAsF8k/9ovuZU5ZJPZXn0+IL/FD70fVb5ww5FiyXWfX4Gv3b
+        9ydkSX+BD/pHOlcgcsaW1gzGouR3kGsOU8XXsKWjXE3q1/U9Sp2YBCTywi13V3rBrv75kuyxkj3W
+        06hvxmlEaRyGbuSZzvgdzyf4Ax7aOfdCEkWu1+D8gG+NlNRITcb9VxB+nu/Ac0zk+xI1JoMczXsJ
+        qAowhoxJxfNZR0N33AbpNVxyDq5n5n0vjGkYUkLcwGTm10UhcNhMrkHcZUwgWS8yH+n39kkURycS
+        s2X/HOSvs+832dfbLvBDEhtq9/d8Ia01yy2eWxmscSUe+KKD0jgk8OiR0WusBLESnicVVlJhNTn3
+        XqPuRyZPXc/DlY+c0EjS+eKhyCcgwBojY4qhwKdzUeQcnx7pB3SJViVGc/yKp2ylWmQoRCoCGsUk
+        PtkM03Fyefmmgk809LGv7UGA0B6oE0Xoe4xcjZIjvRkyLS3BF+PNjiiW91xKyNr1nxLXQQ/Q3Ap7
+        zGSHmRxgNhfBfc2WcM874Ng3U4j2jIE1KdIqOAetSlpIBP5VTC02nbMOK7IJPb2TrTDGeySILQdU
+        JDc2kf23xXJVYpg4spTGVFbFvI4bcRrMIGvzxlsB8s4KUFrDI1TfDnhn905opC94V5u6dYcSobSR
+        zwDfoaOVh1EzwdqiJRVaUkyTHVoPsk/OMx8RI3X/vUA3m6Oh67Sok6QcedctQJVXDWbXfmSkXf/F
+        8EslFWRaO7RdZ8WMgw7FJUrK3V2bolD0qy6+ftAMMpu42sLP4A5o66Fr5GrAGHMhBQyzIT5V0Mnc
+        3SPmjzH6ZzmMgjgmXhRQYibLB/H6iqE8YN7JmFAWcrYWbLaJYtBUUZA7VBZoEEQOOV6FZ+6R7O6h
+        N8X+Hn3rErocx8GfNDYy0nlhjboFlzTwSeCGXRelBh2wwOl4/5d1WGWMKdnNFbcvQI3WQ6jvnY/1
+        Q99IlfqAwzAo5FqN1izHnMga75KvNvIDP6S+E5wE+fMtaJVkDRYMUTNDzQ8llxU9m1rkrMzz9vAH
+        lcYLAr/J9TNIQ/Edau9jHt9XE8yB0KS5kpUMtzCNcaYfuYHftOpjjOGCysAxMqj8iCKbVT0NtMR1
+        AaLdoB2PRE6D5lOQwRIpaqQtf4QZy7isSmDaySldHe6gHlV5IKZHZO+wkgZWD+XI89FJ6BqZvX4q
+        OKxx18sVa41HaERcQpr9v8b84ciNjOz4fdLJCV+gvsqu+SiNMODymjX2czDDhdkY9JnI9fUmFi5y
+        NYfptINsRD4hkXfaU73++1Mf7D4TZvhDH9KAHykK3gze62GDcy5XulLyEtUhCWgUesRxmu5wN7dv
+        rn0SUc/BvIWY2TPdElOdE7DWWamPtbS2JbbpIg3PslydEEgOwXpvjm5pd0IjtfqIdgGwnPwE7d5L
+        tB+ADdePMzOBual7btZS1zBQulYrvF7cgbXCVISnfIXz4B5ezmx2TbnTVuh0nCz5IjlEGy6JNNN1
+        3mz79t0OgDV7Q/vJg5l2GBtZC/mczosiezOyUAuEeqM7zWmZqbIUd4XseM4lOspraouWFXQNM5Q1
+        u56R1vylAKRludSiwnN8YsEX6w46HhJCSXhKt9rgJQ2s4TKd8JcPtfwEq4e0aUpnoA9rvcAUDX00
+        SrSNqhh/ePjWcTzS/4nP3WETI03xX650p1ZCZl0yyaWAGZdKvypY1yBkkbeogO+gUaJNkNPT5Zc3
+        1/0ngXvJNfOE2wHh41LMqrQZQ4nNwcNd27C19B9oN0dOKf/ch4977jSbmWr7FcS85A+v6LC4vk+C
+        2D9NwHeQyQYyOYAcruxBAiO7izVZ2tnp2pA+itytXnpq3usd1IA0429jaS6FdV/oKrL1m9LlOC0u
+        v7eGFYHnBmeiOI2wobwUyQa2D9qfMW5i5P8Gfd39N4NVLFHYc2XNYIIa3qrgBOOUo0P7e7CkBktq
+        sCHcKHVQ3khsZhcXqdJu1MoZEz/RMq/SQz8+Zl1DJRqqIeTfR/rZ+ZSnm2eoHuE/9C2ScgM5AAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1766'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:30 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/services/groups;servicePublicId=INT_Achternaam_gebruiken
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOWYX2/TMBTFv4rl5z7Aw176RtmACQTVKLy0k+XEN6kbx578J5s27btznbVNXMo0
+        JEBsfqps/1LFR+ceX2d5Rx3YTpbg6HR5R69CoWR5LuiUnn9esDfl2oPVnLeshsIG2YCmE6p5C0gM
+        q2S8KoLlXhpNp69fTSgXQsYRV2+D86YFe5qsl/0s/tvdilpw5RpEUHCmeaFArOjU2wCTFS25LkH9
+        NA0tl8rheEVXFMdr6c7FMNTGg3snQYnhyYorFx+VujILuPEDvVUi7s5brp3qXzP++/Lynt5PUnkE
+        aC89SO8azq0fZDmyMkhy8rgiJ89YEPTL7OsgwzfpvYXGgSJFsDVYJTcNEOe5FoRz3VleZ+SXU1OG
+        Fo3Bmmu58cxUWFG4EzUuqB1DeoaYioyYHDx0ITcF4N7doMl4KgcJ5txdGTPOk9HM00vlbysAN+Wa
+        6xrOIvZPhPkOtlHcSl0z02KyYCnVIDBEBqUGhGwRskeeLt0zDpk+gy/mR0N4xp10FmrpfNwpkDlY
+        Z/TvZcsz16YDuw7yFg2SmGY7F0+lGrqMDqVZn6ys45pJzVTcO7uVm9GR9EAQJIjUpCfIlsghjWcB
+        GzmtsGVxzO5OIsyfa+mwpsZn94gke5Ik5MhTL7fMsJxi4jC8FlhW7EVJ6i0CJAIkAfKouZhD3mBf
+        By0WHb43uqVLEmnxsNrGSDogcqi5KND845dxA2QbAGu0X0NVHQrxkr3yIUjXoRlwz/hr66B14pRf
+        rufikxl4juHKOmyQ8YFehW0LOD7Deogch3LofT5BzZXER1AqbNuFhwZSJ40IckDk4KX3HBGPqatU
+        f8GomDK1hOgUF0+rJhErpeM9/Sidg3C7y2lfgayzAK0Alai1Q/r6IymSRUu0C6kaWsA7KRSgeJ/Z
+        Sf+4DanjUA4hdWAlFeLn5UetlCD/z7eRP6rR5f3lD3WWOsGlFwAA
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '723'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:30 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v1/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1SyY4TMRD9lcjnTPDaS04MEQfEICFAQhrEobptJ5a8RF4QKMq/U60sw1y4lFxV
+        79XiVycSTAWyPZFSIVeyJWRNTNSXR00V/BdTmq+FbNmaJGuLQVRs3q+Jd8HdHeuM1+XCg7xvwcSF
+        dDqf12TKEOfD0gW0zqaUXWqx5j837jX67I7I57yTq3efsMycDVSDszAplWT9QIXiA/aF6mrThmwV
+        39BBcYFZ3ote8A5ZrdQUbqWrC+Y5RcSS9y2no3nzGEo1WUMg98ZfK/a5MY6HC5zJFe0pgiKExf+4
+        270wnlw0bAmmuFl9d/5gfHARPEBc8dcwfv8htN/+O0476uvCSkjJqBo5Vz2O1Cbv5g+LKpaNFjgV
+        dNKdElrycZa87zmn4wQdnfU8oVWWWWADjGqWuucTVxQYRtVAbmp8zsa637fZTADnsbyLNr31xuky
+        H/AMIDz8SilPLe830b/stXMVxSNP/wAx6VPcX4WRGzGKsZPDMArWd5ThFcRUnXUzipciXsaPn+e/
+        AtGsAX4CAAA=
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:30 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: http://localhost:8080/qmatic/calendar-backend/public/api/v2/branches/f19fa2030bd653d429c42772209ba60cdcb60c5f1fa18a95c4d72b250a1c5f58/dates/2023-09-08/times;servicePublicId=INT_Achternaam_gebruiken;servicePublicId=Betalen_gemeentebelastingen;numberOfCustomers=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAD3TsW7CMBSF4VepPGdI7rXVNlvbiaWtqm4oQk64oVZtR4qdLoh3r0MOTOYHn48M
+        cFbZBUmq3av6qeVaVdfTbKe+9nPb3E6znYQmNKMZfdvptZt6268nmtCEZjSjNfq2N2hz7aata5zo
+        Bt2gCU1oRjNaozXaoDef4BN8gk/wCT7BJ/gEn+ATfIJP8Bk+w2f4DJ/hM3yGz/AZPsNn+Axfw9fw
+        NXwNX8PX8DV8Dd9gb7A32BvsDfYGe4O9ue81ujxfV6kg2ar2rFK2c1atKp9JPG4v8pSt/5K0+Fx+
+        hI+mUtM4JinX4uJ9pbwL7h6jE39M29DOpyVIXFdnFZfQy/wxvi0pT0Hm9c6+6cq1JPOfG+Rz6b0b
+        duuX7nfv34eX4SfLHK0Nh5P08+J+JVYPr+VBvcTyVpBCSy/epuziSWKnLpdKxSm70Q02uymu/5nu
+        8g8NUH/gQAMAAA==
+    headers:
+      Access-Control-Expose-Headers:
+      - error_code, error_message
+      Cache-Control:
+      - no-store, no-cache, max-age=0, must-revalidate
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '352'
+      Content-Security-Policy:
+      - 'default-src *; style-src * ''unsafe-inline''; script-src * ''unsafe-inline''
+        ''unsafe-eval''; img-src * data: ''unsafe-inline''; connect-src * ''unsafe-inline'';
+        frame-src *;'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Sep 2023 12:52:30 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Layer7-API-Gateway
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
@@ -183,12 +183,37 @@ class TimesListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @requests_mock.Mocker()
     def test_get_times_returns_all_times_for_a_give_location_product_and_date(self, m):
         m.get(
-            f"{self.api_root}v1/branches/1/services/1/dates/2016-12-06/times",
+            f"{self.api_root}v1/branches/1",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "1",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
+        m.get(
+            f"{self.api_root}v2/branches/1/dates/2016-12-06/times;servicePublicId=1",
             text=mock_response("times.json"),
         )
 
         response = self.client.get(
-            f"{self.endpoint}?product_id=1&location_id=1&date=2016-12-06"
+            self.endpoint, {"product_id": "1", "location_id": "1", "date": "2016-12-06"}
         )
 
         self.assertEqual(response.status_code, 200)

--- a/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
@@ -113,7 +113,32 @@ class DatesListTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     @requests_mock.Mocker()
     def test_get_dates_returns_all_dates_for_a_give_location_and_product(self, m):
         m.get(
-            f"{self.api_root}v1/branches/1/services/1/dates",
+            f"{self.api_root}v1/branches/1",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "f364d92b7fa07a48c4ecc862de30c47",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
+        m.get(
+            f"{self.api_root}v2/branches/1/dates;servicePublicId=1",
             text=mock_response("dates.json"),
         )
 

--- a/src/openforms/appointments/contrib/qmatic/tests/test_appointment_create.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_appointment_create.py
@@ -1,0 +1,113 @@
+"""
+VCR tests for creating an appointment with Qmatic.
+"""
+import json
+from datetime import date
+
+from django.test import TestCase
+
+from openforms.utils.tests.vcr import OFVCRMixin
+
+from ..constants import CustomerFields
+from ..plugin import QmaticAppointment, _CustomerDetails
+from .utils import TEST_FILES, MockConfigMixin
+
+QMATIC_BASE_URL = "http://localhost:8080/qmatic/calendar-backend/public/api/"
+
+# The test date below should return actual results when querying for times. So if you
+# need to re-generate the cassettes, pick a week day in the future!
+TEST_DATE = date(2023, 9, 8)
+
+plugin = QmaticAppointment("qmatic")
+
+
+class CreateAppointmentTests(OFVCRMixin, MockConfigMixin, TestCase):
+    VCR_TEST_FILES = TEST_FILES
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # update the dummy service to point to the real service API root
+        cls.service.api_root = QMATIC_BASE_URL
+        cls.service.save()
+
+    def setUp(self):
+        super().setUp()
+
+        locations = plugin.get_locations()
+        self.location = next(
+            location for location in locations if location.name == "KCC"
+        )
+
+    def test_create_appointment_single_product_single_customer(self):
+        customer = _CustomerDetails(
+            details={
+                CustomerFields.email: "automated-test@example.com",
+                CustomerFields.last_name: "TEST (automated)",
+            }
+        )
+        product = plugin.get_available_products(location_id=self.location.identifier)[0]
+        assert product.amount == 1
+        times = plugin.get_times(
+            products=[product], location=self.location, day=TEST_DATE
+        )
+
+        appointment_id = plugin.create_appointment(
+            products=[product],
+            location=self.location,
+            start_at=times[0],
+            client=customer,
+            remarks="AUTOMATED TEST APPOINTMENT - can safely be removed.",
+        )
+
+        self.assertTrue(bool(appointment_id))
+
+        # and cancel it again to clean up after ourselves
+        plugin.delete_appointment(appointment_id)
+
+    def test_create_appointment_multi_product_multi_customer(self):
+        customer = _CustomerDetails(
+            details={
+                CustomerFields.email: "automated-test@example.com",
+                CustomerFields.last_name: "TEST (automated)",
+            }
+        )
+        product1 = plugin.get_available_products(location_id=self.location.identifier)[
+            0
+        ]
+        products2 = plugin.get_available_products(
+            location_id=self.location.identifier, current_products=[product1]
+        )
+        product2 = next(
+            product
+            for product in products2
+            if product.identifier != product1.identifier
+        )
+        assert product1.amount == 1
+        assert product2.amount == 1
+        product1.amount = 2
+        products = [product1, product2]
+
+        times = plugin.get_times(
+            products=products, location=self.location, day=TEST_DATE
+        )
+
+        appointment_id = plugin.create_appointment(
+            products=products,
+            location=self.location,
+            start_at=times[0],
+            client=customer,
+            remarks="AUTOMATED TEST APPOINTMENT - can safely be removed.",
+        )
+
+        self.assertTrue(bool(appointment_id))
+
+        # and cancel it again to clean up after ourselves
+        plugin.delete_appointment(appointment_id)
+
+        create_request = self.cassette.requests[-2]
+        self.assertEqual(create_request.method, "POST")
+        request_data = json.loads(create_request.body.decode("utf-8"))
+        self.assertEqual(len(request_data["customers"]), 2)
+        self.assertEqual(len(request_data["services"]), 2)

--- a/src/openforms/appointments/contrib/qmatic/tests/test_dates_list.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_dates_list.py
@@ -1,0 +1,82 @@
+"""
+Tests for retrieving available appointment dates from Qmatic through our own API.
+"""
+from datetime import date
+
+from django.test import TestCase
+
+from openforms.utils.tests.vcr import OFVCRMixin
+
+from ..plugin import QmaticAppointment
+from .utils import TEST_FILES, MockConfigMixin
+
+QMATIC_BASE_URL = "http://localhost:8080/qmatic/calendar-backend/public/api/"
+
+plugin = QmaticAppointment("qmatic")
+
+
+class ListAvailableDatesTests(OFVCRMixin, MockConfigMixin, TestCase):
+    VCR_TEST_FILES = TEST_FILES
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # update the dummy service to point to the real service API root
+        cls.service.api_root = QMATIC_BASE_URL
+        cls.service.save()
+
+    def setUp(self):
+        super().setUp()
+
+        locations = plugin.get_locations()
+        self.location = next(
+            location for location in locations if location.name == "KCC"
+        )
+
+    def test_listing_dates_single_product_single_customer(self):
+        product = plugin.get_available_products(location_id=self.location.identifier)[0]
+        assert product.amount == 1
+
+        dates = plugin.get_dates(products=[product], location=self.location)
+
+        self.assertGreater(len(dates), 0)
+        self.assertIsInstance(dates[0], date)
+
+    def test_listing_dates_single_product_multiple_customers(self):
+        product = plugin.get_available_products(location_id=self.location.identifier)[0]
+        product.amount = 999  # amount that should not return any dates
+
+        with self.subTest("product.amount set"):
+            dates = plugin.get_dates(products=[product], location=self.location)
+
+            self.assertEqual(len(dates), 0)
+
+        with self.subTest("product repeated"):
+            product.amount = 1
+            dates = plugin.get_dates(products=[product] * 999, location=self.location)
+
+            self.assertEqual(len(dates), 0)
+
+    def test_multiple_products_multiple_customers(self):
+        products = plugin.get_available_products(location_id=self.location.identifier)
+        product1 = products[0]
+        products2 = plugin.get_available_products(
+            location_id=self.location.identifier, current_products=[product1]
+        )
+        product2 = next(
+            product
+            for product in products2
+            if product.identifier != product1.identifier
+        )
+        assert product1.amount == 1
+        assert product2.amount == 1
+        product1.amount = 2
+
+        dates = plugin.get_dates(products=[product1, product2], location=self.location)
+
+        self.assertGreater(len(dates), 0)
+        self.assertIsInstance(dates[0], date)
+
+        get_dates_request = self.cassette.requests[-1]
+        self.assertIn(";numberOfCustomers=1", get_dates_request.uri)

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -4,6 +4,7 @@ from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+import pytz
 import requests_mock
 from hypothesis import given, strategies as st
 
@@ -148,14 +149,45 @@ class PluginTests(MockConfigMixin, TestCase):
         day = date(2016, 12, 6)
 
         m.get(
-            f"{self.api_root}v1/branches/{location.identifier}/services/{product.identifier}/dates/{day.strftime('%Y-%m-%d')}/times",
+            f"{self.api_root}v1/branches/f364d92b7fa07a48c4ecc862de30c47",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "f364d92b7fa07a48c4ecc862de30c47",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
+        m.get(
+            f"{self.api_root}v2/branches/f364d92b7fa07a48c4ecc862de30c47/dates/"
+            "2016-12-06/times;servicePublicId=54b3482204c11bedc8b0a7acbffa308",
             text=mock_response("times.json"),
         )
 
         times = self.plugin.get_times([product], location, day)
 
         self.assertEqual(len(times), 16)
-        self.assertEqual(times[0], datetime(2016, 12, 6, 9, 0, 0))
+        self.assertEqual(
+            times[0],
+            datetime(2016, 12, 6, 9, 0, 0).astimezone(
+                pytz.timezone("Europe/Amsterdam")
+            ),
+        )
 
     def test_get_required_customer_fields(self):
         self.qmatic_config.required_customer_fields = [

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -100,7 +100,32 @@ class PluginTests(MockConfigMixin, TestCase):
         day = date(2016, 12, 6)
 
         m.get(
-            f"{self.api_root}v1/branches/{location.identifier}/services/{product.identifier}/dates",
+            f"{self.api_root}v1/branches/f364d92b7fa07a48c4ecc862de30c47",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "f364d92b7fa07a48c4ecc862de30c47",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
+        m.get(
+            f"{self.api_root}v2/branches/f364d92b7fa07a48c4ecc862de30c47/dates;servicePublicId=54b3482204c11bedc8b0a7acbffa308",
             text=mock_response("dates.json"),
         )
 

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -244,8 +244,34 @@ class PluginTests(MockConfigMixin, TestCase):
         client = Customer(last_name="Doe", birthdate=date(1980, 1, 1))
         day = datetime(2016, 12, 6, 9, 0, 0)
 
+        m.get(
+            f"{self.api_root}v1/branches/f364d92b7fa07a48c4ecc862de30c47",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "f364d92b7fa07a48c4ecc862de30c47",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
         m.post(
-            f"{self.api_root}v1/branches/{location.identifier}/services/{product.identifier}/dates/{day.strftime('%Y-%m-%d')}/times/{day.strftime('%H:%M')}/book",
+            f"{self.api_root}v2/branches/f364d92b7fa07a48c4ecc862de30c47/"
+            "dates/2016-12-06/times/09:00/book",
             text=mock_response("book.json"),
         )
 
@@ -271,9 +297,34 @@ class PluginTests(MockConfigMixin, TestCase):
             product_id="54b3482204c11bedc8b0a7acbffa308",
         )
         assert appointment.products.count() == 1
+        m.get(
+            f"{self.api_root}v1/branches/f364d92b7fa07a48c4ecc862de30c47",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "f364d92b7fa07a48c4ecc862de30c47",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
         m.post(
-            f"{self.api_root}v1/branches/f364d92b7fa07a48c4ecc862de30c47/services/"
-            f"54b3482204c11bedc8b0a7acbffa308/dates/2023-08-21/times/16:15/book",
+            f"{self.api_root}v2/branches/f364d92b7fa07a48c4ecc862de30c47/"
+            "dates/2023-08-21/times/16:15/book",
             text=mock_response("book.json"),
         )
 
@@ -465,29 +516,38 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             )
 
     @requests_mock.Mocker()
-    def test_create_appointment_multiple_products(self, m):
-        product1 = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
-        product2 = Product(identifier="2", code="PASAF", name="Nope")
-        location = Location(identifier="1", name="Maykin Media")
-        client = Customer(last_name="Doe", birthdate=date(1980, 1, 1))
-        start_at = timezone.make_aware(datetime(2021, 8, 23, 6, 0, 0))
-
-        result = self.plugin.create_appointment(
-            [product1, product2], location, start_at, client
-        )
-
-        self.assertIsNone(result)
-        self.assertEqual(len(m.request_history), 0)
-
-    @requests_mock.Mocker()
     def test_create_appointment_failure(self, m):
         product = Product(identifier="1", code="PASAAN", name="Paspoort aanvraag")
         location = Location(identifier="1", name="Maykin Media")
         client = Customer(last_name="Doe", birthdate=date(1980, 1, 1))
         start_at = timezone.make_aware(datetime(2021, 8, 23, 6, 0, 0))
+        m.get(
+            f"{self.api_root}v1/branches/1",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "1",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
         m.post(
-            f"{self.api_root}v1/branches/{location.identifier}/services/{product.identifier}/"
-            f"dates/{start_at.strftime('%Y-%m-%d')}/times/{start_at.strftime('%H:%M')}/book",
+            f"{self.api_root}v2/branches/1/dates/2021-08-23/times/06:00/book",
             headers={
                 "ERROR_CODE": "440",
                 "ERROR_MESSAGE": "No resource is available for the selected date and time",
@@ -508,6 +568,31 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         location = Location(identifier="1", name="Maykin Media")
         client = Customer(last_name="Doe", birthdate=date(1980, 1, 1))
         start_at = datetime(2021, 8, 23, 6, 0, 0).replace(tzinfo=timezone.utc)
+        m.get(
+            f"{self.api_root}v1/branches/1",
+            json={
+                "branch": {
+                    "addressState": "Zuid Holland",
+                    "phone": "071-4023344",
+                    "addressCity": "Katwijk",
+                    "fullTimeZone": "Europe/Amsterdam",
+                    "timeZone": "Europe/Amsterdam",
+                    "addressLine2": "Lageweg 35",
+                    "addressLine1": None,
+                    "updated": 1475589234069,
+                    "created": 1475589234008,
+                    "email": None,
+                    "name": "Branch 1",
+                    "publicId": "1",
+                    "longitude": 4.436127618214371,
+                    "branchPrefix": None,
+                    "latitude": 52.202012993593705,
+                    "addressCountry": "Netherlands",
+                    "custom": None,
+                    "addressZip": "2222 AG",
+                }
+            },
+        )
         m.post(requests_mock.ANY, exc=IOError("tubes are closed"))
 
         with self.assertRaisesMessage(

--- a/src/openforms/appointments/contrib/qmatic/tests/test_products_list.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_products_list.py
@@ -1,20 +1,15 @@
 """
 Tests for retrieving available products from Qmatic through our own API.
 """
-from pathlib import Path
-
 from django.test import TestCase
 
 from openforms.utils.tests.vcr import OFVCRMixin
 
 from ....base import Product
 from ..plugin import QmaticAppointment
-from .utils import MockConfigMixin
-
-TEST_FILES = Path(__file__).parent.resolve() / "data"
+from .utils import TEST_FILES, MockConfigMixin
 
 QMATIC_BASE_URL = "http://localhost:8080/qmatic/calendar-backend/public/api/"
-
 
 plugin = QmaticAppointment("qmatic")
 

--- a/src/openforms/appointments/contrib/qmatic/tests/test_times_list.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_times_list.py
@@ -1,0 +1,94 @@
+"""
+Tests for retrieving available appointment times from Qmatic through our own API.
+"""
+from datetime import date
+
+from django.test import TestCase
+
+from openforms.utils.tests.vcr import OFVCRMixin
+
+from ..plugin import QmaticAppointment
+from .utils import TEST_FILES, MockConfigMixin
+
+QMATIC_BASE_URL = "http://localhost:8080/qmatic/calendar-backend/public/api/"
+
+# The test date below should return actual results when querying for times. So if you
+# need to re-generate the cassettes, pick a week day in the future!
+TEST_DATE = date(2023, 9, 8)
+
+plugin = QmaticAppointment("qmatic")
+
+
+class ListAvailableTimesTests(OFVCRMixin, MockConfigMixin, TestCase):
+    VCR_TEST_FILES = TEST_FILES
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # update the dummy service to point to the real service API root
+        cls.service.api_root = QMATIC_BASE_URL
+        cls.service.save()
+
+    def setUp(self):
+        super().setUp()
+
+        locations = plugin.get_locations()
+        self.location = next(
+            location for location in locations if location.name == "KCC"
+        )
+
+    def test_listing_times_single_product_single_customer(self):
+        product = plugin.get_available_products(location_id=self.location.identifier)[0]
+        assert product.amount == 1
+
+        times = plugin.get_times(
+            products=[product], location=self.location, day=TEST_DATE
+        )
+
+        self.assertGreater(len(times), 0)
+        self.assertIsInstance(times[0], date)
+
+    def test_listing_times_single_product_multiple_customers(self):
+        product = plugin.get_available_products(location_id=self.location.identifier)[0]
+        product.amount = 999  # amount that should not return any times
+
+        with self.subTest("product.amount set"):
+            times = plugin.get_times(
+                products=[product], location=self.location, day=TEST_DATE
+            )
+
+            self.assertEqual(len(times), 0)
+
+        with self.subTest("product repeated"):
+            product.amount = 1
+            times = plugin.get_times(
+                products=[product] * 999, location=self.location, day=TEST_DATE
+            )
+
+            self.assertEqual(len(times), 0)
+
+    def test_multiple_products_multiple_customers(self):
+        products = plugin.get_available_products(location_id=self.location.identifier)
+        product1 = products[0]
+        products2 = plugin.get_available_products(
+            location_id=self.location.identifier, current_products=[product1]
+        )
+        product2 = next(
+            product
+            for product in products2
+            if product.identifier != product1.identifier
+        )
+        assert product1.amount == 1
+        assert product2.amount == 1
+        product1.amount = 2
+
+        times = plugin.get_times(
+            products=[product1, product2], location=self.location, day=TEST_DATE
+        )
+
+        self.assertGreater(len(times), 0)
+        self.assertIsInstance(times[0], date)
+
+        get_times_request = self.cassette.requests[-1]
+        self.assertIn(";numberOfCustomers=1", get_times_request.uri)

--- a/src/openforms/appointments/contrib/qmatic/tests/utils.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/utils.py
@@ -9,7 +9,9 @@ from ....models import AppointmentsConfig
 from ..models import QmaticConfig
 from .factories import ServiceFactory
 
-MOCK_DIR = Path(__file__).parent.resolve() / "mock"
+TESTS_DIR = Path(__file__).parent.resolve()
+TEST_FILES = TESTS_DIR / "data"
+MOCK_DIR = TESTS_DIR / "mock"
 
 
 def mock_response(filename: str):

--- a/src/openforms/appointments/management/commands/appointment.py
+++ b/src/openforms/appointments/management/commands/appointment.py
@@ -1,3 +1,4 @@
+import traceback
 from datetime import date
 
 from django.core.management import BaseCommand
@@ -213,6 +214,7 @@ class Command(BaseCommand):
                 self.stdout.write(f"Booked appointment id: {appointment_id}")
                 break
             except Exception as exc:
+                traceback.print_exception(exc)
                 self.stderr.write(f"Failed to create appointment: {exc}")
 
     def exit(self):

--- a/src/openforms/appointments/management/commands/appointment.py
+++ b/src/openforms/appointments/management/commands/appointment.py
@@ -2,8 +2,12 @@ from datetime import date
 
 from django.core.management import BaseCommand
 from django.core.management.base import CommandError
+from django.db.models import Q
+
+from openforms.submissions.models import Submission
 
 from ...base import Customer
+from ...core import book_for_submission
 from ...registry import register
 from ...utils import get_plugin
 
@@ -37,6 +41,7 @@ class Command(BaseCommand):
             ("Create booking", "create_booking"),
             ("Get booking details", "show_booking"),
             ("Cancel booking", "cancel_booking"),
+            ("Book for submission", "book_for_submission"),
             ("Quit", "exit"),
         ]
         selected_action = self._show_options(
@@ -58,7 +63,7 @@ class Command(BaseCommand):
         if allow_multi:
             msg = f"Choose one or more {obj_name}s (comma separated): "
         else:
-            msg = f"Choose a {obj_name}: "
+            msg = f"Choose a(n) {obj_name}: "
 
         while True:
             selected_option = input(msg)
@@ -182,6 +187,33 @@ class Command(BaseCommand):
                 self.stdout.write("Appointment was not cancelled.")
             else:
                 self.stderr.write(f"{do_cancel} is not a valid choice.")
+
+    def book_for_submission(self):
+        submission_id = None
+        while not submission_id:
+            submission_id = input("Submission ID or reference: ")
+
+        submission = Submission.objects.get(
+            Q(id=submission_id) | Q(public_registration_reference=submission_id)
+        )
+
+        while True:
+            do_book = input("Do you want to book this appointment [y/n]: ")
+            if do_book == "n":
+                self.stdout.write("Appointment was not booked.")
+                return
+
+            if do_book != "y":
+                self.stderr.write(f"{do_book} is not a valid choice.")
+                continue
+
+            assert do_book == "y"
+            try:
+                appointment_id = book_for_submission(submission)
+                self.stdout.write(f"Booked appointment id: {appointment_id}")
+                break
+            except Exception as exc:
+                self.stderr.write(f"Failed to create appointment: {exc}")
 
     def exit(self):
         pass


### PR DESCRIPTION
Closes #3456

Customer details are duplicated for the product with the largest amount. Qmatic considers customers independently from their services (where JCC simply duplicates the product ID for every occurrence).

This means that 2 different products, one with amount 1 and the other amount 3 makes 3 customers in total, and the 3 customers is also applied to product 1. This can lead to some undesired wasted time, for which I will create a Taiga issue with the stakeholder.