### PR TITLE
:adhesive_bandage: [#3593] Un-break mail styling with local design to…

### DIFF
--- a/src/openforms/config/migrations/0061_convert_container_layout_design_tokens.py
+++ b/src/openforms/config/migrations/0061_convert_container_layout_design_tokens.py
@@ -56,11 +56,12 @@ def apply_mapping(design_tokens: TokenContainer) -> TokenContainer:
         assign(result, new, old_value, missing=dict)
         tokens_to_unset.add(old)
 
-    for token in tokens_to_unset:
-        # don't delete utility tokens!
-        if not any(token.startswith(prefix) for prefix in OBSOLETE_PREFIXES):
-            continue
-        delete(result, token)
+    # TODO: re-enable this when #3593 is properly resolved.
+    # for token in tokens_to_unset:
+    #     # don't delete utility tokens!
+    #     if not any(token.startswith(prefix) for prefix in OBSOLETE_PREFIXES):
+    #         continue
+    #     delete(result, token)
 
     return remove_empty_design_tokens(result)
 

--- a/src/openforms/config/tests/test_migrations.py
+++ b/src/openforms/config/tests/test_migrations.py
@@ -88,7 +88,10 @@ class LayoutMapperTests(SimpleTestCase):
 
         self.assertEqual(
             updated,
-            {"utrecht": {"page-footer": {"background-color": {"value": "blue"}}}},
+            {
+                "of": {"page-footer": {"bg": {"value": "blue"}}},
+                "utrecht": {"page-footer": {"background-color": {"value": "blue"}}},
+            },
         )
 
     def test_map_and_merge_old_token_to_new(self):
@@ -102,12 +105,13 @@ class LayoutMapperTests(SimpleTestCase):
         self.assertEqual(
             updated,
             {
+                "of": {"page-header": {"bg": {"value": "blue"}}},
                 "utrecht": {
                     "page-header": {
                         "background-color": {"value": "blue"},
                         "color": {"value": "pink"},
                     }
-                }
+                },
             },
         )
 
@@ -121,7 +125,10 @@ class LayoutMapperTests(SimpleTestCase):
 
         self.assertEqual(
             updated,
-            {"utrecht": {"page-header": {"background-color": {"value": "blue"}}}},
+            {
+                "of": {"page-header": {"bg": {"value": "red"}}},
+                "utrecht": {"page-header": {"background-color": {"value": "blue"}}},
+            },
         )
 
 
@@ -259,6 +266,10 @@ class LayoutDesignTokensMigrationTests(TestMigrations):
         expected = {
             "of": {
                 "text": {"font-size": {"value": "1rem"}},
+                "page-header": {
+                    "bg": {"value": "#07838f"},
+                    "fg": {"value": "#FFFFFF"},
+                },
             },
             "utrecht": {
                 "page-footer": {


### PR DESCRIPTION
…ken overrides

Do not remove the refactored header/footer design tokens yet, as the mail styling makes use of these.

See the Github issue for more context on why we're not structurally fixing this yet, as we'd ideally like to use the dist/tokens.json of organizations in mail rendering too.