### PR TITLE
Use new style typing for unions

### DIFF
--- a/docs/developers/plugins/registration_plugins.rst
+++ b/docs/developers/plugins/registration_plugins.rst
@@ -24,12 +24,10 @@ adhere to the following function signature:
 
 .. code-block:: python
 
-    from typing import Optional
-
     from openforms.submissions.models import Submission
 
 
-    def plugin(submission: Submission, options: dict) -> Optional[dict]:
+    def plugin(submission: Submission, options: dict) -> dict | None:
         # do stuff
 
 

--- a/src/csp_post_processor/processor.py
+++ b/src/csp_post_processor/processor.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-from typing import Union
 
 from django.http import HttpRequest
 from django.utils.safestring import SafeString, mark_safe
@@ -104,9 +103,7 @@ def get_html_id(node):
     return str(id(node))  # CPython: memory address, so should be unique enough
 
 
-def post_process_html(
-    html: str | SafeString, request: Union[HttpRequest, Request]
-) -> str:
+def post_process_html(html: str | SafeString, request: HttpRequest | Request) -> str:
     """
     Replacing inline style attributes with an inline <style> element with nonce added.
 

--- a/src/openforms/api/exception_handling.py
+++ b/src/openforms/api/exception_handling.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 from collections import OrderedDict
-from typing import Union
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
@@ -14,7 +13,7 @@ from .utils import underscore_to_camel
 
 logger = logging.getLogger(__name__)
 
-ErrorSerializer = Union[ExceptionSerializer, ValidationErrorSerializer]
+ErrorSerializer = ExceptionSerializer | ValidationErrorSerializer
 
 
 def _translate_exceptions(exc):
@@ -33,7 +32,7 @@ def _translate_exceptions(exc):
 # that's used to submit formio data to the backend, which contains sub-keys set by
 # end-users and can't be automatically converted. Consequently, error messages for
 # those sub-keys should not be transformed.
-def get_validation_errors(validation_errors: Union[dict, list], camelize=True):
+def get_validation_errors(validation_errors: dict | list, camelize=True):
     if isinstance(validation_errors, list):
         for i, item in enumerate(validation_errors):
             for err in get_validation_errors(item):
@@ -179,5 +178,5 @@ class HandledException:
         return f"urn:uuid:{self._exc_id}"
 
     @property
-    def invalid_params(self) -> Union[None, list]:
+    def invalid_params(self) -> None | list:
         return [error for error in get_validation_errors(self.exc.detail)]

--- a/src/openforms/api/mixins.py
+++ b/src/openforms/api/mixins.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional
+from typing import Iterable
 
 from django.utils.translation import gettext_lazy as _
 
@@ -9,7 +9,7 @@ from rest_framework import serializers
 class ValidateQueryStringParametersMixin:
     validate_params: Iterable[OpenApiParameter] = ()
 
-    def validate_query_parameters(self) -> dict[OpenApiParameter, Optional[str]]:
+    def validate_query_parameters(self) -> dict[OpenApiParameter, str | None]:
         errors, extracted = {}, {}
 
         for param in self.validate_params:

--- a/src/openforms/api/utils.py
+++ b/src/openforms/api/utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Union
+from typing import Any
 
 from django.db import models
 
@@ -12,7 +12,7 @@ from rest_framework.serializers import ModelSerializer, Serializer
 from rest_framework.views import APIView
 
 
-def underscore_to_camel(input_: Union[str, int]) -> str:
+def underscore_to_camel(input_: str | int) -> str:
     """
     Convert a string from under_score to camelCase.
     """

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -4,7 +4,6 @@ import logging
 import re
 import warnings
 from datetime import datetime
-from typing import Optional
 
 from django.utils.translation import gettext_lazy as _
 
@@ -262,7 +261,7 @@ def create_base64_qrcode(text):
     return base64.b64encode(buffer.read()).decode("ascii")
 
 
-def find_first_appointment_step(form: Form) -> Optional[FormStep]:
+def find_first_appointment_step(form: Form) -> FormStep | None:
     """
     Find the first step in a form dealing with appointments.
 

--- a/src/openforms/authentication/base.py
+++ b/src/openforms/authentication/base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 
 from django.db.models import TextChoices
 from django.http import HttpRequest, HttpResponse
@@ -27,7 +27,7 @@ class LoginInfo:
     identifier: str
     label: str
     logo: LoginLogo | None = None
-    url: Optional[str] = None
+    url: str | None = None
     is_for_gemachtigde: bool = False
 
 
@@ -122,5 +122,5 @@ class BasePlugin(AbstractBasePlugin):
     def get_label(self) -> str:
         return self.verbose_name
 
-    def get_logo(self, request: HttpRequest) -> Optional[LoginLogo]:
+    def get_logo(self, request: HttpRequest) -> LoginLogo | None:
         return None

--- a/src/openforms/authentication/contrib/demo/plugin.py
+++ b/src/openforms/authentication/contrib/demo/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from django import forms
 from django.http import (
@@ -53,7 +53,7 @@ class DemoBaseAuthentication(BasePlugin):
 
     def start_login(
         self, request: HttpRequest, form: Form, form_url: str
-    ) -> Union[str, HttpResponse]:
+    ) -> str | HttpResponse:
         context = {
             "form_action": self.get_return_url(request, form),
             "form_url": form_url,
@@ -66,9 +66,7 @@ class DemoBaseAuthentication(BasePlugin):
         }
         return render(request, "authentication/contrib/demo/login.html", context)
 
-    def handle_co_sign(
-        self, request: HttpRequest, form: Form
-    ) -> Optional[dict[str, Any]]:
+    def handle_co_sign(self, request: HttpRequest, form: Form) -> dict[str, Any] | None:
         submitted = self.form_class(request.POST)
         if not submitted.is_valid():
             raise InvalidCoSignData(f"Validation errors: {submitted.errors}")
@@ -78,9 +76,7 @@ class DemoBaseAuthentication(BasePlugin):
             "fields": {},
         }
 
-    def handle_return(
-        self, request: HttpRequest, form: Form
-    ) -> Union[str, HttpResponse]:
+    def handle_return(self, request: HttpRequest, form: Form) -> str | HttpResponse:
         submitted = self.form_class(request.POST)
         if not submitted.is_valid():
             return HttpResponseBadRequest("invalid data")

--- a/src/openforms/authentication/contrib/digid/plugin.py
+++ b/src/openforms/authentication/contrib/digid/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn, Optional
+from typing import Any, NoReturn
 
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
@@ -103,7 +103,7 @@ class DigidAuthentication(BasePlugin):
         required = config.get("loa") or DIGID_DEFAULT_LOA
         return loa_order(authenticated_loa) >= loa_order(required)
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_digid_logo(request))
 
     def logout(self, request: HttpRequest):

--- a/src/openforms/authentication/contrib/digid/tests/test_auth_procedure.py
+++ b/src/openforms/authentication/contrib/digid/tests/test_auth_procedure.py
@@ -1,5 +1,4 @@
 from base64 import b64decode
-from typing import Optional
 from unittest.mock import patch
 
 from django.core.files import File
@@ -35,7 +34,7 @@ def _create_test_artifact() -> str:
     return create_test_artifact(config.idp_service_entity_id)
 
 
-def _get_artifact_response(filename: str, context: Optional[dict] = None) -> bytes:
+def _get_artifact_response(filename: str, context: dict | None = None) -> bytes:
     path = str(TEST_FILES / filename)
     return get_artifact_response(path, context=context)
 

--- a/src/openforms/authentication/contrib/digid/tests/test_signicat_integration.py
+++ b/src/openforms/authentication/contrib/digid/tests/test_signicat_integration.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal, TypeAlias
 from unittest.mock import patch
 
 from django.core.files import File
@@ -612,8 +612,8 @@ class SignicatDigiDIntegrationTests(OFVCRMixin, TestCase):
 # Helper functions
 
 # poor person's enum.StrEnum
-Method = Union[Literal["get"], Literal["post"]]
-Response = Union[TemplateResponse, requests.Response]
+Method: TypeAlias = Literal["get", "post"]
+Response: TypeAlias = TemplateResponse | requests.Response
 
 
 def _parse_form(response: Response) -> tuple[Method, str, dict[str, str]]:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/plugin.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
@@ -56,9 +56,7 @@ class OIDCAuthentication(BasePlugin):
         redirect_url = furl(login_url).set({"next": str(return_url)})
         return HttpResponseRedirect(str(redirect_url))
 
-    def handle_co_sign(
-        self, request: HttpRequest, form: Form
-    ) -> Optional[dict[str, Any]]:
+    def handle_co_sign(self, request: HttpRequest, form: Form) -> dict[str, Any] | None:
         if not (claim := request.session.get(self.session_key)):
             raise InvalidCoSignData(f"Missing '{self.provides_auth}' parameter/value")
         return {
@@ -121,7 +119,7 @@ class DigiDOIDCAuthentication(OIDCAuthentication):
     def get_label(self) -> str:
         return "DigiD"
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_digid_logo(request))
 
 
@@ -137,7 +135,7 @@ class eHerkenningOIDCAuthentication(OIDCAuthentication):
     def get_label(self) -> str:
         return "eHerkenning"
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_eherkenning_logo(request))
 
 
@@ -169,7 +167,7 @@ class DigiDMachtigenOIDCAuthentication(OIDCAuthentication):
     def get_label(self) -> str:
         return "DigiD Machtigen"
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_digid_logo(request))
 
 
@@ -204,5 +202,5 @@ class EHerkenningBewindvoeringOIDCAuthentication(OIDCAuthentication):
     def get_label(self) -> str:
         return "eHerkenning bewindvoering"
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_eherkenning_logo(request))

--- a/src/openforms/authentication/contrib/digid_mock/plugin.py
+++ b/src/openforms/authentication/contrib/digid_mock/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.utils.http import urlencode
@@ -35,9 +35,7 @@ class DigidMockAuthentication(BasePlugin):
         url = f"{url}?{urlencode(params)}"
         return HttpResponseRedirect(url)
 
-    def handle_co_sign(
-        self, request: HttpRequest, form: Form
-    ) -> Optional[dict[str, Any]]:
+    def handle_co_sign(self, request: HttpRequest, form: Form) -> dict[str, Any] | None:
         if not (bsn := request.GET.get("bsn")):
             raise InvalidCoSignData("Missing 'bsn' parameter/value")
         return {
@@ -64,5 +62,5 @@ class DigidMockAuthentication(BasePlugin):
 
         return HttpResponseRedirect(form_url)
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_digid_logo(request))

--- a/src/openforms/authentication/contrib/eherkenning/plugin.py
+++ b/src/openforms/authentication/contrib/eherkenning/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn, Optional
+from typing import Any, NoReturn
 
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.templatetags.static import static
@@ -137,7 +137,7 @@ class EHerkenningAuthentication(AuthenticationBasePlugin):
         required = config.get("loa") or EherkenningConfiguration.get_solo().loa
         return loa_order(authenticated_loa) >= loa_order(required)
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(title=self.get_label(), **get_eherkenning_logo(request))
 
 
@@ -147,7 +147,7 @@ class EIDASAuthentication(AuthenticationBasePlugin):
     provides_auth = AuthAttribute.pseudo
     session_key = EIDAS_AUTH_SESSION_KEY
 
-    def get_logo(self, request) -> Optional[LoginLogo]:
+    def get_logo(self, request) -> LoginLogo | None:
         return LoginLogo(
             title=self.get_label(),
             image_src=request.build_absolute_uri(static("img/eidas.png")),

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eherkenning_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eherkenning_auth.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from base64 import b64decode
-from typing import Optional
 from unittest.mock import patch
 
 from django.core.files import File
@@ -87,7 +86,7 @@ def _create_test_artifact() -> str:
     return create_test_artifact(config.idp_service_entity_id)
 
 
-def _get_artifact_response(filename: str, context: Optional[dict] = None) -> bytes:
+def _get_artifact_response(filename: str, context: dict | None = None) -> bytes:
     filepath = TEST_FILES / filename
     return get_artifact_response(str(filepath), context=context)
 

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from base64 import b64decode
-from typing import Optional
 from unittest.mock import patch
 
 from django.core.files import File
@@ -88,7 +87,7 @@ def _create_test_artifact() -> str:
     return create_test_artifact(config.idp_service_entity_id)
 
 
-def _get_artifact_response(filename: str, context: Optional[dict] = None) -> bytes:
+def _get_artifact_response(filename: str, context: dict | None = None) -> bytes:
     filepath = TEST_FILES / filename
     return get_artifact_response(str(filepath), context=context)
 

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_signicat_integration.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_signicat_integration.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal, TypeAlias
 from unittest.mock import patch
 
 from django.core.files import File
@@ -621,8 +621,8 @@ class SignicatEHerkenningIntegrationTests(OFVCRMixin, TestCase):
 # Helper functions
 
 # poor person's enum.StrEnum
-Method = Union[Literal["get"], Literal["post"]]
-Response = Union[TemplateResponse, requests.Response]
+Method: TypeAlias = Literal["get", "post"]
+Response: TypeAlias = TemplateResponse | requests.Response
 
 
 def _parse_form(response: Response) -> tuple[Method, str, dict[str, str]]:

--- a/src/openforms/authentication/contrib/tests/saml_utils.py
+++ b/src/openforms/authentication/contrib/tests/saml_utils.py
@@ -1,7 +1,6 @@
 from base64 import b64encode
 from hashlib import sha1
 from pathlib import Path
-from typing import Optional
 
 from digid_eherkenning.models import EherkenningConfiguration
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
@@ -18,7 +17,7 @@ def create_test_artifact(service_entity_id: str = "") -> str:
     return b64encoded.decode("ascii")
 
 
-def get_artifact_response(filepath: str, context: Optional[dict] = None) -> bytes:
+def get_artifact_response(filepath: str, context: dict | None = None) -> bytes:
     template_source = Path(filepath).read_text()
     return render_from_string(template_source, context or {}).encode("utf-8")
 

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Iterator, Optional
+from typing import TYPE_CHECKING, Iterator
 
 from django.http import HttpRequest
 
@@ -13,7 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _iter_plugin_ids(form: Optional["Form"], registry: "Registry") -> Iterator[str]:
+def _iter_plugin_ids(form: Form | None, registry: Registry) -> Iterator[str]:
     if form is not None:
         yield from form.authentication_backends
     else:
@@ -29,8 +31,8 @@ class Registry(BaseRegistry["BasePlugin"]):
     module = "authentication"
 
     def get_options(
-        self, request: HttpRequest, form: Optional["Form"] = None
-    ) -> list["LoginInfo"]:
+        self, request: HttpRequest, form: Form | None = None
+    ) -> list[LoginInfo]:
         options = list()
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:

--- a/src/openforms/authentication/static_variables/static_variables.py
+++ b/src/openforms/authentication/static_variables/static_variables.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext_lazy as _
 
@@ -19,9 +21,7 @@ class Auth(BaseStaticVariable):
     name = _("Authentication")
     data_type = FormVariableDataTypes.object
 
-    def get_initial_value(
-        self, submission: Optional["Submission"]
-    ) -> Optional["FormAuth"]:
+    def get_initial_value(self, submission: Submission | None) -> FormAuth | None:
         if not submission or not submission.is_authenticated:
             return None
 
@@ -38,7 +38,7 @@ class Auth(BaseStaticVariable):
         return auth_data
 
 
-def get_auth_value(submission: Optional["Submission"], attribute: str) -> str:
+def get_auth_value(submission: Submission | None, attribute: str) -> str:
     if not submission or not submission.is_authenticated:
         return ""
 
@@ -54,7 +54,7 @@ class AuthBSN(BaseStaticVariable):
     data_type = FormVariableDataTypes.string
 
     @staticmethod
-    def get_initial_value(submission: Optional["Submission"]) -> str:
+    def get_initial_value(submission: Submission | None) -> str:
         return get_auth_value(submission, AuthAttribute.bsn)
 
 
@@ -64,7 +64,7 @@ class AuthKvK(BaseStaticVariable):
     data_type = FormVariableDataTypes.string
 
     @staticmethod
-    def get_initial_value(submission: Optional["Submission"]) -> str:
+    def get_initial_value(submission: Submission | None) -> str:
         return get_auth_value(submission, AuthAttribute.kvk)
 
 
@@ -74,5 +74,5 @@ class AuthPseudo(BaseStaticVariable):
     data_type = FormVariableDataTypes.string
 
     @staticmethod
-    def get_initial_value(submission: Optional["Submission"]) -> str:
+    def get_initial_value(submission: Submission | None) -> str:
         return get_auth_value(submission, AuthAttribute.pseudo)

--- a/src/openforms/authentication/utils.py
+++ b/src/openforms/authentication/utils.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, TypedDict
+from typing import Literal, TypedDict
 
 from furl import furl
 from rest_framework.request import Request
@@ -25,8 +25,8 @@ class BaseAuth(TypedDict):
 
 
 class FormAuth(BaseAuth):
-    machtigen: Optional[dict]
-    loa: Optional[str]
+    machtigen: dict | None
+    loa: str | None
 
 
 def store_auth_details(

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from django.contrib.auth.mixins import PermissionRequiredMixin, UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
@@ -61,7 +60,7 @@ class AuthenticationFlowBaseView(RetrieveAPIView):
         serializers.Serializer
     )  # just to shut up some warnings in drf-spectacular
 
-    def _validate_co_sign_submission(self, plugin: BasePlugin) -> Optional[Submission]:
+    def _validate_co_sign_submission(self, plugin: BasePlugin) -> Submission | None:
         """
         Check if the flow is a co-sign flow and validate the referenced submission.
         """

--- a/src/openforms/config/views.py
+++ b/src/openforms/config/views.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, Optional, Protocol, TypeGuard
+from typing import Any, Generator, Protocol, TypeGuard
 
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse
@@ -22,7 +22,7 @@ from .models import GlobalConfiguration
 from .utils import verify_clamav_connection
 
 
-def _subset_match(requested: Optional[str], checking: str) -> bool:
+def _subset_match(requested: str | None, checking: str) -> bool:
     if not requested:
         return True
     return requested == checking

--- a/src/openforms/emails/connection_check.py
+++ b/src/openforms/emails/connection_check.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Sequence
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -18,8 +18,8 @@ class MailCheckResult:
     sender: str
     success: bool
     backend: str
-    feedback: list[Union[str, LabelValue]] = dataclasses.field(default_factory=list)
-    exception: Optional[Exception] = None
+    feedback: list[str | LabelValue] = dataclasses.field(default_factory=list)
+    exception: Exception | None = None
 
     @property
     def recipients_str(self):

--- a/src/openforms/emails/models.py
+++ b/src/openforms/emails/models.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -9,7 +7,7 @@ from openforms.template.validators import DjangoTemplateValidator
 
 
 class ConfirmationEmailTemplateManager(models.Manager):
-    def set_for_form(self, form: Form, data: Optional[dict]):
+    def set_for_form(self, form: Form, data: dict | None):
         # if there's *no* template data, make sure that we do indeed wipe the fields,
         # making the template not usable
         if not data:

--- a/src/openforms/formio/api/validators.py
+++ b/src/openforms/formio/api/validators.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Optional
+from typing import Iterable
 
 from django.core.files.uploadedfile import UploadedFile
 from django.utils.translation import gettext_lazy as _
@@ -44,7 +44,7 @@ def mimetype_allowed(
 
 
 class MimeTypeValidator:
-    def __init__(self, allowed_mime_types: Optional[Iterable[str]] = None):
+    def __init__(self, allowed_mime_types: Iterable[str] | None = None):
         self.any_allowed = allowed_mime_types is None
 
         allowed_mime_types = allowed_mime_types or []

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -1,7 +1,7 @@
 import re
 from collections import UserDict
 from collections.abc import Hashable
-from typing import Iterator, Optional, cast
+from typing import Iterator, cast
 
 from glom import PathAccessError, assign, glom
 
@@ -25,7 +25,7 @@ class FormioConfigurationWrapper:
 
     _configuration: JSONObject
     # depth-first ordered of all components in the formio configuration tree
-    _cached_component_map: Optional[dict[str, Component]] = None
+    _cached_component_map: dict[str, Component] | None = None
     _flattened_by_path: None | dict[str, Component] = None
     _reverse_flattened: None | dict[str, str] = None
 

--- a/src/openforms/formio/dynamic_config/__init__.py
+++ b/src/openforms/formio/dynamic_config/__init__.py
@@ -1,7 +1,6 @@
 """
 Implement component-specific dynamic configuration based on (submission) state.
 """
-from typing import Optional
 
 from rest_framework.request import Request
 
@@ -17,7 +16,7 @@ __all__ = ["rewrite_formio_components", "rewrite_formio_components_for_request"]
 def rewrite_formio_components(
     configuration_wrapper: FormioConfigurationWrapper,
     submission: Submission,
-    data: Optional[DataMapping] = None,
+    data: DataMapping | None = None,
 ) -> FormioConfigurationWrapper:
     """
     Loop over the formio configuration and mutate components in place.

--- a/src/openforms/formio/dynamic_config/date.py
+++ b/src/openforms/formio/dynamic_config/date.py
@@ -1,6 +1,6 @@
 import operator
 from datetime import date, datetime, time
-from typing import Any, Optional, TypedDict, cast
+from typing import Any, TypedDict, cast
 
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -18,8 +18,8 @@ NOW_VARIABLE = "now"
 
 
 class DatePickerConfig(TypedDict):
-    minDate: Optional[str]
-    maxDate: Optional[str]
+    minDate: str | None
+    maxDate: str | None
 
 
 def mutate(component: DateComponent | DatetimeComponent, data: DataMapping) -> None:
@@ -111,7 +111,7 @@ def calculate_delta(
     component: DateComponent | DatetimeComponent,
     config: DateConstraintConfiguration,
     data: DataMapping,
-) -> Optional[datetime]:
+) -> datetime | None:
     assert config["mode"] == "relativeToVariable"
 
     base_value = glom(data, config["variable"], default=None)

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Iterator, Union
+from typing import Callable, Iterator
 
 from django.urls import reverse
 from django.utils.html import format_html_join
@@ -166,7 +166,7 @@ class WYSIWYGNode(ComponentNode):
         return super().is_visible
 
     @property
-    def value(self) -> Union[str, SafeString]:
+    def value(self) -> str | SafeString:
         content = self.component["html"]
         if self.as_html:
             return mark_safe(content)

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal
 
 from glom import Path, assign, glom
 
@@ -32,7 +32,7 @@ class RenderConfiguration:
     landed), then fall back using the ``default``.
     """
 
-    key: Optional[str]
+    key: str | None
     default: bool
 
 
@@ -257,7 +257,7 @@ class ComponentNode(Node):
             self.component["label"] = f(self.component["label"])
 
     @property
-    def display_value(self) -> Union[str, Any]:
+    def display_value(self) -> str | Any:
         """
         Format the value according to the render mode and/or output content type.
 

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -8,7 +8,7 @@ apps/packages:
 * Keep it small! The actual implementation should be done in specialized subpackages or
   submodules and only their 'public' API should be imported and used.
 """
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import elasticapm
 from rest_framework.request import Request
@@ -77,7 +77,7 @@ def get_dynamic_configuration(
     config_wrapper: FormioConfigurationWrapper,
     request: Request,
     submission: Submission,
-    data: Optional[DataMapping] = None,
+    data: DataMapping | None = None,
 ) -> FormioConfigurationWrapper:
     """
     Given a static Formio configuration, apply the hooks to dynamically transform this.

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterator, Optional, TypeAlias, TypeGuard
+from typing import Any, Iterator, TypeAlias, TypeGuard
 
 import elasticapm
 from glom import Coalesce, Path, glom
@@ -82,7 +82,7 @@ def flatten_by_path(configuration: JSONObject) -> dict[str, Component]:
 
 
 def get_readable_path_from_configuration_path(
-    configuration: JSONObject, path: str, prefix: Optional[str] = ""
+    configuration: JSONObject, path: str, prefix: str | None = ""
 ) -> str:
     """
     Get a readable version of the configuration path.
@@ -187,7 +187,7 @@ def get_component_empty_value(component):
     return DEFAULT_INITIAL_VALUE.get(data_type, "")
 
 
-def get_component_default_value(component) -> Optional[Any]:
+def get_component_default_value(component) -> Any | None:
     # Formio has a getter for the:
     # - emptyValue: https://github.com/formio/formio.js/blob/4.13.x/src/components/textfield/TextField.js#L58
     # - defaultValue:

--- a/src/openforms/forms/api/datastructures.py
+++ b/src/openforms/forms/api/datastructures.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from django.utils.functional import cached_property
 
@@ -14,7 +13,7 @@ class FormVariableWrapper:
     def variables(self) -> dict[str, FormVariable]:
         return {variable.key: variable for variable in self.form.formvariable_set.all()}
 
-    def get(self, key: str, default=None) -> Optional[FormVariable]:
+    def get(self, key: str, default=None) -> FormVariable | None:
         return self.variables.get(key, default)
 
     def __contains__(self, key: str) -> bool:

--- a/src/openforms/forms/messages.py
+++ b/src/openforms/forms/messages.py
@@ -1,4 +1,3 @@
-from typing import Union
 from urllib.parse import quote as urlquote
 
 from django.contrib import messages
@@ -56,7 +55,7 @@ MESSAGE_TEMPLATES = {
 
 
 def add_success_message(
-    request: Union[HttpRequest, Request],
+    request: HttpRequest | Request,
     instance: models.Model,
     submit_action: str,
     is_new: bool,

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -2,7 +2,7 @@ import logging
 import uuid as _uuid
 from contextlib import suppress
 from copy import deepcopy
-from typing import Literal, Optional
+from typing import Literal
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -526,7 +526,7 @@ class Form(models.Model):
 
     @transaction.atomic
     def restore_old_version(
-        self, form_version_uuid: str, user: Optional[User] = None
+        self, form_version_uuid: str, user: User | None = None
     ) -> None:
         from ..utils import import_form_data
         from .form_version import FormVersion

--- a/src/openforms/forms/validators.py
+++ b/src/openforms/forms/validators.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.utils.text import get_text_list
@@ -55,7 +55,7 @@ def validate_not_deleted(form):
 
 def validate_form_definition_is_reusable(
     form_definition: "FormDefinition",
-    new_value: Optional[bool] = None,
+    new_value: bool | None = None,
 ) -> None:
     """
     Validate the integrity of the ``is_reusable`` flag.

--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import asdict
 from functools import partial
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.db.models import Model
 from django.utils import timezone
@@ -18,12 +20,9 @@ from openforms.typing import JSONObject
 from .tasks import log_logic_evaluation
 
 if TYPE_CHECKING:
+    from openforms.payments.models import SubmissionPayment
     from openforms.submissions.logic.rules import EvaluatedRule, FormLogic
-    from openforms.submissions.models import (
-        Submission,
-        SubmissionPayment,
-        SubmissionStep,
-    )
+    from openforms.submissions.models import Submission, SubmissionStep
     from stuf.models import StufService
 
     from .models import TimelineLogProxy
@@ -34,12 +33,12 @@ logger = logging.getLogger(__name__)
 def _create_log(
     object: Model,
     event: str,
-    extra_data: Optional[dict] = None,
-    plugin: Optional["AbstractBasePlugin"] = None,
-    error: Optional[Exception] = None,
-    tags: Optional[list] = None,
-    user: Optional["User"] = None,
-) -> "TimelineLogProxy":
+    extra_data: dict | None = None,
+    plugin: AbstractBasePlugin | None = None,
+    error: Exception | None = None,
+    tags: list | None = None,
+    user: User | None = None,
+) -> TimelineLogProxy:
     # import locally or we'll get "AppRegistryNotReady: Apps aren't loaded yet."
     from openforms.logging.models import TimelineLogProxy
 
@@ -74,7 +73,7 @@ def _create_log(
 
 
 def enabling_analytics_tool(
-    analytics_tools_configuration: "AnalyticsToolsConfiguration", analytics_tool: str
+    analytics_tools_configuration: AnalyticsToolsConfiguration, analytics_tool: str
 ):
     _create_log(
         analytics_tools_configuration,
@@ -84,7 +83,7 @@ def enabling_analytics_tool(
 
 
 def disabling_analytics_tool(
-    analytics_tools_configuration: "AnalyticsToolsConfiguration", analytics_tool: str
+    analytics_tools_configuration: AnalyticsToolsConfiguration, analytics_tool: str
 ):
     _create_log(
         analytics_tools_configuration,
@@ -96,19 +95,19 @@ def disabling_analytics_tool(
 # - - -
 
 
-def submission_start(submission: "Submission"):
+def submission_start(submission: Submission):
     _create_log(submission, "submission_start")
 
 
 def submission_auth(
-    submission: "Submission", delegated: bool = False, user: Optional[User] = None
+    submission: Submission, delegated: bool = False, user: User | None = None
 ):
     _create_log(
         submission, "submission_auth", user=user, extra_data={"delegated": delegated}
     )
 
 
-def submission_step_fill(step: "SubmissionStep"):
+def submission_step_fill(step: SubmissionStep):
     _create_log(
         step.submission,
         "submission_step_fill",
@@ -119,18 +118,18 @@ def submission_step_fill(step: "SubmissionStep"):
     )
 
 
-def form_submit_success(submission: "Submission"):
+def form_submit_success(submission: Submission):
     _create_log(submission, "form_submit_success")
 
 
 # - - -
 
 
-def pdf_generation_start(submission: "Submission"):
+def pdf_generation_start(submission: Submission):
     _create_log(submission, "pdf_generation_start")
 
 
-def pdf_generation_success(submission: "Submission", submission_report):
+def pdf_generation_success(submission: Submission, submission_report):
     _create_log(
         submission,
         "pdf_generation_success",
@@ -140,9 +139,7 @@ def pdf_generation_success(submission: "Submission", submission_report):
     )
 
 
-def pdf_generation_failure(
-    submission: "Submission", submission_report, error: Exception
-):
+def pdf_generation_failure(submission: Submission, submission_report, error: Exception):
     _create_log(
         submission,
         "pdf_generation_failure",
@@ -151,7 +148,7 @@ def pdf_generation_failure(
     )
 
 
-def pdf_generation_skip(submission: "Submission", submission_report):
+def pdf_generation_skip(submission: Submission, submission_report):
     _create_log(
         submission,
         "pdf_generation_skip",
@@ -162,7 +159,7 @@ def pdf_generation_skip(submission: "Submission", submission_report):
 # - - -
 
 
-def prefill_retrieve_success(submission: "Submission", plugin, prefill_fields):
+def prefill_retrieve_success(submission: Submission, plugin, prefill_fields):
     _create_log(
         submission,
         "prefill_retrieve_success",
@@ -172,7 +169,7 @@ def prefill_retrieve_success(submission: "Submission", plugin, prefill_fields):
     )
 
 
-def prefill_retrieve_empty(submission: "Submission", plugin, prefill_fields):
+def prefill_retrieve_empty(submission: Submission, plugin, prefill_fields):
     _create_log(
         submission,
         "prefill_retrieve_empty",
@@ -182,7 +179,7 @@ def prefill_retrieve_empty(submission: "Submission", plugin, prefill_fields):
     )
 
 
-def prefill_retrieve_failure(submission: "Submission", plugin, error: Exception):
+def prefill_retrieve_failure(submission: Submission, plugin, error: Exception):
     _create_log(
         submission,
         "prefill_retrieve_failure",
@@ -194,7 +191,7 @@ def prefill_retrieve_failure(submission: "Submission", plugin, error: Exception)
 # - - -
 
 
-def registration_start(submission: "Submission"):
+def registration_start(submission: Submission):
     _create_log(submission, "registration_start")
 
 
@@ -204,7 +201,7 @@ registration_debug.__doc__ = (
 )
 
 
-def registration_success(submission: "Submission", plugin):
+def registration_success(submission: Submission, plugin):
     _create_log(
         submission,
         "registration_success",
@@ -212,7 +209,7 @@ def registration_success(submission: "Submission", plugin):
     )
 
 
-def registration_failure(submission: "Submission", error: Exception, plugin=None):
+def registration_failure(submission: Submission, error: Exception, plugin=None):
     _create_log(
         submission,
         "registration_failure",
@@ -221,14 +218,14 @@ def registration_failure(submission: "Submission", error: Exception, plugin=None
     )
 
 
-def registration_skip(submission: "Submission"):
+def registration_skip(submission: Submission):
     _create_log(
         submission,
         "registration_skip",
     )
 
 
-def registration_attempts_limited(submission: "Submission"):
+def registration_attempts_limited(submission: Submission):
     _create_log(
         submission,
         "registration_attempts_limited",
@@ -238,42 +235,42 @@ def registration_attempts_limited(submission: "Submission"):
 # - - -
 
 
-def registration_payment_update_start(submission: "Submission", plugin):
+def registration_payment_update_start(submission: Submission, plugin):
     _create_log(submission, "registration_payment_update_start", plugin=plugin)
 
 
-def registration_payment_update_success(submission: "Submission", plugin):
+def registration_payment_update_success(submission: Submission, plugin):
     _create_log(submission, "registration_payment_update_success", plugin=plugin)
 
 
 def registration_payment_update_failure(
-    submission: "Submission", error: Exception, plugin=None
+    submission: Submission, error: Exception, plugin=None
 ):
     _create_log(
         submission, "registration_payment_update_failure", plugin=plugin, error=error
     )
 
 
-def registration_payment_update_skip(submission: "Submission"):
+def registration_payment_update_skip(submission: Submission):
     _create_log(submission, "registration_payment_update_skip")
 
 
-def registration_skipped_not_yet_paid(submission: "Submission"):
+def registration_skipped_not_yet_paid(submission: Submission):
     _create_log(submission, "registration_skipped_not_yet_paid")
 
 
 # - - -
 
 
-def confirmation_email_start(submission: "Submission"):
+def confirmation_email_start(submission: Submission):
     _create_log(submission, "confirmation_email_start")
 
 
-def confirmation_email_success(submission: "Submission"):
+def confirmation_email_success(submission: Submission):
     _create_log(submission, "confirmation_email_success")
 
 
-def confirmation_email_failure(submission: "Submission", error: Exception):
+def confirmation_email_failure(submission: Submission, error: Exception):
     _create_log(
         submission,
         "confirmation_email_failure",
@@ -281,14 +278,14 @@ def confirmation_email_failure(submission: "Submission", error: Exception):
     )
 
 
-def confirmation_email_skip(submission: "Submission"):
+def confirmation_email_skip(submission: Submission):
     _create_log(submission, "confirmation_email_skip")
 
 
 # - - -
 
 
-def payment_flow_start(payment: "SubmissionPayment", plugin):
+def payment_flow_start(payment: SubmissionPayment, plugin):
     _create_log(
         payment.submission,
         "payment_flow_start",
@@ -300,7 +297,7 @@ def payment_flow_start(payment: "SubmissionPayment", plugin):
     )
 
 
-def payment_flow_failure(payment: "SubmissionPayment", plugin, error: Exception):
+def payment_flow_failure(payment: SubmissionPayment, plugin, error: Exception):
     _create_log(
         payment.submission,
         "payment_flow_failure",
@@ -313,7 +310,7 @@ def payment_flow_failure(payment: "SubmissionPayment", plugin, error: Exception)
     )
 
 
-def payment_flow_return(payment: "SubmissionPayment", plugin):
+def payment_flow_return(payment: SubmissionPayment, plugin):
     _create_log(
         payment.submission,
         "payment_flow_return",
@@ -327,7 +324,7 @@ def payment_flow_return(payment: "SubmissionPayment", plugin):
     )
 
 
-def payment_flow_webhook(payment: "SubmissionPayment", plugin):
+def payment_flow_webhook(payment: SubmissionPayment, plugin):
     _create_log(
         payment.submission,
         "payment_flow_webhook",
@@ -344,7 +341,7 @@ def payment_flow_webhook(payment: "SubmissionPayment", plugin):
 # - - -
 
 
-def payment_register_success(payment: "SubmissionPayment", plugin):
+def payment_register_success(payment: SubmissionPayment, plugin):
     _create_log(
         payment.submission,
         "payment_register_success",
@@ -356,7 +353,7 @@ def payment_register_success(payment: "SubmissionPayment", plugin):
     )
 
 
-def payment_register_failure(payment: "SubmissionPayment", plugin, error: Exception):
+def payment_register_failure(payment: SubmissionPayment, plugin, error: Exception):
     _create_log(
         payment.submission,
         "payment_register_failure",
@@ -370,9 +367,9 @@ def payment_register_failure(payment: "SubmissionPayment", plugin, error: Except
 
 
 def payment_transfer_to_new_submission(
-    submission_payment: "SubmissionPayment",
-    old_submission: "Submission",
-    new_submission: "Submission",
+    submission_payment: SubmissionPayment,
+    old_submission: Submission,
+    new_submission: Submission,
 ):
     _create_log(
         object=old_submission,
@@ -388,7 +385,7 @@ def payment_transfer_to_new_submission(
 # - - -
 
 
-def appointment_register_start(submission: "Submission", plugin):
+def appointment_register_start(submission: Submission, plugin):
     _create_log(
         submission,
         "appointment_register_start",
@@ -396,7 +393,7 @@ def appointment_register_start(submission: "Submission", plugin):
     )
 
 
-def appointment_register_success(appointment: "AppointmentInfo", plugin):
+def appointment_register_success(appointment: AppointmentInfo, plugin):
     _create_log(
         appointment.submission,
         "appointment_register_success",
@@ -404,7 +401,7 @@ def appointment_register_success(appointment: "AppointmentInfo", plugin):
     )
 
 
-def appointment_register_failure(appointment: "AppointmentInfo", plugin, error):
+def appointment_register_failure(appointment: AppointmentInfo, plugin, error):
     _create_log(
         appointment.submission,
         "appointment_register_failure",
@@ -413,14 +410,14 @@ def appointment_register_failure(appointment: "AppointmentInfo", plugin, error):
     )
 
 
-def appointment_register_skip(submission: "Submission"):
+def appointment_register_skip(submission: Submission):
     _create_log(submission, "appointment_register_skip")
 
 
 # - - -
 
 
-def appointment_update_start(appointment: "AppointmentInfo", plugin):
+def appointment_update_start(appointment: AppointmentInfo, plugin):
     _create_log(
         appointment.submission,
         "appointment_update_start",
@@ -428,7 +425,7 @@ def appointment_update_start(appointment: "AppointmentInfo", plugin):
     )
 
 
-def appointment_update_success(appointment: "AppointmentInfo", plugin):
+def appointment_update_success(appointment: AppointmentInfo, plugin):
     _create_log(
         appointment.submission,
         "appointment_update_success",
@@ -436,7 +433,7 @@ def appointment_update_success(appointment: "AppointmentInfo", plugin):
     )
 
 
-def appointment_update_failure(appointment: "AppointmentInfo", plugin, error):
+def appointment_update_failure(appointment: AppointmentInfo, plugin, error):
     _create_log(
         appointment.submission,
         "appointment_update_failure",
@@ -448,7 +445,7 @@ def appointment_update_failure(appointment: "AppointmentInfo", plugin, error):
 # - - -
 
 
-def appointment_cancel_start(appointment: "AppointmentInfo", plugin):
+def appointment_cancel_start(appointment: AppointmentInfo, plugin):
     _create_log(
         appointment.submission,
         "appointment_cancel_start",
@@ -456,7 +453,7 @@ def appointment_cancel_start(appointment: "AppointmentInfo", plugin):
     )
 
 
-def appointment_cancel_success(appointment: "AppointmentInfo", plugin):
+def appointment_cancel_success(appointment: AppointmentInfo, plugin):
     _create_log(
         appointment.submission,
         "appointment_cancel_success",
@@ -464,7 +461,7 @@ def appointment_cancel_success(appointment: "AppointmentInfo", plugin):
     )
 
 
-def appointment_cancel_failure(appointment: "AppointmentInfo", plugin, error):
+def appointment_cancel_failure(appointment: AppointmentInfo, plugin, error):
     _create_log(
         appointment.submission,
         "appointment_cancel_failure",
@@ -473,7 +470,7 @@ def appointment_cancel_failure(appointment: "AppointmentInfo", plugin, error):
     )
 
 
-def submission_details_view_admin(submission: "Submission", user: "User"):
+def submission_details_view_admin(submission: Submission, user: User):
     _create_log(
         submission,
         "submission_details_view_admin",
@@ -482,7 +479,7 @@ def submission_details_view_admin(submission: "Submission", user: "User"):
     )
 
 
-def submission_details_view_api(submission: "Submission", user: "User"):
+def submission_details_view_api(submission: Submission, user: User):
     _create_log(
         submission,
         "submission_details_view_api",
@@ -491,7 +488,7 @@ def submission_details_view_api(submission: "Submission", user: "User"):
     )
 
 
-def submission_export_list(form: "Form", user: "User"):
+def submission_export_list(form: Form, user: User):
     _create_log(
         form,
         "submission_export_list",
@@ -501,8 +498,8 @@ def submission_export_list(form: "Form", user: "User"):
 
 
 def submission_logic_evaluated(
-    submission: "Submission",
-    evaluated_rules: list["EvaluatedRule"],
+    submission: Submission,
+    evaluated_rules: list[EvaluatedRule],
     initial_data: JSONObject,
     resolved_data: JSONObject,
 ):
@@ -526,7 +523,7 @@ def submission_logic_evaluated(
 
 
 def logic_evaluation_failed(
-    rule: "FormLogic",
+    rule: FormLogic,
     error: Exception,
     logic: JSONObject,
 ) -> None:
@@ -536,7 +533,7 @@ def logic_evaluation_failed(
 
 
 def form_configuration_error(
-    form: "Form",
+    form: Form,
     component: JSONObject,
     error_message: str,
 ):
@@ -550,7 +547,7 @@ def form_configuration_error(
 # - - -
 
 
-def stuf_zds_request(service: "StufService", url):
+def stuf_zds_request(service: StufService, url):
     _create_log(
         service,
         "stuf_zds_request",
@@ -558,7 +555,7 @@ def stuf_zds_request(service: "StufService", url):
     )
 
 
-def stuf_zds_success_response(service: "StufService", url):
+def stuf_zds_success_response(service: StufService, url):
     _create_log(
         service,
         "stuf_zds_success_response",
@@ -566,7 +563,7 @@ def stuf_zds_success_response(service: "StufService", url):
     )
 
 
-def stuf_zds_failure_response(service: "StufService", url):
+def stuf_zds_failure_response(service: StufService, url):
     _create_log(
         service,
         "stuf_zds_failure_response",
@@ -574,7 +571,7 @@ def stuf_zds_failure_response(service: "StufService", url):
     )
 
 
-def stuf_bg_request(service: "StufService", url):
+def stuf_bg_request(service: StufService, url):
     _create_log(
         service,
         "stuf_bg_request",
@@ -582,7 +579,7 @@ def stuf_bg_request(service: "StufService", url):
     )
 
 
-def stuf_bg_response(service: "StufService", url):
+def stuf_bg_response(service: StufService, url):
     _create_log(
         service,
         "stuf_bg_response",
@@ -646,7 +643,7 @@ def forms_bulk_export_downloaded(bulk_export, user):
     )
 
 
-def bulk_forms_imported(user: "User", failed_files: list[tuple[str, str]]):
+def bulk_forms_imported(user: User, failed_files: list[tuple[str, str]]):
     _create_log(
         user,
         "bulk_forms_imported",
@@ -658,21 +655,21 @@ def bulk_forms_imported(user: "User", failed_files: list[tuple[str, str]]):
 # - - -
 
 
-def cosigner_email_queuing_failure(submission: "Submission"):
+def cosigner_email_queuing_failure(submission: Submission):
     _create_log(
         submission,
         "cosigner_email_queuing_failure",
     )
 
 
-def cosigner_email_queuing_success(submission: "Submission"):
+def cosigner_email_queuing_success(submission: Submission):
     _create_log(
         submission,
         "cosigner_email_queuing_success",
     )
 
 
-def skipped_registration_cosign_required(submission: "Submission"):
+def skipped_registration_cosign_required(submission: Submission):
     _create_log(
         submission,
         "skipped_registration_cosign_required",
@@ -682,17 +679,17 @@ def skipped_registration_cosign_required(submission: "Submission"):
 # - - -
 
 
-def form_activated(form: "Form"):
+def form_activated(form: Form):
     _create_log(form, "form_activated")
 
 
-def form_deactivated(form: "Form"):
+def form_deactivated(form: Form):
     _create_log(form, "form_deactivated")
 
 
 # - - -
 def email_status_change(
-    submission: "Submission",
+    submission: Submission,
     event: str,
     status: int,
     status_label: str,

--- a/src/openforms/logging/logic.py
+++ b/src/openforms/logging/logic.py
@@ -3,8 +3,10 @@ Process the logic evaluation logging information.
 
 This relies on the datastructures used in :mod:`openforms.submissions.form_logic`.
 """
+from __future__ import annotations
+
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from json_logic.typing import JSON
 
@@ -22,10 +24,10 @@ if TYPE_CHECKING:
 
 def log_logic_evaluation(
     submission: Submission,
-    evaluated_rules: list["EvaluatedRule"],
+    evaluated_rules: list[EvaluatedRule],
     initial_data: dict[str, JSON],
     resolved_data: JSONObject,
-) -> Optional["TimelineLogProxy"]:
+) -> TimelineLogProxy | None:
     if not evaluated_rules:
         return
     evaluated_rules_list = []

--- a/src/openforms/payments/contrib/ogone/data.py
+++ b/src/openforms/payments/contrib/ogone/data.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import Union
 
 
 @dataclasses.dataclass()
@@ -49,7 +48,7 @@ class OgoneRequestParams:
 
     # required
     PSPID: str  # fill here your PSPID
-    ORDERID: Union[int, str]  # fill here your REF
+    ORDERID: int | str  # fill here your REF
     AMOUNT: int  # fill here your amount * 100
     CURRENCY: str = "EUR"  # fill here your currency
     LANGUAGE: str = "nl_NL"  # fill here your Client language

--- a/src/openforms/payments/registry.py
+++ b/src/openforms/payments/registry.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Iterator, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
 
 from django.http import HttpRequest
 
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
     from openforms.forms.models import Form
 
 
-def _iter_plugin_ids(form: Optional["Form"], registry: "Registry") -> Iterator[str]:
+def _iter_plugin_ids(form: Form | None, registry: Registry) -> Iterator[str]:
     if form is not None:
         # TODO clean this up as we support multiple backends on the form
         yield form.payment_backend
@@ -34,7 +36,7 @@ class Registry(BaseRegistry[BasePlugin]):
     #         )
 
     def get_options(
-        self, request: HttpRequest, form: Optional["Form"] = None
+        self, request: HttpRequest, form: Form | None = None
     ) -> list["APIInfo"]:
         options = []
         for plugin_id in _iter_plugin_ids(form, self):

--- a/src/openforms/prefill/co_sign.py
+++ b/src/openforms/prefill/co_sign.py
@@ -7,7 +7,6 @@ done by amending the co-sign data on a submission when the co-sign auth event is
 received, see the :mod:`signals` module.
 """
 import logging
-from typing import Optional
 
 from openforms.authentication.constants import AuthAttribute
 from openforms.submissions.models import Submission
@@ -26,7 +25,7 @@ AUTH_ATTRIBUTE_TO_CONFIG_FIELD = {
 
 def get_default_plugin_for_auth_attribute(
     auth_attribute: AuthAttribute | None,
-) -> Optional[str]:
+) -> str | None:
     if not auth_attribute or not (
         config_field := AUTH_ATTRIBUTE_TO_CONFIG_FIELD.get(auth_attribute)
     ):

--- a/src/openforms/registrations/base.py
+++ b/src/openforms/registrations/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from rest_framework import serializers
 
@@ -35,7 +35,7 @@ class BasePlugin(ABC, AbstractBasePlugin):
     @abstractmethod
     def register_submission(
         self, submission: "Submission", options: dict
-    ) -> Optional[dict]:
+    ) -> dict | None:
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/openforms/registrations/contrib/camunda/complex_variables.py
+++ b/src/openforms/registrations/contrib/camunda/complex_variables.py
@@ -5,21 +5,15 @@ The variable schema is both a schema and an instance of the schema. Submission d
 is injected and evaluated using json-logic expressions, while the remainder of the
 data may be static/hardcoded.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any, TypedDict, Union
+from typing import Any, TypeAlias, TypedDict
 
 from django_camunda.types import JSONObject, JSONValue
 from json_logic import jsonLogic
 
-AnyVariable = Union[
-    "ComponentVariable",
-    "StringVariable",
-    "NumberVariable",
-    "BooleanVariable",
-    "NullVariable",
-    "ObjectVariable",
-    "ArrayVariable",
-]
+AnyVariable: TypeAlias = "ComponentVariable | StringVariable | NumberVariable | BooleanVariable | NullVariable | ObjectVariable | ArrayVariable"
 
 
 class VarLogicExpression(TypedDict):
@@ -31,7 +25,7 @@ class Variable:
     source: str
 
     @staticmethod
-    def build(**kwargs) -> Union["ComponentVariable", "ManualVariable"]:
+    def build(**kwargs) -> ComponentVariable | ManualVariable:
         _source_map = {
             "manual": ManualVariable,
             "component": ComponentVariable,
@@ -59,7 +53,7 @@ class ComponentVariable(Variable):
 
 
 class CatLogicExpression(TypedDict):
-    cat: list[Union[str, VarLogicExpression]]  # JSON-logic
+    cat: list[str | VarLogicExpression]  # JSON-logic
 
 
 @dataclass
@@ -80,7 +74,7 @@ class ManualVariable(Variable):
     type: str
 
     @staticmethod
-    def build(**kwargs) -> "ManualVariable":
+    def build(**kwargs) -> ManualVariable:
         this_type = kwargs["type"]
         _type_map = {
             "string": StringVariable,
@@ -129,9 +123,9 @@ class StringVariable(ManualVariable):
 
 @dataclass
 class NumberVariable(ManualVariable):
-    definition: Union[float, int]
+    definition: float | int
 
-    def evaluate(self, data: dict) -> Union[float, int]:
+    def evaluate(self, data: dict) -> float | int:
         return self.definition
 
 
@@ -166,7 +160,7 @@ class ComplexVariable:
     enabled: bool
     alias: str
     type: str
-    definition: Union[ObjectVariable, ArrayVariable]
+    definition: ObjectVariable | ArrayVariable
 
     @classmethod
     def build(cls, **kwargs):

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -1,6 +1,6 @@
 import html
 from mimetypes import types_map
-from typing import Any, NoReturn, Optional, TypedDict
+from typing import Any, NoReturn, TypedDict
 
 from django.conf import settings
 from django.urls import reverse
@@ -41,8 +41,8 @@ class EmailOptions(TypedDict):
     to_emails: list[str]
     attachment_formats: list[str]
     payment_emails: list[str]
-    attach_files_to_email: Optional[bool]
-    email_subject: Optional[str]
+    attach_files_to_email: bool | None
+    email_subject: str | None
 
 
 @register(PLUGIN_ID)

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -80,9 +79,9 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
 
 @dataclass
 class PartialDate:
-    year: Optional[int] = None
-    month: Optional[int] = None
-    day: Optional[int] = None
+    year: int | None = None
+    month: int | None = None
+    day: int | None = None
 
     @property
     def indicator(self):

--- a/src/openforms/submissions/admin.py
+++ b/src/openforms/submissions/admin.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.contenttypes.admin import GenericTabularInline
@@ -227,7 +225,7 @@ class SubmissionAdmin(admin.ModelAdmin):
         qs = qs.select_related("form")
         return qs
 
-    def successfully_processed(self, obj) -> Optional[bool]:
+    def successfully_processed(self, obj) -> bool | None:
         if obj.registration_status == RegistrationStatuses.pending:
             return None
         return not obj.needs_on_completion_retry

--- a/src/openforms/submissions/api/permissions.py
+++ b/src/openforms/submissions/api/permissions.py
@@ -1,4 +1,3 @@
-from typing import Union
 from uuid import UUID
 
 from rest_framework import permissions
@@ -17,7 +16,7 @@ from ..tokens import (
 from .validation import is_step_unexpectedly_incomplete
 
 
-def owns_submission(request: Request, submission_uuid: Union[str, UUID]) -> bool:
+def owns_submission(request: Request, submission_uuid: str | UUID) -> bool:
     # The assumption is that auth plugin requirements like LoA
     # MUST be checked upon/before adding the submission uuid to the session
     # therefore "owning a submission" means those requirements were met.

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -1,7 +1,6 @@
 import logging
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional
 
 from django.conf import settings
 from django.db import transaction
@@ -348,7 +347,7 @@ class SubmissionStateLogicSerializer(serializers.Serializer):
 @dataclass
 class SubmissionStateLogic:
     submission: Submission
-    step: Optional[SubmissionStep] = None
+    step: SubmissionStep | None = None
 
 
 class SubmissionCompletionSerializer(serializers.Serializer):

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Iterable, Iterator, Optional
+from typing import Iterable, Iterator
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -45,7 +45,7 @@ DEFAULT_IMAGE_MAX_SIZE = (10000, 10000)
 file_size_cast = Filesize(system=Filesize.S_BINARY)
 
 
-def temporary_upload_uuid_from_url(url: str) -> Optional[str]:
+def temporary_upload_uuid_from_url(url: str) -> str | None:
     try:
         match = resolve(urlparse(url)[2])
     except Resolver404:
@@ -57,7 +57,7 @@ def temporary_upload_uuid_from_url(url: str) -> Optional[str]:
             return None
 
 
-def temporary_upload_from_url(url: str) -> Optional[TemporaryFileUpload]:
+def temporary_upload_from_url(url: str) -> TemporaryFileUpload | None:
     uuid = temporary_upload_uuid_from_url(url)
     if not uuid:
         return None
@@ -130,7 +130,7 @@ def iter_step_uploads(
             )
 
 
-def validate_uploads(submission_step: SubmissionStep, data: Optional[dict]) -> None:
+def validate_uploads(submission_step: SubmissionStep, data: dict | None) -> None:
     """
     Validate the file uploads in the submission step data.
 

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.utils.functional import empty
 
@@ -211,7 +211,7 @@ def evaluate_form_logic(
 
 
 def check_submission_logic(
-    submission: "Submission", unsaved_data: Optional[dict] = None
+    submission: "Submission", unsaved_data: dict | None = None
 ) -> None:
     if getattr(submission, "_form_logic_evaluated", False):
         return

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Mapping, Optional, TypedDict
+from typing import Any, Callable, Mapping, TypedDict
 
 from glom import assign
 from json_logic import jsonLogic
@@ -74,7 +74,7 @@ class ActionOperation:
         all_variables: dict[str, FormVariable],
         initial_data: dict,
         log_data: dict[str, JSONValue],
-    ) -> Optional[JSONObject]:
+    ) -> JSONObject | None:
         """Get action information to log"""
         return None
 

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -1,7 +1,7 @@
 import operator
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Callable, Iterable, Iterator, Optional
+from typing import Callable, Iterable, Iterator
 
 import elasticapm
 from json_logic import jsonLogic
@@ -29,7 +29,7 @@ def _include_rule(form_steps: list[FormStep], rule: FormLogic, step_index: int) 
 
 
 def get_rules_to_evaluate(
-    submission: Submission, current_step: Optional[SubmissionStep] = None
+    submission: Submission, current_step: SubmissionStep | None = None
 ) -> Iterable[FormLogic]:
     """
     Given a submission, return the logic rules ready for evaluation.
@@ -76,7 +76,7 @@ def get_rules_to_evaluate(
     ]
 
 
-def get_current_step(submission: Submission) -> Optional[SubmissionStep]:
+def get_current_step(submission: Submission) -> SubmissionStep | None:
     """
     Obtain what the 'current step' of a submission is.
 

--- a/src/openforms/submissions/management/commands/render_report.py
+++ b/src/openforms/submissions/management/commands/render_report.py
@@ -5,7 +5,6 @@ On top of that, it is also a realistic example of using the high-level Python AP
 the renderer to output reports.
 """
 import inspect
-from typing import Union
 
 from django.core.management import BaseCommand
 
@@ -31,7 +30,7 @@ INDENT_SIZES = {
 INDENT = "    "
 
 
-def get_indent_level(node_cls: Union[Node, type[Node]]) -> str:
+def get_indent_level(node_cls: Node | type[Node]) -> str:
     """
     Extract the indentation level from the node class configuration.
     """

--- a/src/openforms/submissions/mapping.py
+++ b/src/openforms/submissions/mapping.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Callable, Mapping, Optional, TypeAlias, Union
+from typing import Any, Callable, Mapping, TypeAlias
 
 from glom import Assign, glom
 
@@ -15,7 +15,7 @@ class FieldConf:
     attribute: str = ""
 
     # transform value (eg: dates/times etc)
-    transform: Optional[Callable[[Any], Any]] = None
+    transform: Callable[[Any], Any] | None = None
 
     # support attributes from form
     form_field: str = ""
@@ -34,7 +34,7 @@ class FieldConf:
         assert self.attribute or self.form_field or self.submission_auth_info_attribute
 
 
-MappingConfig: TypeAlias = Mapping[str, Union[str, FieldConf]]
+MappingConfig: TypeAlias = Mapping[str, str | FieldConf]
 
 
 def apply_data_mapping(
@@ -131,7 +131,7 @@ def apply_data_mapping(
 
 def get_unmapped_data(
     submission,
-    mapping_config: Mapping[str, Union[str, FieldConf]],
+    mapping_config: Mapping[str, str | FieldConf],
     component_attribute: str,
 ):
     """

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Mapping
 
 from django.conf import settings
 from django.db import models, transaction
@@ -65,7 +65,7 @@ class SubmissionState:
         )
         return offset
 
-    def get_last_completed_step(self) -> Optional["SubmissionStep"]:
+    def get_last_completed_step(self) -> "SubmissionStep" | None:
         """
         Determine the last step that was filled out.
 
@@ -85,7 +85,7 @@ class SubmissionState:
         )
         return next(candidates, None)
 
-    def get_submission_step(self, form_step_uuid: str) -> Optional["SubmissionStep"]:
+    def get_submission_step(self, form_step_uuid: str) -> "SubmissionStep" | None:
         return next(
             (
                 step
@@ -306,7 +306,7 @@ class Submission(models.Model):
 
     objects = SubmissionManager()
 
-    _form_login_required: Optional[bool] = None  # can be set via annotation
+    _form_login_required: bool | None = None  # can be set via annotation
     _prefilled_data = None
     _total_configuration_wrapper = None
 
@@ -597,7 +597,7 @@ class Submission(models.Model):
         submission_state = self.load_execution_state()
         return submission_state.submission_steps
 
-    def get_last_completed_step(self) -> Optional["SubmissionStep"]:
+    def get_last_completed_step(self) -> "SubmissionStep" | None:
         """
         Determine which is the next step for the current submission.
         """
@@ -622,7 +622,7 @@ class Submission(models.Model):
 
         return ordered_data
 
-    def get_merged_appointment_data(self) -> dict[str, dict[str, Union[str, dict]]]:
+    def get_merged_appointment_data(self) -> dict[str, dict[str, str | dict]]:
         component_config_key_to_appointment_key = {
             "appointments.showProducts": "productIDAndName",
             "appointments.showLocations": "locationIDAndName",

--- a/src/openforms/submissions/models/submission_files.py
+++ b/src/openforms/submissions/models/submission_files.py
@@ -4,7 +4,7 @@ import os.path
 import uuid
 from collections import defaultdict
 from datetime import date, timedelta
-from typing import TYPE_CHECKING, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Mapping, cast
 
 from django.core.files.base import File
 from django.db import models
@@ -89,7 +89,7 @@ class SubmissionFileAttachmentManager(models.Manager):
         configuration_path: str,
         data_path: str,
         upload: TemporaryFileUpload,
-        file_name: Optional[str] = None,
+        file_name: str | None = None,
     ) -> tuple["SubmissionFileAttachment", bool]:
         try:
             return (

--- a/src/openforms/submissions/models/submission_report.py
+++ b/src/openforms/submissions/models/submission_report.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.core.files.base import ContentFile
 from django.db import models
 from django.utils.translation import gettext_lazy as _, override
@@ -83,7 +81,7 @@ class SubmissionReport(models.Model):
         self.save()
         return html_report
 
-    def get_celery_task(self) -> Optional[AsyncResult]:
+    def get_celery_task(self) -> AsyncResult | None:
         if not self.task_id:
             return
 

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -1,6 +1,5 @@
 import uuid
 from copy import deepcopy
-from typing import Optional
 
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
@@ -221,7 +220,7 @@ class SubmissionStep(models.Model):
         return step_data
 
     @data.setter
-    def data(self, data: Optional[dict]) -> None:
+    def data(self, data: dict | None) -> None:
         if isinstance(data, DirtyData):
             self._unsaved_data = data
         else:

--- a/src/openforms/submissions/pricing.py
+++ b/src/openforms/submissions/pricing.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from json_logic import jsonLogic
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_submission_price(submission: "Submission") -> Optional[Decimal]:
+def get_submission_price(submission: "Submission") -> Decimal | None:
     """
     Calculate the price for a given submission.
 

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -5,8 +5,10 @@ The renderer is the public interface to rendering submissions in particular rend
 modes. It is aware of the intrinsic tree-like structure of a submission and associated
 printable data.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Iterator, Union
+from typing import Iterator
 
 from openforms.forms.models import Form
 from openforms.variables.rendering.nodes import VariablesNode
@@ -62,7 +64,7 @@ class Renderer:
         else:
             return True
 
-    def get_children(self) -> Iterator[Union["SubmissionStepNode", "VariablesNode"]]:
+    def get_children(self) -> Iterator[SubmissionStepNode | VariablesNode]:
         """
         Produce only the direct child nodes.
         """
@@ -96,7 +98,7 @@ class Renderer:
         variables_node = VariablesNode(renderer=self, submission=self.submission)
         yield variables_node
 
-    def __iter__(self) -> Iterator["Node"]:
+    def __iter__(self) -> Iterator[Node]:
         """
         Yield the nodes to visualize a complete submission.
         """

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -1,6 +1,5 @@
 import copy
 from datetime import timedelta
-from typing import Optional
 
 from django.conf import settings
 from django.utils import timezone
@@ -313,7 +312,7 @@ class SubmissionFileAttachmentFactory(factory.django.DjangoModelFactory):
     @classmethod
     def create(
         cls,
-        form_key: Optional[str] = None,
+        form_key: str | None = None,
         **kwargs,
     ) -> SubmissionFileAttachment:
         file_attachment = super().create(**kwargs)

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Union
+from typing import Any
 
 from django.conf import settings
 from django.contrib.sessions.backends.base import SessionBase
@@ -205,7 +205,7 @@ def persist_user_defined_variables(
 
 
 def check_form_status(
-    request: Union[HttpRequest, Request],
+    request: HttpRequest | Request,
     form: Form,
     include_safe_methods: bool = False,
 ) -> None:

--- a/src/openforms/translations/utils.py
+++ b/src/openforms/translations/utils.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import TypeAlias
 
 from django.conf import settings
 from django.http.response import HttpResponseBase
@@ -8,7 +8,7 @@ from django.utils.translation import get_language_info
 
 from rest_framework.response import Response
 
-ResponseType = Union[HttpResponseBase, Response]
+ResponseType: TypeAlias = HttpResponseBase | Response
 
 
 def set_language_cookie(response: ResponseType, language_code: str) -> None:

--- a/src/openforms/typing.py
+++ b/src/openforms/typing.py
@@ -1,7 +1,7 @@
 import datetime
 import decimal
 import uuid
-from typing import Any, NewType, Protocol, Union
+from typing import Any, NewType, Protocol, TypeAlias
 
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
@@ -9,15 +9,15 @@ from django.utils.functional import Promise
 
 from rest_framework.request import Request
 
-JSONPrimitive = Union[str, int, None, float, bool]
+JSONPrimitive: TypeAlias = str | int | float | bool | None
 
-JSONValue = Union[JSONPrimitive, "JSONObject", list["JSONValue"]]
+JSONValue: TypeAlias = "JSONPrimitive | JSONObject | list[JSONValue]"
 
-JSONObject = dict[str, JSONValue]
+JSONObject: TypeAlias = dict[str, JSONValue]
 
-DataMapping = dict[str, Any]  # key: value pair
+DataMapping: TypeAlias = dict[str, Any]  # key: value pair
 
-AnyRequest = Union[HttpRequest, Request]
+AnyRequest: TypeAlias = HttpRequest | Request
 
 RegistrationBackendKey = NewType("RegistrationBackendKey", str)
 
@@ -28,16 +28,7 @@ class RequestHandler(Protocol):
 
 
 # Types that `django.core.serializers.json.DjangoJSONEncoder` can handle
-DjangoJSONEncodable = Union[
-    JSONValue,
-    datetime.datetime,
-    datetime.date,
-    datetime.time,
-    datetime.timedelta,
-    decimal.Decimal,
-    uuid.UUID,
-    Promise,
-]
+DjangoJSONEncodable: TypeAlias = "JSONValue | datetime.datetime | datetime.date | datetime.time | datetime.timedelta | decimal.Decimal | uuid.UUID | Promise"
 
 
 class JSONSerializable(Protocol):
@@ -45,4 +36,4 @@ class JSONSerializable(Protocol):
         ...
 
 
-JSONEncodable = DjangoJSONEncodable | JSONSerializable
+JSONEncodable: TypeAlias = "DjangoJSONEncodable | JSONSerializable"

--- a/src/openforms/ui/templatetags/style_dictionary.py
+++ b/src/openforms/ui/templatetags/style_dictionary.py
@@ -1,10 +1,8 @@
-from typing import Union
-
 from django import template
 
-register = template.Library()
+from openforms.typing import JSONPrimitive
 
-JSONPrimitive = Union[str, int, float, None]
+register = template.Library()
 
 
 class InvalidInput(Exception):

--- a/src/openforms/utils/pdf.py
+++ b/src/openforms/utils/pdf.py
@@ -2,7 +2,6 @@ import logging
 import mimetypes
 from io import BytesIO
 from pathlib import PurePosixPath
-from typing import Optional
 from urllib.parse import ParseResult, urljoin, urlparse
 
 from django.conf import settings
@@ -80,7 +79,7 @@ class UrlFetcher:
 
     def get_match_candidate(
         self, url: ParseResult
-    ) -> Optional[tuple[ParseResult, FileSystemStorage]]:
+    ) -> tuple[ParseResult, FileSystemStorage] | None:
         for parsed_base_url, storage, is_local_storage in self.candidates:
             if not is_local_storage:
                 continue

--- a/src/openforms/utils/urls.py
+++ b/src/openforms/utils/urls.py
@@ -1,18 +1,16 @@
-from typing import Any, Optional, Union
+from typing import Any
 from urllib.parse import urljoin, urlsplit
 
 from django.conf import settings
-from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.encoding import iri_to_uri
 
 from furl import furl
-from rest_framework.request import Request
 
-RequestType = Union[HttpRequest, Request]
+from openforms.typing import AnyRequest
 
 
-def build_absolute_uri(location: str, request: Optional[RequestType] = None):
+def build_absolute_uri(location: str, request: AnyRequest | None = None):
     """
     Construct an absolutely qualified URI from a location/path.
 
@@ -62,8 +60,8 @@ def reverse_plus(
     *,
     args=None,
     kwargs=None,
-    request: Optional[RequestType] = None,
-    query: Optional[dict[str, Any]] = None,
+    request: AnyRequest | None = None,
+    query: dict[str, Any] | None = None,
     make_absolute: bool = True,
 ):
     """
@@ -99,7 +97,7 @@ def reverse_plus(
         return location
 
 
-def is_admin_request(request: RequestType) -> bool:
+def is_admin_request(request: AnyRequest) -> bool:
     """
     Checks whether a request is made from the admin
 

--- a/src/openforms/variables/base.py
+++ b/src/openforms/variables/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional
 
 from openforms.forms.models import FormVariable
 from openforms.plugins.plugin import AbstractBasePlugin
@@ -14,10 +13,10 @@ class BaseStaticVariable(ABC, AbstractBasePlugin):
     data_type: str = field(init=False)
 
     @abstractmethod
-    def get_initial_value(self, submission: Optional[Submission] = None):
+    def get_initial_value(self, submission: Submission | None = None):
         raise NotImplementedError()
 
-    def get_static_variable(self, submission: Optional[Submission] = None):
+    def get_static_variable(self, submission: Submission | None = None):
         return FormVariable(
             name=self.name,
             key=self.identifier,

--- a/src/openforms/variables/rendering/nodes.py
+++ b/src/openforms/variables/rendering/nodes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Iterator, Union
+from typing import Any, Iterator
 
 from django.utils.translation import gettext_lazy as _
 
@@ -84,7 +84,7 @@ class SubmissionValueVariableNode(Node):
         return self.variable.form_variable.name
 
     @property
-    def display_value(self) -> Union[str, Any]:
+    def display_value(self) -> str | Any:
         # If we are going to render in different modes, we will need to add a registry of formatters
         # like for Formio ComponentNodes
         return self.variable.value

--- a/src/openforms/variables/service.py
+++ b/src/openforms/variables/service.py
@@ -1,7 +1,6 @@
 """
 Public Python API to access (static) form variables.
 """
-from typing import Optional
 
 from openforms.forms.models import FormVariable
 from openforms.submissions.models import Submission
@@ -11,9 +10,7 @@ from .registry import register_static_variable as register
 __all__ = ["get_static_variables"]
 
 
-def get_static_variables(
-    *, submission: Optional[Submission] = None
-) -> list[FormVariable]:
+def get_static_variables(*, submission: Submission | None = None) -> list[FormVariable]:
     """
     Return the full collection of static variables registered by all apps.
 

--- a/src/openforms/variables/static_variables/static_variables.py
+++ b/src/openforms/variables/static_variables/static_variables.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -16,7 +14,7 @@ class Now(BaseStaticVariable):
     name = _("Now")
     data_type = FormVariableDataTypes.datetime
 
-    def get_initial_value(self, submission: Optional[Submission] = None):
+    def get_initial_value(self, submission: Submission | None = None):
         return timezone.now()
 
 
@@ -25,7 +23,7 @@ class Today(BaseStaticVariable):
     name = _("Today")
     data_type = FormVariableDataTypes.date
 
-    def get_initial_value(self, submission: Optional[Submission] = None) -> str:
+    def get_initial_value(self, submission: Submission | None = None) -> str:
         now_utc = timezone.now()
         return timezone.localtime(now_utc).date()
 
@@ -35,7 +33,7 @@ class CurrentYear(BaseStaticVariable):
     name = _("Current year")
     data_type = FormVariableDataTypes.int
 
-    def get_initial_value(self, submission: Optional[Submission] = None) -> int:
+    def get_initial_value(self, submission: Submission | None = None) -> int:
         now_utc = timezone.now()
         return timezone.localtime(now_utc).year
 
@@ -45,7 +43,7 @@ class Environment(BaseStaticVariable):
     name = _("Environment")
     data_type = FormVariableDataTypes.string
 
-    def get_initial_value(self, submission: Optional[Submission] = None) -> str:
+    def get_initial_value(self, submission: Submission | None = None) -> str:
         return str(settings.ENVIRONMENT)
 
 
@@ -54,7 +52,7 @@ class FormName(BaseStaticVariable):
     name = _("Form name")
     data_type = FormVariableDataTypes.string
 
-    def get_initial_value(self, submission: Optional[Submission] = None) -> str:
+    def get_initial_value(self, submission: Submission | None = None) -> str:
         return submission.form.name if submission else ""
 
 
@@ -63,5 +61,5 @@ class FormID(BaseStaticVariable):
     name = _("Form ID")
     data_type = FormVariableDataTypes.string
 
-    def get_initial_value(self, submission: Optional[Submission] = None) -> str:
+    def get_initial_value(self, submission: Submission | None = None) -> str:
         return str(submission.form.uuid) if submission else ""


### PR DESCRIPTION
This is the last, I promise :pray: 

How it was done:
- the `typing.py` file was treated manually for extra safety
- Ruff rule `UP007` was applied.
- Remaining usage of `Union` and `Optional` was treated manually. This happened when forward references where used. This affected around 10 files, and `from __future__ import annotations` was used in these cases. This doesn't mean that every forward reference in the codebase was "unstrigified" with the future import, only the file where `Union` and `Optional` was used.
- `F401` applied to remove unused imports
- black and isort
- Documentation updated in one place