### PR TITLE
[#3616] Fix default value for cosign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.14.0",
+        "@open-formulieren/formio-builder": "^0.14.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -4580,9 +4580,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.14.0.tgz",
-      "integrity": "sha512-TGzT68MZqpK+zUNuJbgDusmj4BF1zsZ+2mdwWloaY1kZAoCtTiktWRI8Fiipx4nT5LtA2hmGgdeoH90p6pQv8g==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.14.1.tgz",
+      "integrity": "sha512-kaubnlkeMmlBvO6qH/VC9WNuz2Au4kd7c5/9PVc2mAKwC1jFEv3tSt0B1delDWDqW0OqEZEFo/XXVuxTSEcjag==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",
@@ -29542,9 +29542,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.14.0.tgz",
-      "integrity": "sha512-TGzT68MZqpK+zUNuJbgDusmj4BF1zsZ+2mdwWloaY1kZAoCtTiktWRI8Fiipx4nT5LtA2hmGgdeoH90p6pQv8g==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.14.1.tgz",
+      "integrity": "sha512-kaubnlkeMmlBvO6qH/VC9WNuz2Au4kd7c5/9PVc2mAKwC1jFEv3tSt0B1delDWDqW0OqEZEFo/XXVuxTSEcjag==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.14.0",
+    "@open-formulieren/formio-builder": "^0.14.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/js/components/form/cosign.js
+++ b/src/openforms/js/components/form/cosign.js
@@ -27,6 +27,16 @@ export const getAvailableAuthPlugins = async () => {
 const FormioEmail = Formio.Components.components.email;
 
 class CoSignField extends FormioEmail {
+  constructor(...args) {
+    super(...args);
+
+    // somewhere the default emptyValue/defaultValue does not seem to be used and it forces
+    // component.defaultValue to be null, which crashes the builder.
+    if (this.component.defaultValue === null) {
+      this.component.defaultValue = '';
+    }
+  }
+
   static schema(...extend) {
     const schema = FormioEmail.schema(
       {


### PR DESCRIPTION
Part of #3616.

The zod validation schema only allows `""`, `undefined` or a correct time `HH:mm`.

I'm not sure about the solution here, because this part is also used by the legacy builder. Will it break with this change? Otherwise `null` could also be supported as a value in the zod schema.