### PR TITLE
[#3656] OIDC-DigiD return proper message after login cancellation

### DIFF
--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid/test_auth_procedure.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 
 import requests_mock
@@ -322,3 +322,35 @@ class DigiDOIDCTests(TestCase):
             f"http://testserver{reverse('digid_oidc:oidc_authentication_callback')}",
         )
         self.assertEqual(query_params["kc_idp_hint"], "oidc-digid")
+
+    @tag("gh-3656")
+    # This is an example of a specific provider. It may differs when a different provider is used.
+    # According to https://openid.net/specs/openid-connect-core-1_0.html#AuthError and
+    # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1 , this is the error we expect from OIDC
+    def test_redirect_to_form_login_cancelled(self):
+        form_path = reverse("core:form-detail", kwargs={"slug": self.form.slug})
+        form_url = f"http://testserver{form_path}"
+        redirect_form_url = furl(form_url).set({"_start": "1"})
+        redirect_url = furl(
+            reverse(
+                "authentication:return",
+                kwargs={"slug": self.form.slug, "plugin_id": "digid_oidc"},
+            )
+        ).set({"next": redirect_form_url})
+
+        session = self.client.session
+        session["oidc_login_next"] = redirect_url.url
+        session.save()
+
+        response = self.client.get(
+            reverse("digid_oidc:callback"),
+            {"error": "access_denied", "error_description": "The user cancelled"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+        parsed = furl(response.url)
+        query_params = parsed.query.params
+
+        self.assertEqual(query_params["_digid-message"], "login-cancelled")
+        self.assertIsNone(query_params.get("of-auth-problem"))

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning/test_auth_procedure.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 
 import requests_mock
@@ -331,3 +331,35 @@ class eHerkenningOIDCTests(TestCase):
             f"http://testserver{reverse('eherkenning_oidc:oidc_authentication_callback')}",
         )
         self.assertEqual(query_params["kc_idp_hint"], "oidc-eHerkenning")
+
+    @tag("gh-3656")
+    # This is an example of a specific provider. It may differs when a different provider is used.
+    # According to https://openid.net/specs/openid-connect-core-1_0.html#AuthError and
+    # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1 , this is the error we expect from OIDC
+    def test_redirect_to_form_login_cancelled(self):
+        form_path = reverse("core:form-detail", kwargs={"slug": self.form.slug})
+        form_url = f"http://testserver{form_path}"
+        redirect_form_url = furl(form_url).set({"_start": "1"})
+        redirect_url = furl(
+            reverse(
+                "authentication:return",
+                kwargs={"slug": self.form.slug, "plugin_id": "eherkenning_oidc"},
+            )
+        ).set({"next": redirect_form_url})
+
+        session = self.client.session
+        session["oidc_login_next"] = redirect_url.url
+        session.save()
+
+        response = self.client.get(
+            reverse("eherkenning_oidc:callback"),
+            {"error": "access_denied", "error_description": "The user cancelled"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+        parsed = furl(response.url)
+        query_params = parsed.query.params
+
+        self.assertEqual(query_params["_eherkenning-message"], "login-cancelled")
+        self.assertIsNone(query_params.get("of-auth-problem"))

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
@@ -22,6 +22,7 @@ from openforms.authentication.contrib.digid.views import (
     LOGIN_CANCELLED,
 )
 from openforms.authentication.contrib.eherkenning.views import MESSAGE_PARAMETER
+
 from ...views import BACKEND_OUTAGE_RESPONSE_PARAMETER
 from .backends import (
     OIDCAuthenticationDigiDBackend,

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
@@ -17,7 +17,11 @@ from digid_eherkenning_oidc_generics.views import (
     OIDCAuthenticationCallbackView as _OIDCAuthenticationCallbackView,
     OIDCAuthenticationRequestView as _OIDCAuthenticationRequestView,
 )
-
+from openforms.authentication.contrib.digid.views import (
+    DIGID_MESSAGE_PARAMETER,
+    LOGIN_CANCELLED,
+)
+from openforms.authentication.contrib.eherkenning.views import MESSAGE_PARAMETER
 from ...views import BACKEND_OUTAGE_RESPONSE_PARAMETER
 from .backends import (
     OIDCAuthenticationDigiDBackend,
@@ -61,6 +65,17 @@ class OIDCAuthenticationRequestView(_OIDCAuthenticationRequestView):
 
 
 class OIDCAuthenticationCallbackView(_OIDCAuthenticationCallbackView):
+    def get_error_message_parameters(
+        self, parameter: str, problem_code: str
+    ) -> tuple[str, str]:
+        """
+        Return a tuple of the parameter type and the problem code.
+        """
+        return (
+            parameter or BACKEND_OUTAGE_RESPONSE_PARAMETER,
+            problem_code or self.plugin_identifier,
+        )
+
     @property
     def failure_url(self):
         """
@@ -68,7 +83,13 @@ class OIDCAuthenticationCallbackView(_OIDCAuthenticationCallbackView):
         """
         f = furl(self.success_url)
         f = furl(f.args["next"])
-        f.args[BACKEND_OUTAGE_RESPONSE_PARAMETER] = self.plugin_identifier
+
+        parameter, problem_code = self.get_error_message_parameters(
+            self.request.GET.get("error", ""),
+            self.request.GET.get("error_description", ""),
+        )
+        f.args[parameter] = problem_code
+
         return f.url
 
 
@@ -84,6 +105,14 @@ class DigiDOIDCAuthenticationCallbackView(
     plugin_identifier = "digid_oidc"
     auth_backend_class = OIDCAuthenticationDigiDBackend
 
+    def get_error_message_parameters(
+        self, error: str, error_description: str
+    ) -> tuple[str, str]:
+        if error == "access_denied" and error_description == "The user cancelled":
+            return (DIGID_MESSAGE_PARAMETER, LOGIN_CANCELLED)
+
+        return (BACKEND_OUTAGE_RESPONSE_PARAMETER, self.plugin_identifier)
+
 
 class eHerkenningOIDCAuthenticationRequestView(
     SoloConfigEHerkenningMixin, OIDCAuthenticationRequestView
@@ -96,6 +125,17 @@ class eHerkenningOIDCAuthenticationCallbackView(
 ):
     plugin_identifier = "eherkenning_oidc"
     auth_backend_class = OIDCAuthenticationEHerkenningBackend
+
+    def get_error_message_parameters(
+        self, error: str, error_description: str
+    ) -> tuple[str, str]:
+        if error == "access_denied" and error_description == "The user cancelled":
+            return (
+                MESSAGE_PARAMETER % {"plugin_id": self.plugin_identifier.split("_")[0]},
+                LOGIN_CANCELLED,
+            )
+
+        return (BACKEND_OUTAGE_RESPONSE_PARAMETER, self.plugin_identifier)
 
 
 class DigiDMachtigenOIDCAuthenticationRequestView(
@@ -110,6 +150,14 @@ class DigiDMachtigenOIDCAuthenticationCallbackView(
     plugin_identifier = "digid_machtigen_oidc"
     auth_backend_class = OIDCAuthenticationDigiDMachtigenBackend
 
+    def get_error_message_parameters(
+        self, error: str, error_description: str
+    ) -> tuple[str, str]:
+        if error == "access_denied" and error_description == "The user cancelled":
+            return (DIGID_MESSAGE_PARAMETER, LOGIN_CANCELLED)
+
+        return (BACKEND_OUTAGE_RESPONSE_PARAMETER, self.plugin_identifier)
+
 
 class EHerkenningBewindvoeringOIDCAuthenticationRequestView(
     SoloConfigEHerkenningBewindvoeringMixin, OIDCAuthenticationRequestView
@@ -122,3 +170,14 @@ class EHerkenningBewindvoeringOIDCAuthenticationCallbackView(
 ):
     plugin_identifier = "eherkenning_bewindvoering_oidc"
     auth_backend_class = OIDCAuthenticationEHerkenningBewindvoeringBackend
+
+    def get_error_message_parameters(
+        self, error: str, error_description: str
+    ) -> tuple[str, str]:
+        if error == "access_denied" and error_description == "The user cancelled":
+            return (
+                MESSAGE_PARAMETER % {"plugin_id": self.plugin_identifier.split("_")[0]},
+                LOGIN_CANCELLED,
+            )
+
+        return (BACKEND_OUTAGE_RESPONSE_PARAMETER, self.plugin_identifier)


### PR DESCRIPTION
Fixes #3656 

- After investigation we found out (@SilviaAmAm helped with debugging) that OIDC returns an error (required) and an error_description (optional) as query parameters `error=access_denied&error_description=The user cancelled` . 
That's why we explicitly return a message according to DigiD and Logius specs instead of the generic one.

References:

- https://openid.net/specs/openid-connect-core-1_0.html#AuthError
- https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1

In order to test this you will have to set up DigiD-OIDC in the admin so let me know and I will provide you with the needed settings.