### PR TITLE
🐛 Switch ZGW registration backend to a field error

### DIFF
--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -8373,7 +8373,7 @@ msgid "Employee who registered the case on behalf of the customer."
 msgstr "Medewerker die de zaak registreerde voor de klant."
 
 #: openforms/registrations/contrib/zgw_apis/validators.py:26
-msgid "Could not find a roltype with this description related to the zaaktype"
+msgid "Could not find a roltype with this description related to the zaaktype."
 msgstr ""
 "Kon geen roltype vinden met deze omschrijving binnen het opgegeven zaaktype."
 

--- a/src/openforms/js/components/admin/RJSFWrapper.js
+++ b/src/openforms/js/components/admin/RJSFWrapper.js
@@ -1,6 +1,7 @@
 import Form from '@rjsf/core';
 import Widgets from '@rjsf/core/lib/components/widgets';
 import {isSelect, optionsList} from '@rjsf/core/lib/utils';
+import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -167,6 +168,7 @@ const FormRjsfWrapper = ({name, label, schema, uiSchema, formData, onChange, err
 
     */
   for (const [key, msg] of errors) {
+    if (key.includes('nonFieldErrors')) continue;
     const bits = key.split('.');
     // create the nested structure. we can't use lodash, since it creates arrays for
     // indices rather than nested objects.
@@ -179,10 +181,12 @@ const FormRjsfWrapper = ({name, label, schema, uiSchema, formData, onChange, err
     }
     if (!errObj.__errors) errObj.__errors = [];
     errObj.__errors.push(msg);
+    console.log(errObj);
   }
+  console.log(name, label, errors);
 
   return (
-    <Field name={name} label={label} errors={extraErrors ? [] : errors}>
+    <Field name={name} label={label} errors={!isEmpty(extraErrors) ? [] : errors}>
       <Form
         schema={schema}
         uiSchema={uiSchema}

--- a/src/openforms/js/components/admin/forms/Field.js
+++ b/src/openforms/js/components/admin/forms/Field.js
@@ -50,6 +50,7 @@ const Field = ({
   }
   const modifiedChildren = React.cloneElement(children, childProps);
   const [hasErrors, formattedErrors] = normalizeErrors(errors, intl);
+  console.log('formattedErrors :', formattedErrors, errors);
   const className = classNames({
     fieldBox: fieldBox,
     errors: hasErrors,

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext, gettext_lazy as _
 
 import requests
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
 from openforms.api.fields import PrimaryKeyRelatedAsChoicesField
@@ -74,7 +73,7 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
             config = ZgwConfig.get_solo()
             assert isinstance(config, ZgwConfig)
             if config.default_zgw_api_group is None:
-                raise ValidationError(
+                raise serializers.ValidationError(
                     {
                         "zgw_api_group": _(
                             "No ZGW API set was configured on the form and no default was specified globally."
@@ -98,7 +97,7 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         if not roltypen:
             raise serializers.ValidationError(
                 {
-                    "zaaktype": _(
+                    "medewerker_roltype": _(
                         "Could not find a roltype with this description related to the zaaktype."
                     )
                 },

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -79,7 +79,8 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
                         "zgw_api_group": _(
                             "No ZGW API set was configured on the form and no default was specified globally."
                         )
-                    }
+                    },
+                    code="invalid",
                 )
 
         if not ("medewerker_roltype" in attrs and "zaaktype" in attrs):
@@ -96,9 +97,11 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
 
         if not roltypen:
             raise serializers.ValidationError(
-                detail=_(
-                    "Could not find a roltype with this description related to the zaaktype"
-                ),
+                {
+                    "zaaktype": _(
+                        "Could not find a roltype with this description related to the zaaktype."
+                    )
+                },
                 code="invalid",
             )
 

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_validators.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_validators.py
@@ -77,10 +77,10 @@ class OmschrijvingValidatorTests(TestCase):
         is_valid = serializer.is_valid()
 
         self.assertFalse(is_valid)
-        self.assertIn("non_field_errors", serializer.errors)
+        self.assertIn("medewerker_roltype", serializer.errors)
         self.assertEqual(
             "Could not find a roltype with this description related to the zaaktype.",
-            serializer.errors["zaaktype"][0],
+            serializer.errors["medewerker_roltype"][0],
         )
 
 

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_validators.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_validators.py
@@ -79,8 +79,8 @@ class OmschrijvingValidatorTests(TestCase):
         self.assertFalse(is_valid)
         self.assertIn("non_field_errors", serializer.errors)
         self.assertEqual(
-            "Could not find a roltype with this description related to the zaaktype",
-            serializer.errors["non_field_errors"][0],
+            "Could not find a roltype with this description related to the zaaktype.",
+            serializer.errors["zaaktype"][0],
         )
 
 


### PR DESCRIPTION
Fixes #3553.

After taking a look at the test environment, I found at when a non field validation error was raised, it would not show up in the admin.

This fix switches the validation error to a specific field:
![image](https://github.com/open-formulieren/open-forms/assets/65306057/62f65352-339d-4817-8e64-80022e26e2e9)

(validation error later attached to the `roltype`).

This also allows for non field errors to be displayed:

![image](https://github.com/open-formulieren/open-forms/assets/65306057/3967760e-40e4-43ed-a15e-9bee039337aa)
