### PR TITLE
Update `flake8` exclusion list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,10 @@ exclude=
     migrations
     static
     media
+    node_modules
     src/openforms/conf/local_example.py
+    # Might be created by developers:
+    src/openforms/conf/local.py
 
 [isort]
 combine_as_imports = true


### PR DESCRIPTION
CI runs `flake8 src`, but I got flake8 errors when running locally without specifying a path. It's a shame that you can't configure `include` paths in configuration file.