### PR TITLE
:pencil2: replace .config() with .save() (2.4.x)

### DIFF
--- a/src/openforms/contrib/brp/migrations/0003_copy_config_to_haalcentraal.py
+++ b/src/openforms/contrib/brp/migrations/0003_copy_config_to_haalcentraal.py
@@ -25,7 +25,7 @@ def copy_config_to_hc(apps, _):
     # only v1 was functional/supported, so we can make this explicit
     hc_config.brp_personen_service = brp_config.brp_service
     hc_config.brp_personen_version = BRPVersions.v13
-    hc_config.config()
+    hc_config.save()
 
 
 def copy_config_from_hc(apps, _):


### PR DESCRIPTION
Fixes typo

Taiga dimpact-enschede-ssc-ict-1 issue 43