### PR TITLE
[#3616] Missing margin in form definition configuration

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -42,6 +42,10 @@ li.nav-item {
       float: none;
       width: initial;
     }
+
+    input {
+      margin-bottom: 10px;
+    }
   }
 
   .row {


### PR DESCRIPTION
Part of #3616 

This has to do with the form definition page. In a form it's working properly due to different css classes.