### PR TITLE
Fix 3672

### DIFF
--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
@@ -126,12 +126,12 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
     def test_it_can_construct_simple_path_parameters_from_any_input(self, field_value):
         assume(field_value != ".")  # request_mock eats the single dot :pacman:
         # https://swagger.io/docs/specification/describing-parameters/#path-parameters
-        context = {"seconds": field_value}
+        context = {"late": {"seconds": field_value}}
 
         var = FormVariableFactory.build(
             service_fetch_configuration=ServiceFetchConfigurationFactory.build(
                 service=self.service,
-                path="delay/{{seconds}}",  # this is not defined as number in the OAS
+                path="delay/{{late.seconds}}",  # this is not defined as number in the OAS
             )
         )
 
@@ -218,13 +218,13 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
         self, some_text, some_value
     ):
         # https://swagger.io/docs/specification/describing-parameters/#query-parameters
-        context = {"url": some_text, "code": some_value}
+        context = {"url": some_text, "code": [{"foo": some_value}]}
 
         var = FormVariableFactory.build(
             service_fetch_configuration=ServiceFetchConfigurationFactory.build(
                 service=self.service,
                 path="redirect-to",
-                query_params={"status_code": ["{{code}}"], "url": ["{{url}}"]},
+                query_params={"status_code": ["{{code.0.foo}}"], "url": ["{{url}}"]},
             )
         )
 
@@ -281,13 +281,13 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
     def test_it_can_construct_simple_header_parameters(self):
         """Assert a happy path"""
         # https://swagger.io/docs/specification/describing-parameters/#header-parameters
-        context = {"some_value": "x"}
+        context = {"some": [{"nested_value": "x"}]}
         var = FormVariableFactory.build(
             service_fetch_configuration=ServiceFetchConfigurationFactory.build(
                 service=self.service,
                 path="cache",
                 # our OAS spec doesn't care what ETags look like.
-                headers={"If-None-Match": "{{some_value}}"},
+                headers={"If-None-Match": "{{some.0.nested_value}}"},
             )
         )
         with requests_mock.Mocker(case_sensitive=True) as m:


### PR DESCRIPTION
- :white_check_mark: [#3647] Prevent backend from crashing if time/dates are invalid
- :adhesive_bandage: [#3647] Prevent backend from crashing in case of invalid data
- :recycle: Bail early if date/times can't be parsed
- :truck: [#3403] Break out models.py into separate module
- :sparkles: [#3404] Break out theme configuration into standalone model
- :white_check_mark: [#3403] Theme admin tests update/additions
- :card_file_box: [#3403] Add support for form-specific theme configuration
- :sparkles: [#3403] Support form-specific style/theme overrides
- :sparkles: [#3403] Apply form-specific themes to PDF rendering
- :sparkles: [#3403] Apply form theme overrides to confirmation emails
- :card_file_box: [#3403] Implement (data) migration to theme record
- :bento: [#3403] Update fixture for groups and admin index config
- :white_check_mark: [#3403] Add tests for forwards data migration
- :white_check_mark: [#3403] Add tests for reverse migration
- :fire: [#3403] Delete legacy theme-related fields
- :art: [#3403] Prepare for themes in form exports
- :sparkles: [#3403] Ensure that design token editor is hooked up for theme admin
- :rotating_light: [#3403] Remove unused imports
- :sparkles: [#3403] Update frontend to be able to set the theme for a form
- :sparkles: [#3403] Add API endpoint to expose available themes
- :sparkles: [#3403] Support setting the theme of a form via the API
- :globe_with_meridians: [#3403] Extract frontend translations
- :bento: [#3403] Generate API specification for new endpoints
- :sparkles: [#3403] Implement theme preview URLs for forms
- :sparkles: [#3403] Implement theme preview from admin
- :pencil: [#3403] Update documentation for theming/styling
- :white_check_mark: [#3403] Add tests to address drops in coverage
- :art: [#3403] Order forms by (internal) name
- :ok_hand: [#3647] PR Feedback
- :adhesive_bandage: [#3649] Add bestandsomvang field
- :white_check_mark: [#3649] Add test
- :memo: [#3649] Document compatibility with Documenten APIs
- [#3651] Changed optional field's label
- :ok_hand: [#3403] PR feedback
- :pencil: Add 2.4.2 release notes
- 🐛[#3672] Fixes Django template context in service fetch
