### PR TITLE
[#3688] Update Objects API registration options form

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -83,6 +83,12 @@
       "value": "Locations Component"
     }
   ],
+  "/fAEsY": [
+    {
+      "type": 0,
+      "value": "Submission report CSV informatieobjecttype"
+    }
+  ],
   "/gcLcC": [
     {
       "type": 0,
@@ -477,6 +483,12 @@
     {
       "type": 0,
       "value": "Name"
+    }
+  ],
+  "51k2La": [
+    {
+      "type": 0,
+      "value": "JSON content field"
     }
   ],
   "5AC1+x": [
@@ -961,6 +973,12 @@
       "value": "Errored Submissions Removal Limit"
     }
   ],
+  "A/vedA": [
+    {
+      "type": 0,
+      "value": "JSON template for the body of the request sent to the Objects API."
+    }
+  ],
   "A1tDIH": [
     {
       "type": 0,
@@ -1123,12 +1141,6 @@
     {
       "type": 0,
       "value": "Form"
-    }
-  ],
-  "BVuE94": [
-    {
-      "type": 0,
-      "value": "If specified, the user must check at least this many options."
     }
   ],
   "BcuXrg": [
@@ -1701,6 +1713,12 @@
       "value": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
     }
   ],
+  "HKA7Ic": [
+    {
+      "type": 0,
+      "value": "Productaanvraag type"
+    }
+  ],
   "HNoGb8": [
     {
       "type": 0,
@@ -2125,6 +2143,12 @@
       "value": "Component where locations for an appointment will be shown"
     }
   ],
+  "NwxORf": [
+    {
+      "type": 0,
+      "value": "Upload submission CSV"
+    }
+  ],
   "O/wKJh": [
     {
       "type": 0,
@@ -2391,6 +2415,12 @@
       "value": "Initial value"
     }
   ],
+  "RrjozJ": [
+    {
+      "type": 0,
+      "value": "URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: \"submission_id\", \"type\" (the type of productaanvraag) and \"data\" (the submitted form data)"
+    }
+  ],
   "RuAQwk": [
     {
       "type": 0,
@@ -2585,6 +2615,12 @@
     {
       "type": 0,
       "value": "The placeholder text that will appear when this field is empty."
+    }
+  ],
+  "U/t6b+": [
+    {
+      "type": 0,
+      "value": "Variables Mapping"
     }
   ],
   "UCGSib": [
@@ -2833,6 +2869,12 @@
       "value": "In case that multiple identifiers are returned (in the case of eHerkenning bewindvoering and DigiD Machtigen), should the prefill data related to the main identifier be used, or that related to the authorised person?"
     }
   ],
+  "WnKF/i": [
+    {
+      "type": 0,
+      "value": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments"
+    }
+  ],
   "Wz5QZo": [
     {
       "type": 0,
@@ -2861,6 +2903,12 @@
     {
       "type": 0,
       "value": "Invalid JSON logic expression"
+    }
+  ],
+  "XPEv9r": [
+    {
+      "type": 0,
+      "value": "Legacy"
     }
   ],
   "XPLnIL": [
@@ -3007,6 +3055,12 @@
       "value": "Select the plugin to use for the prefill functionality."
     }
   ],
+  "Yyvvx1": [
+    {
+      "type": 0,
+      "value": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV"
+    }
+  ],
   "YzLSHY": [
     {
       "type": 0,
@@ -3119,12 +3173,6 @@
     {
       "type": 0,
       "value": "Products Component"
-    }
-  ],
-  "aWwaAq": [
-    {
-      "type": 0,
-      "value": "Maximum selected checkboxes"
     }
   ],
   "aXJpiI": [
@@ -3423,12 +3471,6 @@
       "value": "Label is a required field."
     }
   ],
-  "dbAJfK": [
-    {
-      "type": 0,
-      "value": "Minimum selected checkboxes"
-    }
-  ],
   "ddDA6+": [
     {
       "type": 0,
@@ -3489,6 +3531,12 @@
       "value": "configured"
     }
   ],
+  "dwkDsV": [
+    {
+      "type": 0,
+      "value": "Version of the objecttype in the Objecttypes API"
+    }
+  ],
   "e6SsfR": [
     {
       "type": 0,
@@ -3501,6 +3549,12 @@
       "value": "Manage process variables"
     }
   ],
+  "eBtStW": [
+    {
+      "type": 0,
+      "value": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF"
+    }
+  ],
   "eJEu3L": [
     {
       "type": 0,
@@ -3511,6 +3565,12 @@
     {
       "type": 0,
       "value": "Advanced options"
+    }
+  ],
+  "eR8wGd": [
+    {
+      "type": 0,
+      "value": "RSIN of organization, which creates the INFORMATIEOBJECT"
     }
   ],
   "eU7+uS": [
@@ -3595,6 +3655,12 @@
     {
       "type": 0,
       "value": "Save the value as this attribute in the registration backend system."
+    }
+  ],
+  "fVNaJK": [
+    {
+      "type": 0,
+      "value": "Objecttype version"
     }
   ],
   "fWcg7I": [
@@ -3777,6 +3843,12 @@
       "value": "Configure"
     }
   ],
+  "hwD3q9": [
+    {
+      "type": 0,
+      "value": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag"
+    }
+  ],
   "hwsnj9": [
     {
       "type": 0,
@@ -3793,6 +3865,18 @@
     {
       "type": 0,
       "value": "Tab name"
+    }
+  ],
+  "iHpAYZ": [
+    {
+      "type": 0,
+      "value": "This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field."
+    }
+  ],
+  "iNmPDd": [
+    {
+      "type": 0,
+      "value": "Attachment informatieobjecttype"
     }
   ],
   "iOADkJ": [
@@ -3871,10 +3955,22 @@
       "value": "Values"
     }
   ],
+  "j7rEgn": [
+    {
+      "type": 0,
+      "value": "Submission report PDF informatieobjecttype"
+    }
+  ],
   "jARYB7": [
     {
       "type": 0,
       "value": "Form definition"
+    }
+  ],
+  "jCUorM": [
+    {
+      "type": 0,
+      "value": "Something went wrong when fectching the available Objecttypes and versions"
     }
   ],
   "jLg5l6": [
@@ -3985,6 +4081,12 @@
       "value": "disabled"
     }
   ],
+  "kQtrKX": [
+    {
+      "type": 0,
+      "value": "The type of ProductAanvraag"
+    }
+  ],
   "kg/eh1": [
     {
       "type": 0,
@@ -4029,6 +4131,12 @@
       ],
       "type": 8,
       "value": "code"
+    }
+  ],
+  "l/mtou": [
+    {
+      "type": 0,
+      "value": "Payment status update JSON template"
     }
   ],
   "l1fi1t": [
@@ -4527,6 +4635,12 @@
       "value": "Data type"
     }
   ],
+  "rJTe9U": [
+    {
+      "type": 0,
+      "value": "Objecttype"
+    }
+  ],
   "rTafvA": [
     {
       "type": 0,
@@ -4571,12 +4685,6 @@
     {
       "type": 0,
       "value": "Whether to send a confirmation email to the end-user who submitted the form."
-    }
-  ],
-  "sR9GVQ": [
-    {
-      "type": 0,
-      "value": "If specified, the user must check at most this many options."
     }
   ],
   "sU/n0S": [
@@ -4637,6 +4745,12 @@
     {
       "type": 0,
       "value": " 3"
+    }
+  ],
+  "sptpzv": [
+    {
+      "type": 0,
+      "value": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?"
     }
   ],
   "t9+e9k": [
@@ -5063,6 +5177,12 @@
     {
       "type": 0,
       "value": "Use globally configured map component settings"
+    }
+  ],
+  "zF8YEc": [
+    {
+      "type": 0,
+      "value": "Organisation RSIN"
     }
   ],
   "zGMQ75": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -83,6 +83,12 @@
       "value": "Locatie veld"
     }
   ],
+  "/fAEsY": [
+    {
+      "type": 0,
+      "value": "Submission report CSV informatieobjecttype"
+    }
+  ],
   "/gcLcC": [
     {
       "type": 0,
@@ -477,6 +483,12 @@
     {
       "type": 0,
       "value": "Naam"
+    }
+  ],
+  "51k2La": [
+    {
+      "type": 0,
+      "value": "JSON content field"
     }
   ],
   "5AC1+x": [
@@ -965,6 +977,12 @@
       "value": "Bewaartermijn voor niet voltooide inzendingen inzendingen"
     }
   ],
+  "A/vedA": [
+    {
+      "type": 0,
+      "value": "JSON template for the body of the request sent to the Objects API."
+    }
+  ],
   "A1tDIH": [
     {
       "type": 0,
@@ -1127,12 +1145,6 @@
     {
       "type": 0,
       "value": "Formulier"
-    }
-  ],
-  "BVuE94": [
-    {
-      "type": 0,
-      "value": "If specified, the user must check at least this many options."
     }
   ],
   "BcuXrg": [
@@ -1705,6 +1717,12 @@
       "value": "Aantal dagen dat een niet voltooide inzendingen (door fouten in de afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken."
     }
   ],
+  "HKA7Ic": [
+    {
+      "type": 0,
+      "value": "Productaanvraag type"
+    }
+  ],
   "HNoGb8": [
     {
       "type": 0,
@@ -2129,6 +2147,12 @@
       "value": "Veld waar beschikbare locaties voor een afspraak komen te staan"
     }
   ],
+  "NwxORf": [
+    {
+      "type": 0,
+      "value": "Upload submission CSV"
+    }
+  ],
   "O/wKJh": [
     {
       "type": 0,
@@ -2391,6 +2415,12 @@
       "value": "Beginwaarde"
     }
   ],
+  "RrjozJ": [
+    {
+      "type": 0,
+      "value": "URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: \"submission_id\", \"type\" (the type of productaanvraag) and \"data\" (the submitted form data)"
+    }
+  ],
   "RuAQwk": [
     {
       "type": 0,
@@ -2585,6 +2615,12 @@
     {
       "type": 0,
       "value": "De placeholder-tekst die verschijnt als dit veld leeg is."
+    }
+  ],
+  "U/t6b+": [
+    {
+      "type": 0,
+      "value": "Variables Mapping"
     }
   ],
   "UCGSib": [
@@ -2833,6 +2869,12 @@
       "value": "Indien meerdere unieke identificaties beschikbaar zijn (bijvoorbeeld bij eHerkenning Bewindvoering en DigiD Machtigen), welke prefill-gegevens moeten dan opgehaald worden? Deze voor de machtiger of de gemachtigde?"
     }
   ],
+  "WnKF/i": [
+    {
+      "type": 0,
+      "value": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments"
+    }
+  ],
   "Wz5QZo": [
     {
       "type": 0,
@@ -2861,6 +2903,12 @@
     {
       "type": 0,
       "value": "Ongeldige JSON-logic expressie. Zie https://jsonlogic.com/operations.html voor beschikbare operaties."
+    }
+  ],
+  "XPEv9r": [
+    {
+      "type": 0,
+      "value": "Legacy"
     }
   ],
   "XPLnIL": [
@@ -3007,6 +3055,12 @@
       "value": "Selecteer de plugin om te gebruiken voor prefill."
     }
   ],
+  "Yyvvx1": [
+    {
+      "type": 0,
+      "value": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV"
+    }
+  ],
   "YzLSHY": [
     {
       "type": 0,
@@ -3120,12 +3174,6 @@
     {
       "type": 0,
       "value": "Product veld"
-    }
-  ],
-  "aWwaAq": [
-    {
-      "type": 0,
-      "value": "Maximum selected checkboxes"
     }
   ],
   "aXJpiI": [
@@ -3424,12 +3472,6 @@
       "value": "Het verplichte veld Label is niet ingevuld."
     }
   ],
-  "dbAJfK": [
-    {
-      "type": 0,
-      "value": "Minimum selected checkboxes"
-    }
-  ],
   "ddDA6+": [
     {
       "type": 0,
@@ -3490,6 +3532,12 @@
       "value": "configured"
     }
   ],
+  "dwkDsV": [
+    {
+      "type": 0,
+      "value": "Version of the objecttype in the Objecttypes API"
+    }
+  ],
   "e6SsfR": [
     {
       "type": 0,
@@ -3502,6 +3550,12 @@
       "value": "Beheer procesvariabelen"
     }
   ],
+  "eBtStW": [
+    {
+      "type": 0,
+      "value": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF"
+    }
+  ],
   "eJEu3L": [
     {
       "type": 0,
@@ -3512,6 +3566,12 @@
     {
       "type": 0,
       "value": "Geavanceerde opties"
+    }
+  ],
+  "eR8wGd": [
+    {
+      "type": 0,
+      "value": "RSIN of organization, which creates the INFORMATIEOBJECT"
     }
   ],
   "eU7+uS": [
@@ -3596,6 +3656,12 @@
     {
       "type": 0,
       "value": "Sla de waarde op onder het geselecteerde attribuut in de geselecteerde registratieplugin."
+    }
+  ],
+  "fVNaJK": [
+    {
+      "type": 0,
+      "value": "Objecttype version"
     }
   ],
   "fWcg7I": [
@@ -3778,6 +3844,12 @@
       "value": "Configureren"
     }
   ],
+  "hwD3q9": [
+    {
+      "type": 0,
+      "value": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag"
+    }
+  ],
   "hwsnj9": [
     {
       "type": 0,
@@ -3794,6 +3866,18 @@
     {
       "type": 0,
       "value": "Tabnaam"
+    }
+  ],
+  "iHpAYZ": [
+    {
+      "type": 0,
+      "value": "This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field."
+    }
+  ],
+  "iNmPDd": [
+    {
+      "type": 0,
+      "value": "Attachment informatieobjecttype"
     }
   ],
   "iOADkJ": [
@@ -3872,10 +3956,22 @@
       "value": "Waarden"
     }
   ],
+  "j7rEgn": [
+    {
+      "type": 0,
+      "value": "Submission report PDF informatieobjecttype"
+    }
+  ],
   "jARYB7": [
     {
       "type": 0,
       "value": "(Herbruikbare) stapgegevens"
+    }
+  ],
+  "jCUorM": [
+    {
+      "type": 0,
+      "value": "Something went wrong when fectching the available Objecttypes and versions"
     }
   ],
   "jLg5l6": [
@@ -3986,6 +4082,12 @@
       "value": "uitgeschakeld"
     }
   ],
+  "kQtrKX": [
+    {
+      "type": 0,
+      "value": "The type of ProductAanvraag"
+    }
+  ],
   "kg/eh1": [
     {
       "type": 0,
@@ -4030,6 +4132,12 @@
       ],
       "type": 8,
       "value": "code"
+    }
+  ],
+  "l/mtou": [
+    {
+      "type": 0,
+      "value": "Payment status update JSON template"
     }
   ],
   "l1fi1t": [
@@ -4529,6 +4637,12 @@
       "value": "Datatype"
     }
   ],
+  "rJTe9U": [
+    {
+      "type": 0,
+      "value": "Objecttype"
+    }
+  ],
   "rTafvA": [
     {
       "type": 0,
@@ -4573,12 +4687,6 @@
     {
       "type": 0,
       "value": "Vink aan om een bevestigingsmail te sturen naar de inzender(s) van het formulier."
-    }
-  ],
-  "sR9GVQ": [
-    {
-      "type": 0,
-      "value": "If specified, the user must check at most this many options."
     }
   ],
   "sU/n0S": [
@@ -4639,6 +4747,12 @@
     {
       "type": 0,
       "value": " 3"
+    }
+  ],
+  "sptpzv": [
+    {
+      "type": 0,
+      "value": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?"
     }
   ],
   "t9+e9k": [
@@ -5065,6 +5179,12 @@
     {
       "type": 0,
       "value": "Gebruik algemene kaartinstellingen"
+    }
+  ],
+  "zF8YEc": [
+    {
+      "type": 0,
+      "value": "Organisation RSIN"
     }
   ],
   "zGMQ75": [

--- a/src/openforms/js/components/admin/form_design/constants.js
+++ b/src/openforms/js/components/admin/form_design/constants.js
@@ -1,6 +1,8 @@
 export const FORM_ENDPOINT = '/api/v2/forms';
 export const FORM_DEFINITIONS_ENDPOINT = '/api/v2/form-definitions';
 export const REGISTRATION_BACKENDS_ENDPOINT = '/api/v2/registration/plugins';
+export const REGISTRATION_OBJECTTYPES_ENDPOINT =
+  '/api/v2/registration/plugins/objects-api/object-types';
 export const AUTH_PLUGINS_ENDPOINT = '/api/v2/authentication/plugins';
 export const PREFILL_PLUGINS_ENDPOINT = '/api/v2/prefill/plugins';
 export const DMN_PLUGINS_ENDPOINT = '/api/v2/dmn/plugins';

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -2,6 +2,7 @@ import {WysiwygWidget} from 'components/admin/RJSFWrapper';
 
 import CamundaOptionsForm from './camunda';
 import {onStepEdit} from './handlers';
+import ObjectsApiOptionsForm from './objectsapi/ObjectsApiOptionsForm';
 import ObjectsApiSummaryHandler from './objectsapi/ObjectsApiSummaryHandler';
 import ZGWOptionsForm from './zgw';
 
@@ -22,20 +23,8 @@ export const BACKEND_OPTIONS_FORMS = {
     onStepEdit: onStepEdit,
   },
   objects_api: {
-    uiSchema: {
-      contentJson: {
-        'ui:widget': 'textarea',
-        'ui:options': {
-          rows: 5,
-        },
-      },
-      paymentStatusUpdateJson: {
-        'ui:widget': 'textarea',
-        'ui:options': {
-          rows: 5,
-        },
-      },
-    },
+    form: ObjectsApiOptionsForm,
+    onStepEdit: null,
     configurableFromVariables: options => options.version === 2,
     formVariableConfigured: (variableKey, options) =>
       options.variablesMapping.some(mapping => mapping.variableKey === variableKey),

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {useIntl} from 'react-intl';
 
@@ -261,6 +262,25 @@ const LegacyConfigFields = ({index, name, formData, onChange}) => {
       </CustomFieldTemplate>
     </>
   );
+};
+
+LegacyConfigFields.propTypes = {
+  index: PropTypes.number,
+  name: PropTypes.string,
+  formData: PropTypes.shape({
+    version: PropTypes.number,
+    objecttype: PropTypes.string,
+    objecttypeVersion: PropTypes.string,
+    productaanvraagType: PropTypes.string,
+    informatieobjecttypeSubmissionReport: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.string,
+    informatieobjecttypeSubmissionCsv: PropTypes.string,
+    informatieobjecttypeAttachment: PropTypes.string,
+    organisatieRsin: PropTypes.string,
+    contentJson: PropTypes.string,
+    paymentStatusUpdateJson: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
 };
 
 export default LegacyConfigFields;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -1,0 +1,266 @@
+import React, {useContext} from 'react';
+import {useIntl} from 'react-intl';
+
+import {CustomFieldTemplate} from 'components/admin/RJSFWrapper';
+import {Checkbox, NumberInput, TextArea, TextInput} from 'components/admin/forms/Inputs';
+import {ValidationErrorContext} from 'components/admin/forms/ValidationErrors';
+
+import {getErrorMarkup, getFieldErrors} from './utils';
+
+const LegacyConfigFields = ({index, name, formData, onChange}) => {
+  const intl = useIntl();
+  const validationErrors = useContext(ValidationErrorContext);
+
+  const {
+    objecttype = '',
+    objecttypeVersion = '',
+    productaanvraagType = '',
+    informatieobjecttypeSubmissionReport = '',
+    uploadSubmissionCsv = '',
+    informatieobjecttypeSubmissionCsv = '',
+    informatieobjecttypeAttachment = '',
+    organisatieRsin = '',
+    contentJson = '',
+    paymentStatusUpdateJson = '',
+  } = formData;
+
+  const buildErrorsComponent = field => {
+    const rawErrors = getFieldErrors(name, index, validationErrors, field);
+    return rawErrors ? getErrorMarkup(rawErrors) : null;
+  };
+
+  return (
+    <>
+      <CustomFieldTemplate
+        id="root_objecttype"
+        label={intl.formatMessage({
+          defaultMessage: 'Objecttype',
+          description: 'Objects API registration options "Objecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: "submission_id", "type" (the type of productaanvraag) and "data" (the submitted form data)',
+          description: 'Objects API registration options "Objecttype" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'objecttype')}
+        errors={buildErrorsComponent('objecttype')}
+        displayLabel
+      >
+        <TextInput id="root_objecttype" name="objecttype" value={objecttype} onChange={onChange} />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_objecttypeVersion"
+        label={intl.formatMessage({
+          defaultMessage: 'Objecttype version',
+          description: 'Objects API registration options "Objecttype version" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'Version of the objecttype in the Objecttypes API',
+          description: 'Objects API registration options "Objecttype version" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'objecttypeVersion')}
+        errors={buildErrorsComponent('objecttypeVersion')}
+        displayLabel
+      >
+        <NumberInput
+          id="root_objecttypeVersion"
+          name="objecttypeVersion"
+          value={objecttypeVersion}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_productaanvraagType"
+        label={intl.formatMessage({
+          defaultMessage: 'Productaanvraag type',
+          description: 'Objects API registration options "Productaanvraag type" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'The type of ProductAanvraag',
+          description: 'Objects API registration options "Productaanvraag type" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'productaanvraagType')}
+        errors={buildErrorsComponent('productaanvraagType')}
+        displayLabel
+      >
+        <TextInput
+          id="root_productaanvraagType"
+          name="productaanvraagType"
+          value={productaanvraagType}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_informatieobjecttypeSubmissionReport"
+        label={intl.formatMessage({
+          defaultMessage: 'Submission report PDF informatieobjecttype',
+          description:
+            'Objects API registration options "Submission report PDF informatieobjecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF',
+          description:
+            'Objects API registration options "Submission report PDF informatieobjecttype" description',
+        })}
+        rawErrors={getFieldErrors(
+          name,
+          index,
+          validationErrors,
+          'informatieobjecttypeSubmissionReport'
+        )}
+        errors={buildErrorsComponent('informatieobjecttypeSubmissionReport')}
+        displayLabel
+      >
+        <TextInput
+          id="root_informatieobjecttypeSubmissionReport"
+          name="informatieobjecttypeSubmissionReport"
+          value={informatieobjecttypeSubmissionReport}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_uploadSubmissionCsv"
+        label={intl.formatMessage({
+          defaultMessage: 'Upload submission CSV',
+          description: 'Objects API registration options "Upload submission CSV" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag',
+          description: 'Objects API registration options "Upload submission CSV" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'uploadSubmissionCsv')}
+        errors={buildErrorsComponent('uploadSubmissionCsv')}
+        displayLabel
+      >
+        <Checkbox
+          id="root_uploadSubmissionCsv"
+          name="uploadSubmissionCsv"
+          value={uploadSubmissionCsv}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_informatieobjecttypeSubmissionCsv"
+        label={intl.formatMessage({
+          defaultMessage: 'Submission report CSV informatieobjecttype',
+          description:
+            'Objects API registration options "Submission report CSV informatieobjecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV',
+          description:
+            'Objects API registration options "Submission report CSV informatieobjecttype" description',
+        })}
+        rawErrors={getFieldErrors(
+          name,
+          index,
+          validationErrors,
+          'informatieobjecttypeSubmissionCsv'
+        )}
+        errors={buildErrorsComponent('informatieobjecttypeSubmissionCsv')}
+        displayLabel
+      >
+        <TextInput
+          id="root_informatieobjecttypeSubmissionCsv"
+          name="informatieobjecttypeSubmissionCsv"
+          value={informatieobjecttypeSubmissionCsv}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_informatieobjecttypeAttachment"
+        label={intl.formatMessage({
+          defaultMessage: 'Attachment informatieobjecttype',
+          description: 'Objects API registration options "Attachment informatieobjecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments',
+          description:
+            'Objects API registration options "Attachment informatieobjecttype" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'informatieobjecttypeAttachment')}
+        errors={buildErrorsComponent('informatieobjecttypeAttachment')}
+        displayLabel
+      >
+        <TextInput
+          id="root_informatieobjecttypeAttachment"
+          name="informatieobjecttypeAttachment"
+          value={informatieobjecttypeAttachment}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_organisatieRsin"
+        label={intl.formatMessage({
+          defaultMessage: 'Organisation RSIN',
+          description: 'Objects API registration options "Organisation RSIN" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'RSIN of organization, which creates the INFORMATIEOBJECT',
+          description: 'Objects API registration options "Organisation RSIN" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'organisatieRsin')}
+        errors={buildErrorsComponent('organisatieRsin')}
+        displayLabel
+      >
+        <TextInput
+          id="root_organisatieRsin"
+          name="organisatieRsin"
+          value={organisatieRsin}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_contentJson"
+        label={intl.formatMessage({
+          defaultMessage: 'JSON content field',
+          description: 'Objects API registration options "JSON content field" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'JSON template for the body of the request sent to the Objects API.',
+          description: 'Objects API registration options "JSON content field" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'contentJson')}
+        errors={buildErrorsComponent('contentJson')}
+        displayLabel
+      >
+        <TextArea
+          id="root_contentJson"
+          name="contentJson"
+          value={contentJson}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_paymentStatusUpdateJson"
+        label={intl.formatMessage({
+          defaultMessage: 'Payment status update JSON template',
+          description:
+            'Objects API registration options "Payment status update JSON template" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field.',
+          description:
+            'Objects API registration options "Payment status update JSON template" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'paymentStatusUpdateJson')}
+        errors={buildErrorsComponent('paymentStatusUpdateJson')}
+        displayLabel
+      >
+        <TextArea
+          id="root_paymentStatusUpdateJson"
+          name="paymentStatusUpdateJson"
+          value={paymentStatusUpdateJson}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+    </>
+  );
+};
+
+export default LegacyConfigFields;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeSelect.js
@@ -49,12 +49,9 @@ const ObjectTypeSelect = ({availableObjectTypesState, objecttype, onChange}) => 
 };
 
 ObjectTypeSelect.propTypes = {
-  /**
-   * URL to the objecttype in the Object types API.
-   */
+  availableObjectTypesState: PropTypes.object.isRequired,
   objecttype: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  onLoadingError: PropTypes.func.isRequired,
 };
 
 export default ObjectTypeSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeSelect.js
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import React, {useEffect} from 'react';
+
+import Select from 'components/admin/forms/Select';
+
+// TODO: properly translate this
+const LOADING_OPTION = [['...', 'loading...']];
+
+const ObjectTypeSelect = ({availableObjectTypesState, objecttype, onChange}) => {
+  const {loading, availableObjecttypes, error} = availableObjectTypesState;
+
+  const choices =
+    loading || error
+      ? LOADING_OPTION
+      : availableObjecttypes.map(({url, name, dataClassification}) => [
+          url,
+          `${name} (${dataClassification})`,
+        ]);
+
+  // ensure that if no valid value is present, the first possible option is set (
+  // synchronize the UI state back to the form state)
+  useEffect(() => {
+    // do nothing if no options have been loaded
+    if (loading) return;
+
+    // check if a valid option is selected, if this is the case -> do nothing
+    const isOptionPresent = availableObjecttypes.find(ot => ot.url === objecttype);
+    if (isOptionPresent) return;
+
+    // otherwise select the first possible option and persist that back into the state
+    const fakeEvent = {target: {name: 'objecttype', value: availableObjecttypes[0].url}};
+    onChange(fakeEvent);
+  });
+
+  useEffect(() => {
+    if (loading) return;
+    onChange({target: {name: 'objecttypeVersion', value: ''}});
+  }, [objecttype]);
+
+  return (
+    <Select
+      id="root_objecttype"
+      name="objecttype"
+      choices={choices}
+      value={objecttype}
+      onChange={onChange}
+    />
+  );
+};
+
+ObjectTypeSelect.propTypes = {
+  /**
+   * URL to the objecttype in the Object types API.
+   */
+  objecttype: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onLoadingError: PropTypes.func.isRequired,
+};
+
+export default ObjectTypeSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeVersionSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeVersionSelect.js
@@ -1,0 +1,82 @@
+import React, {useEffect} from 'react';
+import useAsync from 'react-use/esm/useAsync';
+
+import Select from 'components/admin/forms/Select';
+import {get} from 'utils/fetch';
+
+// TODO: properly translate this
+const LOADING_OPTION = [['...', 'loading...']];
+
+const getObjecttypeVersionsEndpoint = objecttype => {
+  const bits = [
+    '/api/v2/registration/plugins/objects-api/object-types',
+    encodeURIComponent(objecttype.uuid),
+    'versions',
+  ];
+  return bits.join('/');
+};
+
+const ObjectTypeVersionSelect = ({
+  availableObjecttypes = [],
+  selectedObjecttype,
+  selectedVersion,
+  onChange,
+}) => {
+  const objecttypeUrls = JSON.stringify(availableObjecttypes.map(ot => ot.url).sort());
+
+  const {
+    loading,
+    value: availableVersions = [],
+    error,
+  } = useAsync(async () => {
+    const objecttype = availableObjecttypes.find(ot => ot.url == selectedObjecttype);
+    // no match -> no versions to retrieve;
+    if (!objecttype) return [];
+
+    const response = await get(getObjecttypeVersionsEndpoint(objecttype));
+    if (!response.ok) {
+      throw new Error('Loading available object types failed');
+    }
+    const versions = response.data;
+    return versions.sort((v1, v2) => v2.version - v1.version);
+  }, [selectedObjecttype, objecttypeUrls]);
+
+  const choices =
+    loading || error
+      ? LOADING_OPTION
+      : availableVersions.map(version => [
+          version.version,
+          `${version.version} (${version.status})`,
+        ]);
+
+  // ensure that if no valid value is present, the first possible option is set (
+  // synchronize the UI state back to the form state)
+  useEffect(() => {
+    // do nothing if no options have been loaded
+    if (loading || availableVersions.length == 0) return;
+
+    // check if a valid option is selected, if this is the case -> do nothing
+    const isOptionPresent = availableVersions.find(
+      version => parseInt(version.version) === parseInt(selectedVersion)
+    );
+    if (isOptionPresent) return;
+
+    // otherwise select the first possible option and persist that back into the state
+    const fakeEvent = {target: {name: 'objecttypeVersion', value: availableVersions[0].version}};
+    onChange(fakeEvent);
+  });
+
+  return (
+    <>
+      <Select
+        id="root_objecttypeVersion"
+        name="objecttypeVersion"
+        choices={choices}
+        value={selectedVersion ?? ''}
+        onChange={onChange}
+      />
+    </>
+  );
+};
+
+export default ObjectTypeVersionSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeVersionSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeVersionSelect.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {useEffect} from 'react';
 import useAsync from 'react-use/esm/useAsync';
 
@@ -29,7 +30,7 @@ const ObjectTypeVersionSelect = ({
     value: availableVersions = [],
     error,
   } = useAsync(async () => {
-    const objecttype = availableObjecttypes.find(ot => ot.url == selectedObjecttype);
+    const objecttype = availableObjecttypes.find(ot => ot.url === selectedObjecttype);
     // no match -> no versions to retrieve;
     if (!objecttype) return [];
 
@@ -53,7 +54,7 @@ const ObjectTypeVersionSelect = ({
   // synchronize the UI state back to the form state)
   useEffect(() => {
     // do nothing if no options have been loaded
-    if (loading || availableVersions.length == 0) return;
+    if (loading || availableVersions.length === 0) return;
 
     // check if a valid option is selected, if this is the case -> do nothing
     const isOptionPresent = availableVersions.find(
@@ -67,16 +68,21 @@ const ObjectTypeVersionSelect = ({
   });
 
   return (
-    <>
-      <Select
-        id="root_objecttypeVersion"
-        name="objecttypeVersion"
-        choices={choices}
-        value={selectedVersion ?? ''}
-        onChange={onChange}
-      />
-    </>
+    <Select
+      id="root_objecttypeVersion"
+      name="objecttypeVersion"
+      choices={choices}
+      value={selectedVersion ?? ''}
+      onChange={onChange}
+    />
   );
+};
+
+ObjectTypeVersionSelect.propTypes = {
+  availableObjecttypes: PropTypes.array,
+  selectedObjecttype: PropTypes.string.isRequired,
+  selectedVersion: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default ObjectTypeVersionSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Field from 'components/admin/forms/Field';
+
+import ObjectsApiOptionsFormFields from './ObjectsApiOptionsFormFields';
+
+const ObjectsApiOptionsForm = ({index, name, label, schema, formData, onChange}) => {
+  return (
+    <Field name={name} label={label}>
+      <ObjectsApiOptionsFormFields
+        index={index}
+        name={name}
+        schema={schema}
+        formData={formData}
+        onChange={formData => onChange({formData})}
+      />
+    </Field>
+  );
+};
+
+ObjectsApiOptionsForm.propTypes = {
+  index: PropTypes.number,
+  name: PropTypes.string,
+  label: PropTypes.node,
+  schema: PropTypes.any,
+  formData: PropTypes.shape({
+    version: PropTypes.number,
+    objecttype: PropTypes.string,
+    objecttypeVersion: PropTypes.string,
+    productaanvraagType: PropTypes.string,
+    informatieobjecttypeSubmissionReport: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.string,
+    informatieobjecttypeSubmissionCsv: PropTypes.string,
+    informatieobjecttypeAttachment: PropTypes.string,
+    organisatieRsin: PropTypes.string,
+    contentJson: PropTypes.string,
+    paymentStatusUpdateJson: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
+};
+
+export default ObjectsApiOptionsForm;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -1,4 +1,5 @@
 import {produce} from 'immer';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {TabList, TabPanel, Tabs} from 'react-tabs';
@@ -30,15 +31,15 @@ const ObjectsApiOptionsFormFields = ({index, name, schema, formData, onChange}) 
 
   const {version = 1} = formData;
 
-  const changeVersion = index => {
-    if (index === 1) {
+  const changeVersion = v => {
+    if (v === 1) {
       const confirmV2Switch = window.confirm(v2SwitchMessage);
       if (!confirmV2Switch) return;
     }
 
     onChange(
       produce(formData, draft => {
-        draft.version = index + 1;
+        draft.version = v + 1;
         delete draft.contentJson;
         delete draft.paymentStatusUpdateJson;
       })
@@ -97,6 +98,26 @@ const ObjectsApiOptionsFormFields = ({index, name, schema, formData, onChange}) 
       </Tabs>
     </>
   );
+};
+
+ObjectsApiOptionsFormFields.propTypes = {
+  index: PropTypes.number,
+  name: PropTypes.string,
+  schema: PropTypes.any,
+  formData: PropTypes.shape({
+    version: PropTypes.number,
+    objecttype: PropTypes.string,
+    objecttypeVersion: PropTypes.string,
+    productaanvraagType: PropTypes.string,
+    informatieobjecttypeSubmissionReport: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.string,
+    informatieobjecttypeSubmissionCsv: PropTypes.string,
+    informatieobjecttypeAttachment: PropTypes.string,
+    organisatieRsin: PropTypes.string,
+    contentJson: PropTypes.string,
+    paymentStatusUpdateJson: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
 };
 
 export default ObjectsApiOptionsFormFields;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -39,8 +39,8 @@ const ObjectsApiOptionsFormFields = ({index, name, schema, formData, onChange}) 
     onChange(
       produce(formData, draft => {
         draft.version = index + 1;
-        draft.contentJson = '';
-        draft.paymentStatusUpdateJson = '';
+        delete draft.contentJson;
+        delete draft.paymentStatusUpdateJson;
       })
     );
   };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -1,0 +1,102 @@
+import {produce} from 'immer';
+import React from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+import {TabList, TabPanel, Tabs} from 'react-tabs';
+
+import {CustomFieldTemplate} from 'components/admin/RJSFWrapper';
+import Tab from 'components/admin/form_design/Tab';
+
+import LegacyConfigFields from './LegacyConfigFields';
+import V2ConfigFields from './V2ConfigFields';
+
+const Wrapper = ({children}) => (
+  <form className="rjsf" name="form.registrationBackendOptions">
+    <CustomFieldTemplate displayLabel={false} errors={null}>
+      <fieldset id="root">{children}</fieldset>
+    </CustomFieldTemplate>
+  </form>
+);
+
+const ObjectsApiOptionsFormFields = ({index, name, schema, formData, onChange}) => {
+  const intl = useIntl();
+
+  const v2SwitchMessage = intl.formatMessage({
+    defaultMessage: `Switching to the new registration options will remove the existing JSON templates.
+    You will also not be able to save the form until the variables are correctly mapped.
+    Are you sure you want to continue?
+    `,
+    description: 'Objects API registration backend: v2 switch warning message',
+  });
+
+  const {version = 1} = formData;
+
+  const changeVersion = index => {
+    if (index === 1) {
+      const confirmV2Switch = window.confirm(v2SwitchMessage);
+      if (!confirmV2Switch) return;
+    }
+
+    onChange(
+      produce(formData, draft => {
+        draft.version = index + 1;
+        draft.contentJson = '';
+        draft.paymentStatusUpdateJson = '';
+      })
+    );
+  };
+
+  const onFieldChange = event => {
+    const {name, value} = event.target;
+    const updatedFormData = produce(formData, draft => {
+      draft[name] = value;
+    });
+    onChange(updatedFormData);
+  };
+
+  return (
+    <>
+      <Tabs selectedIndex={version - 1} onSelect={changeVersion}>
+        <TabList>
+          <Tab>
+            <FormattedMessage
+              defaultMessage="Legacy"
+              description="Objects API registration backend options 'Legacy' tab label"
+            />
+          </Tab>
+          <Tab>
+            <FormattedMessage
+              defaultMessage="Variables Mapping"
+              description="Objects API registration backend options 'Variables Mapping' tab label"
+            />
+          </Tab>
+        </TabList>
+
+        {/* Legacy format, template based */}
+        <TabPanel>
+          <Wrapper>
+            <LegacyConfigFields
+              index={index}
+              name={name}
+              formData={formData}
+              onChange={onFieldChange}
+            />
+          </Wrapper>
+        </TabPanel>
+
+        {/* Tight objecttypes integration */}
+        <TabPanel>
+          <Wrapper>
+            <V2ConfigFields
+              index={index}
+              name={name}
+              formData={formData}
+              onChange={onFieldChange}
+            />
+          </Wrapper>
+        </TabPanel>
+      </Tabs>
+    </>
+  );
+};
+
+export default ObjectsApiOptionsFormFields;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.mdx
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.mdx
@@ -1,0 +1,21 @@
+import {ArgTypes, Canvas, Meta} from '@storybook/addon-docs';
+
+import ObjectsApiOptionsFormFields from './ObjectsApiOptionsFormFields';
+import * as ObjectsApiOptionsFormFieldsStories from './ObjectsApiOptionsFormFields.stories';
+
+<Meta of={ObjectsApiOptionsFormFieldsStories} />
+
+# Objects API Registration
+
+Here we can set up the registration backend for Objects APIs. The Objecttype and corresponding
+versions are fetched from the API.
+
+<Canvas of={ObjectsApiOptionsFormFieldsStories.Default} />
+
+## Props
+
+<ArgTypes of={ObjectsApiOptionsFormFields} />
+
+**Warning**: this component requires the following contexts:
+
+- `ValidationErrorContext`, for validation errors

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -1,0 +1,187 @@
+import {useArgs} from '@storybook/client-api';
+import {expect, jest} from '@storybook/jest';
+import {userEvent, within} from '@storybook/testing-library';
+
+import {FormDecorator} from 'components/admin/form_design/story-decorators';
+import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+
+import ObjectsApiOptionsFormFields from './ObjectsApiOptionsFormFields';
+import {mockObjecttypeVersionsGet, mockObjecttypesError, mockObjecttypesGet} from './mocks';
+
+// WARNING
+// The `render` function will mutate args, meaning interactions can't be run twice
+// Be sure to refresh the page and remove the args in the query parameters
+
+const render = ({index, label, name}) => {
+  const [{formData}, updateArgs] = useArgs();
+  const onChange = newValues => {
+    updateArgs({formData: newValues});
+  };
+
+  return (
+    <Fieldset>
+      <FormRow>
+        <Field name={name} label={label}>
+          <ObjectsApiOptionsFormFields
+            index={index}
+            name={name}
+            formData={formData}
+            onChange={onChange}
+          />
+        </Field>
+      </FormRow>
+    </Fieldset>
+  );
+};
+
+export default {
+  title: 'Form design/Registration/Objects API',
+  decorators: [FormDecorator],
+  render,
+  args: {
+    formData: {},
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        mockObjecttypesGet([
+          {
+            url: 'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f1',
+            uuid: '2c77babf-a967-4057-9969-0200320d23f1',
+            name: 'Tree',
+            namePlural: 'Trees',
+            dataClassification: 'open',
+          },
+          {
+            url: 'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f2',
+            uuid: '2c77babf-a967-4057-9969-0200320d23f2',
+            name: 'Person',
+            namePlural: 'Persons',
+            dataClassification: 'open',
+          },
+        ]),
+        mockObjecttypeVersionsGet([
+          {version: 1, status: 'published'},
+          {version: 2, status: 'draft'},
+        ]),
+      ],
+    },
+  },
+};
+
+export const Default = {};
+
+export const SwitchToV2Empty = {
+  play: async ({canvasElement}) => {
+    window.confirm = jest.fn(() => true);
+    const canvas = within(canvasElement);
+
+    const v2Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v2Tab);
+
+    await canvas.findByRole('option', {name: 'Tree (open)'}, {timeout: 5000});
+    expect(canvas.getByLabelText('Objecttype')).toHaveValue(
+      'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f1'
+    );
+
+    await canvas.findByRole('option', {name: '2 (draft)'});
+    expect(canvas.getByLabelText('Objecttype version')).toHaveValue('2');
+
+    const v1Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v1Tab);
+
+    expect(canvas.getByLabelText('Objecttype')).toHaveValue(
+      'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f1'
+    );
+    // This time as a number as it is a number input:
+    expect(canvas.getByLabelText('Objecttype version')).toHaveValue(2);
+  },
+};
+
+export const SwitchToV2Existing = {
+  args: {
+    formData: {
+      objecttype: 'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f2',
+      objecttypeVersion: 1,
+    },
+  },
+  play: async ({canvasElement}) => {
+    window.confirm = jest.fn(() => true);
+    const canvas = within(canvasElement);
+
+    const v2Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v2Tab);
+
+    await canvas.findByRole('option', {name: 'Person (open)'}, {timeout: 5000});
+    expect(canvas.getByLabelText('Objecttype')).toHaveValue(
+      'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f2'
+    );
+
+    await canvas.findByRole('option', {name: '1 (published)'});
+    expect(canvas.getByLabelText('Objecttype version')).toHaveValue('1');
+
+    const v1Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v1Tab);
+
+    expect(canvas.getByLabelText('Objecttype')).toHaveValue(
+      'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f2'
+    );
+    expect(canvas.getByLabelText('Objecttype version')).toHaveValue('1');
+  },
+};
+
+export const SwitchToV2NonExisting = {
+  args: {
+    formData: {
+      objecttype: 'https://objecttypen.nl/api/v1/objecttypes/a-non-existing-uuid',
+      objecttypeVersion: 1,
+    },
+  },
+  play: async ({canvasElement}) => {
+    window.confirm = jest.fn(() => true);
+    const canvas = within(canvasElement);
+
+    const v2Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v2Tab);
+
+    await canvas.findByRole('option', {name: 'Tree (open)'}, {timeout: 5000});
+    expect(canvas.getByLabelText('Objecttype')).toHaveValue(
+      'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f1'
+    );
+
+    await canvas.findByRole('option', {name: '2 (draft)'});
+    expect(canvas.getByLabelText('Objecttype version')).toHaveValue('2');
+
+    const v1Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v1Tab);
+
+    expect(canvas.getByLabelText('Objecttype')).toHaveValue(
+      'https://objecttypen.nl/api/v1/objecttypes/2c77babf-a967-4057-9969-0200320d23f1'
+    );
+    // This time as a number as it is a number input:
+    expect(canvas.getByLabelText('Objecttype version')).toHaveValue(2);
+  },
+};
+
+export const APIFetchError = {
+  parameters: {
+    msw: {
+      handlers: [mockObjecttypesError()],
+    },
+  },
+  play: async ({canvasElement}) => {
+    window.confirm = jest.fn(() => true);
+    const canvas = within(canvasElement);
+
+    const v2Tab = canvas.getByRole('tab', {selected: false});
+    await userEvent.click(v2Tab);
+
+    const errorMessage = await canvas.findByText(
+      'Something went wrong when fectching the available Objecttypes and versions'
+    );
+
+    expect(errorMessage).toBeVisible();
+  },
+};

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -1,0 +1,250 @@
+import PropTypes from 'prop-types';
+import React, {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {CustomFieldTemplate} from 'components/admin/RJSFWrapper';
+import {Checkbox, TextInput} from 'components/admin/forms/Inputs';
+import {ValidationErrorContext} from 'components/admin/forms/ValidationErrors';
+import ErrorMessage from 'components/errors/ErrorMessage';
+
+import ObjectTypeSelect from './ObjectTypeSelect';
+import ObjectTypeVersionSelect from './ObjectTypeVersionSelect';
+import {useGetAvailableObjectTypes} from './hooks';
+import {getErrorMarkup, getFieldErrors} from './utils';
+
+const V2ConfigFields = ({index, name, formData, onChange}) => {
+  const intl = useIntl();
+  const validationErrors = useContext(ValidationErrorContext);
+
+  // Track available object types and versions in this component so the state can be
+  // shared.
+  const availableObjectTypesState = useGetAvailableObjectTypes();
+
+  const {
+    objecttype = '',
+    objecttypeVersion = '',
+    productaanvraagType = '',
+    informatieobjecttypeSubmissionReport = '',
+    uploadSubmissionCsv = '',
+    informatieobjecttypeSubmissionCsv = '',
+    informatieobjecttypeAttachment = '',
+    organisatieRsin = '',
+  } = formData;
+
+  const buildErrorsComponent = field => {
+    const rawErrors = getFieldErrors(name, index, validationErrors, field);
+    return rawErrors ? getErrorMarkup(rawErrors) : null;
+  };
+
+  const loadingError = !!availableObjectTypesState.error;
+  if (loadingError) {
+    return (
+      <ErrorMessage>
+        <FormattedMessage
+          defaultMessage="Something went wrong when fectching the available Objecttypes and versions"
+          description="Objects API registrations options API error"
+        />
+      </ErrorMessage>
+    );
+  }
+
+  return (
+    <>
+      <CustomFieldTemplate
+        id="root_objecttype"
+        label={intl.formatMessage({
+          defaultMessage: 'Objecttype',
+          description: 'Objects API registration options "Objecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: "submission_id", "type" (the type of productaanvraag) and "data" (the submitted form data)',
+          description: 'Objects API registration options "Objecttype" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'objecttype')}
+        errors={buildErrorsComponent('objecttype')}
+        displayLabel
+      >
+        {/* TODO: fallback to legacy UI if there are loading errors */}
+        <ObjectTypeSelect
+          availableObjectTypesState={availableObjectTypesState}
+          objecttype={objecttype}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_objecttypeVersion"
+        label={intl.formatMessage({
+          defaultMessage: 'Objecttype version',
+          description: 'Objects API registration options "Objecttype version" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'Version of the objecttype in the Objecttypes API',
+          description: 'Objects API registration options "Objecttype version" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'objecttypeVersion')}
+        errors={buildErrorsComponent('objecttypeVersion')}
+        displayLabel
+      >
+        {/* TODO: fallback to legacy UI if there are loading errors */}
+        <ObjectTypeVersionSelect
+          availableObjecttypes={availableObjectTypesState.availableObjecttypes}
+          selectedObjecttype={objecttype}
+          selectedVersion={objecttypeVersion}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_productaanvraagType"
+        label={intl.formatMessage({
+          defaultMessage: 'Productaanvraag type',
+          description: 'Objects API registration options "Productaanvraag type" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'The type of ProductAanvraag',
+          description: 'Objects API registration options "Productaanvraag type" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'productaanvraagType')}
+        errors={buildErrorsComponent('productaanvraagType')}
+        displayLabel
+      >
+        <TextInput
+          id="root_productaanvraagType"
+          name="productaanvraagType"
+          value={productaanvraagType}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_informatieobjecttypeSubmissionReport"
+        label={intl.formatMessage({
+          defaultMessage: 'Submission report PDF informatieobjecttype',
+          description:
+            'Objects API registration options "Submission report PDF informatieobjecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF',
+          description:
+            'Objects API registration options "Submission report PDF informatieobjecttype" description',
+        })}
+        rawErrors={getFieldErrors(
+          name,
+          index,
+          validationErrors,
+          'informatieobjecttypeSubmissionReport'
+        )}
+        errors={buildErrorsComponent('informatieobjecttypeSubmissionReport')}
+        displayLabel
+      >
+        <TextInput
+          id="root_informatieobjecttypeSubmissionReport"
+          name="informatieobjecttypeSubmissionReport"
+          value={informatieobjecttypeSubmissionReport}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_uploadSubmissionCsv"
+        label={intl.formatMessage({
+          defaultMessage: 'Upload submission CSV',
+          description: 'Objects API registration options "Upload submission CSV" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag',
+          description: 'Objects API registration options "Upload submission CSV" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'uploadSubmissionCsv')}
+        errors={buildErrorsComponent('uploadSubmissionCsv')}
+        displayLabel
+      >
+        <Checkbox
+          id="root_uploadSubmissionCsv"
+          name="uploadSubmissionCsv"
+          value={uploadSubmissionCsv}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_informatieobjecttypeSubmissionCsv"
+        label={intl.formatMessage({
+          defaultMessage: 'Submission report CSV informatieobjecttype',
+          description:
+            'Objects API registration options "Submission report CSV informatieobjecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV',
+          description:
+            'Objects API registration options "Submission report CSV informatieobjecttype" description',
+        })}
+        rawErrors={getFieldErrors(
+          name,
+          index,
+          validationErrors,
+          'informatieobjecttypeSubmissionCsv'
+        )}
+        errors={buildErrorsComponent('informatieobjecttypeSubmissionCsv')}
+        displayLabel
+      >
+        <TextInput
+          id="root_informatieobjecttypeSubmissionCsv"
+          name="informatieobjecttypeSubmissionCsv"
+          value={informatieobjecttypeSubmissionCsv}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_informatieobjecttypeAttachment"
+        label={intl.formatMessage({
+          defaultMessage: 'Attachment informatieobjecttype',
+          description: 'Objects API registration options "Attachment informatieobjecttype" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments',
+          description:
+            'Objects API registration options "Attachment informatieobjecttype" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'informatieobjecttypeAttachment')}
+        errors={buildErrorsComponent('informatieobjecttypeAttachment')}
+        displayLabel
+      >
+        <TextInput
+          id="root_informatieobjecttypeAttachment"
+          name="informatieobjecttypeAttachment"
+          value={informatieobjecttypeAttachment}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_organisatieRsin"
+        label={intl.formatMessage({
+          defaultMessage: 'Organisation RSIN',
+          description: 'Objects API registration options "Organisation RSIN" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage: 'RSIN of organization, which creates the INFORMATIEOBJECT',
+          description: 'Objects API registration options "Organisation RSIN" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'organisatieRsin')}
+        errors={buildErrorsComponent('organisatieRsin')}
+        displayLabel
+      >
+        <TextInput
+          id="root_organisatieRsin"
+          name="organisatieRsin"
+          value={organisatieRsin}
+          onChange={onChange}
+        />
+      </CustomFieldTemplate>
+    </>
+  );
+};
+
+V2ConfigFields.propTypes = {
+  index: PropTypes.number.isRequired,
+};
+
+export default V2ConfigFields;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {CustomFieldTemplate} from 'components/admin/RJSFWrapper';
@@ -244,7 +244,22 @@ const V2ConfigFields = ({index, name, formData, onChange}) => {
 };
 
 V2ConfigFields.propTypes = {
-  index: PropTypes.number.isRequired,
+  index: PropTypes.number,
+  name: PropTypes.string,
+  formData: PropTypes.shape({
+    version: PropTypes.number,
+    objecttype: PropTypes.string,
+    objecttypeVersion: PropTypes.string,
+    productaanvraagType: PropTypes.string,
+    informatieobjecttypeSubmissionReport: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.string,
+    informatieobjecttypeSubmissionCsv: PropTypes.string,
+    informatieobjecttypeAttachment: PropTypes.string,
+    organisatieRsin: PropTypes.string,
+    contentJson: PropTypes.string,
+    paymentStatusUpdateJson: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
 };
 
 export default V2ConfigFields;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/hooks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/hooks.js
@@ -1,0 +1,28 @@
+import useAsync from 'react-use/esm/useAsync';
+
+import {REGISTRATION_OBJECTTYPES_ENDPOINT} from 'components/admin/form_design/constants';
+import {get} from 'utils/fetch';
+
+export const useGetAvailableObjectTypes = () => {
+  const {
+    loading,
+    value: availableObjecttypes = [],
+    error,
+  } = useAsync(
+    async () => {
+      const response = await get(REGISTRATION_OBJECTTYPES_ENDPOINT);
+      if (!response.ok) {
+        throw new Error('Loading available object types failed');
+      }
+      return response.data;
+    },
+    // available object types only need to be loaded once when the component mounts
+    []
+  );
+
+  return {
+    loading,
+    availableObjecttypes,
+    error,
+  };
+};

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -1,0 +1,21 @@
+import {rest} from 'msw';
+
+export const BASE_URL = process.env.SB_BASE_URL || '';
+
+export const mockObjecttypesGet = objecttypes =>
+  rest.get(`${BASE_URL}/api/v2/registration/plugins/objects-api/object-types`, (req, res, ctx) => {
+    return res(ctx.json(objecttypes));
+  });
+
+export const mockObjecttypeVersionsGet = versions =>
+  rest.get(
+    `${BASE_URL}/api/v2/registration/plugins/objects-api/object-types/:uuid/versions`,
+    (req, res, ctx) => {
+      return res(ctx.json(versions));
+    }
+  );
+
+export const mockObjecttypesError = () =>
+  rest.all('*', (req, res, ctx) => {
+    return res(ctx.status(500));
+  });

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/utils.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/utils.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+// TODO This is duplicated from the ZGW registration, but will be cleaned up
+// with the backend UI refactor.
+
+const getFieldErrors = (name, index, errors, field) => {
+  const errorMessages = [];
+
+  for (const [errorName, errorReason] of errors) {
+    if (errorName.startsWith(name)) {
+      const errorNameBits = errorName.split('.');
+      if (errorNameBits[2] === String(index) && errorNameBits.at(-1) === field) {
+        errorMessages.push(errorReason);
+      }
+    }
+  }
+
+  return errorMessages.length > 0 ? errorMessages : null;
+};
+
+const getErrorMarkup = errorMessages => {
+  return (
+    <ul className="error-detail bs-callout bs-callout-info">
+      {errorMessages.map((msg, index) => (
+        <li key={index} className="text-danger">
+          {msg}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export {getErrorMarkup, getFieldErrors};

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -39,6 +39,11 @@
     "description": "Locations Component field label",
     "originalDefault": "Locations Component"
   },
+  "/fAEsY": {
+    "defaultMessage": "Submission report CSV informatieobjecttype",
+    "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
+    "originalDefault": "Submission report CSV informatieobjecttype"
+  },
   "/hIJ8m": {
     "defaultMessage": "Dates Component",
     "description": "Dates Component field label",
@@ -188,6 +193,11 @@
     "defaultMessage": "Name",
     "description": "Form name field label",
     "originalDefault": "Name"
+  },
+  "51k2La": {
+    "defaultMessage": "JSON content field",
+    "description": "Objects API registration options \"JSON content field\" label",
+    "originalDefault": "JSON content field"
   },
   "5AC1+x": {
     "defaultMessage": "The value of the selected field will be the process variable value.",
@@ -393,6 +403,11 @@
     "defaultMessage": "Errored Submissions Removal Limit",
     "description": "Errored Submissions Removal Limit field label",
     "originalDefault": "Errored Submissions Removal Limit"
+  },
+  "A/vedA": {
+    "defaultMessage": "JSON template for the body of the request sent to the Objects API.",
+    "description": "Objects API registration options \"JSON content field\" description",
+    "originalDefault": "JSON template for the body of the request sent to the Objects API."
   },
   "A1tDIH": {
     "defaultMessage": "Name",
@@ -729,6 +744,11 @@
     "description": "Errored Submissions Removal Limit help text",
     "originalDefault": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
   },
+  "HKA7Ic": {
+    "defaultMessage": "Productaanvraag type",
+    "description": "Objects API registration options \"Productaanvraag type\" label",
+    "originalDefault": "Productaanvraag type"
+  },
   "HXE3Mm": {
     "defaultMessage": "Slug of the form, used in URLs",
     "description": "Form slug field help text",
@@ -984,6 +1004,11 @@
     "description": "Locations Component field help text",
     "originalDefault": "Component where locations for an appointment will be shown"
   },
+  "NwxORf": {
+    "defaultMessage": "Upload submission CSV",
+    "description": "Objects API registration options \"Upload submission CSV\" label",
+    "originalDefault": "Upload submission CSV"
+  },
   "O/wKJh": {
     "defaultMessage": "Value",
     "description": "JSON (primitive) value label",
@@ -1139,6 +1164,11 @@
     "description": "Variable table initial value title",
     "originalDefault": "Initial value"
   },
+  "RrjozJ": {
+    "defaultMessage": "URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: \"submission_id\", \"type\" (the type of productaanvraag) and \"data\" (the submitted form data)",
+    "description": "Objects API registration options \"Objecttype\" description",
+    "originalDefault": "URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: \"submission_id\", \"type\" (the type of productaanvraag) and \"data\" (the submitted form data)"
+  },
   "RvJXSo": {
     "defaultMessage": "change the value of a variable/component",
     "description": "action type \"variable\" label",
@@ -1234,6 +1264,11 @@
     "description": "option \"disabled\" of statement checkbox configuration",
     "originalDefault": "Do not ask"
   },
+  "U/t6b+": {
+    "defaultMessage": "Variables Mapping",
+    "description": "Objects API registration backend options 'Variables Mapping' tab label",
+    "originalDefault": "Variables Mapping"
+  },
   "UHlGZJ": {
     "defaultMessage": "Indication of the level to which extend the dossier of the ZAAK is meant to be public.",
     "description": "Confidentiality",
@@ -1309,6 +1344,11 @@
     "description": "Variable table prefill plugin title",
     "originalDefault": "Prefill plugin"
   },
+  "WnKF/i": {
+    "defaultMessage": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments",
+    "description": "Objects API registration options \"Attachment informatieobjecttype\" description",
+    "originalDefault": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments"
+  },
   "Wz5QZo": {
     "defaultMessage": "Active",
     "description": "Form list 'active' column header",
@@ -1328,6 +1368,11 @@
     "defaultMessage": "Invalid JSON logic expression",
     "description": "Advanced logic rule invalid JSON-logic message",
     "originalDefault": "Invalid JSON logic expression"
+  },
+  "XPEv9r": {
+    "defaultMessage": "Legacy",
+    "description": "Objects API registration backend options 'Legacy' tab label",
+    "originalDefault": "Legacy"
   },
   "XPLnIL": {
     "defaultMessage": "Edit variable registration",
@@ -1378,6 +1423,11 @@
     "defaultMessage": "Add item",
     "description": "JSON editor: add array value button",
     "originalDefault": "Add item"
+  },
+  "Yyvvx1": {
+    "defaultMessage": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV",
+    "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" description",
+    "originalDefault": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV"
   },
   "YzLSHY": {
     "defaultMessage": "Are you sure you want to delete this?",
@@ -1574,10 +1624,20 @@
     "description": "data type date",
     "originalDefault": "Date"
   },
+  "dwkDsV": {
+    "defaultMessage": "Version of the objecttype in the Objecttypes API",
+    "description": "Objects API registration options \"Objecttype version\" description",
+    "originalDefault": "Version of the objecttype in the Objecttypes API"
+  },
   "eBk+W0": {
     "defaultMessage": "Manage process variables",
     "description": "Camunda process var selection modal title",
     "originalDefault": "Manage process variables"
+  },
+  "eBtStW": {
+    "defaultMessage": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF",
+    "description": "Objects API registration options \"Submission report PDF informatieobjecttype\" description",
+    "originalDefault": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF"
   },
   "eJEu3L": {
     "defaultMessage": "Are you sure you want to delete this rule?",
@@ -1588,6 +1648,11 @@
     "defaultMessage": "Advanced options",
     "description": "Logic rule advanced options icon title",
     "originalDefault": "Advanced options"
+  },
+  "eR8wGd": {
+    "defaultMessage": "RSIN of organization, which creates the INFORMATIEOBJECT",
+    "description": "Objects API registration options \"Organisation RSIN\" description",
+    "originalDefault": "RSIN of organization, which creates the INFORMATIEOBJECT"
   },
   "eU7+uS": {
     "defaultMessage": "Confirm",
@@ -1618,6 +1683,11 @@
     "defaultMessage": "Pricing logic",
     "description": "Dynamic pricing fieldset title",
     "originalDefault": "Pricing logic"
+  },
+  "fVNaJK": {
+    "defaultMessage": "Objecttype version",
+    "description": "Objects API registration options \"Objecttype version\" label",
+    "originalDefault": "Objecttype version"
   },
   "fWcg7I": {
     "defaultMessage": "Object",
@@ -1719,6 +1789,11 @@
     "description": "Manage complex process vars configure column title",
     "originalDefault": "Configure"
   },
+  "hwD3q9": {
+    "defaultMessage": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag",
+    "description": "Objects API registration options \"Upload submission CSV\" description",
+    "originalDefault": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag"
+  },
   "hzx+WF": {
     "defaultMessage": "Internal name",
     "description": "Form name field label",
@@ -1728,6 +1803,16 @@
     "defaultMessage": "Tab name",
     "description": "Name of the tab in the Form admin",
     "originalDefault": "Tab name"
+  },
+  "iHpAYZ": {
+    "defaultMessage": "This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field.",
+    "description": "Objects API registration options \"Payment status update JSON template\" description",
+    "originalDefault": "This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field."
+  },
+  "iNmPDd": {
+    "defaultMessage": "Attachment informatieobjecttype",
+    "description": "Objects API registration options \"Attachment informatieobjecttype\" label",
+    "originalDefault": "Attachment informatieobjecttype"
   },
   "iZESbd": {
     "defaultMessage": "is less than",
@@ -1749,10 +1834,20 @@
     "description": "form step label in nav",
     "originalDefault": "{name} [new]"
   },
+  "j7rEgn": {
+    "defaultMessage": "Submission report PDF informatieobjecttype",
+    "description": "Objects API registration options \"Submission report PDF informatieobjecttype\" label",
+    "originalDefault": "Submission report PDF informatieobjecttype"
+  },
   "jARYB7": {
     "defaultMessage": "Form definition",
     "description": "Form definition module title",
     "originalDefault": "Form definition"
+  },
+  "jCUorM": {
+    "defaultMessage": "Something went wrong when fectching the available Objecttypes and versions",
+    "description": "Objects API registrations options API error",
+    "originalDefault": "Something went wrong when fectching the available Objecttypes and versions"
   },
   "jU/t8O": {
     "defaultMessage": "Edit complex variable",
@@ -1814,10 +1909,20 @@
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
   },
+  "kQtrKX": {
+    "defaultMessage": "The type of ProductAanvraag",
+    "description": "Objects API registration options \"Productaanvraag type\" description",
+    "originalDefault": "The type of ProductAanvraag"
+  },
   "koVh3m": {
     "defaultMessage": "Category",
     "description": "Form category field label",
     "originalDefault": "Category"
+  },
+  "l/mtou": {
+    "defaultMessage": "Payment status update JSON template",
+    "description": "Objects API registration options \"Payment status update JSON template\" label",
+    "originalDefault": "Payment status update JSON template"
   },
   "l1fi1t": {
     "defaultMessage": "(missing information)",
@@ -2059,6 +2164,11 @@
     "description": "Variable table data type title",
     "originalDefault": "Data type"
   },
+  "rJTe9U": {
+    "defaultMessage": "Objecttype",
+    "description": "Objects API registration options \"Objecttype\" label",
+    "originalDefault": "Objecttype"
+  },
   "rTafvA": {
     "defaultMessage": "Float",
     "description": "data type float",
@@ -2093,6 +2203,11 @@
     "defaultMessage": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }",
     "description": "Managed mappings state feedback",
     "originalDefault": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }"
+  },
+  "sptpzv": {
+    "defaultMessage": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?",
+    "description": "Objects API registration backend: v2 switch warning message",
+    "originalDefault": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?"
   },
   "t9+e9k": {
     "defaultMessage": "Are you sure you want to remove this mapping?",
@@ -2283,6 +2398,11 @@
     "defaultMessage": "Action",
     "description": "Action column header",
     "originalDefault": "Action"
+  },
+  "zF8YEc": {
+    "defaultMessage": "Organisation RSIN",
+    "description": "Objects API registration options \"Organisation RSIN\" label",
+    "originalDefault": "Organisation RSIN"
   },
   "zGMQ75": {
     "defaultMessage": "User defined",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -39,6 +39,11 @@
     "description": "Locations Component field label",
     "originalDefault": "Locations Component"
   },
+  "/fAEsY": {
+    "defaultMessage": "Submission report CSV informatieobjecttype",
+    "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
+    "originalDefault": "Submission report CSV informatieobjecttype"
+  },
   "/hIJ8m": {
     "defaultMessage": "Datum veld",
     "description": "Dates Component field label",
@@ -189,6 +194,11 @@
     "defaultMessage": "Naam",
     "description": "Form name field label",
     "originalDefault": "Name"
+  },
+  "51k2La": {
+    "defaultMessage": "JSON content field",
+    "description": "Objects API registration options \"JSON content field\" label",
+    "originalDefault": "JSON content field"
   },
   "5AC1+x": {
     "defaultMessage": "De ingevulde veldwaarde wordt gebruikt als waarde voor de procesvariabele.",
@@ -397,6 +407,11 @@
     "defaultMessage": "Bewaartermijn voor niet voltooide inzendingen inzendingen",
     "description": "Errored Submissions Removal Limit field label",
     "originalDefault": "Errored Submissions Removal Limit"
+  },
+  "A/vedA": {
+    "defaultMessage": "JSON template for the body of the request sent to the Objects API.",
+    "description": "Objects API registration options \"JSON content field\" description",
+    "originalDefault": "JSON template for the body of the request sent to the Objects API."
   },
   "A1tDIH": {
     "defaultMessage": "Naam",
@@ -735,6 +750,11 @@
     "description": "Errored Submissions Removal Limit help text",
     "originalDefault": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
   },
+  "HKA7Ic": {
+    "defaultMessage": "Productaanvraag type",
+    "description": "Objects API registration options \"Productaanvraag type\" label",
+    "originalDefault": "Productaanvraag type"
+  },
   "HXE3Mm": {
     "defaultMessage": "URL-deel van het formulier.",
     "description": "Form slug field help text",
@@ -990,6 +1010,11 @@
     "description": "Locations Component field help text",
     "originalDefault": "Component where locations for an appointment will be shown"
   },
+  "NwxORf": {
+    "defaultMessage": "Upload submission CSV",
+    "description": "Objects API registration options \"Upload submission CSV\" label",
+    "originalDefault": "Upload submission CSV"
+  },
   "O/wKJh": {
     "defaultMessage": "Waarde",
     "description": "JSON (primitive) value label",
@@ -1149,6 +1174,11 @@
     "description": "Variable table initial value title",
     "originalDefault": "Initial value"
   },
+  "RrjozJ": {
+    "defaultMessage": "URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: \"submission_id\", \"type\" (the type of productaanvraag) and \"data\" (the submitted form data)",
+    "description": "Objects API registration options \"Objecttype\" description",
+    "originalDefault": "URL that points to the ProductAanvraag objecttype in the Objecttypes API. The objecttype should have the following three attributes: \"submission_id\", \"type\" (the type of productaanvraag) and \"data\" (the submitted form data)"
+  },
   "RvJXSo": {
     "defaultMessage": "zet de waarde van een variabele/component",
     "description": "action type \"variable\" label",
@@ -1244,6 +1274,11 @@
     "description": "option \"disabled\" of statement checkbox configuration",
     "originalDefault": "Do not ask"
   },
+  "U/t6b+": {
+    "defaultMessage": "Variables Mapping",
+    "description": "Objects API registration backend options 'Variables Mapping' tab label",
+    "originalDefault": "Variables Mapping"
+  },
   "UHlGZJ": {
     "defaultMessage": "Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de openbaarheid bestemd is. Dit wordt toegepast op de zaakdocumenten die aangemaakt worden.",
     "description": "Confidentiality",
@@ -1321,6 +1356,11 @@
     "description": "Variable table prefill plugin title",
     "originalDefault": "Prefill plugin"
   },
+  "WnKF/i": {
+    "defaultMessage": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments",
+    "description": "Objects API registration options \"Attachment informatieobjecttype\" description",
+    "originalDefault": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission attachments"
+  },
   "Wz5QZo": {
     "defaultMessage": "Actief",
     "description": "Form list 'active' column header",
@@ -1340,6 +1380,11 @@
     "defaultMessage": "Ongeldige JSON-logic expressie. Zie https://jsonlogic.com/operations.html voor beschikbare operaties.",
     "description": "Advanced logic rule invalid JSON-logic message",
     "originalDefault": "Invalid JSON logic expression"
+  },
+  "XPEv9r": {
+    "defaultMessage": "Legacy",
+    "description": "Objects API registration backend options 'Legacy' tab label",
+    "originalDefault": "Legacy"
   },
   "XPLnIL": {
     "defaultMessage": "Registratie-instellingen bewerken",
@@ -1390,6 +1435,11 @@
     "defaultMessage": "Item toevoegen",
     "description": "JSON editor: add array value button",
     "originalDefault": "Add item"
+  },
+  "Yyvvx1": {
+    "defaultMessage": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV",
+    "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" description",
+    "originalDefault": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report CSV"
   },
   "YzLSHY": {
     "defaultMessage": "Weet u zeker dat u dit wilt verwijderen?",
@@ -1588,10 +1638,20 @@
     "description": "data type date",
     "originalDefault": "Date"
   },
+  "dwkDsV": {
+    "defaultMessage": "Version of the objecttype in the Objecttypes API",
+    "description": "Objects API registration options \"Objecttype version\" description",
+    "originalDefault": "Version of the objecttype in the Objecttypes API"
+  },
   "eBk+W0": {
     "defaultMessage": "Beheer procesvariabelen",
     "description": "Camunda process var selection modal title",
     "originalDefault": "Manage process variables"
+  },
+  "eBtStW": {
+    "defaultMessage": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF",
+    "description": "Objects API registration options \"Submission report PDF informatieobjecttype\" description",
+    "originalDefault": "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used for the submission report PDF"
   },
   "eJEu3L": {
     "defaultMessage": "Weet u zeker dat u deze regel wil verwijderen?",
@@ -1602,6 +1662,11 @@
     "defaultMessage": "Geavanceerde opties",
     "description": "Logic rule advanced options icon title",
     "originalDefault": "Advanced options"
+  },
+  "eR8wGd": {
+    "defaultMessage": "RSIN of organization, which creates the INFORMATIEOBJECT",
+    "description": "Objects API registration options \"Organisation RSIN\" description",
+    "originalDefault": "RSIN of organization, which creates the INFORMATIEOBJECT"
   },
   "eU7+uS": {
     "defaultMessage": "Bevestigen",
@@ -1632,6 +1697,11 @@
     "defaultMessage": "Prijslogica",
     "description": "Dynamic pricing fieldset title",
     "originalDefault": "Pricing logic"
+  },
+  "fVNaJK": {
+    "defaultMessage": "Objecttype version",
+    "description": "Objects API registration options \"Objecttype version\" label",
+    "originalDefault": "Objecttype version"
   },
   "fWcg7I": {
     "defaultMessage": "Sleutel-waarde paar (object)",
@@ -1733,6 +1803,11 @@
     "description": "Manage complex process vars configure column title",
     "originalDefault": "Configure"
   },
+  "hwD3q9": {
+    "defaultMessage": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag",
+    "description": "Objects API registration options \"Upload submission CSV\" description",
+    "originalDefault": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the ProductAanvraag"
+  },
   "hzx+WF": {
     "defaultMessage": "Interne naam",
     "description": "Form name field label",
@@ -1742,6 +1817,16 @@
     "defaultMessage": "Tabnaam",
     "description": "Name of the tab in the Form admin",
     "originalDefault": "Tab name"
+  },
+  "iHpAYZ": {
+    "defaultMessage": "This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field.",
+    "description": "Objects API registration options \"Payment status update JSON template\" description",
+    "originalDefault": "This template is evaluated with the submission data and the resulting JSON is sent to the objects API with a PATCH to update the payment field."
+  },
+  "iNmPDd": {
+    "defaultMessage": "Attachment informatieobjecttype",
+    "description": "Objects API registration options \"Attachment informatieobjecttype\" label",
+    "originalDefault": "Attachment informatieobjecttype"
   },
   "iZESbd": {
     "defaultMessage": "is kleiner dan",
@@ -1763,10 +1848,20 @@
     "description": "form step label in nav",
     "originalDefault": "{name} [new]"
   },
+  "j7rEgn": {
+    "defaultMessage": "Submission report PDF informatieobjecttype",
+    "description": "Objects API registration options \"Submission report PDF informatieobjecttype\" label",
+    "originalDefault": "Submission report PDF informatieobjecttype"
+  },
   "jARYB7": {
     "defaultMessage": "(Herbruikbare) stapgegevens",
     "description": "Form definition module title",
     "originalDefault": "Form definition"
+  },
+  "jCUorM": {
+    "defaultMessage": "Something went wrong when fectching the available Objecttypes and versions",
+    "description": "Objects API registrations options API error",
+    "originalDefault": "Something went wrong when fectching the available Objecttypes and versions"
   },
   "jU/t8O": {
     "defaultMessage": "Wijzig complexe waarde",
@@ -1828,10 +1923,20 @@
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
   },
+  "kQtrKX": {
+    "defaultMessage": "The type of ProductAanvraag",
+    "description": "Objects API registration options \"Productaanvraag type\" description",
+    "originalDefault": "The type of ProductAanvraag"
+  },
   "koVh3m": {
     "defaultMessage": "Categorie",
     "description": "Form category field label",
     "originalDefault": "Category"
+  },
+  "l/mtou": {
+    "defaultMessage": "Payment status update JSON template",
+    "description": "Objects API registration options \"Payment status update JSON template\" label",
+    "originalDefault": "Payment status update JSON template"
   },
   "l1fi1t": {
     "defaultMessage": "(ontbrekende informatie)",
@@ -2074,6 +2179,11 @@
     "description": "Variable table data type title",
     "originalDefault": "Data type"
   },
+  "rJTe9U": {
+    "defaultMessage": "Objecttype",
+    "description": "Objects API registration options \"Objecttype\" label",
+    "originalDefault": "Objecttype"
+  },
   "rTafvA": {
     "defaultMessage": "Kommagetal (float)",
     "description": "data type float",
@@ -2109,6 +2219,11 @@
     "defaultMessage": "{varCount, plural, =0 {} one {(1 variabele gekoppeld)} other {({varCount} variabelen gekoppeld)} }",
     "description": "Managed mappings state feedback",
     "originalDefault": "{varCount, plural, =0 {} one {(1 variable mapped)} other {({varCount} variables mapped)} }"
+  },
+  "sptpzv": {
+    "defaultMessage": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?",
+    "description": "Objects API registration backend: v2 switch warning message",
+    "originalDefault": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?"
   },
   "t9+e9k": {
     "defaultMessage": "Ben je zeker dat je deze koppeling wil verwijderen?",
@@ -2299,6 +2414,11 @@
     "defaultMessage": "Actie",
     "description": "Action column header",
     "originalDefault": "Action"
+  },
+  "zF8YEc": {
+    "defaultMessage": "Organisation RSIN",
+    "description": "Objects API registration options \"Organisation RSIN\" label",
+    "originalDefault": "Organisation RSIN"
   },
   "zGMQ75": {
     "defaultMessage": "Gebruikersvariabelen",


### PR DESCRIPTION
Part of #3688.

To be resolved:
- https://github.com/open-formulieren/open-forms/pull/3847#discussion_r1483191636
- https://github.com/open-formulieren/open-forms/pull/3847#discussion_r1483222824
  I'm having an issue right now: as the selects are now required, a default objecttype gets selected as soon as the page loads. However, it does not trigger the `useAsync` for versions, resulting in an empty dropdown for versions.