### PR TITLE
Update dependencies to resolve pip warning.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -312,7 +312,7 @@ mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db
 mozilla-django-oidc-db==0.12.0
     # via -r requirements/base.in
-o365==2.0.18
+o365==2.0.31
     # via -r requirements/base.in
 oauthlib==3.2.2
     # via requests-oauthlib
@@ -387,9 +387,9 @@ pytz==2022.2.1
     #   django-yubin
     #   djangorestframework
     #   flower
-    #   o365
-    #   tzlocal
     #   zeep
+pytz-deprecation-shim==0.1.0.post0
+    # via tzlocal
 pyyaml==6.0.1
     # via
     #   drf-spectacular
@@ -477,7 +477,9 @@ tinycss2==1.1.0
     #   weasyprint
 tornado==6.3.3
     # via flower
-tzlocal==2.1
+tzdata==2023.3
+    # via pytz-deprecation-shim
+tzlocal==4.3.1
     # via o365
 uritemplate==3.0.1
     # via drf-spectacular

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -587,7 +587,7 @@ multidict==6.0.4
     # via yarl
 mypy-extensions==0.4.3
     # via black
-o365==2.0.18
+o365==2.0.31
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -759,9 +759,12 @@ pytz==2022.2.1
     #   django-yubin
     #   djangorestframework
     #   flower
-    #   o365
-    #   tzlocal
     #   zeep
+pytz-deprecation-shim==0.1.0.post0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   tzlocal
 pyyaml==6.0.1
     # via
     #   -c requirements/base.txt
@@ -957,7 +960,12 @@ tornado==6.3.3
     #   flower
 typing-extensions==4.7.1
     # via pyee
-tzlocal==2.1
+tzdata==2023.3
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   pytz-deprecation-shim
+tzlocal==4.3.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -675,7 +675,7 @@ mypy-extensions==0.4.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   black
-o365==2.0.18
+o365==2.0.31
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -882,9 +882,12 @@ pytz==2022.2.1
     #   django-yubin
     #   djangorestframework
     #   flower
-    #   o365
-    #   tzlocal
     #   zeep
+pytz-deprecation-shim==0.1.0.post0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   tzlocal
 pyyaml==6.0.1
     # via
     #   -c requirements/ci.txt
@@ -1135,7 +1138,12 @@ typing-extensions==4.7.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pyee
-tzlocal==2.1
+tzdata==2023.3
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytz-deprecation-shim
+tzlocal==4.3.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -482,7 +482,7 @@ mozilla-django-oidc-db==0.12.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-o365==2.0.18
+o365==2.0.31
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -613,9 +613,11 @@ pytz==2022.2.1
     #   django-yubin
     #   djangorestframework
     #   flower
-    #   o365
-    #   tzlocal
     #   zeep
+pytz-deprecation-shim==0.1.0.post0
+    # via
+    #   -r requirements/base.txt
+    #   tzlocal
 pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
@@ -748,7 +750,11 @@ tornado==6.3.3
     # via
     #   -r requirements/base.txt
     #   flower
-tzlocal==2.1
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   pytz-deprecation-shim
+tzlocal==4.3.1
     # via
     #   -r requirements/base.txt
     #   o365


### PR DESCRIPTION
Fixed the pip warning:

> DEPRECATION: o365 2.0.18 has a non-standard dependency specifier tzlocal<3.*,>=1.5.0. pip 24.0 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of o365 or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063

Fixing the same warning for the django-2fa library fork is a lot more involved, see also #3049 which is blocked by solving this MFA issue.