### PR TITLE
:bug: [DH#606] Update CSP frame-ancestors directive

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1138,7 +1138,7 @@ CSP_INCLUDE_NONCE_IN = ["style-src", "script-src"]
 CSP_BASE_URI = ["'self'"]
 
 # Frame directives do not fall back to default-src
-CSP_FRAME_ANCESTORS = ["'self'"]
+CSP_FRAME_ANCESTORS = ["'none'"]  # equivalent to X-Frame-Options: deny
 CSP_FRAME_SRC = ["'self'"]
 # CSP_NAVIGATE_TO = ["'self'"]  # this will break all outgoing links etc  # too much & tricky, see note on MDN
 # CSP_FORM_ACTION = ["'self'"]  # forms, possibly problematic with payments


### PR DESCRIPTION
The configuration of CSP frame-ancestors conflicted with the X-Frame- Options header configuration (set to DENY). We do not support using frames of any kind (frame, iframe, object, embed) and thus X_FRAME_OPTIONS is set to DENY. This results in the X-Frame-Options HTTP response header, which is obsoleted by the Content Security Policy frame-ancestors directive. The equivalent configuration to block all frames is to set it to 'none' rather than 'self'.

For more context, see:

* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors