### PR TITLE
Fix bugs in new formio builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.13.0",
+        "@open-formulieren/formio-builder": "^0.13.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -4580,9 +4580,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.13.0.tgz",
-      "integrity": "sha512-hRDDaI18Ii+rqairkApXOaVNBm3sj6e+KZT13ipZY0lpqlulc41HvhTP3xrpfh4QKv+OowWgPTNk9+3lGnKe9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.13.1.tgz",
+      "integrity": "sha512-1nsnHq6JNsskvwrxCwrTA8mkxA1/RPLn18HPTWr44SYxFHbRt/Ds7h0xxbvBVqQ/JGHcfx7ZhZdP6OssAoomIg==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",
@@ -29542,9 +29542,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.13.0.tgz",
-      "integrity": "sha512-hRDDaI18Ii+rqairkApXOaVNBm3sj6e+KZT13ipZY0lpqlulc41HvhTP3xrpfh4QKv+OowWgPTNk9+3lGnKe9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.13.1.tgz",
+      "integrity": "sha512-1nsnHq6JNsskvwrxCwrTA8mkxA1/RPLn18HPTWr44SYxFHbRt/Ds7h0xxbvBVqQ/JGHcfx7ZhZdP6OssAoomIg==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.13.0",
+    "@open-formulieren/formio-builder": "^0.13.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/js/components/form/columns.js
+++ b/src/openforms/js/components/form/columns.js
@@ -83,8 +83,8 @@ class ColumnField extends FormioColumnField {
         key: 'columns',
         type: 'columns',
         columns: [
-          {size: '6', components: []},
-          {size: '6', components: []},
+          {size: 6, components: []},
+          {size: 6, components: []},
         ],
       },
       ...extend


### PR DESCRIPTION
Partly closes #3733

* Fixed crash due to validation of `column.size` which was string and should be number
    - The rendering crash on object instead of string for validation error is fixed internally in the builder library
    - [x] TODO: add data migration for type conversion in the backend PR: #3710
* Upgraded builder library version to get the bugfixes applied in there