### PR TITLE
[#3778] Render empty label for content component

### DIFF
--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -153,6 +153,10 @@ class WYSIWYGNode(ComponentNode):
         return self.mode != RenderModes.cli
 
     @property
+    def label(self) -> str:
+        return ""
+
+    @property
     def is_visible(self) -> bool:
         if self.mode in (
             RenderModes.registration,

--- a/src/openforms/submissions/tests/renderer/test_management_command_cli_render.py
+++ b/src/openforms/submissions/tests/renderer/test_management_command_cli_render.py
@@ -122,7 +122,7 @@ Submission {submission.id} - public name
         Currency                           1.234,56
         A container with visible children
         Input 4                            fourth input
-        WYSIWYG Content                    WYSIWYG with markup
+                                           WYSIWYG with markup
         ---------------------------------  -------------------
     Variabelen
         ------------------  -----------
@@ -186,7 +186,7 @@ Submission {submission.id} - public name
         Currency                           1.234,56
         A container with visible children
         Input 4                            fourth input
-        WYSIWYG Content                    <p>WYSIWYG with <strong>markup</strong></p>
+                                           <p>WYSIWYG with <strong>markup</strong></p>
         ---------------------------------  -------------------------------------------
     Variabelen
         ------------------  -----------

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.urls import reverse
 
 from rest_framework import status
@@ -327,6 +327,32 @@ class SubmissionSummaryRendererTests(TestCase):
         conditional_textfield = step_data[3]
 
         self.assertEqual(conditional_textfield["value"], "Some data")
+
+    @tag("gh-3778")
+    def test_content_component_summary_has_empty_label(self):
+        form_step = FormStepFactory.create(
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "content",
+                        "type": "content",
+                        "label": "Content",
+                        "html": "<p>Some data</p>",
+                    }
+                ]
+            },
+            form_definition__slug="fd-0",
+            form_definition__name="Form Definition 0",
+        )
+
+        submission = SubmissionFactory.create(form=form_step.form)
+
+        data = submission.render_summary_page()
+        step_data = data[0]["data"]
+
+        # 1 node for the content component
+        self.assertEqual(1, len(step_data))
+        self.assertEqual(step_data[0]["name"], "")
 
 
 class SubmissionCompletionTests(SubmissionsMixin, APITestCase):


### PR DESCRIPTION
Fixes #3778 

Frontend PR: https://github.com/open-formulieren/open-forms-sdk/pull/635