### PR TITLE
:loud_sound: Ensure that we send tracebacks to Sentry on DigiD errors

### DIFF
--- a/src/openforms/authentication/contrib/digid/views.py
+++ b/src/openforms/authentication/contrib/digid/views.py
@@ -71,7 +71,7 @@ class DigiDAssertionConsumerServiceView(
                     DIGID_MESSAGE_PARAMETER, LOGIN_CANCELLED
                 )
             else:
-                logger.error(exc)
+                logger.error(exc, exc_info=exc)
                 failure_url = self.get_failure_url(
                     DIGID_MESSAGE_PARAMETER, GENERIC_LOGIN_ERROR
                 )
@@ -80,7 +80,7 @@ class DigiDAssertionConsumerServiceView(
         try:
             name_id = response.get_nameid()
         except OneLogin_Saml2_ValidationError as exc:
-            logger.error(exc)
+            logger.error(exc, exc_info=exc)
             failure_url = self.get_failure_url(
                 DIGID_MESSAGE_PARAMETER, GENERIC_LOGIN_ERROR
             )


### PR DESCRIPTION
Sentry only showed the logger line but no traceback info. Related to #3641 