### PR TITLE
[#3625] Fix handling of null values when parsing Stuf responses

### DIFF
--- a/src/openforms/formio/components/np_family_members/tests/responses/stuf_bg_2_children.xml
+++ b/src/openforms/formio/components/np_family_members/tests/responses/stuf_bg_2_children.xml
@@ -87,6 +87,26 @@
                             <ns:inp.geboorteLand>6030</ns:inp.geboorteLand>
                         </ns:gerelateerde>
                     </ns:inp.heeftAlsKinderen>
+                    <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
+                        <ns:gerelateerde StUF:entiteittype="NPS">
+                            <!--Optional:-->
+                            <ns:inp.bsn>123456789</ns:inp.bsn>
+                            <!--Optional:-->
+                            <ns:geslachtsnaam>Doe</ns:geslachtsnaam>
+                            <!--Optional:-->
+                            <ns:voorvoegselGeslachtsnaam>van</ns:voorvoegselGeslachtsnaam>
+                            <!--Optional:-->
+                            <ns:voorletters>K</ns:voorletters>
+                            <!--Optional:-->
+                            <ns:voornamen>Billy</ns:voornamen>
+                            <!--Optional:-->
+                            <ns:geboortedatum xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                            <!--Optional:-->
+                            <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
+                            <!--Optional:-->
+                            <ns:inp.geboorteLand>6030</ns:inp.geboorteLand>
+                        </ns:gerelateerde>
+                    </ns:inp.heeftAlsKinderen>
                 </ns:object>
             </ns:antwoord>
         </ns:npsLa01>

--- a/src/openforms/formio/components/np_family_members/tests/test_family_members.py
+++ b/src/openforms/formio/components/np_family_members/tests/test_family_members.py
@@ -122,9 +122,10 @@ class FamilyMembersCustomFieldTypeTest(TestCase):
                 bsn="111222333", include_children=True, include_partners=False
             )
 
-            self.assertEqual(2, len(kids_choices))
+            self.assertEqual(3, len(kids_choices))
             self.assertEqual(("456789123", "Bolly van Doe"), kids_choices[0])
             self.assertEqual(("789123456", "Billy van Doe"), kids_choices[1])
+            self.assertEqual(("123456789", "Billy van Doe"), kids_choices[2])
 
     @patch("stuf.stuf_bg.client.StufBGConfig.get_solo")
     def test_get_partners_stuf_bg(self, mock_stufbg_config_get_solo):

--- a/src/stuf/stuf_bg/client.py
+++ b/src/stuf/stuf_bg/client.py
@@ -1,6 +1,7 @@
 import logging
+from collections.abc import Mapping
 from functools import partial
-from typing import List, Mapping, TypeVar
+from typing import TypeVar
 
 import xmltodict
 from glom import glom
@@ -60,7 +61,7 @@ class Client(BaseClient):
         )
         return response.content
 
-    def get_values(self, bsn: str, attributes: List[str]) -> dict:
+    def get_values(self, bsn: str, attributes: list[str]) -> dict:
         response_data = self.get_values_for_attributes(bsn, attributes)
 
         dict_response = _remove_nils(
@@ -94,23 +95,32 @@ class Client(BaseClient):
         raise ValueError("Problem processing StUF-BG response")
 
 
-M = TypeVar("M", bound=Mapping)
+# `Sequence` isn't used here at it would match str (and possibly others)
+C = TypeVar("C", bound=Mapping | list)
 
 
-def _remove_nils(d: M) -> M:
+def _remove_nils(container: C) -> C:
     """Return a copy of d with nils removed"""
-    mapping = type(d)  # use the same dict type
+    Container = type(container)  # use the same container type
 
     def is_nil(value):
-        return isinstance(value, mapping) and (
+        return isinstance(value, Mapping) and (
             value.get("@http://www.w3.org/2001/XMLSchema-instance:nil") == "true"
             or value.get("@noValue") == "geenWaarde"
         )
 
-    return mapping(
-        **{
-            k: (_remove_nils(v) if isinstance(v, mapping) else v)
-            for k, v in d.items()
+    return (
+        Container(
+            **{
+                k: (_remove_nils(v) if isinstance(v, (Mapping, list)) else v)
+                for k, v in container.items()
+                if not is_nil(v)
+            }
+        )
+        if issubclass(Container, Mapping)
+        else [
+            _remove_nils(v) if isinstance(v, (Mapping, list)) else v
+            for v in container
             if not is_nil(v)
-        }
+        ]
     )


### PR DESCRIPTION
Fixes #3625.

In the altered xml file test response, `heeftAlsKinderen` is converted to a `list` by `xmltodict`, and `_remove_nils` would skip this branch. Tests didn't catch this as no null value was set, hence the altered test to show this.
cc @CharString 