### PR TITLE
Add missing `FormsExport` import

### DIFF
--- a/src/openforms/forms/models/__init__.py
+++ b/src/openforms/forms/models/__init__.py
@@ -1,5 +1,5 @@
 from .category import Category
-from .form import Form
+from .form import Form, FormsExport
 from .form_definition import FormDefinition
 from .form_registration_backend import FormRegistrationBackend
 from .form_step import FormStep
@@ -10,6 +10,7 @@ from .pricing_logic import FormPriceLogic
 
 __all__ = [
     "Form",
+    "FormsExport",
     "FormDefinition",
     "FormStep",
     "FormVersion",


### PR DESCRIPTION
I don't really know how Django was still able to take this model into account, but according to docs:

https://docs.djangoproject.com/en/5.0/topics/db/models/#organizing-models-in-a-package

> You must import the models in the `__init__.py` file.