### PR TITLE
🏷️ Fix generic type hinting of registry

### DIFF
--- a/src/openforms/plugins/registry.py
+++ b/src/openforms/plugins/registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, TypeVar
 
 from django.db import OperationalError
 
@@ -10,7 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 PluginType_co = TypeVar("PluginType_co", bound="AbstractBasePlugin", covariant=True)
-PluginCls: TypeAlias = type[PluginType_co]
 
 
 class BaseRegistry(Generic[PluginType_co]):
@@ -32,8 +31,8 @@ class BaseRegistry(Generic[PluginType_co]):
 
     def __call__(
         self, unique_identifier: str, *args, **kwargs
-    ) -> Callable[[PluginCls], PluginCls]:
-        def decorator(plugin_cls: PluginCls) -> PluginCls:
+    ) -> Callable[[type[PluginType_co]], type[PluginType_co]]:
+        def decorator(plugin_cls: type[PluginType_co]) -> type[PluginType_co]:
             if len(unique_identifier) > UNIQUE_ID_MAX_LENGTH:
                 raise ValueError(
                     f"The unique identifier '{unique_identifier}' is longer then {UNIQUE_ID_MAX_LENGTH} characters."


### PR DESCRIPTION
A small improvement regarding type checking of the `BaseRegistry` class:

```python
# Before
a = register("coSign")
reveal_type(a)  # Revealed type is "def (type[Any]) -> type[Any]"
b = a(...)
reveal_type(b)  # Revealed type is "Any"

# After
a = register("coSign")
reveal_type(a)  # Revealed type is "def a(type[BaseValidator]) -> type[BaseValidator]"
b = a(...)
reveal_type(b)  # Revealed type is "type[BaseValidator]"
```

I think it doesn't make sense to have a type alias to `type[PluginType_co]` outside any definition, because `PluginType_co` isn't bound to any generic class/function yet.

Only downside here is that in `Callable[[type[PluginType_co]], type[PluginType_co]]`, `type[PluginType_co]` should also be a `TypeVar` bound to `type[PluginType_co]`, but typevars bound to other typevars are not allowed.