### PR TITLE
[#3049] Upgrade to django 4.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,8 +71,8 @@ intersphinx_mapping = {
         None,
     ),
     "django": (
-        "http://docs.djangoproject.com/en/3.2/",
-        "http://docs.djangoproject.com/en/3.2/_objects/",
+        "http://docs.djangoproject.com/en/4.2/",
+        "http://docs.djangoproject.com/en/4.2/_objects/",
     ),
     "zgw_consumers": (
         "https://zgw-consumers.readthedocs.io/en/latest/",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,7 +18,6 @@ O365  # microsoft graph
 Pillow  # handle images
 portalocker[redis]
 psycopg2  # database driver
-pytz  # handle timezones
 python-dotenv  # environment variables for secrets
 python-decouple  # processing of envvar configs
 python-magic

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -37,7 +37,7 @@ setuptools
 frozendict
 
 # Framework libraries
-django ~= 3.2.0
+django ~= 4.2
 django-admin-index
 django-autoslug
 django-axes[ipware]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -87,7 +87,7 @@ cssselect2==0.7.0
     # via weasyprint
 defusedxml==0.7.1
     # via -r requirements/base.in
-django==3.2.24
+django==4.2.10
     # via
     #   -r requirements/base.in
     #   django-admin-index
@@ -160,7 +160,7 @@ django-digid-eherkenning==0.11.0
     # via -r requirements/base.in
 django-filter==23.2
     # via -r requirements/base.in
-django-formtools==2.3
+django-formtools==2.5.1
     # via django-two-factor-auth
 django-hijack==3.4.1
     # via -r requirements/base.in
@@ -180,7 +180,7 @@ django-ordered-model==3.6
     #   django-admin-index
 django-otp==1.3.0
     # via django-two-factor-auth
-django-phonenumber-field==5.2.0
+django-phonenumber-field==7.3.0
     # via django-two-factor-auth
 django-privates==1.5.0
     # via
@@ -370,6 +370,8 @@ pyopenssl==24.0.0
     #   zgw-consumers
 pyphen==0.14.0
     # via weasyprint
+pypng==0.20220715.0
+    # via qrcode
 pyrsistent==0.17.3
     # via jsonschema
 python-dateutil==2.8.1
@@ -387,7 +389,6 @@ pytz==2022.2.1
     # via
     #   -r requirements/base.in
     #   celery
-    #   django
     #   django-yubin
     #   djangorestframework
     #   flower
@@ -399,7 +400,7 @@ pyyaml==6.0.1
     #   drf-spectacular
     #   gemma-zds-client
     #   jsonschema-spec
-qrcode==6.1
+qrcode==7.4.2
     # via django-two-factor-auth
 redis==4.5.4
     # via
@@ -453,7 +454,6 @@ six==1.15.0
     #   orderedmultidict
     #   prance
     #   python-dateutil
-    #   qrcode
     #   requests-file
     #   rfc3339-validator
 soupsieve==2.3
@@ -478,6 +478,7 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/base.in
     #   asgiref
+    #   qrcode
 tzdata==2023.3
     # via pytz-deprecation-shim
 tzlocal==4.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -387,7 +387,6 @@ python-magic==0.4.27
     # via -r requirements/base.in
 pytz==2022.2.1
     # via
-    #   -r requirements/base.in
     #   celery
     #   django-yubin
     #   djangorestframework

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -165,7 +165,7 @@ defusedxml==0.7.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django==3.2.24
+django==4.2.10
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -269,7 +269,7 @@ django-filter==23.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-formtools==2.3
+django-formtools==2.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -308,7 +308,7 @@ django-otp==1.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-two-factor-auth
-django-phonenumber-field==5.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -737,6 +737,11 @@ pyphen==0.14.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
+pypng==0.20220715.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   qrcode
 pyquery==1.4.1
     # via -r requirements/test-tools.in
 pyrsistent==0.17.3
@@ -773,7 +778,6 @@ pytz==2022.2.1
     #   -r requirements/base.txt
     #   babel
     #   celery
-    #   django
     #   django-yubin
     #   djangorestframework
     #   flower
@@ -791,7 +795,7 @@ pyyaml==6.0.1
     #   gemma-zds-client
     #   jsonschema-spec
     #   vcrpy
-qrcode==6.1
+qrcode==7.4.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -891,7 +895,6 @@ six==1.15.0
     #   orderedmultidict
     #   prance
     #   python-dateutil
-    #   qrcode
     #   requests-file
     #   requests-mock
     #   rfc3339-validator
@@ -975,6 +978,7 @@ typing-extensions==4.9.0
     #   asgiref
     #   black
     #   pyee
+    #   qrcode
 tzdata==2023.3
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -188,7 +188,7 @@ defusedxml==0.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django==3.2.24
+django==4.2.10
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -300,7 +300,7 @@ django-filter==23.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-formtools==2.3
+django-formtools==2.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -341,7 +341,7 @@ django-otp==1.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
-django-phonenumber-field==5.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -853,6 +853,11 @@ pyphen==0.14.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
+pypng==0.20220715.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   qrcode
 pyquery==1.4.1
     # via
     #   -c requirements/ci.txt
@@ -893,7 +898,6 @@ pytz==2022.2.1
     #   -r requirements/ci.txt
     #   babel
     #   celery
-    #   django
     #   django-yubin
     #   djangorestframework
     #   flower
@@ -911,7 +915,7 @@ pyyaml==6.0.1
     #   gemma-zds-client
     #   jsonschema-spec
     #   vcrpy
-qrcode==6.1
+qrcode==7.4.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1015,7 +1019,6 @@ six==1.15.0
     #   orderedmultidict
     #   prance
     #   python-dateutil
-    #   qrcode
     #   requests-file
     #   requests-mock
     #   rfc3339-validator
@@ -1146,6 +1149,7 @@ typing-extensions==4.9.0
     #   asgiref
     #   black
     #   pyee
+    #   qrcode
 tzdata==2023.3
     # via
     #   -c requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -130,7 +130,7 @@ defusedxml==0.7.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django==3.2.24
+django==4.2.10
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -234,7 +234,7 @@ django-filter==23.2
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-formtools==2.3
+django-formtools==2.5.1
     # via
     #   -r requirements/base.txt
     #   django-two-factor-auth
@@ -268,7 +268,7 @@ django-otp==1.3.0
     # via
     #   -r requirements/base.txt
     #   django-two-factor-auth
-django-phonenumber-field==5.2.0
+django-phonenumber-field==7.3.0
     # via
     #   -r requirements/base.txt
     #   django-two-factor-auth
@@ -591,6 +591,10 @@ pyphen==0.14.0
     # via
     #   -r requirements/base.txt
     #   weasyprint
+pypng==0.20220715.0
+    # via
+    #   -r requirements/base.txt
+    #   qrcode
 pyrsistent==0.17.3
     # via
     #   -r requirements/base.txt
@@ -618,7 +622,6 @@ pytz==2022.2.1
     #   -c requirements/base.in
     #   -r requirements/base.txt
     #   celery
-    #   django
     #   django-yubin
     #   djangorestframework
     #   flower
@@ -633,7 +636,7 @@ pyyaml==6.0.1
     #   drf-spectacular
     #   gemma-zds-client
     #   jsonschema-spec
-qrcode==6.1
+qrcode==7.4.2
     # via
     #   -r requirements/base.txt
     #   django-two-factor-auth
@@ -713,7 +716,6 @@ six==1.15.0
     #   orderedmultidict
     #   prance
     #   python-dateutil
-    #   qrcode
     #   requests-file
     #   rfc3339-validator
 soupsieve==2.3
@@ -753,6 +755,7 @@ typing-extensions==4.9.0
     #   -c requirements/base.in
     #   -r requirements/base.txt
     #   asgiref
+    #   qrcode
 tzdata==2023.3
     # via
     #   -r requirements/base.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -619,7 +619,6 @@ python-magic==0.4.27
     #   -r requirements/base.txt
 pytz==2022.2.1
     # via
-    #   -c requirements/base.in
     #   -r requirements/base.txt
     #   celery
     #   django-yubin

--- a/src/openforms/accounts/tests/test_hijacking.py
+++ b/src/openforms/accounts/tests/test_hijacking.py
@@ -67,7 +67,7 @@ class HijackTests(WebTest):
             djhj_message = admin_dashboard.pyquery(".djhj")
             self.assertEqual(len(djhj_message), 1)
 
-            release_form = admin_dashboard.form
+            release_form = admin_dashboard.forms["hijack-release"]
 
             response = release_form.submit()
             self.assertRedirects(
@@ -111,7 +111,7 @@ class HijackTests(WebTest):
             )
 
         with self.subTest("release user"):
-            release_form = admin_dashboard.form
+            release_form = admin_dashboard.forms["hijack-release"]
             release_form.submit()
 
             self.assertEqual(TimelineLogProxy.objects.count(), 2)

--- a/src/openforms/accounts/tests/test_user_preferences.py
+++ b/src/openforms/accounts/tests/test_user_preferences.py
@@ -74,16 +74,18 @@ class UserPreferencesTests(WebTest):
         non_model_fields = {"csrfmiddlewaretoken", "_save"}
 
         change_page = self.app.get(self.admin_url, user=staff_user)
+        form = change_page.forms["userpreferences_form"]
 
-        form_fields = set(change_page.form.fields.keys())
+        form_fields = set(form.fields.keys())
         self.assertEqual(form_fields, {"ui_language"} | non_model_fields)
 
     def test_can_update_language_preference(self):
         staff_user = StaffUserFactory.create(ui_language="")
         change_page = self.app.get(self.admin_url, user=staff_user)
+        form = change_page.forms["userpreferences_form"]
 
-        change_page.form["ui_language"].select("en")
-        change_page.form.submit(name="_save")
+        form["ui_language"].select("en")
+        form.submit(name="_save")
 
         staff_user.refresh_from_db()
         self.assertEqual(staff_user.ui_language, "en")

--- a/src/openforms/analytics_tools/tests/test_admin.py
+++ b/src/openforms/analytics_tools/tests/test_admin.py
@@ -18,7 +18,7 @@ class AnalyticsConfigAdminTests(WebTest):
         for field in fields:
             with self.subTest(field=field):
                 change_page = self.app.get(admin_url, user=superuser)
-                form = change_page.form
+                form = change_page.forms["analyticstoolsconfiguration_form"]
                 form[field] = "https://example.com/"
 
                 response = form.submit()
@@ -38,7 +38,7 @@ class AnalyticsConfigAdminTests(WebTest):
         for field in fields:
             with self.subTest(field=field):
                 change_page = self.app.get(admin_url, user=superuser)
-                form = change_page.form
+                form = change_page.forms["analyticstoolsconfiguration_form"]
                 form[field] = "https://example.com"
 
                 response = form.submit()

--- a/src/openforms/appointments/contrib/jcc/plugin.py
+++ b/src/openforms/appointments/contrib/jcc/plugin.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
-import pytz
 from requests.exceptions import RequestException
 from zeep.client import Client
 from zeep.exceptions import Error as ZeepError
@@ -19,6 +18,7 @@ from zgw_consumers.concurrent import parallel
 
 from openforms.formio.typing import Component
 from openforms.plugins.exceptions import InvalidPluginConfiguration
+from openforms.utils.date import TIMEZONE_AMS, datetime_in_amsterdam
 
 from ...base import (
     AppointmentDetails,
@@ -41,8 +41,6 @@ from .exceptions import GracefulJCCError, JCCError
 from .models import JccConfig
 
 logger = logging.getLogger(__name__)
-
-TIMEZONE_AMS = pytz.timezone("Europe/Amsterdam")
 
 
 def squash_ids(products: list[Product]):
@@ -183,7 +181,7 @@ class JccAppointment(BasePlugin[CustomerFields]):
     ) -> list[date]:
         client = get_client()
         product_ids = squash_ids(products)
-        now_in_ams = timezone.make_naive(timezone.now(), timezone=TIMEZONE_AMS)
+        now_in_ams = datetime_in_amsterdam(timezone.now())
         start_at = start_at or now_in_ams.today()
 
         with log_soap_errors(

--- a/src/openforms/appointments/contrib/qmatic/client.py
+++ b/src/openforms/appointments/contrib/qmatic/client.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, time
 from typing import TypedDict
+from zoneinfo import ZoneInfo
 
-import pytz
 from ape_pie.client import APIClient
 from dateutil.parser import isoparse
 from zgw_consumers.client import build_client
@@ -179,7 +179,7 @@ class Client(APIClient):
 
         # get the branch detail so we can interpret the timezone correctly
         branch = self.get_branch(location_id)
-        branch_timezone = pytz.timezone(branch["timeZone"])
+        branch_timezone = ZoneInfo(branch["timeZone"])
 
         # get the dates
         endpoint = f"v2/branches/{location_id}/dates;{serializedParams}"
@@ -217,7 +217,7 @@ class Client(APIClient):
 
         # get the branch detail so we can correctly apply the timezone
         branch = self.get_branch(location_id)
-        branch_timezone = pytz.timezone(branch["timeZone"])
+        branch_timezone = ZoneInfo(branch["timeZone"])
 
         # get the times
         endpoint = f"v2/branches/{location_id}/dates/{day.isoformat()}/times;{serializedParams}"

--- a/src/openforms/appointments/contrib/qmatic/plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/plugin.py
@@ -6,13 +6,13 @@ from contextlib import contextmanager
 from datetime import date, datetime
 from functools import wraps
 from typing import Callable, ParamSpec, TypeVar
+from zoneinfo import ZoneInfo
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-import pytz
 from dateutil.parser import isoparse
 from requests.exceptions import RequestException
 
@@ -341,7 +341,7 @@ class QmaticAppointment(BasePlugin[CustomerFields]):
         with QmaticClient() as api_client:
             # Ensure that we get the appointment time in the timezone of the branch we're booking for
             branch = api_client.get_branch(location_id)
-            branch_timezone = pytz.timezone(branch["timeZone"])
+            branch_timezone = ZoneInfo(branch["timeZone"])
             if not timezone.is_naive(start_at):
                 start_at = timezone.make_naive(start_at, timezone=branch_timezone)
 

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -4,11 +4,11 @@ from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
-import pytz
 import requests_mock
 from hypothesis import given, strategies as st
 
 from openforms.formio.validation import build_validation_chain
+from openforms.utils.date import TIMEZONE_AMS
 from openforms.utils.tests.logging import disable_logging
 
 from ....base import AppointmentDetails, Customer, Location, Product
@@ -183,9 +183,7 @@ class PluginTests(MockConfigMixin, TestCase):
         self.assertEqual(len(times), 16)
         self.assertEqual(
             times[0],
-            datetime(2016, 12, 6, 9, 0, 0).astimezone(
-                pytz.timezone("Europe/Amsterdam")
-            ),
+            datetime(2016, 12, 6, 9, 0, 0).astimezone(TIMEZONE_AMS),
         )
 
     def test_get_required_customer_fields(self):

--- a/src/openforms/appointments/tests/test_admin.py
+++ b/src/openforms/appointments/tests/test_admin.py
@@ -170,7 +170,7 @@ class AppointmentsConfigAdminTests(WebTest):
 
         self.assertEqual(response.status_code, 200)
 
-        form = response.form
+        form = response.forms["appointmentsconfig_form"]
         plugin_options = form["plugin"].options
 
         self.assertEqual([p[0] for p in plugin_options], ["", "test1", "test2"])
@@ -190,7 +190,7 @@ class AppointmentsConfigAdminTests(WebTest):
                 response = self.app.get(url, user=self.user)
 
                 self.assertEqual(response.status_code, 200)
-                form = response.form
+                form = response.forms["appointmentsconfig_form"]
 
                 self.assertEqual(form["plugin"].value, "")
                 location = form["limit_to_location"]
@@ -210,7 +210,7 @@ class AppointmentsConfigAdminTests(WebTest):
                 response = self.app.get(url, user=self.user)
 
                 self.assertEqual(response.status_code, 200)
-                form = response.form
+                form = response.forms["appointmentsconfig_form"]
 
                 self.assertEqual(form["plugin"].value, "test")
                 location = form["limit_to_location"]
@@ -227,7 +227,7 @@ class AppointmentsConfigAdminTests(WebTest):
 
                 response = self.app.get(url, user=self.user)
 
-                form = response.form
+                form = response.forms["appointmentsconfig_form"]
                 form["plugin"].select("")
 
                 form.submit(name="_save")

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid/test_admin.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/digid/test_admin.py
@@ -46,7 +46,7 @@ class DigiDOIDCFormAdminTests(WebTest):
             )
         )
 
-        form = response.form
+        form = response.forms["openidconnectpublicconfig_form"]
         form["enabled"] = False
         # set the value manually, normally this is done through JS
         form["oidc_rp_scopes_list"] = json.dumps(config.oidc_rp_scopes_list)
@@ -69,7 +69,7 @@ class DigiDOIDCFormAdminTests(WebTest):
             )
         )
 
-        form = response.form
+        form = response.forms["openidconnectpublicconfig_form"]
         form["enabled"] = False
         # set the value manually, normally this is done through JS
         form["oidc_rp_scopes_list"] = json.dumps(config.oidc_rp_scopes_list)

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning/test_admin.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/eherkenning/test_admin.py
@@ -46,7 +46,7 @@ class eHerkenningOIDCFormAdminTests(WebTest):
             )
         )
 
-        form = response.form
+        form = response.forms["openidconnecteherkenningconfig_form"]
         form["enabled"] = False
         # set the value manually, normally this is done through JS
         form["oidc_rp_scopes_list"] = json.dumps(config.oidc_rp_scopes_list)
@@ -69,7 +69,7 @@ class eHerkenningOIDCFormAdminTests(WebTest):
             )
         )
 
-        form = response.form
+        form = response.forms["openidconnecteherkenningconfig_form"]
         form["enabled"] = False
         # set the value manually, normally this is done through JS
         form["oidc_rp_scopes_list"] = json.dumps(config.oidc_rp_scopes_list)

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -13,7 +13,7 @@ from log_outgoing_requests.formatters import HttpFormatter
 
 from csp_post_processor.constants import NONCE_HTTP_HEADER
 
-from .utils import Filesize, config, get_sentry_integrations, strip_protocol_from_origin
+from .utils import Filesize, config, get_sentry_integrations
 
 # Build paths inside the project, so further paths can be defined relative to
 # the code root.
@@ -795,7 +795,7 @@ CORS_ALLOW_CREDENTIALS = True  # required to send cross domain cookies
 CSRF_TRUSTED_ORIGINS = config(
     "CSRF_TRUSTED_ORIGINS",
     split=True,
-    default=[strip_protocol_from_origin(origin) for origin in CORS_ALLOWED_ORIGINS],
+    default=CORS_ALLOWED_ORIGINS,
 )
 #
 # SENTRY - error monitoring

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1096,7 +1096,7 @@ with open(os.path.join(os.path.dirname(__file__), "tinymce_config.json")) as f:
 #
 HIJACK_PERMISSION_CHECK = "openforms.accounts.hijack.verified_superusers_only"
 HIJACK_INSERT_BEFORE = (
-    '<div class="content">'  # note that this only applies to the admin
+    '<div id="content" class="colMS">'  # note that this only applies to the admin
 )
 
 #

--- a/src/openforms/conf/utils.py
+++ b/src/openforms/conf/utils.py
@@ -1,6 +1,5 @@
 import re
 from typing import Any
-from urllib.parse import urlparse
 
 from decouple import Csv, config as _config, undefined
 from sentry_sdk.integrations import DidNotEnable, django, redis
@@ -112,8 +111,3 @@ def get_sentry_integrations() -> list:
         extra.append(celery.CeleryIntegration())
 
     return [*default, *extra]
-
-
-def strip_protocol_from_origin(origin: str) -> str:
-    parsed = urlparse(origin)
-    return parsed.netloc

--- a/src/openforms/config/tests/test_global_configuration.py
+++ b/src/openforms/config/tests/test_global_configuration.py
@@ -98,10 +98,11 @@ class AdminTests(WebTest):
 
         change_page = self.app.get(url)
 
-        change_page.form["save_form_email_subject_nl"] = "Subject {{form_name}}"
-        change_page.form["save_form_email_content_nl"] = "Content {{form_name}}"
-        _ensure_arrayfields(change_page.form, config=config)
-        change_page.form.submit()
+        form = change_page.forms["globalconfiguration_form"]
+        form["save_form_email_subject_nl"] = "Subject {{form_name}}"
+        form["save_form_email_content_nl"] = "Content {{form_name}}"
+        _ensure_arrayfields(form, config=config)
+        form.submit()
 
         config.refresh_from_db()
         self.assertEqual(config.save_form_email_subject, "Subject {{form_name}}")
@@ -113,9 +114,10 @@ class AdminTests(WebTest):
 
         change_page = self.app.get(url)
 
-        change_page.form["enable_virus_scan"] = True
-        _ensure_arrayfields(change_page.form)
-        response = change_page.form.submit()
+        form = change_page.forms["globalconfiguration_form"]
+        form["enable_virus_scan"] = True
+        _ensure_arrayfields(form)
+        response = form.submit()
 
         self.assertEqual(200, response.status_code)
 
@@ -138,17 +140,18 @@ class AdminTests(WebTest):
 
         change_page = self.app.get(url)
 
-        change_page.form["enable_virus_scan"] = True
-        change_page.form["clamav_host"] = "clamav.bla"
-        change_page.form["clamav_port"] = 3310
+        form = change_page.forms["globalconfiguration_form"]
+        form["enable_virus_scan"] = True
+        form["clamav_host"] = "clamav.bla"
+        form["clamav_port"] = 3310
 
         with patch.object(
             clamd.ClamdNetworkSocket,
             "ping",
             side_effect=clamd.ConnectionError("Cannot connect!"),
         ):
-            _ensure_arrayfields(change_page.form)
-            response = change_page.form.submit()
+            _ensure_arrayfields(form)
+            response = form.submit()
 
         self.assertEqual(200, response.status_code)
 

--- a/src/openforms/config/tests/test_theme.py
+++ b/src/openforms/config/tests/test_theme.py
@@ -51,8 +51,9 @@ class AdminTests(WebTest):
             with open(LOGO_FILE, "rb") as infile:
                 upload = Upload("logo.svg", infile.read(), "image/svg+xml")
 
-            change_page.form["logo"] = upload
-            response = change_page.form.submit()
+            form = change_page.forms["theme_form"]
+            form["logo"] = upload
+            response = form.submit()
 
             self.assertEqual(response.status_code, 302)
             theme.refresh_from_db()
@@ -86,8 +87,9 @@ class AdminTests(WebTest):
         with open(logo, "rb") as infile:
             upload = Upload("digid.png", infile.read(), "image/png")
 
-        change_page.form["logo"] = upload
-        response = change_page.form.submit()
+        form = change_page.forms["theme_form"]
+        form["logo"] = upload
+        response = form.submit()
 
         self.assertEqual(response.status_code, 302)
         theme.refresh_from_db()
@@ -99,7 +101,8 @@ class AdminTests(WebTest):
         url = reverse("admin:config_theme_change", args=(theme.pk,))
         change_page = self.app.get(url)
 
-        response = change_page.form.submit()
+        form = change_page.forms["theme_form"]
+        response = form.submit()
 
         self.assertEqual(response.status_code, 302)
         theme.refresh_from_db()
@@ -112,8 +115,9 @@ class AdminTests(WebTest):
 
         change_page = self.app.get(url)
 
-        change_page.form["stylesheet_file"] = upload
-        response = change_page.form.submit()
+        form = change_page.forms["theme_form"]
+        form["stylesheet_file"] = upload
+        response = form.submit()
 
         self.assertEqual(response.status_code, 302)
         theme.refresh_from_db()

--- a/src/openforms/contrib/zgw/clients/utils.py
+++ b/src/openforms/contrib/zgw/clients/utils.py
@@ -1,16 +1,8 @@
-from datetime import datetime
-
 from django.utils import timezone
 
-import pytz
-
-TIMEZONE_AMS = pytz.timezone("Europe/Amsterdam")
+from openforms.utils.date import datetime_in_amsterdam
 
 
 def get_today() -> str:
     now = datetime_in_amsterdam(timezone.now())
     return now.date().isoformat()
-
-
-def datetime_in_amsterdam(value: datetime) -> datetime:
-    return timezone.make_naive(value, timezone=TIMEZONE_AMS)

--- a/src/openforms/formio/components/np_family_members/tests/test_family_members.py
+++ b/src/openforms/formio/components/np_family_members/tests/test_family_members.py
@@ -12,6 +12,7 @@ from zgw_consumers.test.factories import ServiceFactory
 from openforms.authentication.constants import AuthAttribute
 from openforms.contrib.haal_centraal.models import HaalCentraalConfig
 from openforms.formio.service import get_dynamic_configuration
+from openforms.logging.tests.utils import disable_timelinelog
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.template import render_from_string
 from stuf.constants import EndpointType
@@ -26,6 +27,7 @@ from ..stuf_bg import get_np_family_members_stuf_bg
 TEST_FILES = Path(__file__).parent.resolve() / "responses"
 
 
+@disable_timelinelog()
 class FamilyMembersCustomFieldTypeTest(TestCase):
     @patch(
         "openforms.formio.components.custom.get_np_family_members_haal_centraal",

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any
 
-from django.test import SimpleTestCase, tag
+from django.test import TestCase, tag
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -17,15 +17,15 @@ from ...typing import DateComponent
 request_factory = APIRequestFactory()
 
 
-class DynamicDateConfigurationTests(SimpleTestCase):
+class DynamicDateConfigurationTests(TestCase):
     @staticmethod
     def _get_dynamic_config(
         component: DateComponent, variables: dict[str, Any]
     ) -> DateComponent:
         config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")
-        submission = SubmissionFactory.build()
-        static_vars = get_static_variables(submission=None)  # don't do queries
+        submission = SubmissionFactory.create()
+        static_vars = get_static_variables(submission=submission)  # don't do queries
         variables.update({var.key: var.initial_value for var in static_vars})
         config_wrapper = get_dynamic_configuration(
             config_wrapper, request=request, submission=submission, data=variables
@@ -201,7 +201,7 @@ class DynamicDateConfigurationTests(SimpleTestCase):
         }
         # Amsterdam time
         some_date = timezone.make_aware(datetime(2022, 10, 14, 0, 0, 0))
-        assert some_date.tzinfo.zone == "Europe/Amsterdam"
+        assert some_date.tzinfo.key == "Europe/Amsterdam"
 
         new_component = self._get_dynamic_config(component, {"someDate": some_date})
 
@@ -227,7 +227,7 @@ class DynamicDateConfigurationTests(SimpleTestCase):
         }
         # Amsterdam time
         some_date = timezone.make_aware(datetime(2022, 10, 14, 0, 0, 0))
-        assert some_date.tzinfo.zone == "Europe/Amsterdam"
+        assert some_date.tzinfo.key == "Europe/Amsterdam"
 
         new_component = self._get_dynamic_config(component, {"someDate": some_date})
 

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -1,3 +1,4 @@
+import zoneinfo
 from datetime import datetime
 from typing import Any
 
@@ -154,7 +155,7 @@ class DynamicDatetimeConfigurationTests(TestCase):
         )
 
     def test_relative_to_variable_add_delta(self):
-        component = {
+        component: DatetimeComponent = {
             "type": "datetime",
             "key": "aDatetime",
             "openForms": {
@@ -171,10 +172,14 @@ class DynamicDatetimeConfigurationTests(TestCase):
         }
         # Amsterdam time
         some_date = timezone.make_aware(datetime(2022, 10, 14, 15, 0, 0))
+        assert isinstance(some_date.tzinfo, zoneinfo.ZoneInfo)
         assert some_date.tzinfo.key == "Europe/Amsterdam"
 
         new_component = self._get_dynamic_config(component, {"someDatetime": some_date})
 
+        assert "datePicker" in new_component
+        assert new_component["datePicker"] is not None
+        assert "minDate" in new_component["datePicker"]
         self.assertEqual(
             new_component["datePicker"]["minDate"],
             "2022-11-04T14:00:00+01:00",  # Nov. 4th Amsterdam time, where DST has ended

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from django.test import SimpleTestCase, override_settings
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -17,15 +17,15 @@ request_factory = APIRequestFactory()
 
 
 @override_settings(TIME_ZONE="Europe/Amsterdam")
-class DynamicDatetimeConfigurationTests(SimpleTestCase):
+class DynamicDatetimeConfigurationTests(TestCase):
     @staticmethod
     def _get_dynamic_config(
         component: DatetimeComponent, variables: dict[str, Any]
     ) -> DatetimeComponent:
         config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")
-        submission = SubmissionFactory.build()
-        static_vars = get_static_variables(submission=None)  # don't do queries
+        submission = SubmissionFactory.create()
+        static_vars = get_static_variables(submission=submission)  # don't do queries
         variables.update({var.key: var.initial_value for var in static_vars})
         config_wrapper = get_dynamic_configuration(
             config_wrapper, request=request, submission=submission, data=variables
@@ -171,7 +171,7 @@ class DynamicDatetimeConfigurationTests(SimpleTestCase):
         }
         # Amsterdam time
         some_date = timezone.make_aware(datetime(2022, 10, 14, 15, 0, 0))
-        assert some_date.tzinfo.zone == "Europe/Amsterdam"
+        assert some_date.tzinfo.key == "Europe/Amsterdam"
 
         new_component = self._get_dynamic_config(component, {"someDatetime": some_date})
 
@@ -197,7 +197,7 @@ class DynamicDatetimeConfigurationTests(SimpleTestCase):
         }
         # Amsterdam time
         some_date = timezone.make_aware(datetime(2022, 10, 14, 15, 0, 0))
-        assert some_date.tzinfo.zone == "Europe/Amsterdam"
+        assert some_date.tzinfo.key == "Europe/Amsterdam"
 
         new_component = self._get_dynamic_config(component, {"someDatetime": some_date})
 

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -180,9 +180,14 @@ class DynamicDatetimeConfigurationTests(TestCase):
         assert "datePicker" in new_component
         assert new_component["datePicker"] is not None
         assert "minDate" in new_component["datePicker"]
+        # DST ended on Oct 30, so we go from UTC+2 to UTC+1 (clock goes backwards one hour)
+        # On Django 3.2, this hour backwards was calculated in, but on 4.2 the local time
+        # (15:00) stays identical. You can argue for both of those cases that they're the
+        # correct behaviour...
+        # At least the zoneinfo variant ends up with the correct final timezone...
         self.assertEqual(
             new_component["datePicker"]["minDate"],
-            "2022-11-04T14:00:00+01:00",  # Nov. 4th Amsterdam time, where DST has ended
+            "2022-11-04T15:00:00+01:00",  # Nov. 4th Amsterdam time, where DST has ended
         )
 
     def test_relative_to_variable_subtract_delta(self):

--- a/src/openforms/formio/typing/dates.py
+++ b/src/openforms/formio/typing/dates.py
@@ -4,19 +4,21 @@ Types for our date/datetime validation extension.
 
 from typing import Literal, TypedDict
 
+from typing_extensions import NotRequired
+
 
 class DateConstraintDelta(TypedDict):
-    years: int | None
-    months: int | None
-    days: int | None
+    years: NotRequired[int | None]
+    months: NotRequired[int | None]
+    days: NotRequired[int | None]
 
 
 class DateConstraintConfiguration(TypedDict):
     mode: Literal["", "fixedValue", "future", "past", "relativeToVariable"]
-    includeToday: bool | None
-    variable: str | None
-    delta: DateConstraintDelta | None
-    operator: Literal["add", "subtract"] | None
+    includeToday: NotRequired[bool | None]
+    variable: NotRequired[str | None]
+    delta: NotRequired[DateConstraintDelta | None]
+    operator: NotRequired[Literal["add", "subtract"] | None]
 
 
 class DatePickerConfig(TypedDict):

--- a/src/openforms/formio/typing/vanilla.py
+++ b/src/openforms/formio/typing/vanilla.py
@@ -1,5 +1,7 @@
 from typing import Literal, TypedDict
 
+from typing_extensions import NotRequired
+
 from .base import Component, OptionDict
 from .dates import DatePickerConfig
 
@@ -37,7 +39,7 @@ class ContentComponent(Component):
 
 
 class DatetimeComponent(Component):
-    datePicker: DatePickerConfig | None
+    datePicker: NotRequired[DatePickerConfig | None]
 
 
 class Column(TypedDict):

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -643,7 +643,8 @@ class FormAdminActionsTests(FormListAjaxMixin, WebTest):
 
         self.assertEqual(200, response.status_code)
 
-        forms_uuids = response.form["forms_uuids"].value.split(",")
+        html_form = response.forms[1]
+        forms_uuids = html_form["forms_uuids"].value.split(",")
 
         self.assertEqual(2, len(forms_uuids))
         self.assertIn(str(form2.uuid), forms_uuids)
@@ -1015,7 +1016,8 @@ class FormDeleteTests(FormListAjaxMixin, WebTest):
         html_form["action"] = "delete_selected"
         html_form["_selected_action"] = [form.pk]
         confirm_page = html_form.submit(name="index")
-        confirm_page.form.submit()
+        confirm_form = confirm_page.forms[1]
+        confirm_form.submit()
 
         # check that the form is soft deleted
         form.refresh_from_db()
@@ -1036,7 +1038,8 @@ class FormDeleteTests(FormListAjaxMixin, WebTest):
         html_form["action"] = "delete_selected"
         html_form["_selected_action"] = [form.pk]
         confirm_page = html_form.submit(name="index")
-        confirm_page.form.submit()
+        confirm_form = confirm_page.forms[1]
+        confirm_form.submit()
 
         self.assertFalse(Form.objects.exists())
         # delete cascades - steps are deleted, and single-use form definitions are
@@ -1063,7 +1066,8 @@ class FormDeleteTests(FormListAjaxMixin, WebTest):
         html_form["action"] = "delete_selected"
         html_form["_selected_action"] = [form.pk]
         confirm_page = html_form.submit(name="index")
-        confirm_page.form.submit()
+        confirm_form = confirm_page.forms[1]
+        confirm_form.submit()
 
         self.assertFalse(Form.objects.exists())
         self.assertFalse(FormStep.objects.exists())
@@ -1079,7 +1083,8 @@ class FormDeleteTests(FormListAjaxMixin, WebTest):
             reverse("admin:forms_form_delete", args=(form.pk,)),
             user=self.user,
         )
-        delete_page.form.submit()
+        delete_form = delete_page.forms[1]
+        delete_form.submit()
 
         # check that the form is soft deleted
         form.refresh_from_db()
@@ -1099,7 +1104,8 @@ class FormDeleteTests(FormListAjaxMixin, WebTest):
             reverse("admin:forms_form_delete", args=(form.pk,)),
             user=self.user,
         )
-        delete_page.form.submit()
+        delete_form = delete_page.forms[1]
+        delete_form.submit()
 
         # check that the form/form variables are hard deleted and reusable form definitions are kept
         self.assertFalse(Form.objects.exists())

--- a/src/openforms/forms/tests/admin/test_form_definition.py
+++ b/src/openforms/forms/tests/admin/test_form_definition.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
 from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
@@ -107,8 +107,9 @@ class TestFormDefinitionAdmin(WebTest):
                 kwargs={"object_id": step.form_definition.pk},
             ),
         )
-        response.form["is_reusable"] = False
-        response = response.form.submit()
+        form = response.forms["formdefinition_form"]
+        form["is_reusable"] = False
+        response = form.submit()
 
         self.assertInHTML(
             _(
@@ -134,10 +135,11 @@ class TestFormDefinitionAdmin(WebTest):
         change_page = self.app.get(
             reverse("admin:forms_formdefinition_change", kwargs={"object_id": fd.pk}),
         )
-        assert "{% bad tag and syntax %}" in change_page.form["configuration"].value
+        form = change_page.forms["formdefinition_form"]
+        assert "{% bad tag and syntax %}" in form["configuration"].value
 
         # submit the form, which throws validation errors
-        submit_response = change_page.form.submit()
+        submit_response = form.submit()
 
         self.assertEqual(submit_response.status_code, 200)
         errors = submit_response.context["adminform"].errors

--- a/src/openforms/forms/tests/test_api_forms.py
+++ b/src/openforms/forms/tests/test_api_forms.py
@@ -120,7 +120,7 @@ class FormSerializerTests(APITestCase):
             ask_statement_of_truth=True,
             statement_of_truth_label="I am honest",
         )
-        form = FormFactory.build()
+        form = FormFactory.create()
         with patch(
             "openforms.forms.api.serializers.form.GlobalConfiguration.get_solo",
             return_value=config,
@@ -155,7 +155,7 @@ class FormSerializerTests(APITestCase):
         config = GlobalConfiguration(
             ask_privacy_consent=False, ask_statement_of_truth=False
         )
-        form = FormFactory.build(
+        form = FormFactory.create(
             ask_privacy_consent=StatementCheckboxChoices.required,
             ask_statement_of_truth=StatementCheckboxChoices.required,
         )
@@ -184,7 +184,7 @@ class FormSerializerTests(APITestCase):
         config = GlobalConfiguration(
             ask_privacy_consent=True, ask_statement_of_truth=True
         )
-        form = FormFactory.build(
+        form = FormFactory.create(
             ask_privacy_consent=StatementCheckboxChoices.disabled,
             ask_statement_of_truth=StatementCheckboxChoices.disabled,
         )

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -140,6 +140,7 @@ class ImportExportAPITests(APITestCase):
         self.user.save()
 
         form1 = FormFactory.create(send_confirmation_email=True)
+        original_registration_backends = form1.registration_backends.order_by("id")
         form2 = FormFactory.create()
         FormRegistrationBackendFactory.create_batch(2, form=form1, backend="demo")
         form_definition1, form_definition2 = FormDefinitionFactory.create_batch(2)
@@ -188,7 +189,7 @@ class ImportExportAPITests(APITestCase):
         self.assertEqual(imported_form.active, False)
         for imported, original in zip(
             imported_form.registration_backends.order_by("id"),
-            form1.registration_backends.order_by("id"),
+            original_registration_backends,
         ):
             self.assertEqual(imported.key, original.key)
             self.assertEqual(imported.name, original.name)

--- a/src/openforms/forms/tests/test_form_admin.py
+++ b/src/openforms/forms/tests/test_form_admin.py
@@ -77,7 +77,8 @@ class FormAdminTests(FormListAjaxMixin, WebTest):
         response = form.submit(status=200)
 
         # deletion confirmation
-        response.form.submit()
+        delete_confirmation_form = response.forms[1]
+        delete_confirmation_form.submit()
 
         form_delete.refresh_from_db()
         form_keep.refresh_from_db()
@@ -99,7 +100,8 @@ class FormAdminTests(FormListAjaxMixin, WebTest):
         response = self.app.get(url, user=self.superuser)
 
         # deletion confirmation
-        response.form.submit()
+        delete_confirmation_form = response.forms[1]
+        delete_confirmation_form.submit()
 
         form.refresh_from_db()
         self.assertTrue(form._is_deleted)

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -273,13 +273,14 @@ class FormSerializerTest(TestCase):
         # deprecated case
         context = {"request": None}
         data = FormSerializer(context=context).to_representation(
-            instance=FormFactory.build()
+            instance=FormFactory.create(slug="unicorn-slug")
         )
         # not a v3 call
         del data["registration_backends"]
         # options v2 are nullable
         data["registration_backend"] = "nullable-unicorn"
         data["registration_backend_options"] = None
+        data["slug"] = "another-slug"
 
         mock_register = RegistrationPluginRegistry()
 

--- a/src/openforms/js/components/admin/form_design/AuthPluginField.js
+++ b/src/openforms/js/components/admin/form_design/AuthPluginField.js
@@ -24,15 +24,15 @@ const AuthPluginField = ({availableAuthPlugins, selectedAuthPlugins, onChange, e
     );
 
     return (
-      <li key={plugin.id}>
-        <Checkbox
-          name={plugin.label}
-          value={plugin.id}
-          label={label}
-          onChange={onChange}
-          checked={selectedAuthPlugins.includes(plugin.id)}
-        />
-      </li>
+      <Checkbox
+        key={plugin.id}
+        name={plugin.label}
+        value={plugin.id}
+        label={label}
+        onChange={onChange}
+        checked={selectedAuthPlugins.includes(plugin.id)}
+        noVCheckbox
+      />
     );
   });
 
@@ -51,7 +51,7 @@ const AuthPluginField = ({availableAuthPlugins, selectedAuthPlugins, onChange, e
       errors={errors}
       required
     >
-      <ul>{authCheckboxes}</ul>
+      <div>{authCheckboxes}</div>
     </Field>
   );
 };

--- a/src/openforms/js/components/admin/form_design/Editor.js
+++ b/src/openforms/js/components/admin/form_design/Editor.js
@@ -1,6 +1,7 @@
 import {Editor} from '@tinymce/tinymce-react';
 import React, {useContext, useRef} from 'react';
 import {useIntl} from 'react-intl';
+import getTinyMCEAppearance from 'tinymce_appearance';
 
 import tinyMceConfig from '../../../../conf/tinymce_config.json';
 import {TinyMceContext} from './Context';
@@ -9,21 +10,22 @@ const TinyMCEEditor = ({content, onEditorChange}) => {
   const editorRef = useRef(null);
   const tinyMceUrl = useContext(TinyMceContext);
   const intl = useIntl();
-  // TODO Django 4.2: use explicit theme names rather than the media query approach:
-  // https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/dark_mode.css#L36
-  const useDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
+  const appearance = getTinyMCEAppearance();
+  // when appearance changes, the key changes, which re-initializes the editor. tinymce
+  // does not have a built-in way to change the skin/content_css on the fly.
+  const key = `${appearance.skin}/${appearance.content_css}`;
   return (
     <>
       <Editor
+        key={key}
         tinymceScriptSrc={tinyMceUrl}
         onInit={(evt, editor) => (editorRef.current = editor)}
         value={content}
         init={{
           ...tinyMceConfig,
           language: intl.locale,
-          skin: useDarkMode ? 'oxide-dark' : 'oxide',
-          content_css: useDarkMode ? 'dark' : 'default',
+          ...appearance,
         }}
         onEditorChange={onEditorChange}
       />

--- a/src/openforms/js/components/admin/form_design/Editor.js
+++ b/src/openforms/js/components/admin/form_design/Editor.js
@@ -1,7 +1,10 @@
 import {Editor} from '@tinymce/tinymce-react';
 import React, {useContext, useRef} from 'react';
 import {useIntl} from 'react-intl';
+import {useGlobalState} from 'state-pool';
 import getTinyMCEAppearance from 'tinymce_appearance';
+
+import {currentTheme} from 'utils/theme';
 
 import tinyMceConfig from '../../../../conf/tinymce_config.json';
 import {TinyMceContext} from './Context';
@@ -10,8 +13,9 @@ const TinyMCEEditor = ({content, onEditorChange}) => {
   const editorRef = useRef(null);
   const tinyMceUrl = useContext(TinyMceContext);
   const intl = useIntl();
+  const [theme] = useGlobalState(currentTheme);
 
-  const appearance = getTinyMCEAppearance();
+  const appearance = getTinyMCEAppearance(theme);
   // when appearance changes, the key changes, which re-initializes the editor. tinymce
   // does not have a built-in way to change the skin/content_css on the fly.
   const key = `${appearance.skin}/${appearance.content_css}`;

--- a/src/openforms/js/components/admin/forms/Field.js
+++ b/src/openforms/js/components/admin/forms/Field.js
@@ -81,7 +81,7 @@ const Field = ({
 
         {helpText ? (
           <div className="help" id={`id_${name}_helptext`}>
-            {helpText}
+            <div>{helpText}</div>
           </div>
         ) : null}
       </div>

--- a/src/openforms/js/components/admin/forms/Field.js
+++ b/src/openforms/js/components/admin/forms/Field.js
@@ -69,13 +69,21 @@ const Field = ({
             {formattedErrors}
           </ErrorList>
         ) : null}
-        {label && (
-          <label className={required ? 'required' : ''} htmlFor={htmlFor}>
-            {label}
-          </label>
-        )}
-        {modifiedChildren}
-        {helpText ? <div className="help">{helpText}</div> : null}
+
+        <div className="flex-container">
+          {label && (
+            <label className={required ? 'required' : ''} htmlFor={htmlFor}>
+              {label}
+            </label>
+          )}
+          {modifiedChildren}
+        </div>
+
+        {helpText ? (
+          <div className="help" id={`id_${name}_helptext`}>
+            {helpText}
+          </div>
+        ) : null}
       </div>
     </>
   );

--- a/src/openforms/js/components/admin/forms/Inputs.js
+++ b/src/openforms/js/components/admin/forms/Inputs.js
@@ -109,7 +109,11 @@ const Checkbox = ({name, label, helpText, noVCheckbox = false, ...extraProps}) =
       <label className={classNames('inline', {vCheckboxLabel: !noVCheckbox})} htmlFor={idFor}>
         {label}
       </label>
-      {helpText ? <div className="help">{helpText}</div> : null}
+      {helpText ? (
+        <div className="help">
+          <div>{helpText}</div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/openforms/js/components/admin/forms/Inputs.js
+++ b/src/openforms/js/components/admin/forms/Inputs.js
@@ -96,15 +96,17 @@ DateTimeInput.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Checkbox = ({name, label, helpText, ...extraProps}) => {
+const Checkbox = ({name, label, helpText, noVCheckbox = false, ...extraProps}) => {
   const {disabled = false} = extraProps;
   const prefix = useContext(PrefixContext);
   name = prefix ? `${prefix}-${name}` : name;
   const idFor = disabled ? undefined : `id_${name}`;
   return (
-    <div className={classNames('checkbox-row', {'checkbox-row--disabled': disabled})}>
+    <div
+      className={classNames('flex-container', 'checkbox-row', {'checkbox-row--disabled': disabled})}
+    >
       <input type="checkbox" name={name} id={idFor} {...extraProps} />{' '}
-      <label className="vCheckboxLabel inline" htmlFor={idFor}>
+      <label className={classNames('inline', {vCheckboxLabel: !noVCheckbox})} htmlFor={idFor}>
         {label}
       </label>
       {helpText ? <div className="help">{helpText}</div> : null}
@@ -116,6 +118,7 @@ Checkbox.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
   helpText: PropTypes.node,
+  noVCheckbox: PropTypes.bool,
 };
 
 const Radio = ({name, idFor, label, helpText, ...extraProps}) => {

--- a/src/openforms/js/components/admin/plugin_configuration/PluginConfig.js
+++ b/src/openforms/js/components/admin/plugin_configuration/PluginConfig.js
@@ -18,6 +18,7 @@ const PluginConfig = ({module, plugin, label, enabled = true, onChange}) => {
         }
         checked={enabled}
         onChange={() => onChange(!enabled)}
+        noVCheckbox
       />
     </>
   );

--- a/src/openforms/js/initTinymce.js
+++ b/src/openforms/js/initTinymce.js
@@ -1,9 +1,12 @@
 // Taken from https://github.com/jazzband/django-tinymce/blob/master/tinymce/static/django_tinymce/init_tinymce.js
-// Updated to add dark theme detection (L35-44)
+// Updated to add dark theme detection (L3, L8, L38, L67)
+import getTinyMCEAppearance from './tinymce_appearance';
 
-'use strict';
+('use strict');
 
 {
+  let appearance = {};
+
   function initTinyMCE(el) {
     if (el.closest('.empty-form') === null) {
       // Don't do empty inlines
@@ -32,16 +35,7 @@
         }
       });
 
-      // TODO Django 4.2: use explicit theme names rather than the media query approach:
-      // https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/dark_mode.css#L36
-      const useDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      mce_conf = {
-        ...mce_conf,
-        ...{
-          skin: useDarkMode ? 'oxide-dark' : 'oxide',
-          content_css: useDarkMode ? 'dark' : 'default',
-        },
-      };
+      mce_conf = {...mce_conf, ...appearance};
 
       // replace default prefix of 'empty-form' if used in selector
       if (mce_conf.selector && mce_conf.selector.includes('__prefix__')) {
@@ -70,6 +64,7 @@
   }
 
   function initializeTinyMCE(element, formsetName) {
+    appearance = getTinyMCEAppearance();
     Array.from(element.querySelectorAll('.tinymce')).forEach(area => initTinyMCE(area));
   }
 

--- a/src/openforms/js/initTinymce.js
+++ b/src/openforms/js/initTinymce.js
@@ -1,5 +1,7 @@
 // Taken from https://github.com/jazzband/django-tinymce/blob/master/tinymce/static/django_tinymce/init_tinymce.js
-// Updated to add dark theme detection (L3, L8, L38, L67)
+// Updated to handle dark/light mode
+import {currentTheme} from 'utils/theme';
+
 import getTinyMCEAppearance from './tinymce_appearance';
 
 ('use strict');
@@ -64,7 +66,6 @@ import getTinyMCEAppearance from './tinymce_appearance';
   }
 
   function initializeTinyMCE(element, formsetName) {
-    appearance = getTinyMCEAppearance();
     Array.from(element.querySelectorAll('.tinymce')).forEach(area => initTinyMCE(area));
   }
 
@@ -75,6 +76,7 @@ import getTinyMCEAppearance from './tinymce_appearance';
       return;
       // throw 'tinyMCE is not loaded. If you customized TINYMCE_JS_URL, double-check its content.';
     }
+    handleThemes();
     // initialize the TinyMCE editors on load
     initializeTinyMCE(document);
 
@@ -91,4 +93,21 @@ import getTinyMCEAppearance from './tinymce_appearance';
       });
     }
   });
+
+  // taken from the tinymce react package for inspiration:
+  // https://github.com/tinymce/tinymce-react/blob/e2b1907eadb751f81e01d8239fdf876e77430d43/src/main/ts/components/Editor.tsx#L139
+  const resetEditor = el => {
+    const editor = window.tinyMCE.get(el.id);
+    editor.remove();
+    initTinyMCE(el);
+  };
+
+  const handleThemes = () => {
+    appearance = getTinyMCEAppearance(currentTheme.getValue());
+
+    currentTheme.subscribe(newTheme => {
+      appearance = getTinyMCEAppearance(newTheme);
+      document.querySelectorAll('.tinymce').forEach(resetEditor);
+    });
+  };
 }

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1754,7 +1754,7 @@
     "originalDefault": "years"
   },
   "iq0ppL": {
-    "defaultMessage": "[EXPERIMENTEEL] Gebruik de nieuwe afspraakformulierenimplementatie.",
+    "defaultMessage": "Bij het inschakelen van de afsprakenmodus doorloopt de gebruiker een vaste flow.",
     "description": "Form appointment enabled field help text",
     "originalDefault": "Experimental mode. Indicates whether appointments are enabled for this form."
   },

--- a/src/openforms/js/tinymce_appearance.js
+++ b/src/openforms/js/tinymce_appearance.js
@@ -1,0 +1,18 @@
+import {THEMES, detectTheme} from 'utils/theme';
+
+const APPEARANCE = {
+  [THEMES.light]: {
+    skin: 'oxide',
+    content_css: 'default',
+  },
+  [THEMES.dark]: {
+    skin: 'oxide-dark',
+    content_css: 'dark',
+  },
+};
+
+const getTinyMCEAppearance = (theme = detectTheme()) => {
+  return APPEARANCE[theme];
+};
+
+export default getTinyMCEAppearance;

--- a/src/openforms/js/tinymce_appearance.js
+++ b/src/openforms/js/tinymce_appearance.js
@@ -1,4 +1,4 @@
-import {THEMES, detectTheme} from 'utils/theme';
+import {THEMES} from 'utils/theme';
 
 const APPEARANCE = {
   [THEMES.light]: {
@@ -11,7 +11,7 @@ const APPEARANCE = {
   },
 };
 
-const getTinyMCEAppearance = (theme = detectTheme()) => {
+const getTinyMCEAppearance = theme => {
   return APPEARANCE[theme];
 };
 

--- a/src/openforms/js/utils/theme.js
+++ b/src/openforms/js/utils/theme.js
@@ -1,3 +1,7 @@
+import {createGlobalstate} from 'state-pool';
+
+import {onLoaded} from 'utils/dom';
+
 export const THEMES = {
   light: 'light',
   dark: 'dark',
@@ -7,7 +11,7 @@ export const THEMES = {
  * Detect the active theme in JS so that the correct theme can be applied in places
  * that are not simply styled through CSS.
  */
-export const detectTheme = () => {
+const detectTheme = () => {
   // See admin/js/theme.js
   const theme = window.localStorage.getItem('theme') || 'auto';
 
@@ -20,3 +24,27 @@ export const detectTheme = () => {
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   return prefersDark ? THEMES.dark : THEMES.light;
 };
+
+/**
+ * Watches for changes to the data attribute of the html element.
+ *
+ * Note that we cannot use the storage event, as that is meant as a synchronization
+ * mechanism across tabs. It does not work in the same tab/window.
+ */
+const watchForThemeChanges = () => {
+  const htmlNode = document.documentElement; // the html node
+
+  const observer = new MutationObserver(() => {
+    const newTheme = detectTheme();
+    currentTheme.updateValue(() => newTheme);
+  });
+
+  observer.observe(htmlNode, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+};
+
+onLoaded(watchForThemeChanges);
+
+export const currentTheme = createGlobalstate(detectTheme());

--- a/src/openforms/js/utils/theme.js
+++ b/src/openforms/js/utils/theme.js
@@ -1,0 +1,22 @@
+export const THEMES = {
+  light: 'light',
+  dark: 'dark',
+};
+
+/**
+ * Detect the active theme in JS so that the correct theme can be applied in places
+ * that are not simply styled through CSS.
+ */
+export const detectTheme = () => {
+  // See admin/js/theme.js
+  const theme = window.localStorage.getItem('theme') || 'auto';
+
+  if (theme !== 'auto') {
+    // normalize to our 'constants' in case django renames themes in the future
+    return THEMES[theme];
+  }
+
+  // in auto mode, we need to look at the media query
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? THEMES.dark : THEMES.light;
+};

--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -4,6 +4,7 @@ import logging
 from functools import partial
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.db.models import Model
 
 from openforms.accounts.models import User
@@ -33,7 +34,10 @@ def _create_log(
     error: Exception | None = None,
     tags: list | None = None,
     user: User | None = None,
-) -> TimelineLogProxy:
+) -> TimelineLogProxy | None:
+    if getattr(settings, "AUDITLOG_DISABLED", False):
+        return
+
     # import locally or we'll get "AppRegistryNotReady: Apps aren't loaded yet."
     from openforms.logging.models import TimelineLogProxy
 

--- a/src/openforms/logging/tests/utils.py
+++ b/src/openforms/logging/tests/utils.py
@@ -1,0 +1,8 @@
+from django.test import override_settings
+
+
+def disable_timelinelog():
+    """
+    Disable actually creating the audit logs in timeline logger.
+    """
+    return override_settings(AUDITLOG_DISABLED=True)

--- a/src/openforms/prefill/tests/test_admin.py
+++ b/src/openforms/prefill/tests/test_admin.py
@@ -43,5 +43,6 @@ class PrefillConfigTests(WebTest):
         response = self.app.get(url, user=user)
 
         # check that it's a dropdown-like widget with options/choices
-        self.assertGreater(len(response.form["default_person_plugin"].options), 1)
-        self.assertGreater(len(response.form["default_company_plugin"].options), 1)
+        form = response.forms["prefillconfig_form"]
+        self.assertGreater(len(form["default_person_plugin"].options), 1)
+        self.assertGreater(len(form["default_company_plugin"].options), 1)

--- a/src/openforms/registrations/contrib/zgw_apis/utils.py
+++ b/src/openforms/registrations/contrib/zgw_apis/utils.py
@@ -3,8 +3,8 @@ from typing import Literal, TypedDict
 
 from typing_extensions import NotRequired
 
-from openforms.contrib.zgw.clients.utils import datetime_in_amsterdam
 from openforms.typing import JSONValue
+from openforms.utils.date import datetime_in_amsterdam
 
 
 class EigenschapSpecificatie(TypedDict):

--- a/src/openforms/scss/_vars.scss
+++ b/src/openforms/scss/_vars.scss
@@ -24,5 +24,8 @@ $color-tooltip-border: #f7f071;
 $color-tooltip-text: #000;
 $django-hijack-yellow: #ffe761;
 
-/* Dimensions */
-$input-field-size: 40em; // original: 20em;
+:root {
+  /* Dimensions */
+  --of-admin-input-field-size: 40em; // original: 20em;
+  --of-admin-checkbox-gap: 5px;
+}

--- a/src/openforms/scss/_vars.scss
+++ b/src/openforms/scss/_vars.scss
@@ -28,4 +28,10 @@ $django-hijack-yellow: #ffe761;
   /* Dimensions */
   --of-admin-input-field-size: 40em; // original: 20em;
   --of-admin-checkbox-gap: 5px;
+
+  /* Tooltip */
+  --of-admin-tooltip-background-color: #fffeaa;
+  --of-admin-tooltip-border-color: #f7f071;
+  --of-admin-tooltip-color: #000;
+  --of-admin-tooltip-size: 14px;
 }

--- a/src/openforms/scss/admin/_admin_theme.scss
+++ b/src/openforms/scss/admin/_admin_theme.scss
@@ -35,6 +35,20 @@ div#header {
   line-height: normal;
 }
 
+#logout-form {
+  // ensure the button is styled like the links
+  button {
+    border-bottom: none;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus {
+      color: var(--header-link-color);
+      text-decoration: none;
+    }
+  }
+}
+
 #user-tools {
   // fixme - hardcoded magic numbers, because of the domain switcher that may or may not be there
   height: 32px;

--- a/src/openforms/scss/admin/_admin_theme.scss
+++ b/src/openforms/scss/admin/_admin_theme.scss
@@ -8,6 +8,7 @@ DO NOT PUT ANY TARGET APP-SPECIFIC RULES HERE.
 
 @use './themes/dark' as dark-theme;
 @use './themes/light' as light-theme;
+@use './tooltip';
 
 @import 'microscope-sass/lib/bem';
 
@@ -396,41 +397,6 @@ body.popup {
 /**
  * Help text mouseover
  */
-div.help:hover {
-  text-indent: inherit;
-  width: auto;
-  background-image: none;
-  background-color: $color-tooltip-background;
-  border: 1px solid $color-tooltip-border;
-  color: $color-tooltip-text;
-  padding: 5px 5px 3px 5px !important;
-  max-width: 300px;
-  height: auto !important;
-  z-index: 10;
-}
-
-div.help {
-  cursor: help;
-  width: 16px;
-  height: 16px;
-  background-image: url(../admin/img/icon-unknown.svg);
-  display: inline-block;
-  background-repeat: no-repeat;
-  background-size: 14px;
-  margin-left: 2px !important;
-  position: absolute;
-  text-indent: -9999px;
-}
-
-/* Overrides default Django CSS */
-.aligned label + p,
-.aligned label + div.readonly {
-  display: inline-block;
-  margin-left: inherit !important;
-}
-.aligned label + div.help {
-  margin-left: 2px !important;
-}
 
 /* Additional components seem to need the same behaviour */
 /* TODO: TinyMCE is different... */

--- a/src/openforms/scss/admin/_admin_theme.scss
+++ b/src/openforms/scss/admin/_admin_theme.scss
@@ -96,6 +96,44 @@ div.breadcrumbs {
   }
 }
 
+/**
+ * Properly align inputs and labels
+ */
+.flex-container {
+  // otherwise long labels vertically stretch the input boxes
+  align-items: flex-start;
+}
+
+.checkbox-row {
+  gap: var(--of-admin-checkbox-gap);
+  align-items: center;
+
+  input[type='checkbox'] {
+    margin: 0;
+  }
+
+  @at-root .aligned & label {
+    width: auto;
+    vertical-align: unset !important;
+    padding: 0 !important;
+    margin-bottom: 0 !important;
+  }
+
+  .vCheckboxLabel {
+    vertical-align: unset !important;
+    padding: 0 !important;
+    margin-bottom: 0 !important;
+  }
+}
+
+.aligned label:has(input[type='checkbox']) {
+  display: flex;
+  align-items: center;
+  gap: var(--of-admin-checkbox-gap);
+  margin: 0;
+  padding: 0;
+}
+
 /* Calendar & time widget */
 .calendarbox,
 .clockbox {
@@ -222,7 +260,7 @@ div.breadcrumbs {
  */
 .change-form {
   .vTextField {
-    width: $input-field-size;
+    width: var(--of-admin-input-field-size);
   }
 }
 
@@ -300,7 +338,7 @@ body.popup {
  */
 .rjf-form-wrapper {
   .rjf-form-group {
-    max-inline-size: calc($input-field-size + 72px + 0.5rem);
+    max-inline-size: calc(var(--of-admin-input-field-size) + 72px + 0.5rem);
   }
 
   .rjf-form-group-inner {
@@ -317,7 +355,7 @@ body.popup {
     padding: 0;
 
     input {
-      inline-size: $input-field-size;
+      inline-size: var(--of-admin-input-field-size);
       max-inline-size: 100%;
       margin-block-start: 2px !important;
       margin-block-end: 2px !important;
@@ -330,7 +368,7 @@ body.popup {
 
   @at-root div[data-django-jsonform-container] {
     display: inline-block;
-    inline-size: calc($input-field-size + 72px + 0.5rem);
+    inline-size: calc(var(--of-admin-input-field-size) + 72px + 0.5rem);
 
     & ~ .help {
       background-position-y: 7px;

--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -44,11 +44,6 @@ $djai-padding--tablet: 30px;
   @at-root #header {
     padding-bottom: 0 !important;
 
-    // remove the border height from the breadcrumbs padding
-    & + .breadcrumbs {
-      padding-top: calc(10px - var(--of-djai-border-bottom-width)); // 10px is original django value
-    }
-
     // overwrite admin '#header a:link' rule which is otherwise more specific
     .djai-dropdown-menu .djai-dropdown-menu__item--active:link,
     .djai-dropdown-menu .djai-dropdown-menu__item--active:visited {
@@ -58,6 +53,10 @@ $djai-padding--tablet: 30px;
         color: var(--djai-tab-fg--hover);
       }
     }
+  }
+  // remove the border height from the breadcrumbs padding
+  @at-root div.breadcrumbs {
+    padding-top: calc(10px - var(--of-djai-border-bottom-width)); // 10px is original django value
   }
 
   @at-root body.login #header {

--- a/src/openforms/scss/admin/_tooltip.scss
+++ b/src/openforms/scss/admin/_tooltip.scss
@@ -1,0 +1,113 @@
+/**
+ * Replace the form field help text with a tooltip icon by default,
+ * displaying the content on hover.
+ *
+ * Appearance/variables can be tweaked in ../vars.scss.
+ *
+ * The django markup (since 4.2) is typically of the form:
+ *
+ *   <div class="form-row">
+ *     <ul class="errorlist">...</ul>
+ *     <div>
+ *       <!-- possibly there are errors here too -->
+ *       <div class="flex-container"></div>
+ *       <div class="help"><div>...</div></div>
+ *     </div>
+ *   </div>
+ *
+ * The implementation uses the :has pseudo selector to target the relevant nodes, so
+ * that we don't have to override the django field templates/markup. Modern browsers
+ * support this, on old browsers this will degrade to the default django admin styles.
+ *
+ * There are a number of cases to consider when applying this CSS:
+ *
+ * - form row with a single field or multiple fields (.fieldBox selector present or not)
+ * - form field with or without validation errors - complicated by the above.
+ *
+ * They require specific attention to the styling.
+ */
+
+// ensure that we *only* display the tooltip icon in the 'normal' state
+div.help {
+  cursor: help;
+  block-size: var(--of-admin-tooltip-size);
+  inline-size: var(--of-admin-tooltip-size);
+
+  background-image: url(../admin/img/icon-unknown.svg);
+  background-repeat: no-repeat;
+  background-size: var(--of-admin-tooltip-size);
+  margin-inline: 0 !important;
+  margin-block: 0 !important;
+  padding-inline: 0 !important;
+  padding-block: 0 !important;
+
+  position: relative; // provides an anchor for the nested div absolute positioning
+
+  // the actual content is nested in a div, so we can easily hide it by default
+  > div {
+    display: none;
+  }
+
+  // On hover of the icon, we display the real help text content.
+  &:hover {
+    background-image: none;
+
+    > div {
+      display: block;
+      position: absolute;
+      top: 1px;
+      z-index: 10;
+
+      block-size: auto;
+      inline-size: max-content;
+      max-inline-size: 300px;
+      padding-block: 5px 3px;
+      padding-inline: 5px 5px;
+
+      background-color: var(--of-admin-tooltip-background-color);
+      border: solid 1px var(--of-admin-tooltip-border-color);
+
+      color: var(--of-admin-tooltip-color);
+    }
+  }
+}
+
+// Unsure why Django hides the overflow here :/
+.form-row:has(.help) {
+  overflow: visible;
+}
+
+// field on a single form row with multiple fields, without validation errors
+div:has(> .fieldBox + .help) {
+  display: grid;
+  grid-template-columns: auto var(--of-admin-tooltip-size);
+  column-gap: 2px;
+
+  // move the margin right (djagno's styles) from fieldbox to the parent so that the
+  // tooltip is not too far away
+  margin-right: 20px;
+  > .fieldBox {
+    margin-right: 0;
+  }
+}
+
+// field on a single form row with multiple fields, with validation errors
+div:has(> .errorlist + .fieldBox + .help) {
+  // split the 1-row, 2-columns up into 2-rows, 2 columns and make sure the top
+  // row is assigned to the validation errors.
+  // The rest of the styles are shared with the regular fieldBox styles.
+  grid-template-areas:
+    'errors errors'
+    'field tooltip';
+
+  > .errorlist {
+    grid-area: errors;
+    margin-bottom: 0;
+  }
+}
+
+// field, alone on single form row (with/without validation errors)
+div:has(> .help):not(:has(> .fieldBox)) {
+  display: flex;
+  column-gap: 2px;
+}

--- a/src/openforms/scss/admin/themes/_dark.scss
+++ b/src/openforms/scss/admin/themes/_dark.scss
@@ -77,6 +77,37 @@
   }
 }
 
+@mixin tinymce {
+  .tox {
+    .tox-toolbar__primary,
+    .tox-statusbar,
+    .tox-menu {
+      background-color: var(--form-input-bg);
+    }
+
+    .tox-dialog,
+    .tox-dialog__header,
+    .tox-dialog__footer {
+      background-color: var(--body-bg);
+    }
+
+    .tox-collection__item-label {
+      p,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      pre {
+        &[style] {
+          background-color: transparent !important;
+        }
+      }
+    }
+  }
+}
+
 /**
  * Aggregate the bits and pieces to define the dark theme style rules.
  */
@@ -94,6 +125,7 @@
     html[data-theme='auto'] {
       @include djai-variables;
       @include custom-css;
+      @include tinymce;
     }
   }
 
@@ -102,5 +134,6 @@
     @include variables;
     @include djai-variables;
     @include custom-css;
+    @include tinymce;
   }
 }

--- a/src/openforms/scss/admin/themes/_dark.scss
+++ b/src/openforms/scss/admin/themes/_dark.scss
@@ -77,6 +77,48 @@
   }
 }
 
+@mixin bootstrap {
+  .card-header {
+    background-color: #333;
+  }
+
+  .btn,
+  .btn:hover {
+    color: var(--body-fg);
+  }
+
+  .formio-dialog {
+    background: rgba(0, 0, 0, 0.7);
+    color: var(--body-fg);
+  }
+
+  .formio-dialog.formio-dialog-theme-default {
+    .formio-dialog-content {
+      background: var(--body-bg);
+    }
+  }
+
+  .nav-tabs {
+    .nav-link.active {
+      color: var(--body-fg);
+      background-color: var(--body-bg);
+      border-color: var(--border-color) var(--border-color) var(--body-bg);
+    }
+
+    .nav-link {
+      &:focus,
+      &:hover {
+        color: var(--body-fg);
+        border-color: var(--hairline-color) var(--hairline-color) var(--body-bg);
+      }
+    }
+  }
+
+  .formio-button-add-another {
+    color: var(--body-fg) !important;
+  }
+}
+
 @mixin tinymce {
   .tox {
     .tox-toolbar__primary,
@@ -108,6 +150,27 @@
   }
 }
 
+@mixin ckeditor-variables {
+  // TODO: CKeditor uses CSS vars internally, so we can sort this out properly in the
+  // future.
+  // // See https://ckeditor.com/docs/ckeditor5/latest/examples/framework/theme-customization.html
+  // // > View the editor CSS tyle listing
+  // --ck-custom-background: var(--form-input-bg);
+
+  // --ck-color-base-background: var(--form-input-bg);
+  // --ck-color-base-foreground: var(--body-fg);
+
+  // --ck-color-button-default-background: var(--ck-custom-background);
+}
+
+@mixin ckeditor {
+  .ck-editor__main {
+    // TODO: Formio uses CKEditor5, but using their dark theme seems more complex than for the tinymce.
+    // So for now we keep the default theme, but ensure that the text in the editor is dark and not light.
+    color: #333;
+  }
+}
+
 /**
  * Aggregate the bits and pieces to define the dark theme style rules.
  */
@@ -118,6 +181,7 @@
     // in auto mode through the media query.
     :root {
       @include variables;
+      @include ckeditor-variables;
     }
 
     // only apply based on browser preferences if the theme is not explicitly set to
@@ -125,7 +189,9 @@
     html[data-theme='auto'] {
       @include djai-variables;
       @include custom-css;
+      @include bootstrap;
       @include tinymce;
+      @include ckeditor;
     }
   }
 
@@ -134,6 +200,9 @@
     @include variables;
     @include djai-variables;
     @include custom-css;
+    @include bootstrap;
     @include tinymce;
+    @include ckeditor;
+    @include ckeditor-variables;
   }
 }

--- a/src/openforms/scss/admin/themes/_dark.scss
+++ b/src/openforms/scss/admin/themes/_dark.scss
@@ -40,11 +40,15 @@
 }
 
 @mixin djai-variables {
-  --djai-tab-bg--hover: #04a5bb;
-  --djai-tab-fg--active: #fff;
-  --djai-dropdown-bg--hover: #04a5bb;
+  // use a more specific selector so that the dark theme overrides the default,
+  // less specific selector.
+  .djai-dropdown-menu {
+    --djai-tab-bg--hover: #04a5bb;
+    --djai-tab-fg--active: #fff;
+    --djai-dropdown-bg--hover: #04a5bb;
 
-  --of-djai-border-bottom-color: #333;
+    --of-djai-border-bottom-color: #333;
+  }
 }
 
 /**
@@ -77,17 +81,26 @@
  * Aggregate the bits and pieces to define the dark theme style rules.
  */
 @mixin styles {
+  // Include the relevant variables
   @media (prefers-color-scheme: dark) {
+    // This either gets overridden by the more specific light theme selector, or applies
+    // in auto mode through the media query.
     :root {
       @include variables;
     }
 
-    @include custom-css;
-
-    // use a more specific selector so that the dark theme overrides the default,
-    // less specific selector.
-    .djai-dropdown-menu {
+    // only apply based on browser preferences if the theme is not explicitly set to
+    // light or dark
+    html[data-theme='auto'] {
       @include djai-variables;
+      @include custom-css;
     }
+  }
+
+  // explicit dark-mode -> apply all relevant styles
+  html[data-theme='dark'] {
+    @include variables;
+    @include djai-variables;
+    @include custom-css;
   }
 }

--- a/src/openforms/scss/admin/themes/_light.scss
+++ b/src/openforms/scss/admin/themes/_light.scss
@@ -79,6 +79,7 @@
  * default that is applied.
  */
 @mixin styles {
+  html[data-theme='light'],
   :root {
     @include variables;
   }

--- a/src/openforms/scss/components/admin/_json-widget.scss
+++ b/src/openforms/scss/components/admin/_json-widget.scss
@@ -4,7 +4,7 @@
 
 .json-widget {
   textarea {
-    width: $input-field-size;
+    width: var(--of-admin-input-field-size);
   }
 
   @include bem.modifier('collapsed') {

--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -221,48 +221,6 @@ div.flatpickr-calendar.open {
   color: var(--body-fg);
 }
 
-@media (prefers-color-scheme: dark) {
-  .card-header {
-    background-color: $color-dark;
-  }
-
-  .btn,
-  .btn:hover {
-    color: var(--body-fg);
-  }
-
-  .formio-dialog {
-    background: rgba(0, 0, 0, 0.7);
-    color: var(--body-fg);
-  }
-
-  .formio-dialog.formio-dialog-theme-default {
-    .formio-dialog-content {
-      background: var(--body-bg);
-    }
-  }
-
-  .nav-tabs {
-    .nav-link.active {
-      color: var(--body-fg);
-      background-color: var(--body-bg);
-      border-color: var(--border-color) var(--border-color) var(--body-bg);
-    }
-
-    .nav-link {
-      &:focus,
-      &:hover {
-        color: var(--body-fg);
-        border-color: var(--hairline-color) var(--hairline-color) var(--body-bg);
-      }
-    }
-  }
-
-  .formio-button-add-another {
-    color: var(--body-fg) !important;
-  }
-}
-
 .form-row {
   .form-builder__container {
     color: var(--body-fg);

--- a/src/openforms/scss/components/builder/_openforms-component.scss
+++ b/src/openforms/scss/components/builder/_openforms-component.scss
@@ -28,12 +28,4 @@
       opacity: 0.9;
     }
   }
-
-  .ck-editor__main {
-    // TODO: Formio uses CKEditor5, but using their dark theme seems more complex than for the tinymce.
-    // So for now we keep the default theme, but ensure that the text in the editor is dark and not light.
-    @media (prefers-color-scheme: dark) {
-      color: $color-dark;
-    }
-  }
 }

--- a/src/openforms/scss/vendor/_rjsf-field.scss
+++ b/src/openforms/scss/vendor/_rjsf-field.scss
@@ -18,7 +18,7 @@
 
     input[type='url'],
     input[type='text'] {
-      width: $input-field-size;
+      width: var(--of-admin-input-field-size);
     }
   }
 
@@ -30,7 +30,7 @@
 
   &__input {
     input[type='email'] {
-      width: $input-field-size; // override from admin/rjsf default
+      width: var(--of-admin-input-field-size); // override from admin/rjsf default
     }
 
     textarea {

--- a/src/openforms/templates/admin/base_site.html
+++ b/src/openforms/templates/admin/base_site.html
@@ -21,6 +21,9 @@
 
 {% block branding %}
     <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ settings.PROJECT_NAME }} {% trans 'Administration' %}</a></h1>
+    {% if user.is_anonymous %}
+      {% include "admin/color_theme_toggle.html" %}
+    {% endif %}
 {% endblock %}
 
 {# part of block usertools #}
@@ -43,9 +46,14 @@
         <a href="{{ 2fa_account_security_url }}">{% trans "Account security" %}</a> /
     {% endif %}
 
-    <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+    <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+        {% csrf_token %}
+        <button type="submit">{% translate 'Log out' %}</button>
+    </form>
 
     {% multidomain_switcher %}
+
+    {% include "admin/color_theme_toggle.html" %}
 {% endblock %}
 
 {# end block usertools #}

--- a/src/openforms/templates/hijack/notification.html
+++ b/src/openforms/templates/hijack/notification.html
@@ -8,7 +8,7 @@
           You are currently working on behalf of <em>{{ user }}</em>.
         {% endblocktrans %}
       </div>
-      <form action="{% url 'hijack:release' %}" method="post" class="djhj-actions">
+      <form id="hijack-release" action="{% url 'hijack:release' %}" method="post" class="djhj-actions">
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ request.path }}">
         {# TODO: CSP - this will break if CSP is enforced in the admin #}

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
 
 from django.utils import timezone
 from django.utils.dateparse import (
@@ -8,6 +9,9 @@ from django.utils.dateparse import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+TIMEZONE_AMS = ZoneInfo("Europe/Amsterdam")
 
 
 def format_date_value(date_value: str) -> str:
@@ -67,3 +71,7 @@ def parse_time(value: str) -> None | time:
         return
 
     return time_value
+
+
+def datetime_in_amsterdam(value: datetime) -> datetime:
+    return timezone.make_naive(value, timezone=TIMEZONE_AMS)

--- a/src/stuf/stuf_zds/tests/test_backend.py
+++ b/src/stuf/stuf_zds/tests/test_backend.py
@@ -32,7 +32,7 @@ class StufZDSClientTests(StUFZDSTestBase):
     def setUpTestData(cls):
         super().setUpTestData()
 
-        cls.service = StufServiceFactory.build(
+        cls.service = StufServiceFactory.create(
             zender_organisatie="ZenOrg",
             zender_applicatie="ZenApp",
             zender_administratie="ZenAdmin",

--- a/src/stuf/stuf_zds/tests/test_client.py
+++ b/src/stuf/stuf_zds/tests/test_client.py
@@ -2,12 +2,13 @@ from unittest import skipIf
 from unittest.mock import patch
 
 from django.template.loader import render_to_string
-from django.test import TestCase, tag
+from django.test import SimpleTestCase, TestCase, tag
 
 import requests_mock
 from simple_certmanager.constants import CertificateTypes
 from simple_certmanager.test.factories import CertificateFactory
 
+from openforms.logging.tests.utils import disable_timelinelog
 from openforms.registrations.exceptions import RegistrationFailed
 from openforms.tests.utils import can_connect
 
@@ -122,7 +123,8 @@ class StufZdsClientTest(TestCase):
         self.assertIsNone(request_with_tls.cert)
 
 
-class StufZdsRegressionTests(TestCase):
+@disable_timelinelog()
+class StufZdsRegressionTests(SimpleTestCase):
     @tag("gh-1731")
     @skipIf(not can_connect("example.com:443"), "Need real socket/connection for test")
     def test_non_latin1_characters(self):


### PR DESCRIPTION
Fixes #3049

Todo:

- [x] Fix datetime test
- [x] Expose dark/light theme control in admin
- [x] Fix light/dark mode integration with tinymce
- [x] Fix styling for tooltip icons
- [x] Update markup React admin components to use the new markup from django templates (brings back the inline-labels)
- [x] Report issues for default project
    - [x] Logout form
    - [x] Missing control for dark/light toggle (admin index + admin login page)
    - [x] Broken tooltip styling
    - [x] Broken admin index style overrides
    - [x] Sort out light/dark styles in proper CSS vars

Old findings:

- Decide what to do about the styling changes:
   - Label no longer on the same line -> checked on a non-modified project, labels are intended to be inline but there may be some responsiveness in play here
   - ~~Submit buttons on the left~~ that's the new django layout, we stick with it :) there are A11Y reasons to do this
![Screenshot from 2024-02-09 12-21-43](https://github.com/open-formulieren/open-forms/assets/19154114/4abe7c0d-c2d8-4ea4-b16d-572eba361ee8)
![Screenshot from 2024-02-09 12-22-15](https://github.com/open-formulieren/open-forms/assets/19154114/f70870ca-ae5e-4df9-bcd4-91fb85f927ba)
