### PR TITLE
:lock: Add CSP object-src directive to settings

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1121,6 +1121,10 @@ CSP_IMG_SRC = (
     + config("CSP_EXTRA_IMG_SRC", default=[], split=True)
 )
 
+# affects <object> and <embed> tags, block everything by default but allow deploy-time
+# overrides.
+CSP_OBJECT_SRC = config("CSP_OBJECT_SRC", default=["'none'"], split=True)
+
 # we must include this explicitly, otherwise the style-src only includes the nonce because
 # of CSP_INCLUDE_NONCE_IN
 CSP_STYLE_SRC = CSP_DEFAULT_SRC


### PR DESCRIPTION
This configuration was missing (but as a workaround it can be added through the admin interface). Now we include it, which restricts some functionality (which was not intended in the first place).

The envvar lookup/fallback allows an escape hatch for those who are making use of object and embed tags.