### PR TITLE
Catch errors in the admin for fields making outgoing requests

### DIFF
--- a/docs/developers/backend/core/utils.rst
+++ b/docs/developers/backend/core/utils.rst
@@ -45,6 +45,13 @@ Decorators
    :members:
 
 
+Admin decorators
+----------------
+
+.. automodule:: openforms.admin.decorators
+   :members:
+
+
 URL handling and manipulation
 -----------------------------
 

--- a/src/openforms/admin/decorators.py
+++ b/src/openforms/admin/decorators.py
@@ -1,0 +1,70 @@
+from functools import wraps
+
+from django.contrib import admin
+from django.db import models
+from django.utils.html import format_html
+from django.utils.translation import gettext_lazy as _
+
+import requests
+
+
+def suppress_requests_errors(model: type[models.Model], fields: list[str]):
+    """
+    Add robustness to admin fields which make outgoing requests that may fail.
+
+    If a :class:`requests.RequestException` is caught, return the base (non-enhanced)
+    form field that Django would generate by default and append an error message
+    for the end-user.
+
+    :arg fields: A list of model field names for which to suppress errors.
+    """
+
+    def fallback(self, db_field, request, *args, **kwargs):
+        kwargs = {**self.formfield_overrides[db_field.__class__], **kwargs}
+
+        class CustomWidget(kwargs["widget"]):
+            def render(self, *args, **kwargs):
+                output = super().render(*args, **kwargs)
+
+                error_message = _(
+                    "Could not load data - enable and check the request logs for more details."
+                )
+
+                html = format_html(
+                    """
+                    <div class="openforms-error-widget">
+                        <div class="openforms-error-widget__column">
+                            {}
+                            <small class="openforms-error-widget openforms-error-widget--error-text">{}</small>
+                        </div>
+                    </div>""",
+                    output,
+                    error_message,
+                )
+
+                return html
+
+        kwargs["widget"] = CustomWidget
+        return db_field.formfield(**kwargs)
+
+    def _decorator(admin_class: type[admin.ModelAdmin]):
+        original_func = admin_class.formfield_for_dbfield
+        for field in fields:
+            assert model._meta.get_field(field)
+
+        @wraps(original_func)
+        def _wrapped(self, db_field, request, *args, **kwargs):
+            field_name = db_field.name
+
+            try:
+                return original_func(self, db_field, request, *args, **kwargs)
+            except requests.RequestException as exc:
+                if field_name not in fields:
+                    raise exc
+                return fallback(self, db_field, request, *args, **kwargs)
+
+        admin_class.formfield_for_dbfield = _wrapped
+
+        return admin_class
+
+    return _decorator

--- a/src/openforms/appointments/admin.py
+++ b/src/openforms/appointments/admin.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 
 from solo.admin import SingletonModelAdmin
 
-from openforms.utils.decorators import suppress_requests_errors
+from openforms.admin.decorators import suppress_requests_errors
 
 from .base import BasePlugin
 from .constants import AppointmentDetailsStatus

--- a/src/openforms/appointments/admin.py
+++ b/src/openforms/appointments/admin.py
@@ -9,11 +9,10 @@ from django.utils.translation import gettext, gettext_lazy as _
 
 from solo.admin import SingletonModelAdmin
 
-from openforms.utils.decorators import supress_requests_errors
+from openforms.utils.decorators import suppress_requests_errors
 
 from .base import BasePlugin
 from .constants import AppointmentDetailsStatus
-from .contrib.qmatic.exceptions import QmaticException
 from .fields import AppointmentBackendChoiceField
 from .models import Appointment, AppointmentInfo, AppointmentProduct, AppointmentsConfig
 from .registry import register
@@ -29,7 +28,7 @@ class PluginFieldMixin:
         return super().formfield_for_dbfield(db_field, request, **kwargs)  # type: ignore
 
 
-@supress_requests_errors(fields=["locatie"])
+@suppress_requests_errors(AppointmentsConfig, fields=["limit_to_location"])
 @admin.register(AppointmentsConfig)
 class AppointmentsConfigAdmin(PluginFieldMixin, SingletonModelAdmin):
     def formfield_for_dbfield(self, db_field, request, **kwargs):

--- a/src/openforms/appointments/admin.py
+++ b/src/openforms/appointments/admin.py
@@ -4,14 +4,12 @@ from typing import Literal
 from django.contrib import admin
 from django.contrib.admin.widgets import AdminTextInputWidget
 from django.utils import timezone
-from django.utils.decorators import method_decorator
 from django.utils.html import format_html_join
 from django.utils.translation import gettext, gettext_lazy as _
 
-from requests.exceptions import RequestException
 from solo.admin import SingletonModelAdmin
 
-from openforms.utils.decorators import dbfields_exception_handler
+from openforms.utils.decorators import supress_requests_errors
 
 from .base import BasePlugin
 from .constants import AppointmentDetailsStatus
@@ -31,15 +29,7 @@ class PluginFieldMixin:
         return super().formfield_for_dbfield(db_field, request, **kwargs)  # type: ignore
 
 
-@method_decorator(
-    dbfields_exception_handler(
-        exceptions=(
-            QmaticException,
-            RequestException,
-        )
-    ),
-    name="formfield_for_dbfield",
-)
+@supress_requests_errors(fields=["locatie"])
 @admin.register(AppointmentsConfig)
 class AppointmentsConfigAdmin(PluginFieldMixin, SingletonModelAdmin):
     def formfield_for_dbfield(self, db_field, request, **kwargs):

--- a/src/openforms/appointments/contrib/jcc/tests/test_admin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_admin.py
@@ -1,0 +1,117 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+import requests
+import requests_mock
+from django_webtest import WebTest
+
+from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.appointments.contrib.jcc.models import JccConfig
+from openforms.appointments.models import AppointmentsConfig
+from openforms.utils.tests.cache import clear_caches
+from openforms.utils.tests.logging import disable_logging
+from soap.tests.factories import SoapServiceFactory
+
+from .utils import WSDL
+
+
+@disable_logging()
+class ApointmentConfigAdminTests(WebTest):
+    def setUp(self):
+        super().setUp()
+
+        self.addCleanup(clear_caches)
+
+    @requests_mock.Mocker()
+    def test_admin_while_service_is_down(self, m):
+        m.register_uri(
+            requests_mock.ANY, requests_mock.ANY, exc=requests.RequestException
+        )
+
+        appointments_config = AppointmentsConfig.get_solo()
+        appointments_config.plugin = "jcc"
+        appointments_config.limit_to_location = "test"
+        appointments_config.save()
+
+        config = JccConfig.get_solo()
+        config.service = SoapServiceFactory.create(url=str(WSDL))
+        config.save()
+
+        superuser = SuperUserFactory.create()
+        response = self.app.get(
+            reverse(
+                "admin:appointments_appointmentsconfig_change",
+                args=(AppointmentsConfig.singleton_instance_id,),
+            ),
+            user=superuser,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["appointmentsconfig_form"]
+
+        self.assertEqual(form["plugin"].value, "jcc")
+        self.assertEqual(form["limit_to_location"].value, "test")
+
+        error_node = response.pyquery(
+            ".field-limit_to_location .openforms-error-widget .openforms-error-widget__column small"
+        )
+        self.assertNotIn(
+            _(
+                "Could not load data - enable and check the request logs for more details."
+            ),
+            error_node.text(),
+        )
+
+        form.submit()
+
+        self.assertEqual(form["limit_to_location"].value, "test")
+
+    @requests_mock.Mocker()
+    @patch(
+        "openforms.appointments.contrib.jcc.client.build_client",
+        side_effect=requests.RequestException,
+    )
+    def test_admin_while_wsdl_is_down(self, m, mock_client):
+        m.register_uri(
+            requests_mock.ANY, requests_mock.ANY, exc=requests.RequestException
+        )
+
+        appointments_config = AppointmentsConfig.get_solo()
+        appointments_config.plugin = "jcc"
+        appointments_config.limit_to_location = "test"
+        appointments_config.save()
+
+        config = JccConfig.get_solo()
+        config.service = SoapServiceFactory.create(url=str(WSDL))
+        config.save()
+
+        superuser = SuperUserFactory.create()
+        response = self.app.get(
+            reverse(
+                "admin:appointments_appointmentsconfig_change",
+                args=(AppointmentsConfig.singleton_instance_id,),
+            ),
+            user=superuser,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["appointmentsconfig_form"]
+
+        self.assertEqual(form["plugin"].value, "jcc")
+        self.assertEqual(form["limit_to_location"].value, "test")
+
+        error_node = response.pyquery(
+            ".field-limit_to_location .openforms-error-widget .openforms-error-widget__column small"
+        )
+        self.assertIn(
+            _(
+                "Could not load data - enable and check the request logs for more details."
+            ),
+            error_node.text(),
+        )
+
+        form.submit()
+
+        self.assertEqual(form["limit_to_location"].value, "test")

--- a/src/openforms/appointments/contrib/qmatic/tests/test_admin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_admin.py
@@ -1,11 +1,18 @@
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
+import requests
+import requests_mock
 from django_webtest import WebTest
 
 from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.appointments.contrib.qmatic.models import QmaticConfig
+from openforms.appointments.models import AppointmentsConfig
 from openforms.utils.tests.cache import clear_caches
+from openforms.utils.tests.logging import disable_logging
 
 from ..constants import CustomerFields
+from .factories import ServiceFactory
 
 
 class QmaticConfigAdminTests(WebTest):
@@ -26,3 +33,53 @@ class QmaticConfigAdminTests(WebTest):
         for value in checked_field_values:
             with self.subTest(f"{value=}"):
                 self.assertIn(value, CustomerFields)
+
+
+@disable_logging()
+class ApointmentConfigAdminTests(WebTest):
+    def setUp(self):
+        super().setUp()
+
+        self.addCleanup(clear_caches)
+
+    @requests_mock.Mocker()
+    def test_admin_while_service_is_down(self, m):
+        appointments_config = AppointmentsConfig.get_solo()
+        appointments_config.plugin = "qmatic"
+        appointments_config.limit_to_location = "test"
+        appointments_config.save()
+
+        config = QmaticConfig.get_solo()
+        config.service = ServiceFactory.create()
+        config.save()
+
+        m.get(requests_mock.ANY, exc=requests.RequestException)
+
+        superuser = SuperUserFactory.create()
+        response = self.app.get(
+            reverse(
+                "admin:appointments_appointmentsconfig_change",
+                args=(AppointmentsConfig.singleton_instance_id,),
+            ),
+            user=superuser,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["appointmentsconfig_form"]
+
+        self.assertEqual(form["plugin"].value, "qmatic")
+        self.assertEqual(form["limit_to_location"].value, "test")
+
+        error_node = response.pyquery(
+            ".field-limit_to_location .openforms-error-widget .openforms-error-widget__column small"
+        )
+        self.assertNotIn(
+            _(
+                "Could not load data - enable and check the request logs for more details."
+            ),
+            error_node.text(),
+        )
+
+        form.submit()
+
+        self.assertEqual(form["limit_to_location"].value, "test")

--- a/src/openforms/registrations/contrib/zgw_apis/admin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from solo.admin import SingletonModelAdmin
 from zgw_consumers.admin import ListZaaktypenMixin
 
-from openforms.utils.decorators import supress_requests_errors
+from openforms.utils.decorators import suppress_requests_errors
 
 from .models import ZGWApiGroupConfig, ZgwConfig
 
@@ -13,7 +13,7 @@ class ZgwConfigAdmin(SingletonModelAdmin):
     pass
 
 
-@supress_requests_errors(fields=["zaaktype"])
+@suppress_requests_errors(ZGWApiGroupConfig, fields=["zaaktype"])
 @admin.register(ZGWApiGroupConfig)
 class ZGWApiGroupConfigAdmin(ListZaaktypenMixin, admin.ModelAdmin):
     zaaktype_fields = [

--- a/src/openforms/registrations/contrib/zgw_apis/admin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/admin.py
@@ -1,7 +1,12 @@
 from django.contrib import admin
+from django.utils.decorators import method_decorator
 
+import requests
+import zds_client
 from solo.admin import SingletonModelAdmin
 from zgw_consumers.admin import ListZaaktypenMixin
+
+from openforms.utils.decorators import dbfields_exception_handler
 
 from .models import ZGWApiGroupConfig, ZgwConfig
 
@@ -11,6 +16,12 @@ class ZgwConfigAdmin(SingletonModelAdmin):
     pass
 
 
+@method_decorator(
+    dbfields_exception_handler(
+        exceptions=(requests.exceptions.RequestException, zds_client.ClientError),
+    ),
+    name="formfield_for_dbfield",
+)
 @admin.register(ZGWApiGroupConfig)
 class ZGWApiGroupConfigAdmin(ListZaaktypenMixin, admin.ModelAdmin):
     zaaktype_fields = [

--- a/src/openforms/registrations/contrib/zgw_apis/admin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/admin.py
@@ -1,12 +1,9 @@
 from django.contrib import admin
-from django.utils.decorators import method_decorator
 
-import requests
-import zds_client
 from solo.admin import SingletonModelAdmin
 from zgw_consumers.admin import ListZaaktypenMixin
 
-from openforms.utils.decorators import dbfields_exception_handler
+from openforms.utils.decorators import supress_requests_errors
 
 from .models import ZGWApiGroupConfig, ZgwConfig
 
@@ -16,12 +13,7 @@ class ZgwConfigAdmin(SingletonModelAdmin):
     pass
 
 
-@method_decorator(
-    dbfields_exception_handler(
-        exceptions=(requests.exceptions.RequestException, zds_client.ClientError),
-    ),
-    name="formfield_for_dbfield",
-)
+@supress_requests_errors(fields=["zaaktype"])
 @admin.register(ZGWApiGroupConfig)
 class ZGWApiGroupConfigAdmin(ListZaaktypenMixin, admin.ModelAdmin):
     zaaktype_fields = [

--- a/src/openforms/registrations/contrib/zgw_apis/admin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from solo.admin import SingletonModelAdmin
 from zgw_consumers.admin import ListZaaktypenMixin
 
-from openforms.utils.decorators import suppress_requests_errors
+from openforms.admin.decorators import suppress_requests_errors
 
 from .models import ZGWApiGroupConfig, ZgwConfig
 

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_admin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_admin.py
@@ -1,0 +1,66 @@
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+import requests
+import requests_mock
+from django_webtest import WebTest
+from privates.test import temp_private_root
+from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
+
+from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.tests.utils import disable_2fa
+
+from .factories import ZGWApiGroupConfigFactory
+
+
+@disable_2fa
+@temp_private_root()
+class ZGWApiGroupConfigAdminTests(WebTest):
+    csrf_checks = False
+
+    def test_admin_while_services_are_down(self):
+        zgw_group = ZGWApiGroupConfigFactory.create(
+            zrc_service__api_root="https://zaken-1.nl/api/v1/",
+            zrc_service__oas="https://zaken-1.nl/api/v1/schema/openapi.yaml",
+            drc_service__api_root="https://documenten-1.nl/api/v1/",
+            drc_service__oas="https://documenten-1.nl/api/v1/schema/openapi.yaml",
+            ztc_service__api_root="https://catalogus-1.nl/api/v1/",
+            ztc_service__oas="https://catalogus-1.nl/api/v1/schema/openapi.yaml",
+            zaaktype="https://catalogi-1.nl/api/v1/zaaktypen/1",
+            informatieobjecttype="https://catalogi-1.nl/api/v1/informatieobjecttypen/1",
+            organisatie_rsin="000000000",
+            zaak_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+        superuser = SuperUserFactory.create()
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.ANY,
+                requests_mock.ANY,
+                exc=requests.exceptions.ConnectTimeout,
+            )
+            response = self.app.get(
+                reverse("admin:zgw_apis_zgwapigroupconfig_change", args=(1,)),
+                user=superuser,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            form = response.forms["zgwapigroupconfig_form"]
+
+            self.assertEqual(form["zaaktype"].value, zgw_group.zaaktype)
+
+            error_node = response.pyquery(
+                ".field-zaaktype .openforms-error-widget .openforms-error-widget__column small"
+            )
+            self.assertEqual(
+                error_node.text(),
+                _(
+                    "Could not load data - enable and check the request logs for more details."
+                ),
+            )
+
+            form.submit()
+
+            self.assertEqual(
+                form["zaaktype"].value, "https://catalogi-1.nl/api/v1/zaaktypen/1"
+            )

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_zgw_api_config.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_zgw_api_config.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.urls import reverse
 
 import requests_mock
+from django_webtest import WebTest
 from privates.test import temp_private_root
 from requests.models import HTTPError
 from zds_client.oas import schema_fetcher
@@ -10,6 +12,7 @@ from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from zgw_consumers.test import generate_oas_component
 from zgw_consumers.test.schema_mock import mock_service_oas_get
 
+from openforms.accounts.tests.factories import SuperUserFactory
 from openforms.plugins.exceptions import InvalidPluginConfiguration
 from openforms.submissions.models import SubmissionStep
 from openforms.submissions.tests.factories import (
@@ -544,3 +547,58 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
             api_group = plugin.get_zgw_config({})
 
         self.assertEqual(api_group, self.zgw_group1)
+
+
+@temp_private_root()
+class ZGWApiGroupConfigAdminTests(WebTest):
+    csrf_checks = False
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.zgw_group = ZGWApiGroupConfigFactory.create(
+            zrc_service__api_root="https://zaken-1.nl/api/v1/",
+            zrc_service__oas="https://zaken-1.nl/api/v1/schema/openapi.yaml",
+            drc_service__api_root="https://documenten-1.nl/api/v1/",
+            drc_service__oas="https://documenten-1.nl/api/v1/schema/openapi.yaml",
+            ztc_service__api_root="https://catalogus-1.nl/api/v1/",
+            ztc_service__oas="https://catalogus-1.nl/api/v1/schema/openapi.yaml",
+            zaaktype="https://catalogi-1.nl/api/v1/zaaktypen/1",
+            informatieobjecttype="https://catalogi-1.nl/api/v1/informatieobjecttypen/1",
+            organisatie_rsin="000000000",
+            zaak_vertrouwelijkheidaanduiding=VertrouwelijkheidsAanduidingen.openbaar,
+        )
+
+    def setUp(self):
+        super().setUp()
+        # reset cache to keep request_history indexes consistent
+        schema_fetcher.cache.clear()
+        self.addCleanup(schema_fetcher.cache.clear)
+
+    def test_admin_while_services_are_down(self):
+        superuser = SuperUserFactory.create(app=self.app)
+
+        # calling admin page without requests calls being set up to mimic services that are down.
+        response = self.app.get(
+            reverse("admin:zgw_apis_zgwapigroupconfig_change", args=(1,)),
+            user=superuser,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        zaaktype = response.context["adminform"].form["zaaktype"]
+        self.assertEqual(zaaktype.initial, self.zgw_group.zaaktype)
+
+        zaaktype_rendered_widget = zaaktype.field.widget.render(
+            zaaktype.name, [zaaktype.initial]
+        )
+
+        self.assertIn(
+            "Could not load data - enable and check the request logs for more details",
+            zaaktype_rendered_widget,
+        )
+
+        response.forms[0].submit()
+        self.zgw_group.refresh_from_db()
+
+        self.assertEqual(
+            self.zgw_group.zaaktype, "https://catalogi-1.nl/api/v1/zaaktypen/1"
+        )

--- a/src/openforms/scss/admin/admin_overrides.scss
+++ b/src/openforms/scss/admin/admin_overrides.scss
@@ -1,4 +1,4 @@
 @import 'admin_theme';
 @import 'app_overrides';
 @import 'hijack';
-@import './widgets';
+@import 'widgets';

--- a/src/openforms/scss/admin/admin_overrides.scss
+++ b/src/openforms/scss/admin/admin_overrides.scss
@@ -1,3 +1,4 @@
 @import 'admin_theme';
 @import 'app_overrides';
 @import 'hijack';
+@import './widgets';

--- a/src/openforms/scss/admin/widgets/_error-widget.scss
+++ b/src/openforms/scss/admin/widgets/_error-widget.scss
@@ -1,0 +1,15 @@
+@import '../../vars';
+
+.openforms-error-widget {
+  display: inline-block;
+
+  &__column {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  &--error-text {
+    color: $color-error;
+  }
+}

--- a/src/openforms/scss/admin/widgets/_error-widget.scss
+++ b/src/openforms/scss/admin/widgets/_error-widget.scss
@@ -1,15 +1,17 @@
+@use 'microscope-sass/lib/bem';
+@import 'microscope-sass/lib/typography';
 @import '../../vars';
 
 .openforms-error-widget {
   display: inline-block;
 
-  &__column {
+  @include bem.element('column') {
     display: flex;
     flex-direction: column;
     gap: 5px;
   }
 
-  &--error-text {
+  @include bem.modifier('error-text') {
     color: $color-error;
   }
 }

--- a/src/openforms/scss/admin/widgets/_index.scss
+++ b/src/openforms/scss/admin/widgets/_index.scss
@@ -1,0 +1,1 @@
+@import './error-widget';

--- a/src/openforms/utils/decorators.py
+++ b/src/openforms/utils/decorators.py
@@ -102,7 +102,6 @@ def dbfields_exception_handler(
                 return db_field.formfield(
                     help_text=db_field.help_text,
                     validators=db_field.validators,
-                    max_length=db_field.max_length,
                     disabled=True,
                 )
 

--- a/src/openforms/utils/decorators.py
+++ b/src/openforms/utils/decorators.py
@@ -1,14 +1,8 @@
 from dataclasses import dataclass
 from functools import wraps
 
-from django.contrib import admin
-from django.db import models
 from django.utils.cache import patch_vary_headers
-from django.utils.html import format_html
-from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache as django_never_cache
-
-import requests
 
 from openforms.config.models import GlobalConfiguration
 
@@ -71,65 +65,3 @@ def conditional_search_engine_index(config_attr: str, content="noindex, nofollow
         return _wrapped_view_func
 
     return decorator
-
-
-def suppress_requests_errors(model: type[models.Model], fields: list[str]):
-    """
-    Add robustness to admin fields making outgoing requests that may fail.
-
-    If a :class:`requests.RequestException`is caught, return the base (non-enhanced)
-    form field that Django would generate by default and append an error message
-    for the end-user.
-
-    :arg fields: A list of model field names for which to suppress errors.
-    """
-
-    def fallback(self, db_field, request, *args, **kwargs):
-        kwargs = {**self.formfield_overrides[db_field.__class__], **kwargs}
-
-        class CustomWidget(kwargs["widget"]):
-            def render(self, *args, **kwargs):
-                output = super().render(*args, **kwargs)
-
-                error_message = _(
-                    "Could not load data - enable and check the request logs for more details."
-                )
-
-                html = format_html(
-                    """
-                    <div class="openforms-error-widget">
-                        <div class="openforms-error-widget__column">
-                            {}
-                            <small class="openforms-error-widget openforms-error-widget--error-text">{}</small>
-                        </div>
-                    </div>""",
-                    output,
-                    error_message,
-                )
-
-                return html
-
-        kwargs["widget"] = CustomWidget
-        return db_field.formfield(**kwargs)
-
-    def _decorator(admin_class: type[admin.ModelAdmin]):
-        original_func = admin_class.formfield_for_dbfield
-        for field in fields:
-            assert model._meta.get_field(field)
-
-        @wraps(original_func)
-        def _wrapped(self, db_field, request, *args, **kwargs):
-            field_name = db_field.name
-
-            try:
-                return original_func(self, db_field, request, *args, **kwargs)
-            except requests.RequestException as exc:
-                if field_name not in fields:
-                    raise exc
-                return fallback(self, db_field, request, *args, **kwargs)
-
-        admin_class.formfield_for_dbfield = _wrapped
-
-        return admin_class
-
-    return _decorator

--- a/src/openforms/utils/tests/test_decorators.py
+++ b/src/openforms/utils/tests/test_decorators.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext as _
 import requests
 
 from openforms.accounts.models import User
-from openforms.utils.decorators import suppress_requests_errors
+from openforms.admin.decorators import suppress_requests_errors
 
 
 @suppress_requests_errors(User, fields=["first_name"])

--- a/src/openforms/utils/tests/test_decorators.py
+++ b/src/openforms/utils/tests/test_decorators.py
@@ -1,0 +1,66 @@
+from django import forms
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.client import RequestFactory
+
+import requests
+import zds_client
+
+from openforms.utils.decorators import dbfields_exception_handler
+
+
+class DbFieldsExceptionHandlerTests(SimpleTestCase):
+    def setUp(self):
+        self.db_field = models.CharField(
+            "db field",
+            blank=True,
+            help_text="help text",
+        )
+
+        self.request = RequestFactory().get("/test")
+
+        # setup django.messages
+        setattr(self.request, "session", "session")
+        messages = FallbackStorage(self.request)
+        setattr(self.request, "_messages", messages)
+
+    def test_no_exception_detected(self):
+        @dbfields_exception_handler(exceptions=(Exception))
+        def formfield_for_dbfield(db_field, request):
+            return forms.CharField(
+                label="db field",
+                help_text="help text",
+            )
+
+        form_field = formfield_for_dbfield(self.db_field, self.request)
+
+        messages = (m.message for m in get_messages(self.request))
+        self.assertTrue(not any(messages))
+        self.assertIsInstance(form_field, forms.CharField)
+
+    def test_trigger_exception(self):
+        @dbfields_exception_handler(exceptions=(requests.exceptions.RequestException,))
+        def formfield_for_dbfield(db_field, request):
+            raise requests.exceptions.RequestException()
+
+        form_field = formfield_for_dbfield(self.db_field, self.request)
+        messages = [m.message for m in get_messages(self.request)]
+        self.assertEqual(
+            messages,
+            [
+                "Could not load data for field 'db field' - enable and check the request logs for more details",
+            ],
+        )
+        self.assertIsInstance(form_field, forms.CharField)
+
+    def test_raising_not_given_exception(self):
+        @dbfields_exception_handler(exceptions=(requests.exceptions.RequestException,))
+        def formfield_for_dbfield(db_field, request):
+            raise zds_client.ClientError()
+
+        with self.assertRaises(zds_client.ClientError):
+            formfield_for_dbfield(self.db_field, self.request)
+        messages = (m.message for m in get_messages(self.request))
+        self.assertTrue(not any(messages))


### PR DESCRIPTION
fixes #3279 

Made a decorator that wraps a try, catch around a function and either returns it normally or returns a default value with a django message error

todo:
- write a nice explanation what the decorator does and should be used
- look into where we need to use it for now
- look into which exceptions the function should handle per usecase
- look into nice, understandable and none incriminating error messages