### PR TITLE
[#3649] Add bestandsomvang field

### DIFF
--- a/docs/configuration/registration/zgw.rst
+++ b/docs/configuration/registration/zgw.rst
@@ -35,7 +35,7 @@ OAS                           URL to the OAS.
 Client ID                     Client ID for the JWT-token.
 Secret                        Secret for the JWT-token.
 **Documenten API**
-API root URL                  Root URL for the Documenten API that Open Forms can access.
+API root URL                  Root URL for the Documenten API (version 1.1+) that Open Forms can access.
 OAS                           URL to the OAS.
 Client ID                     Client ID for the JWT-token.
 Secret                        Secret for the JWT-token.
@@ -133,6 +133,6 @@ Technical
 API               Supported versions
 ================  ===================
 Zaken API         1.0
-Documenten API    1.0
+Documenten API    1.1+
 Catalogi API      1.0
 ================  ===================

--- a/src/openforms/contrib/zgw/clients/documenten.py
+++ b/src/openforms/contrib/zgw/clients/documenten.py
@@ -32,7 +32,8 @@ class DocumentenClient(NLXClient):
     ):
         assert author, "author must be a non-empty string"
         today = get_today()
-        base64_body = b64encode(content.read()).decode()
+        file_content = content.read()
+        base64_body = b64encode(file_content).decode()
         data = {
             "informatieobjecttype": informatieobjecttype,
             "bronorganisatie": bronorganisatie,
@@ -46,6 +47,9 @@ class DocumentenClient(NLXClient):
             "bestandsnaam": filename,
             "beschrijving": description,
             "indicatieGebruiksrecht": False,
+            "bestandsomvang": (
+                content.size if hasattr(content, "size") else len(file_content)
+            ),
         }
 
         if vertrouwelijkheidaanduiding:


### PR DESCRIPTION
Fixes #3649 

For compatibility with the RXMission API (for which this field is required and `null` values are not accepted).