### PR TITLE
[#3749] Replace useEffect with useAsync

### DIFF
--- a/src/openforms/js/components/admin/form_design/logic/LogicDescription.js
+++ b/src/openforms/js/components/admin/form_design/logic/LogicDescription.js
@@ -1,6 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
-import React, {useContext, useEffect, useState} from 'react';
+import React, {useContext, useState} from 'react';
+import useAsync from 'react-use/esm/useAsync';
 
 import {APIContext} from 'components/admin/form_design/Context';
 import {LOGIC_DESCRIPTION_ENDPOINT} from 'components/admin/form_design/constants';
@@ -42,7 +43,7 @@ const LogicDescriptionInput = ({
 
   const mustBail = isEmpty(logicExpression) || !generationAllowed || modifiedByHuman || hasFocus;
 
-  useEffect(async () => {
+  useAsync(async () => {
     if (mustBail) {
       return;
     }


### PR DESCRIPTION
In react 18, there has been this change (https://github.com/facebook/react/blob/main/CHANGELOG.md#breaking-changes):

```
Consistent useEffect timing: React now always synchronously flushes effect functions if the update was triggered during a discrete user input event such as a click or a keydown event. Previously, the behavior wasn't always predictable or consistent.
```

normally the callback function of the useEffect should return the cleanup function. However, in the LogicInputDescription we had an async callback (which returns a promise). Then when clicking on the logic rule description this would trigger the error `Uncaught TypeError: destroy is not a function` . I think this happens because it tries to use the promise as the cleanup function.