### PR TITLE
Prepare release 2.2.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 2.2.7
+current_version = 2.2.8
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<pre>[a-z]+)\.(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{pre}.{build}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,23 @@
 Changelog
 =========
 
+2.2.8 (2024-01-12)
+==================
+
+Periodic bugfix release
+
+* [#3656] Fixed incorrect DigiD error messages being shown when using OIDC-based plugins.
+* [#3692] Fixed crash when using OIDC DigiD login while logged into the admin interface.
+* [#3744] Fixed conditionally marking a postcode component as required/optional.
+
+  .. note:: We cannot automatically fix existing logic rules. For affected forms, you
+     can remove and re-add the logic rule action to modify the 'required' state.
+
+* [#3704] Fixed the family members component not retrieving the partners when using
+  StUF-BG as data source.
+* [#2710] Added missing initials (voorletters) prefill option for StUF-BG plugin.
+* Fixed failing docs build by disabling/changing some link checks.
+
 2.2.7 (2023-12-12)
 ==================
 

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -2,7 +2,7 @@
 Open Formulieren
 ================
 
-:Version: 2.2.7
+:Version: 2.2.8
 :Source: https://github.com/open-formulieren/open-forms
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Forms
 ==========
 
-:Version: 2.2.7
+:Version: 2.2.8
 :Source: https://github.com/open-formulieren/open-forms
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openforms",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openforms",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "UNLICENSED",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openforms",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "Open Forms",
   "main": "src/static/openforms/js/openforms.js",
   "directories": {

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,7 +7,7 @@ publiccodeYmlVersion: '0.2'
 name: Open Forms Builder and API
 url: 'http://github.com/open-formulieren/open-forms.git'
 softwareType: standalone/backend
-softwareVersion: 2.2.7
+softwareVersion: 2.2.8
 releaseDate: '2022-03-10'
 logo: 'https://github.com/open-formulieren/open-forms/blob/master/docs/logo.svg'
 platforms:

--- a/src/openforms/__init__.py
+++ b/src/openforms/__init__.py
@@ -1,6 +1,6 @@
 from .celery import app as celery_app
 
 __all__ = ("celery_app",)
-__version__ = "2.2.7"
+__version__ = "2.2.8"
 __author__ = "Maykin Media"
 __homepage__ = "https://github.com/open-formulieren/open-forms"


### PR DESCRIPTION
There is no new SDK version for this release.

After merging, make sure to tag the merge commit with `2.2.8`.