### PR TITLE
🐛[#3580] Fix zrc rol_create

### DIFF
--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -154,12 +154,12 @@ class ZGWRegistration(BasePlugin):
         ),
         # "betrokkeneIdentificatie.aanschrijfwijze": FieldConf(RegistrationAttribute.initiator_aanschrijfwijze),
         # Verblijfsadres for both Natuurlijk Persoon and Vestiging
-        "betrokkeneIdentificatie.verblijfsadres.woonplaatsNaam": RegistrationAttribute.initiator_woonplaats,
-        "betrokkeneIdentificatie.verblijfsadres.postcode": RegistrationAttribute.initiator_postcode,
-        "betrokkeneIdentificatie.verblijfsadres.straatnaam": RegistrationAttribute.initiator_straat,
-        "betrokkeneIdentificatie.verblijfsadres.huisnummer": RegistrationAttribute.initiator_huisnummer,
-        "betrokkeneIdentificatie.verblijfsadres.huisletter": RegistrationAttribute.initiator_huisletter,
-        "betrokkeneIdentificatie.verblijfsadres.huisnummertoevoeging": RegistrationAttribute.initiator_huisnummer_toevoeging,
+        "betrokkeneIdentificatie.verblijfsadres.wplWoonplaatsNaam": RegistrationAttribute.initiator_woonplaats,
+        "betrokkeneIdentificatie.verblijfsadres.aoaPostcode": RegistrationAttribute.initiator_postcode,
+        "betrokkeneIdentificatie.verblijfsadres.gorOpenbareRuimteNaam": RegistrationAttribute.initiator_straat,
+        "betrokkeneIdentificatie.verblijfsadres.aoaHuisnummer": RegistrationAttribute.initiator_huisnummer,
+        "betrokkeneIdentificatie.verblijfsadres.aoaHuisletter": RegistrationAttribute.initiator_huisletter,
+        "betrokkeneIdentificatie.verblijfsadres.aoaHuisnummertoevoeging": RegistrationAttribute.initiator_huisnummer_toevoeging,
         # Contactpersoon (NOT SUPPORTED BY ZGW APIs)
         # "betrokkeneIdentificatie.telefoonnummer": RegistrationAttribute.initiator_telefoonnummer,
         # "betrokkeneIdentificatie.emailadres": RegistrationAttribute.initiator_emailadres,

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -343,7 +343,7 @@ class ZGWBackendTests(TestCase):
                     "inpBsn": "111222333",
                     "voorvoegselGeslachtsnaam": "de",
                     "geslachtsnaam": "Bar",
-                    "verblijfsadres": {"postcode": "1000 AA"},
+                    "verblijfsadres": {"aoaPostcode": "1000 AA"},
                     "voorletters": "J.W.",
                     "geslachtsaanduiding": "m",
                 },
@@ -555,7 +555,7 @@ class ZGWBackendTests(TestCase):
                     "vestigingsNummer": "87654321",
                     "innNnpId": "12345678",
                     "statutaireNaam": "ACME",
-                    "verblijfsadres": {"postcode": "1000 AA"},
+                    "verblijfsadres": {"aoaPostcode": "1000 AA"},
                 },
             )
 
@@ -824,7 +824,7 @@ class ZGWBackendTests(TestCase):
                     "handelsnaam": "ACME",
                     "innNnpId": "12345678",
                     "statutaireNaam": "ACME",
-                    "verblijfsadres": {"postcode": "1000 AA"},
+                    "verblijfsadres": {"aoaPostcode": "1000 AA"},
                 },
             )
 


### PR DESCRIPTION
I assume `gorOpenbareRuimteNaam` is semantically the same as streetname.

This fixes the reported bug. But doesn't test against the spec.

Closes #3580
