### PR TITLE
API clients rework: establish NLX integration

### DIFF
--- a/src/openforms/pre_requests/clients.py
+++ b/src/openforms/pre_requests/clients.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from requests.models import PreparedRequest, Request
 from zgw_consumers.client import ZGWClient
+from zgw_consumers.nlx import NLXClientMixin
 
 from .registry import register as registry
 
@@ -15,7 +16,7 @@ class PreRequestClientContext(TypedDict):
     submission: Submission | None
 
 
-class PreRequestZGWClient(ZGWClient):
+class PreRequestZGWClient(NLXClientMixin, ZGWClient):
     """
     A :class:`zgw_consumers.client.ZGWClient` with pre-requests support.
 

--- a/src/openforms/pre_requests/tests/test_clients.py
+++ b/src/openforms/pre_requests/tests/test_clients.py
@@ -6,6 +6,7 @@ import requests_mock
 from zgw_consumers.test import mock_service_oas_get
 
 from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.utils.tests.nlx import DisableNLXRewritingMixin
 from zgw_consumers_ext.tests.factories import ServiceFactory
 
 from ..base import PreRequestHookBase
@@ -13,7 +14,7 @@ from ..clients import PreRequestClientContext
 from ..registry import Registry
 
 
-class PreRequestHooksTest(SimpleTestCase):
+class PreRequestHooksTest(DisableNLXRewritingMixin, SimpleTestCase):
     def test_pre_request_hook(self):
         register = Registry()
 

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_varaiable_values_from_services.py
@@ -14,6 +14,7 @@ from zgw_consumers.constants import APITypes, AuthTypes
 
 from openforms.forms.tests.factories import FormVariableFactory
 from openforms.tests.utils import c_profile
+from openforms.utils.tests.nlx import DisableNLXRewritingMixin
 from openforms.variables.constants import DataMappingTypes
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 from openforms.variables.validators import HeaderValidator, ValidationError
@@ -35,7 +36,7 @@ def data_mapping_values() -> st.SearchStrategy[Any]:
     return st.one_of(st.text(), st.integers(), st.floats(), st.dates(), st.datetimes())
 
 
-class ServiceFetchConfigVariableBindingTests(SimpleTestCase):
+class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/src/openforms/utils/tests/nlx.py
+++ b/src/openforms/utils/tests/nlx.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+
+class DisableNLXRewritingMixin:
+    """
+    Disable NLX rewriting.
+
+    This is especially useful when you want to keep using SimpleTestCase, as the
+    rewriter queries the database for rewrite targets.
+    """
+
+    def setUp(self):
+        patchers = (
+            patch("zgw_consumers.nlx.Rewriter._rewrite", new=lambda *args: None),
+            patch("zgw_consumers.nlx.Rewriter.reverse_rewrites", new=[]),
+        )
+        for patcher in patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        super().setUp()

--- a/src/openforms/utils/tests/nlx.py
+++ b/src/openforms/utils/tests/nlx.py
@@ -11,8 +11,8 @@ class DisableNLXRewritingMixin:
 
     def setUp(self):
         patchers = (
-            patch("zgw_consumers.nlx.Rewriter._rewrite", new=lambda *args: None),
-            patch("zgw_consumers.nlx.Rewriter.reverse_rewrites", new=[]),
+            patch("zgw_consumers_ext.nlx.Rewriter._rewrite", new=lambda *args: None),
+            patch("zgw_consumers_ext.nlx.Rewriter.reverse_rewrites", new=[]),
         )
         for patcher in patchers:
             patcher.start()

--- a/src/zgw_consumers_ext/api_client.py
+++ b/src/zgw_consumers_ext/api_client.py
@@ -69,3 +69,7 @@ class ZGWAuth(AuthBase):
     def __call__(self, request: PreparedRequest):
         request.headers.update(self.auth.credentials())
         return request
+
+
+class NLXMixin:
+    pass

--- a/src/zgw_consumers_ext/api_client.py
+++ b/src/zgw_consumers_ext/api_client.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -6,6 +7,18 @@ from requests.models import PreparedRequest
 from zds_client import ClientAuth
 from zgw_consumers.constants import AuthTypes
 from zgw_consumers.models import Service
+
+from .nlx import NLXClient
+
+logger = logging.getLogger(__name__)
+
+
+def build_client(service: Service, client_factory=NLXClient):
+    """
+    Build a client for a given :class:`zgw_consumers.models.Service`.
+    """
+    factory = ServiceClientFactory(service)
+    return client_factory.configure_from(factory, nlx_base_url=service.nlx)
 
 
 @dataclass
@@ -69,7 +82,3 @@ class ZGWAuth(AuthBase):
     def __call__(self, request: PreparedRequest):
         request.headers.update(self.auth.credentials())
         return request
-
-
-class NLXMixin:
-    pass

--- a/src/zgw_consumers_ext/nlx.py
+++ b/src/zgw_consumers_ext/nlx.py
@@ -1,0 +1,81 @@
+import json
+import logging
+
+from requests import JSONDecodeError
+from requests.models import PreparedRequest, Request, Response
+from requests.utils import guess_json_utf
+from zgw_consumers.nlx import Rewriter
+
+from api_client import APIClient
+
+logger = logging.getLogger(__name__)
+
+
+def nlx_rewrite_hook(response: Response, *args, **kwargs):
+    try:
+        json_data = response.json()
+    # it may be a different content type than JSON! Checking for application/json
+    # content type header is a bit annoying because there are alternatives like
+    # application/hal+json :(
+    except JSONDecodeError:
+        return response
+
+    # rewrite the JSON
+    logger.debug(
+        "NLX client: Rewriting response JSON to replace outway URLs",
+        extra={"request": response.request},
+    )
+    # apply similar logic to response.json() itself
+    encoding = (
+        response.encoding
+        or guess_json_utf(response.content)
+        or response.apparent_encoding
+    )
+    assert encoding
+    rewriter = Rewriter()
+    rewriter.backwards(json_data)
+    response._content = json.dumps(json_data).encode(encoding)
+
+    return response
+
+
+class NLXMixin:
+    base_url: str
+
+    def __init__(self, *args, nlx_base_url: str = "", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.nlx_base_url = nlx_base_url
+
+        if self.nlx_base_url:
+            self.hooks["response"].insert(0, nlx_rewrite_hook)  # type: ignore
+
+    def prepare_request(self, request: Request) -> PreparedRequest:
+        prepared_request = super().prepare_request(request)  # type: ignore
+
+        if not self.nlx_base_url:
+            return prepared_request
+
+        # change the actual URL being called so that it uses NLX
+        # XXX: it would be really nice if at some point NLX would be just a normal HTTP
+        # proxy so we can instead just map DB configuration to proxy setup.
+        new_url = (original := prepared_request.url).replace(
+            self.base_url, self.nlx_base_url, 1
+        )
+        logger.debug(
+            "NLX client: URL %s rewritten to %s",
+            original,
+            new_url,
+            extra={
+                "original_url": original,
+                "base_url": self.base_url,
+                "nlx_base_url": self.nlx_base_url,
+                "client": self,
+            },
+        )
+        prepared_request.url = new_url
+
+        return prepared_request
+
+
+class NLXClient(NLXMixin, APIClient):
+    pass

--- a/src/zgw_consumers_ext/tests/test_nlx_rewriting.py
+++ b/src/zgw_consumers_ext/tests/test_nlx_rewriting.py
@@ -32,3 +32,58 @@ class NLXClientTests(TestCase):
             "http://localhost:8081/:serial-number/:service/some-resource",
         )
         self.assertEqual(response_data, {"url": "https://example.com/some-resource"})
+
+    @requests_mock.Mocker()
+    def test_non_json_response_data(self, m):
+        nlx_service = ServiceFactory.create(
+            label="Service with NLX",
+            api_root="https://example.com/",
+            auth_type=AuthTypes.no_auth,
+            nlx="http://localhost:8081/:serial-number/:service/",
+        )
+        client = build_client(nlx_service)
+
+        m.get(
+            "http://localhost:8081/:serial-number/:service/some-resource",
+            content=b"AAAAA",
+        )
+
+        with client:
+            response_data = client.get("some-resource").content
+
+        self.assertEqual(m.last_request.method, "GET")
+        self.assertEqual(
+            m.last_request.url,
+            "http://localhost:8081/:serial-number/:service/some-resource",
+        )
+        self.assertEqual(response_data, b"AAAAA")
+
+    @requests_mock.Mocker()
+    def test_service_without_nlx(self, m):
+        ServiceFactory.create(
+            label="Service with NLX",
+            api_root="https://example.com/",
+            auth_type=AuthTypes.no_auth,
+            nlx="http://localhost:8081/:serial-number/:service/",
+        )
+        normal_service = ServiceFactory.create(
+            label="Service without NLX",
+            api_root="https://second.example.com/",
+            auth_type=AuthTypes.no_auth,
+        )
+        client = build_client(normal_service)
+        m.get(
+            "https://second.example.com/some-resource",
+            json={"url": "https://example.com"},
+        )
+
+        with client:
+            response_data = client.get("some-resource").json()
+
+        self.assertEqual(m.last_request.method, "GET")
+        self.assertEqual(
+            m.last_request.url,
+            "https://second.example.com/some-resource",
+        )
+        # no rewriting of any sorts
+        self.assertEqual(response_data, {"url": "https://example.com"})

--- a/src/zgw_consumers_ext/tests/test_nlx_rewriting.py
+++ b/src/zgw_consumers_ext/tests/test_nlx_rewriting.py
@@ -3,14 +3,8 @@ from django.test import TestCase
 import requests_mock
 from zgw_consumers.constants import AuthTypes
 
-from api_client import APIClient
-
-from ..api_client import NLXMixin, build_client
+from ..api_client import build_client
 from .factories import ServiceFactory
-
-
-class NLXClient(NLXMixin, APIClient):
-    pass
 
 
 class NLXClientTests(TestCase):

--- a/src/zgw_consumers_ext/tests/test_nlx_rewriting.py
+++ b/src/zgw_consumers_ext/tests/test_nlx_rewriting.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+
+import requests_mock
+from zgw_consumers.constants import AuthTypes
+
+from .factories import ServiceFactory
+
+DUMMY_SCHEMA = {
+    "openapi": "3.0.1",
+    "paths": {},
+}
+
+
+class NLXClientTests(TestCase):
+    @requests_mock.Mocker()
+    def test_request_url_and_response_data_rewritten(self, m):
+        nlx_service = ServiceFactory.create(
+            label="Service with NLX",
+            api_root="https://example.com/",
+            auth_type=AuthTypes.no_auth,
+            nlx="http://localhost:8081/:serial-number/:service/",
+        )
+        client = nlx_service.build_client()
+        client.schema = DUMMY_SCHEMA
+        m.get(
+            "http://localhost:8081/:serial-number/:service/some-resource",
+            json=lambda req, _: {"url": req.url},
+        )
+
+        response_data = client.request(
+            path="some-resource",
+            operation="dummy-operation",
+            method="GET",
+        )
+
+        self.assertEqual(m.last_request.method, "GET")
+        self.assertEqual(
+            m.last_request.url,
+            "http://localhost:8081/:serial-number/:service/some-resource",
+        )
+        self.assertEqual(response_data, {"url": "https://example.com/some-resource"})


### PR DESCRIPTION
Partially closes #3489, depends on #3507

---

* Added tests and improved NLX support for current situation
* Updated test to make use of new client approach
* Added NLX support to new client approach