### PR TITLE
Feature/3680 remove auth plugin from cosign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.14.2",
+        "@open-formulieren/formio-builder": "^0.15.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -4580,9 +4580,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.14.2.tgz",
-      "integrity": "sha512-GADU3Y4VrhtX5BzYnlXKVntJWnH9X/wxhCjmVj/owMVrLUvYXAUBUELTRssqopBgjFeOBsZNXlG8P4l5yHgRrw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.15.1.tgz",
+      "integrity": "sha512-dBNgHi6TuCigNltWHovtxaNRfpqEQ3tf5FPZ3w/7ll8Xe1U0f7EBT9hztWPOlZT9Q0v2HkZ2gx1tXprfeLWdyw==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",
@@ -29542,9 +29542,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.14.2.tgz",
-      "integrity": "sha512-GADU3Y4VrhtX5BzYnlXKVntJWnH9X/wxhCjmVj/owMVrLUvYXAUBUELTRssqopBgjFeOBsZNXlG8P4l5yHgRrw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.15.1.tgz",
+      "integrity": "sha512-dBNgHi6TuCigNltWHovtxaNRfpqEQ3tf5FPZ3w/7ll8Xe1U0f7EBT9hztWPOlZT9Q0v2HkZ2gx1tXprfeLWdyw==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.14.2",
+    "@open-formulieren/formio-builder": "^0.15.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7061,10 +7061,16 @@ components:
         hideNonApplicableSteps:
           type: boolean
           readOnly: true
+        cosignLoginOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LoginOption'
+          readOnly: true
         cosignLoginInfo:
           allOf:
           - $ref: '#/components/schemas/CosignLoginInfo'
           readOnly: true
+          deprecated: true
         submissionStatementsConfiguration:
           type: array
           items:
@@ -7102,6 +7108,7 @@ components:
           nullable: true
       required:
       - cosignLoginInfo
+      - cosignLoginOptions
       - hideNonApplicableSteps
       - loginOptions
       - loginRequired
@@ -8619,10 +8626,16 @@ components:
         hideNonApplicableSteps:
           type: boolean
           readOnly: true
+        cosignLoginOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LoginOption'
+          readOnly: true
         cosignLoginInfo:
           allOf:
           - $ref: '#/components/schemas/CosignLoginInfo'
           readOnly: true
+          deprecated: true
         submissionStatementsConfiguration:
           type: array
           items:

--- a/src/openforms/authentication/api/fields.py
+++ b/src/openforms/authentication/api/fields.py
@@ -11,10 +11,13 @@ class LoginOptionsReadOnlyField(serializers.ListField):
     there is no write-mode support because this data is not writable
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, is_for_cosign: bool = False, *args, **kwargs) -> None:
         kwargs.setdefault("child", LoginOptionSerializer())
         kwargs["read_only"] = True
         kwargs["source"] = "*"
+
+        self.is_for_cosign = is_for_cosign
+
         super().__init__(*args, **kwargs)
 
     def to_internal_value(self, data):
@@ -22,5 +25,5 @@ class LoginOptionsReadOnlyField(serializers.ListField):
 
     def to_representation(self, form):
         request = self.context["request"]
-        temp = auth_register.get_options(request, form)
+        temp = auth_register.get_options(request, form, self.is_for_cosign)
         return super().to_representation(temp)

--- a/src/openforms/authentication/api/serializers.py
+++ b/src/openforms/authentication/api/serializers.py
@@ -5,7 +5,6 @@ from rest_framework import serializers
 from openforms.plugins.api.serializers import PluginBaseSerializer
 
 from ..constants import LogoAppearance
-from ..utils import get_cosign_login_info
 
 
 class TextChoiceSerializer(serializers.Serializer):
@@ -79,8 +78,3 @@ class LoginOptionSerializer(serializers.Serializer):
         ),
         read_only=True,
     )
-
-
-class CosignLoginInfoSerializer(LoginOptionSerializer):
-    def get_attribute(self, form):
-        return get_cosign_login_info(self.context["request"], form)

--- a/src/openforms/authentication/api/serializers.py
+++ b/src/openforms/authentication/api/serializers.py
@@ -1,7 +1,11 @@
 from django.utils.translation import gettext_lazy as _
 
+from furl import furl
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
+from openforms.authentication.base import LoginInfo
+from openforms.authentication.registry import register as auth_register
 from openforms.plugins.api.serializers import PluginBaseSerializer
 
 from ..constants import LogoAppearance
@@ -78,3 +82,36 @@ class LoginOptionSerializer(serializers.Serializer):
         ),
         read_only=True,
     )
+
+
+class CosignLoginInfoSerializer(LoginOptionSerializer):
+    def get_attribute(self, form):
+        if not form.cosign_component:
+            return None
+
+        auth_plugin_id = form.authentication_backends[0]
+        auth_url = reverse(
+            "authentication:start",
+            kwargs={
+                "slug": form.slug,
+                "plugin_id": auth_plugin_id,
+            },
+            request=self.context["request"],
+        )
+        next_url = reverse(
+            "submissions:find-submission-for-cosign",
+            kwargs={"form_slug": form.slug},
+            request=self.context["request"],
+        )
+        auth_page = furl(auth_url)
+        auth_page.args.set("next", next_url)
+
+        auth_plugin = auth_register[auth_plugin_id]
+
+        return LoginInfo(
+            auth_plugin.identifier,
+            auth_plugin.get_label(),
+            url=auth_page.url,
+            logo=auth_plugin.get_logo(self.context["request"]),
+            is_for_gemachtigde=auth_plugin.is_for_gemachtigde,
+        )

--- a/src/openforms/authentication/base.py
+++ b/src/openforms/authentication/base.py
@@ -12,6 +12,7 @@ from openforms.plugins.plugin import AbstractBasePlugin
 from openforms.typing import AnyRequest
 
 from .constants import AuthAttribute
+from .utils import get_cosign_login_url
 
 
 @dataclass()
@@ -98,11 +99,18 @@ class BasePlugin(AbstractBasePlugin):
         """
         pass
 
-    def get_login_info(self, request: HttpRequest, form: Form | None) -> LoginInfo:
+    def get_login_info(
+        self, request: HttpRequest, form: Form | None, is_for_cosign: bool = False
+    ) -> LoginInfo:
+        if is_for_cosign:
+            login_url = get_cosign_login_url(request, form, self.identifier)
+        else:
+            login_url = self.get_start_url(request, form) if form else ""
+
         info = LoginInfo(
             self.identifier,
             self.get_label(),
-            url=self.get_start_url(request, form) if form else "",
+            url=login_url,
             logo=self.get_logo(request),
             is_for_gemachtigde=self.is_for_gemachtigde,
         )

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -31,9 +31,15 @@ class Registry(BaseRegistry["BasePlugin"]):
     module = "authentication"
 
     def get_options(
-        self, request: HttpRequest, form: Form | None = None
-    ) -> list[LoginInfo]:
+        self,
+        request: HttpRequest,
+        form: Form | None = None,
+        is_for_cosign: bool = False,
+    ) -> list["LoginInfo"]:
         options = list()
+        if is_for_cosign and (not form or not form.cosign_component):
+            return options
+
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:
                 logger.warning(
@@ -43,7 +49,7 @@ class Registry(BaseRegistry["BasePlugin"]):
                 )
                 continue
             plugin = self._registry[plugin_id]
-            info = plugin.get_login_info(request, form)
+            info = plugin.get_login_info(request, form, is_for_cosign)
             options.append(info)
         return options
 

--- a/src/openforms/authentication/tests/test_utils.py
+++ b/src/openforms/authentication/tests/test_utils.py
@@ -6,7 +6,7 @@ from furl import furl
 from openforms.forms.tests.factories import FormStepFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 
-from ..utils import get_cosign_login_info, store_auth_details, store_registrator_details
+from ..utils import get_cosign_login_url, store_auth_details, store_registrator_details
 
 
 class UtilsTests(TestCase):
@@ -28,22 +28,6 @@ class UtilsTests(TestCase):
                 {"plugin": "digid", "attribute": "WRONG", "value": "some-value"},
             )
 
-    def test_get_cosign_info_when_no_cosign_on_form(self):
-        form_step = FormStepFactory.create(
-            form_definition__configuration={
-                "components": [
-                    {"key": "textField", "label": "Not cosign", "type": "textfield"}
-                ]
-            }
-        )
-
-        factory = RequestFactory()
-        request = factory.get("/foo")
-
-        login_info = get_cosign_login_info(request=request, form=form_step.form)
-
-        self.assertIsNone(login_info)
-
     def test_get_cosign_info(self):
         form_step = FormStepFactory.create(
             form__slug="form-with-cosign",
@@ -62,11 +46,11 @@ class UtilsTests(TestCase):
         factory = RequestFactory()
         request = factory.get("/foo")
 
-        login_info = get_cosign_login_info(request=request, form=form_step.form)
+        login_url = get_cosign_login_url(
+            request=request, form=form_step.form, plugin_id="digid"
+        )
+        login_url = furl(login_url)
 
-        self.assertIsNotNone(login_info)
-
-        login_url = furl(login_info.url)
         submission_find_url = furl(
             login_url.args["next"]
         )  # Page where the user will look for the submission to cosign

--- a/src/openforms/formio/typing/__init__.py
+++ b/src/openforms/formio/typing/__init__.py
@@ -7,7 +7,7 @@ Formio components are JSON blobs adhering to a formio-specific schema. We define
 """
 
 from .base import Component, OptionDict
-from .custom import CosignComponent, DateComponent
+from .custom import DateComponent
 from .vanilla import (
     Column,
     ColumnsComponent,
@@ -30,6 +30,5 @@ __all__ = [
     "Column",
     "ColumnsComponent",
     "DatetimeComponent",
-    "CosignComponent",
     "DateComponent",
 ]

--- a/src/openforms/formio/typing/custom.py
+++ b/src/openforms/formio/typing/custom.py
@@ -2,9 +2,5 @@ from .base import Component
 from .dates import DatePickerConfig
 
 
-class CosignComponent(Component):
-    authPlugin: str
-
-
 class DateComponent(Component):
     datePicker: DatePickerConfig | None

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -12,7 +12,6 @@ from openforms.api.serializers import PublicFieldsSerializerMixin
 from openforms.api.utils import get_from_serializer_data_or_instance
 from openforms.appointments.api.serializers import AppointmentOptionsSerializer
 from openforms.authentication.api.fields import LoginOptionsReadOnlyField
-from openforms.authentication.api.serializers import CosignLoginInfoSerializer
 from openforms.authentication.registry import register as auth_register
 from openforms.config.api.constants import STATEMENT_CHECKBOX_SCHEMA
 from openforms.config.models import GlobalConfiguration, Theme
@@ -120,7 +119,7 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
     )
     authentication_backend_options = serializers.DictField(required=False, default=dict)
     login_options = LoginOptionsReadOnlyField()
-    cosign_login_info = CosignLoginInfoSerializer(source="*", read_only=True)
+    cosign_login_options = LoginOptionsReadOnlyField(is_for_cosign=True)
     auto_login_authentication_backend = serializers.CharField(
         required=False,
         allow_blank=True,
@@ -262,7 +261,7 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
             "translations",
             "resume_link_lifetime",
             "hide_non_applicable_steps",
-            "cosign_login_info",
+            "cosign_login_options",
             "submission_statements_configuration",
             "submission_report_download_link_title",
             "brp_personen_request_options",
@@ -292,7 +291,7 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
             "appointment_options",
             "resume_link_lifetime",
             "hide_non_applicable_steps",
-            "cosign_login_info",
+            "cosign_login_options",
             "submission_statements_configuration",
             "submission_report_download_link_title",
         )

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -12,6 +12,7 @@ from openforms.api.serializers import PublicFieldsSerializerMixin
 from openforms.api.utils import get_from_serializer_data_or_instance
 from openforms.appointments.api.serializers import AppointmentOptionsSerializer
 from openforms.authentication.api.fields import LoginOptionsReadOnlyField
+from openforms.authentication.api.serializers import CosignLoginInfoSerializer
 from openforms.authentication.registry import register as auth_register
 from openforms.config.api.constants import STATEMENT_CHECKBOX_SCHEMA
 from openforms.config.models import GlobalConfiguration, Theme
@@ -95,7 +96,11 @@ class FormRegistrationBackendSerializer(serializers.ModelSerializer):
 
 
 @extend_schema_serializer(
-    deprecate_fields=["registration_backend", "registration_backend_options"]
+    deprecate_fields=[
+        "registration_backend",
+        "registration_backend_options",
+        "cosign_login_info",
+    ]
 )
 class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
     """
@@ -120,6 +125,8 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
     authentication_backend_options = serializers.DictField(required=False, default=dict)
     login_options = LoginOptionsReadOnlyField()
     cosign_login_options = LoginOptionsReadOnlyField(is_for_cosign=True)
+    # TODO: deprecated, remove in 3.0.0
+    cosign_login_info = CosignLoginInfoSerializer(source="*", read_only=True)
     auto_login_authentication_backend = serializers.CharField(
         required=False,
         allow_blank=True,
@@ -262,6 +269,7 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
             "resume_link_lifetime",
             "hide_non_applicable_steps",
             "cosign_login_options",
+            "cosign_login_info",
             "submission_statements_configuration",
             "submission_report_download_link_title",
             "brp_personen_request_options",
@@ -292,6 +300,7 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
             "resume_link_lifetime",
             "hide_non_applicable_steps",
             "cosign_login_options",
+            "cosign_login_info",
             "submission_statements_configuration",
             "submission_report_download_link_title",
         )

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -22,7 +22,7 @@ from openforms.authentication.fields import AuthenticationBackendMultiSelectFiel
 from openforms.authentication.registry import register as authentication_register
 from openforms.config.models import GlobalConfiguration
 from openforms.data_removal.constants import RemovalMethods
-from openforms.formio.typing import CosignComponent
+from openforms.formio.typing import Component
 from openforms.payments.fields import PaymentBackendChoiceField
 from openforms.payments.registry import register as payment_register
 from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
@@ -417,10 +417,18 @@ class Form(models.Model):
         "authentication backend(s)"
     )
 
-    def get_cosign_component(self) -> CosignComponent | None:
+    _cosign_component = None
+
+    def get_cosign_component(self) -> Component | None:
         for component in self.iter_components():
             if component["type"] == "cosign":
                 return component
+
+    @property
+    def cosign_component(self) -> Component | None:
+        if not self._cosign_component:
+            self._cosign_component = self.get_cosign_component()
+        return self._cosign_component
 
     @property
     def cosigning_required(self) -> bool:

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -37,6 +37,8 @@ from .utils import literal_getter
 User = get_user_model()
 logger = logging.getLogger(__name__)
 
+_sentinel = object()
+
 
 class FormQuerySet(models.QuerySet):
     def live(self):
@@ -417,7 +419,7 @@ class Form(models.Model):
         "authentication backend(s)"
     )
 
-    _cosign_component = None
+    _cosign_component = _sentinel
 
     def get_cosign_component(self) -> Component | None:
         for component in self.iter_components():
@@ -426,7 +428,7 @@ class Form(models.Model):
 
     @property
     def cosign_component(self) -> Component | None:
-        if not self._cosign_component:
+        if self._cosign_component is _sentinel:
             self._cosign_component = self.get_cosign_component()
         return self._cosign_component
 

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -147,9 +147,12 @@ class FormSerializerTest(TestCase):
             instance=form_step.form, context={"request": request}
         )
         cosign_login_options = serializer.data["cosign_login_options"]
+        cosign_login_info = serializer.data["cosign_login_info"]
 
         self.assertEqual(len(cosign_login_options), 1)
         self.assertEqual(cosign_login_options[0]["identifier"], "digid")
+        self.assertIsNotNone(cosign_login_info)
+        self.assertEqual(cosign_login_info["identifier"], "digid")
 
     def test_form_without_cosign(self):
         form_step = FormStepFactory.create(
@@ -174,8 +177,10 @@ class FormSerializerTest(TestCase):
             instance=form_step.form, context={"request": request}
         )
         cosign_login_options = serializer.data["cosign_login_options"]
+        cosign_login_info = serializer.data["cosign_login_info"]
 
         self.assertEqual(cosign_login_options, [])
+        self.assertIsNone(cosign_login_info)
 
     def test_patching_registrations_deleting_the_first(self):
         form = FormFactory.create()

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -127,13 +127,13 @@ class FormSerializerTest(TestCase):
     def test_form_with_cosign(self):
         form_step = FormStepFactory.create(
             form__slug="form-with-cosign",
+            form__authentication_backends=["digid"],
             form_definition__configuration={
                 "components": [
                     {
                         "key": "cosignField",
                         "label": "Cosign",
                         "type": "cosign",
-                        "authPlugin": "digid",
                     }
                 ]
             },
@@ -146,13 +146,15 @@ class FormSerializerTest(TestCase):
         serializer = FormSerializer(
             instance=form_step.form, context={"request": request}
         )
-        cosign_login_info = serializer.data["cosign_login_info"]
+        cosign_login_options = serializer.data["cosign_login_options"]
 
-        self.assertIsNotNone(cosign_login_info)
+        self.assertEqual(len(cosign_login_options), 1)
+        self.assertEqual(cosign_login_options[0]["identifier"], "digid")
 
     def test_form_without_cosign(self):
         form_step = FormStepFactory.create(
             form__slug="form-without-cosign",
+            form__authentication_backends=["digid"],
             form_definition__configuration={
                 "components": [
                     {
@@ -171,9 +173,9 @@ class FormSerializerTest(TestCase):
         serializer = FormSerializer(
             instance=form_step.form, context={"request": request}
         )
-        cosign_login_info = serializer.data["cosign_login_info"]
+        cosign_login_options = serializer.data["cosign_login_options"]
 
-        self.assertIsNone(cosign_login_info)
+        self.assertEqual(cosign_login_options, [])
 
     def test_patching_registrations_deleting_the_first(self):
         form = FormFactory.create()

--- a/src/openforms/js/components/admin/form_design/Warnings/FormWarnings.js
+++ b/src/openforms/js/components/admin/form_design/Warnings/FormWarnings.js
@@ -30,9 +30,7 @@ const FormWarnings = ({form}) => {
         <MissingTranslationsWarning form={form} formSteps={formSteps} />
       ) : null}
       <MultipleCosignComponentsWarning cosignComponents={cosignComponentsWithoutPath} />
-      {cosignComponentsWithoutPath.length === 1 && (
-        <MissingAuthCosignWarning cosignComponent={cosignComponentsWithoutPath[0]} />
-      )}
+      {cosignComponentsWithoutPath.length === 1 && <MissingAuthCosignWarning />}
       <CosignInRepeatingGroupWarning
         cosignComponents={cosignComponentsWithPath}
         availableComponents={components}

--- a/src/openforms/js/components/admin/form_design/Warnings/MissingAuthCosignWarning.js
+++ b/src/openforms/js/components/admin/form_design/Warnings/MissingAuthCosignWarning.js
@@ -1,30 +1,20 @@
-import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import MessageList from 'components/admin/MessageList';
 import {FormContext} from 'components/admin/form_design/Context';
 
-const MissingAuthCosignWarning = ({cosignComponent}) => {
-  const {selectedAuthPlugins, plugins} = useContext(FormContext);
+const MissingAuthCosignWarning = () => {
+  const {selectedAuthPlugins} = useContext(FormContext);
 
-  if (selectedAuthPlugins.includes(cosignComponent.authPlugin)) return null;
-
-  const getAuthPluginLabel = pluginId => {
-    for (const plugin of plugins.availableAuthPlugins) {
-      if (plugin.id === pluginId) return plugin.label;
-    }
-
-    return pluginId;
-  };
+  if (selectedAuthPlugins.length > 0) return null;
 
   const warning = {
     level: 'warning',
     message: (
       <FormattedMessage
         description="MissingAuthCosignWarning message"
-        defaultMessage="The the co-sign component requires the {plugin} authentication plugin, but this plugin is not enabled on the form."
-        values={{plugin: getAuthPluginLabel(cosignComponent.authPlugin)}}
+        defaultMessage="The the co-sign component requires at least one authentication plugin to be enabled."
       />
     ),
   };
@@ -32,8 +22,6 @@ const MissingAuthCosignWarning = ({cosignComponent}) => {
   return <MessageList messages={[warning]} />;
 };
 
-MissingAuthCosignWarning.propTypes = {
-  cosignComponent: PropTypes.object.isRequired,
-};
+MissingAuthCosignWarning.propTypes = {};
 
 export default MissingAuthCosignWarning;

--- a/src/openforms/js/components/admin/form_design/Warnings/MissingAuthCosignWarning.js
+++ b/src/openforms/js/components/admin/form_design/Warnings/MissingAuthCosignWarning.js
@@ -14,7 +14,7 @@ const MissingAuthCosignWarning = () => {
     message: (
       <FormattedMessage
         description="MissingAuthCosignWarning message"
-        defaultMessage="The the co-sign component requires at least one authentication plugin to be enabled."
+        defaultMessage="The co-sign component requires at least one authentication plugin to be enabled."
       />
     ),
   };

--- a/src/openforms/js/components/admin/form_design/Warnings/Warnings.mdx
+++ b/src/openforms/js/components/admin/form_design/Warnings/Warnings.mdx
@@ -14,8 +14,8 @@ about:
   have been translated.
 - Multiple co-sign components: currently Open Forms supports only one co-sign component per form. If
   there are multiple, any extra component will be ignored.
-- Missing authentication plugin: if the co-sign component requires an authentication plugin that is
-  not enabled on the form.
+- Missing authentication plugin: if the co-sign component is present and no authentication plugins
+  are enabled on the form.
 - Co-sign component in repeating groups: since only one co-sign component is allowed per form, it
   makes no sense to add them inside a repeating group.
 
@@ -23,8 +23,8 @@ about:
 
 ## Warning for missing authentication plugin for co-sign component
 
-This component catches situations in which the co-sign component specifies that the co-signer should
-authenticate with a particular authentication plugin, but that plugin is not enabled on the form.
+This component catches situations in which the co-sign component is present but no authentication
+plugin is enabled on the form.
 
 <Canvas of={WarningsStories.MissingAuthCosignWarning} />
 

--- a/src/openforms/js/components/admin/form_design/Warnings/Warnings.stories.js
+++ b/src/openforms/js/components/admin/form_design/Warnings/Warnings.stories.js
@@ -33,7 +33,6 @@ export const FormWarningsWithoutTranslations = {
               key: 'coSignerEmail',
               type: 'cosign',
               label: 'Co-signer email',
-              authPlugin: 'digid',
             },
             {
               type: 'editgrid',
@@ -43,7 +42,6 @@ export const FormWarningsWithoutTranslations = {
                   key: 'extraCoSignerEmail',
                   type: 'cosign',
                   label: 'Extra co-signer email',
-                  authPlugin: 'demo',
                 },
               ],
             },
@@ -110,7 +108,6 @@ export const FormWarningsWithoutTranslations = {
             key: 'extraCoSignerEmail',
             type: 'cosign',
             label: 'Co-signer email',
-            authPlugin: 'demo',
           },
         ],
       },
@@ -118,7 +115,6 @@ export const FormWarningsWithoutTranslations = {
         key: 'extraCoSignerEmail',
         type: 'cosign',
         label: 'Co-signer email',
-        authPlugin: 'demo',
       },
     },
     availableAuthPlugins: [
@@ -137,19 +133,26 @@ export const FormWarningsWithoutTranslations = {
   },
 };
 
-const cosignRender = ({coSignComponent, selectedAuthPlugins}) => (
-  <MissingAuthCosignWarningComponent
-    cosignComponent={coSignComponent}
-    selectedAuthPlugins={selectedAuthPlugins}
-  />
-);
-
 export const MissingAuthCosignWarning = {
   name: 'Warning missing authentication plugin for co-sign component',
   component: MissingAuthCosignWarningComponent,
-  render: cosignRender,
   args: {
-    coSignComponent: {type: 'cosign', key: 'cosign', authPlugin: 'digid'},
+    form: {
+      selectedAuthPlugins: [],
+    },
+    availableComponents: {
+      mainPersonEmail: {
+        key: 'mainPersonEmail',
+        type: 'email',
+        label: 'Main person email',
+      },
+      coSignerEmail: {
+        key: 'coSignerEmail',
+        type: 'cosign',
+        label: 'Co-signer email',
+        authPlugin: 'digid',
+      },
+    },
     availableAuthPlugins: [
       {
         id: 'digid',
@@ -157,6 +160,5 @@ export const MissingAuthCosignWarning = {
         providesAuth: ['bsn'],
       },
     ],
-    selectedAuthPlugins: [],
   },
 };

--- a/src/openforms/js/components/form/cosign.js
+++ b/src/openforms/js/components/form/cosign.js
@@ -2,7 +2,6 @@ import {Formio} from 'formiojs';
 
 import {AUTH_PLUGINS_ENDPOINT} from 'components/admin/form_design/constants.js';
 import {get} from 'utils/fetch';
-import {getFullyQualifiedUrl} from 'utils/urls';
 
 import {
   AUTOCOMPLETE,
@@ -44,7 +43,6 @@ class CoSignField extends FormioEmail {
         key: 'cosign',
         label: 'Co-signer email address',
         validateOn: 'blur',
-        authPlugin: 'digid',
         defaultValue: '',
       },
       ...extend
@@ -70,25 +68,6 @@ class CoSignField extends FormioEmail {
         KEY,
         DESCRIPTION,
         TOOLTIP,
-        {
-          type: 'select',
-          key: 'authPlugin',
-          label: 'Authentication method',
-          description:
-            'Which authentication method the co-signer must use. Note that this must be an authentication method available on the form.',
-          dataSrc: 'url',
-          data: {
-            // if the url starts with '/', then formio will prefix it with the formio
-            // base URL, which is of course wrong. So, we explicitly use the detected
-            // host.
-            url: getFullyQualifiedUrl(AUTH_PLUGINS_ENDPOINT),
-          },
-          valueProperty: 'id',
-          template: `<span>{{ item.label }}, provides: {{ item.providesAuth }}</span>`,
-          validate: {
-            required: true,
-          },
-        },
         PRESENTATION,
         HIDDEN,
         CLEAR_ON_HIDE,


### PR DESCRIPTION
Fixes #3680 

This has a breaking change, because the `cosign_login_info` is no longer returned by the form endpoint. If we want to avoid the breaking change, we could let it return the first of the authentication methods or something else :thinking: 

SDK PR: https://github.com/open-formulieren/open-forms-sdk/pull/639
builder PR: https://github.com/open-formulieren/formio-builder/pull/118 + https://github.com/open-formulieren/formio-builder/pull/119
types PR: https://github.com/open-formulieren/types/pull/41