### PR TITLE
🏷️ Use new style typing syntax

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
 # adapted prettier for JS and SCSS
 a39b15a21d28ee995e861cad489f0648fc971f7e
 6115015c0cadfdff238e2a0f0871d4c7a5ac3bf7
+
+# New style typing
+f185fedaa603a1ef0285dd30e47f74218677c2c6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,10 @@ Additionally, while we allow usage of the `typing_extensions` module, this usage
 features that are not yet available in the Python version used by Open Forms but implemented in
 later versions. Non-stable and/or proposal features are not allowed.
 
+Make use of the new typing syntax, i.e. `str | None` instead of `Optional[str]`/`Union[str, None]`,
+`dict[str, str]` instead of `Dict[str, str]`, etc. If you are not sure, you can refer to the typing
+documentation for the type you are using, a deprecation notice will be indicated.
+
 ### Making a pull request
 
 If all changes have been committed, you can push the branch to your fork of the repository and

--- a/src/csp_post_processor/drf/spectacular.py
+++ b/src/csp_post_processor/drf/spectacular.py
@@ -2,7 +2,6 @@
 API schema generation extension using drf-spectacular.
 """
 import logging
-from typing import Type
 
 from django.utils.translation import gettext_lazy as _
 
@@ -37,7 +36,7 @@ NONCE_PARAMETER = OpenApiParameter(
 
 # Can't use the auto_schema as it's not passed to view inspectors. Code inspired on
 # drf_spectacular.openapi.AutoSchema._get_serializer
-def _get_serializer_class(view_cls: Type[APIView]):
+def _get_serializer_class(view_cls: type[APIView]):
     # be lenient - there may be views that don't have any serializer set at all
     if not issubclass(view_cls, GenericAPIView):
         serializer_attrs = [

--- a/src/openforms/api/exception_handling.py
+++ b/src/openforms/api/exception_handling.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from collections import OrderedDict
-from typing import List, Union
+from typing import Union
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
@@ -179,5 +179,5 @@ class HandledException:
         return f"urn:uuid:{self._exc_id}"
 
     @property
-    def invalid_params(self) -> Union[None, List]:
+    def invalid_params(self) -> Union[None, list]:
         return [error for error in get_validation_errors(self.exc.detail)]

--- a/src/openforms/api/mixins.py
+++ b/src/openforms/api/mixins.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, Optional
+from typing import Iterable, Optional
 
 from django.utils.translation import gettext_lazy as _
 
@@ -9,7 +9,7 @@ from rest_framework import serializers
 class ValidateQueryStringParametersMixin:
     validate_params: Iterable[OpenApiParameter] = ()
 
-    def validate_query_parameters(self) -> Dict[OpenApiParameter, Optional[str]]:
+    def validate_query_parameters(self) -> dict[OpenApiParameter, Optional[str]]:
         errors, extracted = {}, {}
 
         for param in self.validate_params:

--- a/src/openforms/api/serializers.py
+++ b/src/openforms/api/serializers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
@@ -119,7 +117,7 @@ class PublicFieldsSerializerMixin:
     #             )
 
     @classmethod
-    def _get_admin_field_names(cls, camelize=True) -> List[str]:
+    def _get_admin_field_names(cls, camelize=True) -> list[str]:
         formatter = underscore_to_camel if camelize else lambda x: x
         return [
             formatter(name)

--- a/src/openforms/appointments/contrib/jcc/plugin.py
+++ b/src/openforms/appointments/contrib/jcc/plugin.py
@@ -4,7 +4,7 @@ from collections import Counter
 from contextlib import contextmanager
 from datetime import date, datetime
 from functools import wraps
-from typing import Callable, List, ParamSpec, TypeVar
+from typing import Callable, ParamSpec, TypeVar
 
 from django.urls import reverse
 from django.utils import timezone
@@ -180,7 +180,7 @@ class JccAppointment(BasePlugin[CustomerFields]):
         location: Location,
         start_at: date | None = None,
         end_at: date | None = None,
-    ) -> List[date]:
+    ) -> list[date]:
         client = get_client()
         product_ids = squash_ids(products)
         now_in_ams = timezone.make_naive(timezone.now(), timezone=TIMEZONE_AMS)
@@ -207,7 +207,7 @@ class JccAppointment(BasePlugin[CustomerFields]):
     @with_graceful_default(default=[])
     def get_times(
         self,
-        products: List[Product],
+        products: list[Product],
         location: Location,
         day: date,
     ) -> list[datetime]:

--- a/src/openforms/appointments/tokens.py
+++ b/src/openforms/appointments/tokens.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import List
 
 from django.utils import timezone
 
@@ -44,7 +43,7 @@ class SubmissionAppointmentTokenGenerator(BaseTokenGenerator):
         assert delta > timedelta(0, 0), "Expected a positive delta"
         return delta.days + 1
 
-    def get_hash_value_parts(self, submission: Submission) -> List[str]:
+    def get_hash_value_parts(self, submission: Submission) -> list[str]:
         return [
             str(submission.id),
             str(submission.uuid),

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -4,7 +4,7 @@ import logging
 import re
 import warnings
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from django.utils.translation import gettext_lazy as _
 
@@ -39,8 +39,8 @@ def get_plugin(plugin: str = "") -> BasePlugin:
 
 
 def get_missing_fields_labels(
-    appointment_data: dict, missing_fields_keys: List[str]
-) -> List[str]:
+    appointment_data: dict, missing_fields_keys: list[str]
+) -> list[str]:
     labels = []
     for key in missing_fields_keys:
         if label := appointment_data.get(key, {}).get("label"):

--- a/src/openforms/authentication/base.py
+++ b/src/openforms/authentication/base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, TypedDict
+from typing import Any, Optional, TypedDict
 
 from django.db.models import TextChoices
 from django.http import HttpRequest, HttpResponse
@@ -54,7 +54,7 @@ class BasePlugin(AbstractBasePlugin):
         # process and validate return information, store bsn in session
         raise NotImplementedError()  # noqa
 
-    def handle_co_sign(self, request: HttpRequest, form: Form) -> Dict[str, Any]:
+    def handle_co_sign(self, request: HttpRequest, form: Form) -> dict[str, Any]:
         """
         Process the authentication and return a dict of co-sign details.
 

--- a/src/openforms/authentication/contrib/demo/plugin.py
+++ b/src/openforms/authentication/contrib/demo/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from django import forms
 from django.http import (
@@ -68,7 +68,7 @@ class DemoBaseAuthentication(BasePlugin):
 
     def handle_co_sign(
         self, request: HttpRequest, form: Form
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         submitted = self.form_class(request.POST)
         if not submitted.is_valid():
             raise InvalidCoSignData(f"Validation errors: {submitted.errors}")

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/plugin.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
@@ -58,7 +58,7 @@ class OIDCAuthentication(BasePlugin):
 
     def handle_co_sign(
         self, request: HttpRequest, form: Form
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         if not (claim := request.session.get(self.session_key)):
             raise InvalidCoSignData(f"Missing '{self.provides_auth}' parameter/value")
         return {

--- a/src/openforms/authentication/contrib/digid_mock/plugin.py
+++ b/src/openforms/authentication/contrib/digid_mock/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.http import urlencode
@@ -37,7 +37,7 @@ class DigidMockAuthentication(BasePlugin):
 
     def handle_co_sign(
         self, request: HttpRequest, form: Form
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         if not (bsn := request.GET.get("bsn")):
             raise InvalidCoSignData("Missing 'bsn' parameter/value")
         return {

--- a/src/openforms/authentication/contrib/eherkenning/views.py
+++ b/src/openforms/authentication/contrib/eherkenning/views.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -65,7 +65,7 @@ class eHerkenningAssertionConsumerServiceView(
         },
     )
 
-    def _extract_qualifiers(self, attributes: dict) -> Dict[str, str]:
+    def _extract_qualifiers(self, attributes: dict) -> dict[str, str]:
         qualifiers = {}
         expected_ids = [
             "urn:etoegang:core:ActingSubjectID",

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from django.http import HttpRequest
 
@@ -30,7 +30,7 @@ class Registry(BaseRegistry["BasePlugin"]):
 
     def get_options(
         self, request: HttpRequest, form: Optional["Form"] = None
-    ) -> List["LoginInfo"]:
+    ) -> list["LoginInfo"]:
         options = list()
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:

--- a/src/openforms/conf/local_example.py
+++ b/src/openforms/conf/local_example.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-from .dev import DATABASES, LOGGING as _LOGGING
+from .dev import LOGGING as _LOGGING
 from .utils import config
 
 # Configure your database via the DB_* envvars in .env, see also dotenv.example file.

--- a/src/openforms/config/views.py
+++ b/src/openforms/config/views.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generator, Optional, Protocol, TypeGuard
+from typing import Any, Generator, Optional, Protocol, TypeGuard
 
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse
@@ -50,7 +50,7 @@ class ConfigurationView(UserIsStaffMixin, PermissionRequiredMixin, TemplateView)
         "accounts.configuration_overview",
     ]
 
-    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         sections = []
 

--- a/src/openforms/config/widgets.py
+++ b/src/openforms/config/widgets.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from django.forms import Textarea
 
@@ -28,7 +28,7 @@ class PluginConfigurationTextAreaReact(Textarea):
         }
         js = ("bundles/core-js.js",)
 
-    def get_context(self, name: str, value, attrs: dict) -> Dict[str, Any]:
+    def get_context(self, name: str, value, attrs: dict) -> dict[str, Any]:
         context = super().get_context(name, value, attrs)
 
         with_demos = GlobalConfiguration.get_solo().enable_demo_plugins

--- a/src/openforms/contrib/digid_eherkenning/utils.py
+++ b/src/openforms/contrib/digid_eherkenning/utils.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from django.templatetags.static import static
 
 from digid_eherkenning.models import DigidConfiguration, EherkenningConfiguration
@@ -13,7 +11,7 @@ from openforms.config.models import CSPSetting
 from .constants import ADDITIONAL_CSP_VALUES
 
 
-def get_digid_logo(request) -> Dict[str, str]:
+def get_digid_logo(request) -> dict[str, str]:
     return {
         "image_src": request.build_absolute_uri(static("img/digid-46x46.png")),
         "href": "https://www.digid.nl/",
@@ -21,7 +19,7 @@ def get_digid_logo(request) -> Dict[str, str]:
     }
 
 
-def get_eherkenning_logo(request) -> Dict[str, str]:
+def get_eherkenning_logo(request) -> dict[str, str]:
     return {
         "image_src": request.build_absolute_uri(static("img/eherkenning.png")),
         "href": "https://www.eherkenning.nl/",

--- a/src/openforms/dmn/api/views.py
+++ b/src/openforms/dmn/api/views.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
@@ -22,7 +20,7 @@ from .serializers import (
 )
 
 
-def get_available_engines() -> List[str]:
+def get_available_engines() -> list[str]:
     return [engine.identifier for engine in register.iter_enabled_plugins()]
 
 
@@ -99,7 +97,7 @@ class DecisionDefinitionListView(
     serializer_class = DecisionDefinitionSerializer
     validate_params = (ENGINE_PARAMETER,)
 
-    def get_objects(self) -> List[DecisionDefinition]:
+    def get_objects(self) -> list[DecisionDefinition]:
         engine = self.validate_query_parameters()[ENGINE_PARAMETER]
         plugin = register[engine]
         definitions = plugin.get_available_decision_definitions()
@@ -133,7 +131,7 @@ class DecisionDefinitionVersionListView(
     serializer_class = DecisionDefinitionVersionSerializer
     validate_params = (ENGINE_PARAMETER, DEFINITION_PARAMETER)
 
-    def get_objects(self) -> List[DecisionDefinition]:
+    def get_objects(self) -> list[DecisionDefinition]:
         query_params = self.validate_query_parameters()
         engine = query_params[ENGINE_PARAMETER]
         definition_id = query_params[DEFINITION_PARAMETER]

--- a/src/openforms/dmn/base.py
+++ b/src/openforms/dmn/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 from openforms.plugins.plugin import AbstractBasePlugin
 
@@ -27,7 +27,7 @@ class DecisionDefinitionVersion:
 
 class BasePlugin(ABC, AbstractBasePlugin):
     @abstractmethod
-    def get_available_decision_definitions(self) -> List[DecisionDefinition]:
+    def get_available_decision_definitions(self) -> list[DecisionDefinition]:
         """
         Get a collection of all the available decision definitions.
 
@@ -39,8 +39,8 @@ class BasePlugin(ABC, AbstractBasePlugin):
 
     @abstractmethod
     def evaluate(
-        self, definition_id: str, *, version: str = "", input_values: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, definition_id: str, *, version: str = "", input_values: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Evaluate the decision definition with the given input data.
         """
@@ -48,7 +48,7 @@ class BasePlugin(ABC, AbstractBasePlugin):
 
     def get_decision_definition_versions(
         self, definition_id: str
-    ) -> List[DecisionDefinitionVersion]:
+    ) -> list[DecisionDefinitionVersion]:
         """
         Get a collection of available versions for a given decision definition.
 

--- a/src/openforms/dmn/contrib/camunda/plugin.py
+++ b/src/openforms/dmn/contrib/camunda/plugin.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 from django.utils.translation import gettext_lazy as _
 
@@ -57,7 +57,7 @@ class Plugin(BasePlugin):
     verbose_name = _("Camunda")
 
     @staticmethod
-    def get_available_decision_definitions() -> List[DecisionDefinition]:
+    def get_available_decision_definitions() -> list[DecisionDefinition]:
         with get_client() as client:
             results = client.get(
                 "decision-definition",
@@ -72,8 +72,8 @@ class Plugin(BasePlugin):
 
     @staticmethod
     def evaluate(
-        definition_id: str, *, version: str = "", input_values: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        definition_id: str, *, version: str = "", input_values: dict[str, Any]
+    ) -> dict[str, Any]:
         with get_client() as client:
             camunda_id = _get_decision_definition_id(client, definition_id, version)
             try:
@@ -91,7 +91,7 @@ class Plugin(BasePlugin):
     @staticmethod
     def get_decision_definition_versions(
         definition_id: str,
-    ) -> List[DecisionDefinitionVersion]:
+    ) -> list[DecisionDefinitionVersion]:
         """
         Get a collection of available versions for a given decision definition.
 

--- a/src/openforms/dmn/management/commands/dmn_evaluate.py
+++ b/src/openforms/dmn/management/commands/dmn_evaluate.py
@@ -1,6 +1,6 @@
 import argparse
 import builtins
-from typing import Any, Tuple
+from typing import Any
 
 from django.core.management import BaseCommand
 
@@ -10,7 +10,7 @@ from ...registry import register
 from ...service import evaluate_dmn
 
 
-def input_variable(input_string: str) -> Tuple[str, Any]:
+def input_variable(input_string: str) -> tuple[str, Any]:
     bits = input_string.split("::")
     if len(bits) == 2:
         bits = [bits[0], "str", bits[1]]

--- a/src/openforms/dmn/service.py
+++ b/src/openforms/dmn/service.py
@@ -1,14 +1,14 @@
 """
 Public Python API for the DMN module.
 """
-from typing import Any, Dict
+from typing import Any
 
 from .base import BasePlugin
 from .registry import register
 
 __all__ = ["evaluate_dmn", "VariablesMapping"]
 
-VariablesMapping = Dict[str, Any]
+VariablesMapping = dict[str, Any]
 
 
 def evaluate_dmn(

--- a/src/openforms/dmn/tests/test_api.py
+++ b/src/openforms/dmn/tests/test_api.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from unittest.mock import patch
 
 from rest_framework import status
@@ -31,8 +30,8 @@ class TestPlugin(BasePlugin):
 
     @staticmethod
     def evaluate(
-        definition_id, *, version: str = "", input_values: Dict[str, int]
-    ) -> Dict[str, int]:
+        definition_id, *, version: str = "", input_values: dict[str, int]
+    ) -> dict[str, int]:
         return {"sum": sum([input_values["a"], input_values["b"]])}
 
 

--- a/src/openforms/dmn/tests/test_registry.py
+++ b/src/openforms/dmn/tests/test_registry.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from django.test import TestCase
 
 from ..base import BasePlugin, DecisionDefinition
@@ -16,8 +14,8 @@ class TestPlugin(BasePlugin):
 
     @staticmethod
     def evaluate(
-        definition_id, *, version: str = "", input_values: Dict[str, int]
-    ) -> Dict[str, int]:
+        definition_id, *, version: str = "", input_values: dict[str, int]
+    ) -> dict[str, int]:
         return {"sum": sum([input_values["a"], input_values["b"]])}
 
 

--- a/src/openforms/emails/confirmation_emails.py
+++ b/src/openforms/emails/confirmation_emails.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from django.template.defaultfilters import date as date_filter
 from django.urls import reverse
@@ -36,7 +36,7 @@ def get_confirmation_email_templates(submission: "Submission") -> tuple[str, str
         return (subject_template, content_template)
 
 
-def get_confirmation_email_context_data(submission: "Submission") -> Dict[str, Any]:
+def get_confirmation_email_context_data(submission: "Submission") -> dict[str, Any]:
     with translation.override(submission.language_code):
         context = {
             # use private variables that can't be accessed in the template data, so that

--- a/src/openforms/emails/connection_check.py
+++ b/src/openforms/emails/connection_check.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, Optional, Sequence, Union
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -18,7 +18,7 @@ class MailCheckResult:
     sender: str
     success: bool
     backend: str
-    feedback: List[Union[str, LabelValue]] = dataclasses.field(default_factory=list)
+    feedback: list[Union[str, LabelValue]] = dataclasses.field(default_factory=list)
     exception: Optional[Exception] = None
 
     @property

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -1,7 +1,7 @@
 import re
 from collections import UserDict
 from collections.abc import Hashable
-from typing import Dict, Iterator, Optional, cast
+from typing import Iterator, Optional, cast
 
 from glom import PathAccessError, assign, glom
 
@@ -25,7 +25,7 @@ class FormioConfigurationWrapper:
 
     _configuration: JSONObject
     # depth-first ordered of all components in the formio configuration tree
-    _cached_component_map: Optional[Dict[str, Component]] = None
+    _cached_component_map: Optional[dict[str, Component]] = None
     _flattened_by_path: None | dict[str, Component] = None
     _reverse_flattened: None | dict[str, str] = None
 
@@ -33,7 +33,7 @@ class FormioConfigurationWrapper:
         self._configuration = configuration
 
     @property
-    def component_map(self) -> Dict[str, Component]:
+    def component_map(self) -> dict[str, Component]:
         if self._cached_component_map is None:
             self._cached_component_map = {
                 component["key"]: component

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
 from django.test import SimpleTestCase, tag
 from django.utils import timezone
@@ -20,7 +20,7 @@ request_factory = APIRequestFactory()
 class DynamicDateConfigurationTests(SimpleTestCase):
     @staticmethod
     def _get_dynamic_config(
-        component: DateComponent, variables: Dict[str, Any]
+        component: DateComponent, variables: dict[str, Any]
     ) -> DateComponent:
         config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
@@ -20,7 +20,7 @@ request_factory = APIRequestFactory()
 class DynamicDatetimeConfigurationTests(SimpleTestCase):
     @staticmethod
     def _get_dynamic_config(
-        component: DatetimeComponent, variables: Dict[str, Any]
+        component: DatetimeComponent, variables: dict[str, Any]
     ) -> DatetimeComponent:
         config_wrapper = FormioConfigurationWrapper({"components": [component]})
         request = request_factory.get("/irrelevant")

--- a/src/openforms/formio/formatters/tests/utils.py
+++ b/src/openforms/formio/formatters/tests/utils.py
@@ -1,10 +1,10 @@
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 FILES_DIR = Path(__file__).parent / "files"
 
 
-def load_json(filename: str) -> Dict[str, Any]:
+def load_json(filename: str) -> dict[str, Any]:
     with open(FILES_DIR / filename, "r") as infile:
         return json.load(infile)

--- a/src/openforms/formio/tests/assertions.py
+++ b/src/openforms/formio/tests/assertions.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from glom import GlomError, glom
 
 from openforms.typing import JSONObject, JSONValue
@@ -16,7 +14,7 @@ def _get_component(configuration: JSONObject, key: str) -> Component | None:
 
 class FormioMixin:
     def assertFormioComponent(
-        self, configuration: JSONObject, key: str, properties_map: Dict[str, JSONValue]
+        self, configuration: JSONObject, key: str, properties_map: dict[str, JSONValue]
     ) -> None:
         """
         Assert that the formio component with specified key has the expected properties.

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, Tuple, TypeAlias, TypeGuard
+from typing import Any, Iterator, Optional, TypeAlias, TypeGuard
 
 import elasticapm
 from glom import Coalesce, Path, glom
@@ -47,7 +47,7 @@ def iter_components(
 
 def iterate_components_with_configuration_path(
     configuration: ComponentLike, prefix: str = "components", recursive=True
-) -> Iterator[Tuple[str, Component]]:
+) -> Iterator[tuple[str, Component]]:
     for index, component in enumerate(iter_components(configuration, recursive=False)):
         full_path = f"{prefix}.{index}"
         yield full_path, component
@@ -69,7 +69,7 @@ def iterate_components_with_configuration_path(
 
 
 @elasticapm.capture_span(span_type="app.formio.configuration")
-def flatten_by_path(configuration: JSONObject) -> Dict[str, Component]:
+def flatten_by_path(configuration: JSONObject) -> dict[str, Component]:
     """
     Flatten the formio configuration.
 
@@ -214,7 +214,7 @@ def conform_to_mask(value: str, mask: str) -> str:
     # NOTE: we don't check for numeric masks or not, let that be handled by Formio itself
 
     # the final result characters, build from the value and mask
-    result: List[str] = []
+    result: list[str] = []
     char_index, mask_index = 0, 0
     LOOP_GUARD, iterations = 1000, 0
 

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, Iterator, Tuple
+from typing import Callable, Iterator
 
 from django.template import TemplateSyntaxError
 
@@ -65,7 +65,7 @@ def render(formio_bit: JSONValue, context: dict) -> JSONValue:
     return _recursive_apply(formio_bit, render_from_string, context=context)
 
 
-def iter_template_properties(component: Component) -> Iterator[Tuple[str, JSONValue]]:
+def iter_template_properties(component: Component) -> Iterator[tuple[str, JSONValue]]:
     """
     Return an iterator over the formio component properties that are template-enabled.
 
@@ -76,7 +76,7 @@ def iter_template_properties(component: Component) -> Iterator[Tuple[str, JSONVa
         yield (property_name, property_value)
 
 
-def validate_configuration(configuration: JSONObject) -> Dict[str, str]:
+def validate_configuration(configuration: JSONObject) -> dict[str, str]:
     """
     Check the Formio configuration for template syntax errors.
 

--- a/src/openforms/forms/api/datastructures.py
+++ b/src/openforms/forms/api/datastructures.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Optional
 
 from django.utils.functional import cached_property
 
@@ -11,7 +11,7 @@ class FormVariableWrapper:
     form: Form
 
     @cached_property
-    def variables(self) -> Dict[str, FormVariable]:
+    def variables(self) -> dict[str, FormVariable]:
         return {variable.key: variable for variable in self.form.formvariable_set.all()}
 
     def get(self, key: str, default=None) -> Optional[FormVariable]:

--- a/src/openforms/forms/api/serializers/category.py
+++ b/src/openforms/forms/api/serializers/category.py
@@ -1,4 +1,4 @@
-from typing import List, TypedDict
+from typing import TypedDict
 
 from rest_framework import serializers
 
@@ -27,6 +27,6 @@ class CategorySerializer(serializers.HyperlinkedModelSerializer):
         name: str
         uuid: str
 
-    def get_ancestors(self, obj) -> List[NameUUID]:
+    def get_ancestors(self, obj) -> list[NameUUID]:
         ancestors = obj.get_ancestors()
         return [{"uuid": str(n.uuid), "name": n.name} for n in ancestors]

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -2,7 +2,7 @@ import logging
 import uuid as _uuid
 from contextlib import suppress
 from copy import deepcopy
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -510,7 +510,7 @@ class Form(models.Model):
 
         return copy
 
-    def get_keys_for_email_confirmation(self) -> List[str]:
+    def get_keys_for_email_confirmation(self) -> list[str]:
         return_keys = set()
         for form_step in self.formstep_set.select_related("form_definition"):
             for key in form_step.form_definition.get_keys_for_email_confirmation():

--- a/src/openforms/forms/models/form_definition.py
+++ b/src/openforms/forms/models/form_definition.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from copy import deepcopy
 from functools import partial
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -192,7 +192,7 @@ class FormDefinition(models.Model):
             configuration=configuration, recursive=recursive, **kwargs
         )
 
-    def get_keys_for_email_confirmation(self) -> List[Tuple[str, str]]:
+    def get_keys_for_email_confirmation(self) -> list[tuple[str, str]]:
         """Return the key of fields to include in the confirmation email"""
         keys_for_email_confirmation = []
 

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from django.core.validators import RegexValidator
 from django.db import models, transaction
@@ -47,7 +47,7 @@ class FormVariableManager(models.Manager):
         for form_step in form_steps:
             self.create_for_formstep(form_step)
 
-    def create_for_formstep(self, form_step: "FormStep") -> List["FormVariable"]:
+    def create_for_formstep(self, form_step: "FormStep") -> list["FormVariable"]:
         form_definition_configuration = form_step.form_definition.configuration
         component_keys = [
             component["key"]

--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import asdict
 from functools import partial
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 from django.db.models import Model
 from django.utils import timezone
@@ -502,7 +502,7 @@ def submission_export_list(form: "Form", user: "User"):
 
 def submission_logic_evaluated(
     submission: "Submission",
-    evaluated_rules: List["EvaluatedRule"],
+    evaluated_rules: list["EvaluatedRule"],
     initial_data: JSONObject,
     resolved_data: JSONObject,
 ):
@@ -646,7 +646,7 @@ def forms_bulk_export_downloaded(bulk_export, user):
     )
 
 
-def bulk_forms_imported(user: "User", failed_files: List[Tuple[str, str]]):
+def bulk_forms_imported(user: "User", failed_files: list[tuple[str, str]]):
     _create_log(
         user,
         "bulk_forms_imported",

--- a/src/openforms/logging/logic.py
+++ b/src/openforms/logging/logic.py
@@ -4,7 +4,7 @@ Process the logic evaluation logging information.
 This relies on the datastructures used in :mod:`openforms.submissions.form_logic`.
 """
 from dataclasses import asdict
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from json_logic.typing import JSON
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 def log_logic_evaluation(
     submission: Submission,
-    evaluated_rules: List["EvaluatedRule"],
+    evaluated_rules: list["EvaluatedRule"],
     initial_data: dict[str, JSON],
     resolved_data: JSONObject,
 ) -> Optional["TimelineLogProxy"]:

--- a/src/openforms/logging/models.py
+++ b/src/openforms/logging/models.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.db import models
 from django.template.defaultfilters import capfirst
 from django.urls import reverse
@@ -91,7 +89,7 @@ class TimelineLogProxy(TimelineLog):
             return ""
         return f'"{plugin_label}" ({plugin_id})'
 
-    def get_formatted_prefill_fields(self, fields) -> List:
+    def get_formatted_prefill_fields(self, fields) -> list:
         formatted_fields = []
         components = self.content_object.form.iter_components(recursive=True)
 

--- a/src/openforms/logging/tasks.py
+++ b/src/openforms/logging/tasks.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, TypedDict
+from typing import TypedDict
 
 from openforms.celery import app
 from openforms.forms.models import FormLogic
@@ -17,7 +17,7 @@ def log_logic_evaluation(
     *,
     submission_id: int,
     timestamp: str,  # ISO-8601 timestamp
-    evaluated_rules: List[EvaluatedRuleDict],
+    evaluated_rules: list[EvaluatedRuleDict],
     initial_data: JSONObject,
     resolved_data: JSONObject,
 ):

--- a/src/openforms/payments/models.py
+++ b/src/openforms/payments/models.py
@@ -1,6 +1,6 @@
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from django.db import IntegrityError, models, transaction
 from django.db.models import Max, Sum
@@ -66,7 +66,7 @@ class SubmissionPaymentQuerySet(models.QuerySet):
     def sum_amount(self) -> Decimal:
         return self.aggregate(sum_amount=Sum("amount"))["sum_amount"] or Decimal("0")
 
-    def get_completed_public_order_ids(self) -> List[int]:
+    def get_completed_public_order_ids(self) -> list[int]:
         return list(
             self.filter(
                 status__in=(PaymentStatus.registered, PaymentStatus.completed)

--- a/src/openforms/payments/registry.py
+++ b/src/openforms/payments/registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterator, List, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from django.http import HttpRequest
 
@@ -35,7 +35,7 @@ class Registry(BaseRegistry[BasePlugin]):
 
     def get_options(
         self, request: HttpRequest, form: Optional["Form"] = None
-    ) -> List["APIInfo"]:
+    ) -> list["APIInfo"]:
         options = []
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:

--- a/src/openforms/plugins/plugin.py
+++ b/src/openforms/plugins/plugin.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 from django.utils.translation import gettext_lazy as _
 
 from openforms.config.models import GlobalConfiguration
@@ -45,7 +43,7 @@ class AbstractBasePlugin:
         """
         raise NotImplementedError()
 
-    def get_config_actions(self) -> List[Tuple[str, str]]:
+    def get_config_actions(self) -> list[tuple[str, str]]:
         """
         Returns a list of tuples containing the label and URL of each action
         that is related to the configuration of this plugin. This can be to

--- a/src/openforms/prefill/base.py
+++ b/src/openforms/prefill/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Container, Dict, Iterable, List, Tuple
+from typing import Any, Container, Iterable
 
 from openforms.authentication.constants import AuthAttribute
 from openforms.plugins.plugin import AbstractBasePlugin
@@ -18,7 +18,7 @@ class BasePlugin(AbstractBasePlugin):
     requires_auth: AuthAttribute | None = None
     for_components: Container[str] = AllComponentTypes()
 
-    def get_available_attributes(self) -> Iterable[Tuple[str, str]]:
+    def get_available_attributes(self) -> Iterable[tuple[str, str]]:
         """
         Return a choice list of available attributes this plugin offers.
         """
@@ -29,7 +29,7 @@ class BasePlugin(AbstractBasePlugin):
     def get_prefill_values(
         self,
         submission: Submission,
-        attributes: List[str],
+        attributes: list[str],
         identifier_role: IdentifierRoles = IdentifierRoles.main,
     ) -> dict[str, JSONEncodable]:
         """
@@ -50,7 +50,7 @@ class BasePlugin(AbstractBasePlugin):
 
     def get_co_sign_values(
         self, submission: Submission, identifier: str
-    ) -> Tuple[Dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str]:
         """
         Given an identifier, fetch the co-sign specific values.
 

--- a/src/openforms/prefill/contrib/demo/plugin.py
+++ b/src/openforms/prefill/contrib/demo/plugin.py
@@ -1,5 +1,5 @@
 import random
-from typing import Any, Dict, List
+from typing import Any
 
 from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
@@ -27,8 +27,8 @@ class DemoPrefill(BasePlugin):
 
     @staticmethod
     def get_prefill_values(
-        submission: Submission, attributes: List[str], identifier_role: str
-    ) -> Dict[str, Any]:
+        submission: Submission, attributes: list[str], identifier_role: str
+    ) -> dict[str, Any]:
         """
         Given the requested attributes, look up the appropriate values and return them.
 

--- a/src/openforms/prefill/contrib/kvk/plugin.py
+++ b/src/openforms/prefill/contrib/kvk/plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List
+from typing import Any
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -55,7 +55,7 @@ class KVK_KVKNumberPrefill(BasePlugin):
     def get_prefill_values(
         self,
         submission: Submission,
-        attributes: List[str],
+        attributes: list[str],
         identifier_role: str = IdentifierRoles.main,
     ) -> dict[str, Any]:
         # check if submission was logged in with the identifier we're interested

--- a/src/openforms/prefill/management/commands/generate_prefill_from_spec.py
+++ b/src/openforms/prefill/management/commands/generate_prefill_from_spec.py
@@ -1,6 +1,5 @@
 import os.path
 from dataclasses import dataclass
-from typing import Tuple
 
 from django.core.management import BaseCommand
 
@@ -29,7 +28,7 @@ def json_path(obj, reference):
 class Choice:
     name: str
     path: str
-    labels: Tuple[str] = None
+    labels: tuple[str] = None
 
 
 simple_types = (

--- a/src/openforms/registrations/base.py
+++ b/src/openforms/registrations/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any, Optional
 
 from rest_framework import serializers
 
@@ -9,7 +9,7 @@ from openforms.utils.mixins import JsonSchemaSerializerMixin
 if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
-SerializerCls = Type[serializers.Serializer]
+SerializerCls = type[serializers.Serializer]
 
 
 class EmptyOptions(JsonSchemaSerializerMixin, serializers.Serializer):

--- a/src/openforms/registrations/contrib/camunda/api.py
+++ b/src/openforms/registrations/contrib/camunda/api.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
@@ -47,7 +45,7 @@ class ProcessDefinitionListView(ListMixin, views.APIView):
     serializer_class = ProcessDefinitionSerializer
 
     @staticmethod
-    def get_objects() -> List[ProcessDefinition]:
+    def get_objects() -> list[ProcessDefinition]:
         return get_process_definitions()
 
 

--- a/src/openforms/registrations/contrib/camunda/complex_variables.py
+++ b/src/openforms/registrations/contrib/camunda/complex_variables.py
@@ -6,7 +6,7 @@ is injected and evaluated using json-logic expressions, while the remainder of t
 data may be static/hardcoded.
 """
 from dataclasses import dataclass
-from typing import Any, Dict, List, TypedDict, Union
+from typing import Any, TypedDict, Union
 
 from django_camunda.types import JSONObject, JSONValue
 from json_logic import jsonLogic
@@ -40,7 +40,7 @@ class Variable:
         cls = _source_map[kwargs["source"]]
         return cls.build(**kwargs)
 
-    def evaluate(self, data: Dict[str, Any]) -> JSONValue:
+    def evaluate(self, data: dict[str, Any]) -> JSONValue:
         raise NotImplementedError(
             "Subclass %r must implement 'def evaluate'.", type(self)
         )
@@ -59,7 +59,7 @@ class ComponentVariable(Variable):
 
 
 class CatLogicExpression(TypedDict):
-    cat: List[Union[str, VarLogicExpression]]  # JSON-logic
+    cat: list[Union[str, VarLogicExpression]]  # JSON-logic
 
 
 @dataclass
@@ -153,12 +153,12 @@ class NullVariable(ManualVariable):
 
 @dataclass
 class ObjectVariable(ManualVariable):
-    definition: Dict[str, AnyVariable]
+    definition: dict[str, AnyVariable]
 
 
 @dataclass
 class ArrayVariable(ManualVariable):
-    definition: List[AnyVariable]
+    definition: list[AnyVariable]
 
 
 @dataclass
@@ -190,8 +190,8 @@ class ComplexVariable:
 
 
 def get_complex_process_variables(
-    variables: List[dict], merged_data: dict
-) -> Dict[str, JSONObject]:
+    variables: list[dict], merged_data: dict
+) -> dict[str, JSONObject]:
     if not variables:
         return {}
 

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -6,7 +6,7 @@ See the `documentation <_variables>` to learn more about Camunda variable types.
 .. _variables: https://docs.camunda.org/manual/7.16/reference/rest/overview/variables/
 """
 import logging
-from typing import Any, Dict, List, NoReturn, Tuple
+from typing import Any, NoReturn
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_process_variables(
-    submission: Submission, options: Dict[str, Any]
-) -> Dict[str, Any]:
+    submission: Submission, options: dict[str, Any]
+) -> dict[str, Any]:
     """
     Extract the values from the submission and map onto the requested process variables.
     """
@@ -48,7 +48,7 @@ def get_process_variables(
         ]
     )
 
-    merged_data: Dict[str, Any] = submission.get_merged_data()
+    merged_data: dict[str, Any] = submission.get_merged_data()
     for component in submission.form.iter_components(recursive=True):
         if (key := component.get("key")) not in simple_mappings:
             continue
@@ -79,7 +79,7 @@ class CamundaRegistration(BasePlugin):
 
     def register_submission(
         self, submission: Submission, options: dict
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         process_definition = options["process_definition"]
         version = options["process_definition_version"]
 
@@ -143,7 +143,7 @@ class CamundaRegistration(BasePlugin):
             }
         }
 
-    def get_reference_from_result(self, result: Dict[str, str]) -> NoReturn:
+    def get_reference_from_result(self, result: dict[str, str]) -> NoReturn:
         """
         Extract the public submission reference from the result data.
 
@@ -162,7 +162,7 @@ class CamundaRegistration(BasePlugin):
     def check_config(self):
         check_config()
 
-    def get_config_actions(self) -> List[Tuple[str, str]]:
+    def get_config_actions(self) -> list[tuple[str, str]]:
         return [
             (
                 _("Configuration"),

--- a/src/openforms/registrations/contrib/camunda/type_mapping.py
+++ b/src/openforms/registrations/contrib/camunda/type_mapping.py
@@ -7,7 +7,7 @@ so that django-camunda can map it to the appropriate Camunda type information.
 The work in #1068 should eventually make this module obsolete.
 """
 from decimal import Decimal
-from typing import Any, Dict, List
+from typing import Any
 
 from dateutil import parser
 
@@ -36,7 +36,7 @@ def select(component, value) -> str:
     return str(value)
 
 
-def selectboxes(component, value) -> List[str]:
+def selectboxes(component, value) -> list[str]:
     return [key for key, checked in value.items() if checked]
 
 
@@ -74,7 +74,7 @@ def convert_if_not_none(converter: callable, component: dict, value: Any) -> Any
         return converter(component, value)
 
 
-def to_python(component: Dict[str, Any], value: Any) -> Any:
+def to_python(component: dict[str, Any], value: Any) -> Any:
     converter = TYPE_MAP.get(component["type"], to_str)
 
     multiple = component.get("multiple", False)

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -1,6 +1,6 @@
 import html
 from mimetypes import types_map
-from typing import Any, List, NoReturn, Optional, Tuple, TypedDict
+from typing import Any, NoReturn, Optional, TypedDict
 
 from django.conf import settings
 from django.urls import reverse
@@ -38,9 +38,9 @@ from .utils import get_registration_email_templates
 
 
 class EmailOptions(TypedDict):
-    to_emails: List[str]
-    attachment_formats: List[str]
-    payment_emails: List[str]
+    to_emails: list[str]
+    attachment_formats: list[str]
+    payment_emails: list[str]
     attach_files_to_email: Optional[bool]
     email_subject: Optional[str]
 
@@ -210,7 +210,7 @@ class EmailRegistration(BasePlugin):
     def check_config(self):
         check_config()
 
-    def get_config_actions(self) -> List[Tuple[str, str]]:
+    def get_config_actions(self) -> list[tuple[str, str]]:
         return [
             (_("Test"), reverse("admin_email_test")),
         ]

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Dict, NoReturn
+from typing import Any, NoReturn
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -62,7 +62,7 @@ class ObjectsAPIRegistration(BasePlugin):
 
     def register_submission(
         self, submission: Submission, options: dict
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Register a submission using the ObjectsAPI backend
 
         The creation of submission documents (report, attachment, csv) makes use of ZGW

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Optional
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -321,7 +321,7 @@ class StufZDSRegistration(BasePlugin):
         }
         return result
 
-    def get_reference_from_result(self, result: Dict[str, str]) -> str:
+    def get_reference_from_result(self, result: dict[str, str]) -> str:
         """
         Extract the public submission reference from the result data.
 

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-from typing import Tuple
 from uuid import UUID
 
 from django.db import transaction
@@ -588,7 +587,7 @@ class SubmissionStepViewSet(
 
     def _validate_step_input(
         self, request
-    ) -> Tuple[SubmissionStep, SubmissionStepSerializer]:
+    ) -> tuple[SubmissionStep, SubmissionStepSerializer]:
         instance = self.get_object()
         create = instance.pk is None
         if create:

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Iterable, Iterator, Optional, Tuple
+from typing import Iterable, Iterator, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -337,7 +337,7 @@ def resolve_uploads_from_data(configuration: JSONObject, data: dict) -> dict:
 
 
 def resize_attachment(
-    attachment: SubmissionFileAttachment, size: Tuple[int, int]
+    attachment: SubmissionFileAttachment, size: tuple[int, int]
 ) -> bool:
     """
     'safe' resize an attached image that might not be an image or not need resize at all

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from django.utils.functional import empty
 
@@ -95,7 +95,7 @@ def evaluate_form_logic(
 
     # 5. Evaluate the logic rules in order
     mutation_operations = []
-    evaluated_rules: List[EvaluatedRule] = []
+    evaluated_rules: list[EvaluatedRule] = []
 
     # 5.1 - if the action type is to set a variable, update the variable state. This
     # happens inside of iter_evaluate_rules. This is the ONLY operation that is allowed

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Dict, Mapping, Optional, Type, TypedDict
+from typing import Any, Callable, Mapping, Optional, TypedDict
 
 from glom import assign
 from json_logic import jsonLogic
@@ -70,8 +70,8 @@ class ActionOperation:
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> Optional[JSONObject]:
@@ -103,8 +103,8 @@ class PropertyAction(ActionOperation):
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> JSONObject:
@@ -139,8 +139,8 @@ class DisableNextAction(ActionOperation):
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> JSONObject:
@@ -179,8 +179,8 @@ class StepNotApplicableAction(ActionOperation):
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> JSONObject:
@@ -215,8 +215,8 @@ class StepApplicableAction(ActionOperation):
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> JSONObject:
@@ -249,8 +249,8 @@ class VariableAction(ActionOperation):
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> JSONObject:
@@ -294,8 +294,8 @@ class ServiceFetchAction(ActionOperation):
 
     def get_action_log_data(
         self,
-        component_map: Dict[str, ComponentMeta],
-        all_variables: Dict[str, FormVariable],
+        component_map: dict[str, ComponentMeta],
+        all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
     ) -> JSONObject:
@@ -332,7 +332,7 @@ class SetRegistrationBackendAction(ActionOperation):
         }
 
 
-ACTION_TYPE_MAPPING: Mapping[LogicActionTypes, Type[ActionOperation]] = {
+ACTION_TYPE_MAPPING: Mapping[LogicActionTypes, type[ActionOperation]] = {
     LogicActionTypes.property: PropertyAction,
     LogicActionTypes.disable_next: DisableNextAction,
     LogicActionTypes.step_not_applicable: StepNotApplicableAction,

--- a/src/openforms/submissions/logic/datastructures.py
+++ b/src/openforms/submissions/logic/datastructures.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Tuple
+from typing import Any
 
 from openforms.formio.service import FormioData
 from openforms.typing import DataMapping
@@ -16,7 +16,7 @@ class DataContainer:
 
     state: SubmissionValueVariablesState
 
-    _initial_data: Tuple[Tuple[str, Any]] = field(init=False, default_factory=tuple)
+    _initial_data: tuple[tuple[str, Any]] = field(init=False, default_factory=tuple)
 
     def __post_init__(self):
         # ensure the initial data is immutable

--- a/src/openforms/submissions/logic/log_utils.py
+++ b/src/openforms/submissions/logic/log_utils.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 from openforms.forms.models import FormLogic, FormVariable
 from openforms.logging import logevent
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 def get_targeted_components(
     rule: FormLogic,
     components_map: dict,
-    all_variables: Dict[str, FormVariable],
+    all_variables: dict[str, FormVariable],
     initial_data: dict,
     action_log_data: dict[int, JSONValue],
-) -> List[dict]:
+) -> list[dict]:
     return [
         action_operation.get_action_log_data(
             component_map=components_map,

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -1,7 +1,7 @@
 import operator
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Callable, Iterable, Iterator, List, Optional
+from typing import Callable, Iterable, Iterator, Optional
 
 import elasticapm
 from json_logic import jsonLogic
@@ -15,7 +15,7 @@ from .datastructures import DataContainer
 from .log_utils import log_errors
 
 
-def _include_rule(form_steps: List[FormStep], rule: FormLogic, step_index: int) -> bool:
+def _include_rule(form_steps: list[FormStep], rule: FormLogic, step_index: int) -> bool:
     # rules that always apply
     if not rule.trigger_from_step:
         return True

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -5,7 +5,7 @@ On top of that, it is also a realistic example of using the high-level Python AP
 the renderer to output reports.
 """
 import inspect
-from typing import List, Type, Union
+from typing import Union
 
 from django.core.management import BaseCommand
 
@@ -31,7 +31,7 @@ INDENT_SIZES = {
 INDENT = "    "
 
 
-def get_indent_level(node_cls: Union[Node, Type[Node]]) -> str:
+def get_indent_level(node_cls: Union[Node, type[Node]]) -> str:
     """
     Extract the indentation level from the node class configuration.
     """
@@ -120,7 +120,7 @@ class Command(BaseCommand):
 
         self._print_tabulate_data(tabulate_data)
 
-    def _print_tabulate_data(self, tabulate_data: List[List[str]]) -> None:
+    def _print_tabulate_data(self, tabulate_data: list[list[str]]) -> None:
         if not tabulate_data:
             return
         table = tabulate(tabulate_data)

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Mapping, Optional, Union
 
 from django.conf import settings
 from django.db import models, transaction
@@ -50,8 +50,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class SubmissionState:
-    form_steps: List[FormStep]
-    submission_steps: List["SubmissionStep"]
+    form_steps: list[FormStep]
+    submission_steps: list["SubmissionStep"]
 
     def _get_step_offset(self):
         completed_steps = sorted(
@@ -505,7 +505,7 @@ class Submission(models.Model):
 
         # build the resulting list - some SubmissionStep instances will probably not exist
         # in the database yet - this is on purpose!
-        steps: List[SubmissionStep] = []
+        steps: list[SubmissionStep] = []
         for form_step in form_steps:
             if form_step.id in submission_steps:
                 step = submission_steps[form_step.id]
@@ -553,7 +553,7 @@ class Submission(models.Model):
         }
         return render_from_string(template, context_data, backend=openforms_backend)
 
-    def render_summary_page(self) -> List[JSONObject]:
+    def render_summary_page(self) -> list[JSONObject]:
         """Use the renderer logic to decide what to display in the summary page.
 
         The values of the component are returned raw, because the frontend decides how to display them.
@@ -592,7 +592,7 @@ class Submission(models.Model):
         return summary_data
 
     @property
-    def steps(self) -> List["SubmissionStep"]:
+    def steps(self) -> list["SubmissionStep"]:
         # fetch the existing DB records for submitted form steps
         submission_state = self.load_execution_state()
         return submission_state.submission_steps
@@ -622,7 +622,7 @@ class Submission(models.Model):
 
         return ordered_data
 
-    def get_merged_appointment_data(self) -> Dict[str, Dict[str, Union[str, dict]]]:
+    def get_merged_appointment_data(self) -> dict[str, dict[str, Union[str, dict]]]:
         component_config_key_to_appointment_key = {
             "appointments.showProducts": "productIDAndName",
             "appointments.showLocations": "locationIDAndName",

--- a/src/openforms/submissions/models/submission_files.py
+++ b/src/openforms/submissions/models/submission_files.py
@@ -4,7 +4,7 @@ import os.path
 import uuid
 from collections import defaultdict
 from datetime import date, timedelta
-from typing import TYPE_CHECKING, List, Mapping, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Mapping, Optional, cast
 
 from django.core.files.base import File
 from django.db import models
@@ -74,7 +74,7 @@ class SubmissionFileAttachmentQuerySet(DeleteFilesQuerySetMixin, models.QuerySet
     def for_submission(self, submission: Submission):
         return self.filter(submission_step__submission=submission)
 
-    def as_form_dict(self) -> Mapping[str, List["SubmissionFileAttachment"]]:
+    def as_form_dict(self) -> Mapping[str, list["SubmissionFileAttachment"]]:
         files = defaultdict(list)
         for file in self:
             files[file._component_configuration_path].append(file)
@@ -90,7 +90,7 @@ class SubmissionFileAttachmentManager(models.Manager):
         data_path: str,
         upload: TemporaryFileUpload,
         file_name: Optional[str] = None,
-    ) -> Tuple["SubmissionFileAttachment", bool]:
+    ) -> tuple["SubmissionFileAttachment", bool]:
         try:
             return (
                 self.get(

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -32,19 +32,19 @@ class ValueEncoder(DjangoJSONEncoder):
 @dataclass
 class SubmissionValueVariablesState:
     submission: "Submission"
-    _variables: Optional[Dict[str, "SubmissionValueVariable"]] = field(
+    _variables: Optional[dict[str, "SubmissionValueVariable"]] = field(
         init=False, default=None
     )
-    _static_data: Optional[Dict[str, Any]] = field(init=False, default=None)
+    _static_data: Optional[dict[str, Any]] = field(init=False, default=None)
 
     @property
-    def variables(self) -> Dict[str, "SubmissionValueVariable"]:
+    def variables(self) -> dict[str, "SubmissionValueVariable"]:
         if not self._variables:
             self._variables = self.collect_variables()
         return self._variables
 
     @property
-    def saved_variables(self) -> Dict[str, "SubmissionValueVariable"]:
+    def saved_variables(self) -> dict[str, "SubmissionValueVariable"]:
         return {
             variable_key: variable
             for variable_key, variable in self.variables.items()
@@ -83,7 +83,7 @@ class SubmissionValueVariablesState:
         self,
         submission_step: "SubmissionStep",
         include_unsaved=True,
-    ) -> Dict[str, "SubmissionValueVariable"]:
+    ) -> dict[str, "SubmissionValueVariable"]:
         configuration_wrapper = (
             submission_step.form_step.form_definition.configuration_wrapper
         )
@@ -99,7 +99,7 @@ class SubmissionValueVariablesState:
             if variable.key in keys_in_step
         }
 
-    def collect_variables(self) -> Dict[str, "SubmissionValueVariable"]:
+    def collect_variables(self) -> dict[str, "SubmissionValueVariable"]:
         # leverage the (already populated) submission state to get access to form
         # steps and form definitions
         submission_state = self.submission.load_execution_state()
@@ -163,7 +163,7 @@ class SubmissionValueVariablesState:
             }
         return self._static_data
 
-    def get_prefill_variables(self) -> List["SubmissionValueVariable"]:
+    def get_prefill_variables(self) -> list["SubmissionValueVariable"]:
         prefill_vars = []
         for variable in self.variables.values():
             if not variable.is_initially_prefilled:
@@ -171,7 +171,7 @@ class SubmissionValueVariablesState:
             prefill_vars.append(variable)
         return prefill_vars
 
-    def save_prefill_data(self, data: Dict[str, Any]) -> None:
+    def save_prefill_data(self, data: dict[str, Any]) -> None:
         variables_to_prefill = self.get_prefill_variables()
         for variable in variables_to_prefill:
             if variable.key not in data:

--- a/src/openforms/submissions/status.py
+++ b/src/openforms/submissions/status.py
@@ -2,7 +2,6 @@
 Utility to interact with the celery task status.
 """
 from dataclasses import dataclass
-from typing import List
 
 from django.urls import reverse
 
@@ -22,14 +21,14 @@ class SubmissionProcessingStatus:
     request: Request
     submission: Submission
 
-    def get_async_results(self) -> List[AsyncResult]:
+    def get_async_results(self) -> list[AsyncResult]:
         """Retrieve the results for the task scheduled ONLY when the submission was completed."""
         if not hasattr(self, "_async_result"):
             task_ids = self.submission.post_completion_task_ids
             self._async_results = [AsyncResult(task_id) for task_id in task_ids]
         return self._async_results
 
-    def get_all_async_results(self) -> List[AsyncResult]:
+    def get_all_async_results(self) -> list[AsyncResult]:
         """Retrieve the results for ALL tasks scheduled while processing a submission.
 
         This includes tasks scheduled when the submission was completed, when it was cosigned, when a payment was

--- a/src/openforms/submissions/tasks/user_uploads.py
+++ b/src/openforms/submissions/tasks/user_uploads.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Tuple
 
 from django.conf import settings
 
@@ -32,6 +31,6 @@ def cleanup_unclaimed_temporary_files() -> None:
 
 
 @app.task(ignore_result=True)
-def resize_submission_attachment(attachment_id: int, size: Tuple[int, int]) -> None:
+def resize_submission_attachment(attachment_id: int, size: tuple[int, int]) -> None:
     attachment = SubmissionFileAttachment.objects.get(id=attachment_id)
     resize_attachment(attachment, size)

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -1,6 +1,6 @@
 import copy
 from datetime import timedelta
-from typing import List, Optional
+from typing import Optional
 
 from django.conf import settings
 from django.utils import timezone
@@ -148,7 +148,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
     @classmethod
     def from_components(
         cls,
-        components_list: List[dict],
+        components_list: list[dict],
         submitted_data: dict | None = None,
         form_definition_kwargs: dict | None = None,
         **kwargs,

--- a/src/openforms/submissions/tokens.py
+++ b/src/openforms/submissions/tokens.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.conf import settings
 
 from openforms.config.models import GlobalConfiguration
@@ -21,7 +19,7 @@ class SubmissionReportTokenGenerator(BaseTokenGenerator):
     key_salt = "openforms.submissions.tokens.SubmissionReportTokenGenerator"
     token_timeout_days = settings.SUBMISSION_REPORT_URL_TOKEN_TIMEOUT_DAYS
 
-    def get_hash_value_parts(self, submission_report: SubmissionReport) -> List[str]:
+    def get_hash_value_parts(self, submission_report: SubmissionReport) -> list[str]:
         submission_report_attributes = (
             "id",
             "submission",
@@ -39,7 +37,7 @@ class SubmissionStatusTokenGenerator(BaseTokenGenerator):
     # about a minute anyway.
     token_timeout_days = 1
 
-    def get_hash_value_parts(self, submission: Submission) -> List[str]:
+    def get_hash_value_parts(self, submission: Submission) -> list[str]:
         """
         Obtain the attribute values that mutate to invalidate the token.
 
@@ -70,7 +68,7 @@ class SubmissionResumeTokenGenerator(BaseTokenGenerator):
             or GlobalConfiguration.get_solo().incomplete_submissions_removal_limit
         )
 
-    def get_hash_value_parts(self, submission: Submission) -> List[str]:
+    def get_hash_value_parts(self, submission: Submission) -> list[str]:
         """
         Obtain the attribute values that mutate to invalidate the token.
         """

--- a/src/openforms/typing.py
+++ b/src/openforms/typing.py
@@ -1,7 +1,7 @@
 import datetime
 import decimal
 import uuid
-from typing import Any, Dict, List, NewType, Protocol, Union
+from typing import Any, NewType, Protocol, Union
 
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
@@ -11,11 +11,11 @@ from rest_framework.request import Request
 
 JSONPrimitive = Union[str, int, None, float, bool]
 
-JSONValue = Union[JSONPrimitive, "JSONObject", List["JSONValue"]]
+JSONValue = Union[JSONPrimitive, "JSONObject", list["JSONValue"]]
 
-JSONObject = Dict[str, JSONValue]
+JSONObject = dict[str, JSONValue]
 
-DataMapping = Dict[str, Any]  # key: value pair
+DataMapping = dict[str, Any]  # key: value pair
 
 AnyRequest = Union[HttpRequest, Request]
 

--- a/src/openforms/ui/templatetags/style_dictionary.py
+++ b/src/openforms/ui/templatetags/style_dictionary.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Union
 
 from django import template
 
@@ -11,7 +11,7 @@ class InvalidInput(Exception):
     pass
 
 
-def extract_tokens(node: dict, prefix: str | None = None) -> Dict[str, JSONPrimitive]:
+def extract_tokens(node: dict, prefix: str | None = None) -> dict[str, JSONPrimitive]:
     if not isinstance(node, dict):
         raise InvalidInput(
             "The node is not a dict, can't extract a value or nested keys."
@@ -37,7 +37,7 @@ def extract_tokens(node: dict, prefix: str | None = None) -> Dict[str, JSONPrimi
 
 
 @register.simple_tag()
-def style_dictionary(styles: dict) -> Dict[str, JSONPrimitive]:
+def style_dictionary(styles: dict) -> dict[str, JSONPrimitive]:
     """
     Transform a style dictionary into a mapping of resolved design tokens.
     """

--- a/src/openforms/utils/files.py
+++ b/src/openforms/utils/files.py
@@ -4,7 +4,6 @@ Implement :class:`django.db.models.FileField` related utilities.
 These utilities apply to file fields and subclasses thereof.
 """
 import logging
-from typing import List
 
 from django.db import models, transaction
 from django.db.models.base import ModelBase
@@ -13,7 +12,7 @@ from django.db.models.fields.files import FieldFile
 logger = logging.getLogger(__name__)
 
 
-def get_file_field_names(model: ModelBase) -> List[str]:
+def get_file_field_names(model: ModelBase) -> list[str]:
     """
     Collect names of :class:`django.db.models.FileField` (& subclass) model fields.
     """
@@ -51,7 +50,7 @@ class log_failed_deletes:
             return True
 
 
-def _delete_obj_files(fields: List[str], obj: models.Model) -> None:
+def _delete_obj_files(fields: list[str], obj: models.Model) -> None:
     for name in fields:
         filefield = getattr(obj, name)
         with log_failed_deletes(filefield):

--- a/src/openforms/utils/middleware.py
+++ b/src/openforms/utils/middleware.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 from openforms.config.models import CSPSetting
 
 
@@ -13,7 +11,7 @@ class UpdateCSPMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
-    def get_csp_update(self) -> Dict[str, List[str]]:
+    def get_csp_update(self) -> dict[str, list[str]]:
         update = dict()
 
         # dynamic admin driven
@@ -42,7 +40,7 @@ class UpdateCSPMiddleware:
         return response
 
 
-def _merge_list_values(left, right) -> List[str]:
+def _merge_list_values(left, right) -> list[str]:
     # combine strings or lists to a list with unique values
     if isinstance(left, str):
         left = [left]

--- a/src/openforms/utils/pdf.py
+++ b/src/openforms/utils/pdf.py
@@ -2,7 +2,7 @@ import logging
 import mimetypes
 from io import BytesIO
 from pathlib import PurePosixPath
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import ParseResult, urljoin, urlparse
 
 from django.conf import settings
@@ -80,7 +80,7 @@ class UrlFetcher:
 
     def get_match_candidate(
         self, url: ParseResult
-    ) -> Optional[Tuple[ParseResult, FileSystemStorage]]:
+    ) -> Optional[tuple[ParseResult, FileSystemStorage]]:
         for parsed_base_url, storage, is_local_storage in self.candidates:
             if not is_local_storage:
                 continue
@@ -96,7 +96,7 @@ class UrlFetcher:
         return None
 
 
-def render_to_pdf(template_name: str, context: dict) -> Tuple[str, bytes]:
+def render_to_pdf(template_name: str, context: dict) -> tuple[str, bytes]:
     """
     Render a (HTML) template to PDF with the given context.
     """

--- a/src/openforms/utils/urls.py
+++ b/src/openforms/utils/urls.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 from urllib.parse import urljoin, urlsplit
 
 from django.conf import settings
@@ -63,7 +63,7 @@ def reverse_plus(
     args=None,
     kwargs=None,
     request: Optional[RequestType] = None,
-    query: Optional[Dict[str, Any]] = None,
+    query: Optional[dict[str, Any]] = None,
     make_absolute: bool = True,
 ):
     """

--- a/src/openforms/utils/validators.py
+++ b/src/openforms/utils/validators.py
@@ -1,5 +1,3 @@
-from typing import List, Type
-
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.utils.deconstruct import deconstructible
@@ -87,7 +85,7 @@ class UniqueValuesValidator:
     message = _("Values must be unique")
     code = "invalid"
 
-    def __call__(self, value: List[str]):
+    def __call__(self, value: list[str]):
         uniq = set(value)
         if len(uniq) != len(value):
             raise ValidationError(self.message, code=self.code)
@@ -116,7 +114,7 @@ class SerializerValidator:
     message = _("The data shape does not match the expected shape: {errors}")
     code = "invalid"
 
-    def __init__(self, serializer_cls: Type[serializers.Serializer], many=False):
+    def __init__(self, serializer_cls: type[serializers.Serializer], many=False):
         self.serializer_cls = serializer_cls
         self.many = many
 

--- a/src/openforms/variables/service.py
+++ b/src/openforms/variables/service.py
@@ -1,7 +1,7 @@
 """
 Public Python API to access (static) form variables.
 """
-from typing import List, Optional
+from typing import Optional
 
 from openforms.forms.models import FormVariable
 from openforms.submissions.models import Submission
@@ -13,7 +13,7 @@ __all__ = ["get_static_variables"]
 
 def get_static_variables(
     *, submission: Optional[Submission] = None
-) -> List[FormVariable]:
+) -> list[FormVariable]:
     """
     Return the full collection of static variables registered by all apps.
 


### PR DESCRIPTION
How it was done:
- Using ruff, I've set the following rules: [`UP006`](https://docs.astral.sh/ruff/rules/non-pep585-annotation/) and [`UP007`](https://docs.astral.sh/ruff/rules/non-pep604-annotation/)
- Ran `ruff check --fix src/`: only `UP006` is considered safe
- Used [`F401`](https://docs.astral.sh/ruff/rules/unused-import/) for unused imports, which has a safe fix
- Ran black and isort

`Union` and `Optional` still remains, as the fix for `UP007` is unsafe. I believe the only place where it can lead to actual errors is when using forward references:

`JSONValue = Union[JSONPrimitive, "JSONObject", list["JSONValue"]]`

to

`JSONValue = JSONPrimitive | "JSONObject" | list["JSONValue"]`

which can be rewritten as `"JSONPrimitive | JSONObject | list[JSONValue]"`.

I would prefer having only this merged for now (after 2.5), and I can investigate further for the remaining `Union/Optional`