### PR TITLE
Replace deprecated calls to `uget*`

### DIFF
--- a/src/openforms/accounts/admin.py
+++ b/src/openforms/accounts/admin.py
@@ -6,7 +6,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
 from django.urls import path
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .forms import UserPreferencesForm
 from .models import User, UserPreferences

--- a/src/openforms/accounts/models.py
+++ b/src/openforms/accounts/models.py
@@ -3,7 +3,7 @@ from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from openforms.translations.utils import get_supported_languages
 

--- a/src/openforms/analytics_tools/admin.py
+++ b/src/openforms/analytics_tools/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from solo.admin import SingletonModelAdmin
 

--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import requests_mock
 from hypothesis import given, strategies as st

--- a/src/openforms/authentication/contrib/eherkenning/views.py
+++ b/src/openforms/authentication/contrib/eherkenning/views.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import resolve
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from digid_eherkenning.backends import BaseSaml2Backend
 from digid_eherkenning.saml2.eherkenning import eHerkenningClient

--- a/src/openforms/config/admin.py
+++ b/src/openforms/config/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_better_admin_arrayfield.admin.mixins import DynamicArrayMixin
 from modeltranslation.admin import TranslationAdmin

--- a/src/openforms/config/views.py
+++ b/src/openforms/config/views.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Generator, Optional, Protocol, TypeGuard
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
 from openforms.appointments.registry import register as appointments_register

--- a/src/openforms/contrib/kvk/tests/test_validators.py
+++ b/src/openforms/contrib/kvk/tests/test_validators.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import requests_mock
 from privates.test import temp_private_root

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -4,7 +4,7 @@ from typing import Callable, Iterator, Union
 from django.urls import reverse
 from django.utils.html import format_html_join
 from django.utils.safestring import SafeString, mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from furl import furl
 from glom import Path

--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -5,7 +5,7 @@ from django.http.response import HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html_join
-from django.utils.translation import ngettext, ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from modeltranslation.manager import get_translatable_fields_for_model
 from ordered_model.admin import OrderedInlineModelAdminMixin, OrderedTabularInline

--- a/src/openforms/forms/admin/form_definition.py
+++ b/src/openforms/forms/admin/form_definition.py
@@ -3,7 +3,7 @@ from django.contrib.admin.actions import delete_selected as _delete_selected
 from django.db.models import Prefetch
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from modeltranslation.admin import TranslationAdmin
 

--- a/src/openforms/forms/admin/views.py
+++ b/src/openforms/forms/admin/views.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.forms import SimpleArrayField
 from django.http import FileResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic.edit import FormView
 

--- a/src/openforms/forms/api/serializers/form_admin_message.py
+++ b/src/openforms/forms/api/serializers/form_admin_message.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer

--- a/src/openforms/forms/api/serializers/logic/action_serializers.py
+++ b/src/openforms/forms/api/serializers/logic/action_serializers.py
@@ -2,7 +2,7 @@ import warnings
 from datetime import date
 
 from django.urls import resolve
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from drf_polymorphic.serializers import PolymorphicSerializer
 from drf_spectacular.utils import extend_schema_serializer

--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ordered_model.serializers import OrderedModelSerializer
 from rest_framework import serializers

--- a/src/openforms/forms/forms/form.py
+++ b/src/openforms/forms/forms/form.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class FormImportForm(forms.Form):

--- a/src/openforms/forms/management/commands/export.py
+++ b/src/openforms/forms/management/commands/export.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ...utils import export_form
 

--- a/src/openforms/forms/management/commands/import.py
+++ b/src/openforms/forms/management/commands/import.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
 

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -8,7 +8,7 @@ from django.contrib import admin
 from django.test import RequestFactory, TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from django_webtest import WebTest
 

--- a/src/openforms/forms/tests/admin/test_form_definition.py
+++ b/src/openforms/forms/tests/admin/test_form_definition.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_webtest import WebTest
 

--- a/src/openforms/forms/tests/test_models.py
+++ b/src/openforms/forms/tests/test_models.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from ..models import Form, FormDefinition, FormStep
 from .factories import (

--- a/src/openforms/multidomain/models.py
+++ b/src/openforms/multidomain/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Domain(models.Model):

--- a/src/openforms/products/models/product.py
+++ b/src/openforms/products/models/product.py
@@ -1,7 +1,7 @@
 import uuid as _uuid
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from tinymce.models import HTMLField
 

--- a/src/openforms/registrations/api/filters.py
+++ b/src/openforms/registrations/api/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 

--- a/src/openforms/registrations/contrib/demo/plugin.py
+++ b/src/openforms/registrations/contrib/demo/plugin.py
@@ -1,6 +1,6 @@
 from typing import NoReturn
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from openforms.submissions.models import Submission
 from openforms.submissions.public_references import set_submission_reference

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -5,7 +5,7 @@ from typing import Any, List, NoReturn, Optional, Tuple, TypedDict
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import get_language_info, ugettext_lazy as _
+from django.utils.translation import get_language_info, gettext_lazy as _
 
 from openforms.emails.constants import (
     X_OF_CONTENT_TYPE_HEADER,

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -6,7 +6,7 @@ from django.core import mail
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import tablib
 from furl import furl

--- a/src/openforms/registrations/contrib/microsoft_graph/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/tests/test_backend.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 from django.test import TestCase
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from freezegun import freeze_time
 from O365 import Account

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from openforms.contrib.zgw.clients import DocumentenClient
 from openforms.contrib.zgw.clients.utils import get_today

--- a/src/openforms/urls.py
+++ b/src/openforms/urls.py
@@ -6,7 +6,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
 from decorator_include import decorator_include

--- a/src/openforms/utils/tests/test_redirect.py
+++ b/src/openforms/utils/tests/test_redirect.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from ..redirect import allow_redirect_url
 from ..validators import AllowedRedirectValidator

--- a/src/openforms/validations/api/serializers.py
+++ b/src/openforms/validations/api/serializers.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from djangorestframework_camel_case.util import underscoreize
 from drf_spectacular.types import OpenApiTypes

--- a/src/openforms/validations/api/views.py
+++ b/src/openforms/validations/api/views.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view


### PR DESCRIPTION
Part of #3049 

Switched to django stubs locally instead of django types and noticed this