### PR TITLE
Component level translations

### DIFF
--- a/src/openforms/formio/components/translations.py
+++ b/src/openforms/formio/components/translations.py
@@ -1,0 +1,18 @@
+from ..typing import OptionDict
+
+
+def translate_options(
+    options: list[OptionDict],
+    language_code: str,
+    enabled: bool,
+) -> None:
+    for option in options:
+        if not (translations := option.get("openForms", {}).get("translations")):
+            continue
+
+        translated_label = translations.get(language_code, {}).get("label", "")
+        if enabled and translated_label:
+            option["label"] = translated_label
+
+        # always clean up
+        del option["openForms"]["translations"]  # type: ignore

--- a/src/openforms/formio/dynamic_config/__init__.py
+++ b/src/openforms/formio/dynamic_config/__init__.py
@@ -62,3 +62,19 @@ def get_translated_custom_error_messages(
         component["errors"] = custom_error_messages[language]
 
     return config_wrapper
+
+
+def localize_components(
+    configuration_wrapper: FormioConfigurationWrapper,
+    language_code: str,
+    enabled: bool = True,
+) -> None:
+    """
+    Apply the configured translations for each component in the configuration.
+
+    .. note:: this function mutates the configuration.
+    """
+    for component in configuration_wrapper:
+        register.localize_component(
+            component, language_code=language_code, enabled=enabled
+        )

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -169,8 +169,9 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         # apply the generic translation behaviour even for unregistered components
         if enabled and (translations := generic_translations.get(language_code, {})):
             for prop, translation in translations.items():
-                if translation:
-                    component[prop] = translation
+                if not translation:
+                    continue
+                component[prop] = translation
 
         if (component_type := component["type"]) in self:
             component_plugin = self[component_type]

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -20,6 +20,7 @@ from openforms.typing import DataMapping
 from .datastructures import FormioConfigurationWrapper, FormioData
 from .dynamic_config import (
     get_translated_custom_error_messages,
+    localize_components,
     rewrite_formio_components,
     rewrite_formio_components_for_request,
 )
@@ -88,6 +89,11 @@ def get_dynamic_configuration(
 
     # Add to each component the custom errors in the current locale
     get_translated_custom_error_messages(config_wrapper, submission)
+    localize_components(
+        config_wrapper,
+        submission.language_code,
+        enabled=submission.form.translation_enabled,
+    )
 
     # prefill is still 'special' even though it uses variables, as we specifically
     # set the `defaultValue` key to the resulting variable.

--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -1,0 +1,199 @@
+"""
+Test that component translations are respected in the context of a submission.
+"""
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from rest_framework.test import APIRequestFactory
+
+from openforms.forms.tests.factories import FormFactory
+from openforms.submissions.tests.factories import SubmissionFactory
+
+from ..datastructures import FormioConfigurationWrapper
+from ..service import get_dynamic_configuration
+
+rf = APIRequestFactory()
+
+
+def disable_prefill_injection():
+    """
+    Disable prefill to prevent prefill-related queries.
+    """
+    return patch("openforms.formio.service.inject_prefill", new=MagicMock)
+
+
+TEST_CONFIGURATION = {
+    "components": [
+        {
+            "type": "textfield",
+            "key": "textfield",
+            "label": "Text field",
+            "openForms": {
+                "translations": {
+                    "nl": {
+                        "label": "Tekstveld",
+                    }
+                }
+            },
+        },
+        {
+            "type": "select",
+            "key": "select",
+            "label": "Pick an option",
+            "data": {
+                "values": [
+                    {
+                        "value": "option1",
+                        "label": "Option 1",
+                        "openForms": {
+                            "translations": {
+                                "nl": {"label": "Optie 1"},
+                            },
+                        },
+                    },
+                    {
+                        "value": "option2",
+                        "label": "Option 2",
+                        "openForms": {
+                            "translations": {
+                                "nl": {"label": "Optie 2"},
+                            },
+                        },
+                    },
+                ],
+            },
+            "openForms": {
+                "translations": {
+                    "nl": {
+                        "label": "Maak een keuze",
+                    }
+                }
+            },
+        },
+        {
+            "type": "editgrid",
+            "key": "editgrid",
+            "components": [
+                {
+                    "type": "content",
+                    "key": "content",
+                    "html": "<p>EN content</p>",
+                    "openForms": {
+                        "translations": {
+                            "nl": {
+                                "html": "<p>NL-inhoud</p>",
+                            }
+                        }
+                    },
+                }
+            ],
+        },
+    ],
+}
+
+
+@disable_prefill_injection()
+class ComponentTranslationTests(SimpleTestCase):
+    """
+    Test some sample component types for translations at the component-level.
+
+    This is not meant to exhaustively test all component types - for that, you should
+    write appropriate unit tests for each supported component type. Rather, the
+    mechanism here is tested to configure translations are the comopnent level instead
+    of the entire form definition level and avoid leaking the excessive data to the
+    frontend.
+
+    Translations need to be 'injected' by the backend and be ready to use for the
+    frontend, depending on the submission language.
+    """
+
+    def test_translations_ignored_if_form_disables_translations(self):
+        form = FormFactory.build(translation_enabled=False)
+        submission = SubmissionFactory.build(form=form)
+        request = rf.get("/dummy")
+        config_wrapper = FormioConfigurationWrapper(configuration=TEST_CONFIGURATION)
+
+        configuration = get_dynamic_configuration(config_wrapper, request, submission)
+
+        with self.subTest("textfield"):
+            textfield = configuration["textfield"]
+
+            self.assertEqual(textfield["label"], "Text field")
+            self.assertNotIn("translations", textfield["openForms"])
+
+        with self.subTest("select"):
+            select = configuration["select"]
+
+            self.assertEqual(select["label"], "Pick an option")
+            self.assertNotIn("translations", select["openForms"])
+            self.assertEqual(select["data"]["values"][0]["label"], "Option 1")
+            self.assertNotIn("translations", select["data"]["values"][0]["openForms"])
+            self.assertEqual(select["data"]["values"][1]["label"], "Option 2")
+            self.assertNotIn("translations", select["data"]["values"][1]["openForms"])
+
+        with self.subTest("content (nested in editgrid)"):
+            content = configuration["content"]
+
+            self.assertEqual(content["html"], "<p>EN content</p>")
+            self.assertNotIn("translations", content["openForms"])
+
+    def test_translations_applied_with_submission_language(self):
+        form = FormFactory.build(translation_enabled=True)
+        submission = SubmissionFactory.build(form=form, language_code="nl")
+        request = rf.get("/dummy")
+        config_wrapper = FormioConfigurationWrapper(configuration=TEST_CONFIGURATION)
+
+        configuration = get_dynamic_configuration(config_wrapper, request, submission)
+
+        with self.subTest("textfield"):
+            textfield = configuration["textfield"]
+
+            self.assertEqual(textfield["label"], "Tekstveld")
+            self.assertNotIn("translations", textfield["openForms"])
+
+        with self.subTest("select"):
+            select = configuration["select"]
+
+            self.assertEqual(select["label"], "Maak een keuze")
+            self.assertNotIn("translations", select["openForms"])
+            self.assertEqual(select["data"]["values"][0]["label"], "Optie 1")
+            self.assertNotIn("translations", select["data"]["values"][0]["openForms"])
+            self.assertEqual(select["data"]["values"][1]["label"], "Optie 2")
+            self.assertNotIn("translations", select["data"]["values"][1]["openForms"])
+
+        with self.subTest("content (nested in editgrid)"):
+            content = configuration["content"]
+
+            self.assertEqual(content["html"], "<p>NL-inhoud</p>")
+            self.assertNotIn("translations", content["openForms"])
+
+    def test_translations_applied_with_fallback(self):
+        form = FormFactory.build(translation_enabled=True)
+        submission = SubmissionFactory.build(form=form, language_code="en")
+        request = rf.get("/dummy")
+        config_wrapper = FormioConfigurationWrapper(configuration=TEST_CONFIGURATION)
+
+        configuration = get_dynamic_configuration(config_wrapper, request, submission)
+
+        with self.subTest("textfield"):
+            textfield = configuration["textfield"]
+
+            self.assertEqual(textfield["label"], "Text field")
+            self.assertNotIn("translations", textfield["openForms"])
+
+        with self.subTest("select"):
+            select = configuration["select"]
+
+            self.assertEqual(select["label"], "Pick an option")
+            self.assertNotIn("translations", select["openForms"])
+            self.assertEqual(select["data"]["values"][0]["label"], "Option 1")
+            self.assertNotIn("translations", select["data"]["values"][0]["openForms"])
+            self.assertEqual(select["data"]["values"][1]["label"], "Option 2")
+            self.assertNotIn("translations", select["data"]["values"][1]["openForms"])
+
+        with self.subTest("content (nested in editgrid)"):
+            content = configuration["content"]
+
+            self.assertEqual(content["html"], "<p>EN content</p>")
+            self.assertNotIn("translations", content["openForms"])

--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -107,8 +107,8 @@ class ConfigurationTranslationTests(SimpleTestCase):
 
     This is not meant to exhaustively test all component types - for that, you should
     write appropriate unit tests for each supported component type. Rather, the
-    mechanism here is tested to configure translations are the comopnent level instead
-    of the entire form definition level and avoid leaking the excessive data to the
+    mechanism here is tested to configure translations at the component level instead
+    of at the form definition level. This avoids leaking excessive data to the
     frontend.
 
     Translations need to be 'injected' by the backend and be ready to use for the
@@ -869,6 +869,29 @@ class CoSignTranslationTests(SimpleTestCase):
         component = {
             "type": "cosign",
             "key": "cosign",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class OldCoSignTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_cosign_old(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "coSign",
+            "key": "coSign",
             "label": "Must always have a label",
             prop: f"Default {prop} value",
             "openForms": {"translations": {lang_code: {prop: translation}}},

--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -2,6 +2,7 @@
 Test that component translations are respected in the context of a submission.
 """
 from copy import deepcopy
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
@@ -9,7 +10,6 @@ from django.test import SimpleTestCase
 from hypothesis import given, strategies as st
 from rest_framework.test import APIRequestFactory
 
-from openforms.formio.typing.vanilla import SelectComponent
 from openforms.forms.tests.factories import FormFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.tests.search_strategies import language_code
@@ -17,6 +17,7 @@ from openforms.tests.search_strategies import language_code
 from ..datastructures import FormioConfigurationWrapper
 from ..registry import register
 from ..service import get_dynamic_configuration
+from ..typing import RadioComponent, SelectComponent
 
 rf = APIRequestFactory()
 
@@ -209,6 +210,9 @@ class ConfigurationTranslationTests(SimpleTestCase):
             self.assertEqual(content["html"], "<p>EN content</p>")
             self.assertNotIn("translations", content["openForms"])
 
+    def test_does_not_crash_on_kitchensink(self):
+        raise NotImplementedError("Use kitchensink components JSON file")
+
 
 class ComponentTranslationTests(SimpleTestCase):
     """
@@ -235,6 +239,313 @@ class ComponentTranslationTests(SimpleTestCase):
 
         self.assertEqual(component["label"], "Label")
         self.assertEqual(component["description"], "Description")
+
+
+class TextFieldTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(
+            ["label", "description", "tooltip", "defaultValue", "placeholder"]
+        ),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_textfield(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "textfield",
+            "key": "textfield",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class EmailTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_email(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "email",
+            "key": "email",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class DateTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_date(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "date",
+            "key": "date",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class DateTetimeTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_datetetime(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "datetetime",
+            "key": "datetetime",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class TimeTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_time(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "time",
+            "key": "time",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class PhoneTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_phone(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "phone",
+            "key": "phone",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class PostcodeTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_postcode(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "postcode",
+            "key": "postcode",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class FileTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_file(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "file",
+            "key": "file",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class TextareaTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(
+            ["label", "description", "tooltip", "defaultValue", "placeholder"]
+        ),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_textarea(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "textarea",
+            "key": "textarea",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class NumberTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip", "suffix"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_number(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "number",
+            "key": "number",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class CheckboxTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_checkbox(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "checkbox",
+            "key": "checkbox",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class SelectBoxesTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_selectboxes(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "selectboxes",
+            "key": "selectboxes",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+    @given(lang_code=language_code, translation=st.text(min_size=1))
+    def test_options_translated(self, lang_code, translation):
+        component = {
+            "type": "selectboxes",
+            "key": "selectboxes",
+            "values": [
+                {
+                    "value": "1",
+                    "label": "First option",
+                    "openForms": {
+                        "translations": {
+                            lang_code: {"label": translation},
+                        }
+                    },
+                }
+            ],
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        assert "values" in component
+        opt1 = component["values"][0]
+        assert "label" in opt1
+        assert "openForms" in opt1
+        self.assertEqual(opt1["label"], translation)
+        self.assertNotIn("translations", opt1["openForms"])
 
 
 class SelectTranslationTests(SimpleTestCase):
@@ -331,3 +642,324 @@ class SelectTranslationTests(SimpleTestCase):
         assert "label" in opt1
         self.assertEqual(opt1["label"], "First option")
         self.assertNotIn("openForms", opt1)
+
+
+class CurrencyTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_currency(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "currency",
+            "key": "currency",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class RadioTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_radio(
+        self,
+        lang_code: str,
+        prop: Literal["label", "description", "tooltip"],
+        translation: str,
+    ):
+        component: RadioComponent = {
+            "type": "radio",
+            "key": "radio",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+            "values": [],
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+    @given(lang_code=language_code, translation=st.text(min_size=1))
+    def test_options_translated(self, lang_code, translation):
+        component: RadioComponent = {
+            "type": "radio",
+            "key": "radio",
+            "values": [
+                {
+                    "value": "1",
+                    "label": "First option",
+                    "openForms": {
+                        "translations": {
+                            lang_code: {"label": translation},
+                        }
+                    },
+                }
+            ],
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        assert "values" in component
+        opt1 = component["values"][0]
+        assert "label" in opt1
+        assert "openForms" in opt1
+        self.assertEqual(opt1["label"], translation)
+        self.assertNotIn("translations", opt1["openForms"])
+
+
+class IBANTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_iban(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "iban",
+            "key": "iban",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class LicensePlateTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_licenseplate(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "licenseplate",
+            "key": "licenseplate",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class BSNTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_bsn(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "bsn",
+            "key": "bsn",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class NPFamilyMembersTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_npFamilyMembers(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "npFamilyMembers",
+            "key": "npFamilyMembers",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class SignatureTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_signature(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "signature",
+            "key": "signature",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class CoSignTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_cosign(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "cosign",
+            "key": "cosign",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class MapTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_map(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "map",
+            "key": "map",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class ContentTranslationTests(SimpleTestCase):
+    @given(lang_code=language_code, translation=st.text(min_size=1))
+    def test_translatable_properties_content(self, lang_code: str, translation: str):
+        component = {
+            "type": "content",
+            "key": "content",
+            "label": "Must always have a label",
+            "html": "Default value",
+            "openForms": {"translations": {lang_code: {"html": translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component["html"], translation)
+        self.assertNotIn("translations", component["openForms"])
+
+
+class FieldsetTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "tooltip"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_fieldset(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "fieldset",
+            "key": "fieldset",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "textfield",
+                    "label": "Textfield",
+                    "openForms": {"translations": {lang_code: "-translated-"}},
+                }
+            ],
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+        nested = component["components"][0]
+        self.assertEqual(nested["label"], "Textfield")
+
+
+class EditGridTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=st.sampled_from(["label", "description", "tooltip", "groupLabel"]),
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_editgrid(
+        self, lang_code: str, prop: str, translation: str
+    ):
+        component = {
+            "type": "editgrid",
+            "key": "editgrid",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "textfield",
+                    "label": "Textfield",
+                    "openForms": {"translations": {lang_code: "-translated-"}},
+                }
+            ],
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component[prop], translation)
+        self.assertNotIn("translations", component["openForms"])
+        nested = component["components"][0]
+        self.assertEqual(nested["label"], "Textfield")

--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -1,6 +1,7 @@
 """
 Test that component translations are respected in the context of a submission.
 """
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
@@ -112,7 +113,9 @@ class ComponentTranslationTests(SimpleTestCase):
         form = FormFactory.build(translation_enabled=False)
         submission = SubmissionFactory.build(form=form)
         request = rf.get("/dummy")
-        config_wrapper = FormioConfigurationWrapper(configuration=TEST_CONFIGURATION)
+        config_wrapper = FormioConfigurationWrapper(
+            configuration=deepcopy(TEST_CONFIGURATION)
+        )
 
         configuration = get_dynamic_configuration(config_wrapper, request, submission)
 
@@ -142,7 +145,9 @@ class ComponentTranslationTests(SimpleTestCase):
         form = FormFactory.build(translation_enabled=True)
         submission = SubmissionFactory.build(form=form, language_code="nl")
         request = rf.get("/dummy")
-        config_wrapper = FormioConfigurationWrapper(configuration=TEST_CONFIGURATION)
+        config_wrapper = FormioConfigurationWrapper(
+            configuration=deepcopy(TEST_CONFIGURATION)
+        )
 
         configuration = get_dynamic_configuration(config_wrapper, request, submission)
 
@@ -172,7 +177,9 @@ class ComponentTranslationTests(SimpleTestCase):
         form = FormFactory.build(translation_enabled=True)
         submission = SubmissionFactory.build(form=form, language_code="en")
         request = rf.get("/dummy")
-        config_wrapper = FormioConfigurationWrapper(configuration=TEST_CONFIGURATION)
+        config_wrapper = FormioConfigurationWrapper(
+            configuration=deepcopy(TEST_CONFIGURATION)
+        )
 
         configuration = get_dynamic_configuration(config_wrapper, request, submission)
 

--- a/src/openforms/formio/typing/__init__.py
+++ b/src/openforms/formio/typing/__init__.py
@@ -15,6 +15,7 @@ from .vanilla import (
     DatetimeComponent,
     FileComponent,
     RadioComponent,
+    SelectBoxesComponent,
     SelectComponent,
 )
 
@@ -24,6 +25,7 @@ __all__ = [
     "ContentComponent",
     "FileComponent",
     "SelectComponent",
+    "SelectBoxesComponent",
     "RadioComponent",
     "Column",
     "ColumnsComponent",

--- a/src/openforms/formio/typing/__init__.py
+++ b/src/openforms/formio/typing/__init__.py
@@ -15,6 +15,7 @@ from .vanilla import (
     DatetimeComponent,
     FileComponent,
     RadioComponent,
+    SelectComponent,
 )
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "OptionDict",
     "ContentComponent",
     "FileComponent",
+    "SelectComponent",
     "RadioComponent",
     "Column",
     "ColumnsComponent",

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -7,11 +7,13 @@ These are common ancestors for all specific component types.
 # TODO: on python 3.11+ we can use typing.NotRequired to mark keys that may be absent.
 # For now at least, we use total=False.
 
-from typing import TypedDict
+from typing import TypeAlias, TypedDict
 
 from openforms.typing import JSONValue
 
 from .dates import DateConstraintConfiguration
+
+TranslationsDict: TypeAlias = dict[str, dict[str, str]]
 
 
 class Validate(TypedDict, total=False):
@@ -25,10 +27,11 @@ class OpenFormsConfig(TypedDict, total=False):
     widget: str
     minDate: DateConstraintConfiguration | None
     maxDate: DateConstraintConfiguration | None
+    translations: TranslationsDict
 
 
 class OpenFormsOptionExtension(TypedDict, total=False):
-    translations: dict[str, dict[str, str]]
+    translations: TranslationsDict
 
 
 class OptionDict(TypedDict, total=False):

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -27,7 +27,11 @@ class OpenFormsConfig(TypedDict, total=False):
     maxDate: DateConstraintConfiguration | None
 
 
-class OptionDict(TypedDict):
+class OpenFormsOptionExtension(TypedDict, total=False):
+    translations: dict[str, dict[str, str]]
+
+
+class OptionDict(TypedDict, total=False):
     """
     Value as used in a select/radio/... component.
 
@@ -37,6 +41,7 @@ class OptionDict(TypedDict):
 
     value: str
     label: str
+    openForms: OpenFormsOptionExtension
 
 
 class PrefillConfiguration(TypedDict):

--- a/src/openforms/formio/typing/vanilla.py
+++ b/src/openforms/formio/typing/vanilla.py
@@ -16,6 +16,14 @@ class FileComponent(Component):
     file: FileConfig
 
 
+class SelectData(TypedDict, total=False):
+    values: list[OptionDict]
+
+
+class SelectComponent(Component):
+    data: SelectData
+
+
 class RadioComponent(Component):
     values: list[OptionDict]
 

--- a/src/openforms/formio/typing/vanilla.py
+++ b/src/openforms/formio/typing/vanilla.py
@@ -28,6 +28,10 @@ class RadioComponent(Component):
     values: list[OptionDict]
 
 
+class SelectBoxesComponent(Component):
+    values: list[OptionDict]
+
+
 class ContentComponent(Component):
     html: str
 

--- a/src/openforms/tests/search_strategies.py
+++ b/src/openforms/tests/search_strategies.py
@@ -7,6 +7,8 @@ from hypothesis import strategies as st
 from openforms.forms.models.form_variable import variable_key_validator
 from openforms.typing import JSONPrimitive, JSONValue
 
+language_code = st.sampled_from(["nl", "en", "fy"])
+
 
 def json_primitives(text_strategy=st.text()) -> st.SearchStrategy[JSONPrimitive]:
     return st.one_of(


### PR DESCRIPTION
Partly fixes #2958

This sets up a mechanism for component-level translations.

Translation aspects:

- [x] textfield: label, description, tooltip, default value, placeholder
- [x] email: label, description, tooltip
- [x] date: label, description, tooltip
- [x] datetime: label, description, tooltip
- [x] time: label, description, tooltip
- [x] phone: label, description, tooltip
- [x] postcode: label, description, tooltip
- [x] file: label, description, tooltip
- [x] textarea: label, description, tooltip, default value, placeholder
- [x] number: label, description, tooltip, suffix
- [x] checkbox: label, description, tooltip
- [x] selectboxes: label, description, tooltip, value label
- [x] select: label, description, tooltip, value label
- [x] currency: label, description, tooltip
- [x] radio: label, description, tooltip, value label
- [x] iban: label, description, tooltip
- [x] license plate: label, description, tooltip
- [x] bsn: label, description, tooltip
- [x] family members: label, description, tooltip
- [x] signature: label, description, tooltip
- [x] cosign: label, description, tooltip
- [x] map: label, description, tooltip
- [x] content: html
- [x] fieldset: label, tooltip
- [x] editgrid: label, description, tooltip, group label