### PR TITLE
[#3481] Escape "special" characters when saving data in the Objects API

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -592,10 +592,16 @@ if SUBPATH:
         STATIC_URL = f"{SUBPATH}{STATIC_URL}"
         MEDIA_URL = f"{SUBPATH}{MEDIA_URL}"
 
-# Objects API registration backend maximum JSON body size in bytes
+#
+# Objects API
+#
+
+# Registration backend maximum JSON body size in bytes
 MAX_UNTRUSTED_JSON_PARSE_SIZE = config(
     "MAX_UNTRUSTED_JSON_PARSE_SIZE", 1_000_000
 )  # 1mb in bytes
+# Perform HTML escaping on user's data-input
+ESCAPE_REGISTRATION_OUTPUT = config("ESCAPE_REGISTRATION_OUTPUT", default=False)
 
 
 ##############################

--- a/src/openforms/registrations/contrib/objects_api/templatetags/registrations/contrib/objects_api/json_tags.py
+++ b/src/openforms/registrations/contrib/objects_api/templatetags/registrations/contrib/objects_api/json_tags.py
@@ -1,9 +1,11 @@
 import json
 
 from django import template
+from django.conf import settings
 from django.utils.safestring import SafeString
 
 from openforms.formio.rendering.structured import render_json
+from openforms.registrations.contrib.objects_api.utils import escape_html_manually
 
 register = template.Library()
 
@@ -25,4 +27,8 @@ def json_summary(context):
         return {}
 
     json_data = render_json(submission)
+
+    if settings.ESCAPE_REGISTRATION_OUTPUT:
+        json_data = escape_html_manually(json_data)
+
     return SafeString(json.dumps(json_data))

--- a/src/openforms/registrations/contrib/objects_api/tests/test_templatetags.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_templatetags.py
@@ -1,4 +1,4 @@
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, override_settings
 
 from openforms.forms.tests.factories import FormFactory
 from openforms.registrations.constants import RegistrationAttribute
@@ -10,13 +10,15 @@ from openforms.template import openforms_backend, render_from_string
 
 
 class JsonSummeryTests(TransactionTestCase):
-    def test_render_json_summary(self):
-        form = FormFactory.create()
-        submission = SubmissionFactory.create(
-            form=form, completed=True, form_url="http://maykinmedia.nl/myform/"
+    def setUp(self):
+        self.form = FormFactory.create()
+        self.submission = SubmissionFactory.create(
+            form=self.form, completed=True, form_url="http://maykinmedia.nl/myform/"
         )
+
+    def test_render_json_summary(self):
         SubmissionStepFactory.create(
-            form_step__form=form,
+            form_step__form=self.form,
             form_step__form_definition__slug="json-summery-step",
             form_step__form_definition__configuration={
                 "display": "form",
@@ -44,7 +46,7 @@ class JsonSummeryTests(TransactionTestCase):
                     },
                 ],
             },
-            submission=submission,
+            submission=self.submission,
             data={
                 "voornaam": "Foo",
                 "achternaam": "Bar",
@@ -54,12 +56,80 @@ class JsonSummeryTests(TransactionTestCase):
 
         rendered = render_from_string(
             "{% json_summary %}",
-            context={"_submission": submission},
+            context={"_submission": self.submission},
             backend=openforms_backend,
             disable_autoescape=True,
         )
 
         expected = '{"json-summery-step": {"voornaam": "Foo", "achternaam": "Bar", "tussenvoegsel": "de"}}'
+
+        self.assertEqual(rendered, expected)
+
+    @override_settings(ESCAPE_REGISTRATION_OUTPUT=False)
+    def test_render_json_summary_doesnt_escape_html_when_disabled(self):
+        SubmissionStepFactory.create(
+            form_step__form=self.form,
+            form_step__form_definition__slug="json-summery-step",
+            form_step__form_definition__configuration={
+                "display": "form",
+                "components": [
+                    {
+                        "key": "voornaam",
+                        "type": "textfield",
+                        "registration": {
+                            "attribute": RegistrationAttribute.initiator_voornamen,
+                        },
+                    }
+                ],
+            },
+            submission=self.submission,
+            data={
+                "voornaam": "<script>alert();</script>",
+            },
+        )
+
+        rendered = render_from_string(
+            "{% json_summary %}",
+            context={"_submission": self.submission},
+            backend=openforms_backend,
+            disable_autoescape=True,
+        )
+
+        expected = '{"json-summery-step": {"voornaam": "<script>alert();</script>"}}'
+
+        self.assertEqual(rendered, expected)
+
+    @override_settings(ESCAPE_REGISTRATION_OUTPUT=True)
+    def test_render_json_summary_escapes_html_when_enabled(self):
+        SubmissionStepFactory.create(
+            form_step__form=self.form,
+            form_step__form_definition__slug="json-summery-step",
+            form_step__form_definition__configuration={
+                "display": "form",
+                "components": [
+                    {
+                        "key": "voornaam",
+                        "type": "textfield",
+                        "registration": {
+                            "attribute": RegistrationAttribute.initiator_voornamen,
+                        },
+                    }
+                ],
+            },
+            submission=self.submission,
+            data={
+                "voornaam": "<script>alert();</script>",
+            },
+        )
+
+        rendered = render_from_string(
+            "{% json_summary %}",
+            context={"_submission": self.submission},
+            backend=openforms_backend,
+            disable_autoescape=True,
+        )
+
+        expected = '{"json-summery-step": {"voornaam": "&lt;script&gt;alert();&lt;/script&gt;"}}'
 
         self.assertEqual(rendered, expected)
 

--- a/src/openforms/registrations/contrib/objects_api/tests/test_utils.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_utils.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from ..utils import escape_html_manually
+
+
+class EscapeHTMLTests(TestCase):
+    def test_given_dict_values_are_escaped(self):
+        sample = {
+            "test1": "normal value",
+            "test2": "<script>alert();</script>",
+            "nested1": {
+                "n_test": {"escape": "<script>alert();</script>"},
+            },
+        }
+        expected = {
+            "test1": "normal value",
+            "test2": "&lt;script&gt;alert();&lt;/script&gt;",
+            "nested1": {
+                "n_test": {"escape": "&lt;script&gt;alert();&lt;/script&gt;"},
+            },
+        }
+
+        result = escape_html_manually(sample)
+
+        self.assertEqual(expected, result)
+
+    def test_not_type_of_dict_returns_empty_dict(self):
+        samples = [["test"], "test", 6]
+
+        for sample in samples:
+            with self.subTest(sample=sample):
+                result = escape_html_manually(sample)
+
+                self.assertEqual(result, {})

--- a/src/openforms/registrations/contrib/objects_api/utils.py
+++ b/src/openforms/registrations/contrib/objects_api/utils.py
@@ -1,0 +1,19 @@
+from django.utils.html import escape
+
+from openforms.typing import JSONValue
+
+
+def escape_html_manually(input: dict) -> dict[str, JSONValue]:
+    """
+    Used optionally (based on ESCAPE_REGISTRATION_OUTPUT env setting) in order
+    to perform HTML escaping before we send the data to the Objects API.
+    """
+    if not isinstance(input, dict):
+        return {}
+
+    for key, value in input.items():
+        if isinstance(value, str):
+            input[key] = escape(value)
+        elif isinstance(value, dict):
+            escape_html_manually(value)
+    return input

--- a/src/openforms/variables/utils.py
+++ b/src/openforms/variables/utils.py
@@ -1,6 +1,9 @@
 from datetime import datetime, time
 from typing import TYPE_CHECKING
 
+from django.conf import settings
+
+from openforms.registrations.contrib.objects_api.utils import escape_html_manually
 from openforms.typing import JSONObject, JSONValue
 from openforms.utils.date import parse_date
 
@@ -42,11 +45,15 @@ def get_variables_for_context(submission: "Submission") -> dict[str, JSONValue]:
 
     from .service import get_static_variables
 
+    data = submission.data
+    if settings.ESCAPE_REGISTRATION_OUTPUT:
+        data = escape_html_manually(submission.data)
+
     formio_data = FormioData(
         **{
             variable.key: variable.initial_value
             for variable in get_static_variables(submission=submission)
         },
-        **submission.data,
+        **data,
     )
     return formio_data.data


### PR DESCRIPTION
Fixes #3481 