### PR TITLE
:green_heart: Fix tests failing with dev-settings

### DIFF
--- a/src/openforms/authentication/contrib/digid/tests/test_signicat_integration.py
+++ b/src/openforms/authentication/contrib/digid/tests/test_signicat_integration.py
@@ -33,6 +33,9 @@ SIGNICAT_BROKER_BASE = furl("https://maykin.pre.ie01.signicat.pro/broker")
 
 
 @patch(
+    "openforms.submissions.tokens.submission_resume_token_generator.secret", new="dummy"
+)
+@patch(
     "onelogin.saml2.authn_request.OneLogin_Saml2_Utils.generate_unique_id",
     lambda *_, **__: "ONELOGIN_123456",
 )
@@ -484,6 +487,7 @@ class SignicatDigiDIntegrationTests(OFVCRMixin, TestCase):
         clear_caches()
 
         acs_response = self.client.get(acs_url.url, follow=True)
+        assert acs_response.status_code == 200
         # we are not not logged in
         self.assertNotIn(FORM_AUTH_SESSION_KEY, self.client.session)
         # and are redirected back to the broker

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_signicat_integration.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_signicat_integration.py
@@ -34,6 +34,9 @@ SELECT_EHERKENNING_SIM = SIGNICAT_BROKER_BASE / "authn/simulator/selection/eh"
 
 
 @patch(
+    "openforms.submissions.tokens.submission_resume_token_generator.secret", new="dummy"
+)
+@patch(
     "onelogin.saml2.authn_request.OneLogin_Saml2_Utils.generate_unique_id",
     lambda *_, **__: "ONELOGIN_123456",
 )
@@ -207,6 +210,7 @@ class SignicatEHerkenningIntegrationTests(OFVCRMixin, TestCase):
         # prep the URL for Django test client consumption
         acs_url.remove(netloc=True, scheme=True)
         acs_response = self.client.get(acs_url.url, follow=True)
+        assert acs_response.status_code == 200
 
         # we are logged in
         self.assertIn(FORM_AUTH_SESSION_KEY, self.client.session)


### PR DESCRIPTION
Story time!

A couple of signicat integration tests were failing locally but not in CI. This is/was weird, because the tests were just replaying the VCR cassettes and the behaviour should be the same on both environments!

However, after much investigation, it was clear that the tests were crashing because the ACS (redirected) view was eventually returning an HTTP 403 (with dev settings), while returning an HTTP 200 (as expected) with ci settings. Tracing the origin of that 403 revealed that it was the nature of the submission resume URL/view being used was the culprit - this relies on cryptographically secure tokens to automatically let resumption (and other state changes) be time-limited and reduce the risk of replay attacks.

Now, looking at the tokens generated, it was clear with the CI settings that the same token was used every time, but not with the dev settings. The initial token is different from future tokens, and the future token happens to align with the token value of CI (probably because it's baked into a VCR cassette somewhere).

Okay Sergei, but why are the tokens different? Well, tokens with the same inputs on different environments should be! Otherwise attackers could craft tokens on one environment and then try them on the env to be attacked. Therefore, the tokens have some secret tied to the specific environment, which happens to be the Django setting SECRET_KEY. And indeed, the SECRET_KEY for dev and ci is different.

Presumably the cassettes were recorded with the same 'dummy' value for the secret key, so things pass on CI, but the dev settings use a real secret key value and that results in different tokens being generated and the tests erroring.

The patch is simple - mock the secret used in the token generator to be a fixed value during tests and you're good to go.