### PR TITLE
Add `typings/` as an entry to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ local.py
 !/tmp/.gitkeep
 /bin/ssh_tunnel*
 
+# Local type stubs
+typings/
+
 # Static files
 src/openforms/static/bundles/
 src/openforms/fonts/


### PR DESCRIPTION
I have a local copy of django-stubs that is used by pyright