### PR TITLE
:arrow_up: Bump to latest design-token-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "babel-jest": "^29.3.1",
         "classnames": "^2.3.1",
         "copy-to-clipboard": "^3.3.1",
-        "design-token-editor": "^0.5.1",
+        "design-token-editor": "^0.6.0",
         "flatpickr": "^4.6.9",
         "formik": "^2.2.9",
         "formiojs": "~4.13.0",
@@ -15685,14 +15685,12 @@
       }
     },
     "node_modules/design-token-editor": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/design-token-editor/-/design-token-editor-0.5.1.tgz",
-      "integrity": "sha512-zc/8h3KW0Cxtlro4QViDRYtsCdI3HOVT5cZ7xFDpUaSiSLLDW5kg3Bo/uER1ZA4Bm3zjO5VPLELCYETGQjcjtw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/design-token-editor/-/design-token-editor-0.6.0.tgz",
+      "integrity": "sha512-bX7+si7IXRUfsrcAm/rUX2QEMGvb3KXpUB5F887WT2C+d0pOSI0hdybzFGXC1fiB7KzMEsSFyX4T71gXAgMRKA==",
       "dependencies": {
         "clsx": "^1.2.1",
-        "color": "^4.2.3",
-        "lodash.isequal": "^4.5.0",
-        "lodash.set": "^4.3.2"
+        "color": "^4.2.3"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -20743,11 +20741,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -37992,14 +37985,12 @@
       "dev": true
     },
     "design-token-editor": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/design-token-editor/-/design-token-editor-0.5.1.tgz",
-      "integrity": "sha512-zc/8h3KW0Cxtlro4QViDRYtsCdI3HOVT5cZ7xFDpUaSiSLLDW5kg3Bo/uER1ZA4Bm3zjO5VPLELCYETGQjcjtw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/design-token-editor/-/design-token-editor-0.6.0.tgz",
+      "integrity": "sha512-bX7+si7IXRUfsrcAm/rUX2QEMGvb3KXpUB5F887WT2C+d0pOSI0hdybzFGXC1fiB7KzMEsSFyX4T71gXAgMRKA==",
       "requires": {
         "clsx": "^1.2.1",
-        "color": "^4.2.3",
-        "lodash.isequal": "^4.5.0",
-        "lodash.set": "^4.3.2"
+        "color": "^4.2.3"
       }
     },
     "destroy": {
@@ -41826,11 +41817,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-jest": "^29.3.1",
     "classnames": "^2.3.1",
     "copy-to-clipboard": "^3.3.1",
-    "design-token-editor": "^0.5.1",
+    "design-token-editor": "^0.6.0",
     "flatpickr": "^4.6.9",
     "formik": "^2.2.9",
     "formiojs": "~4.13.0",


### PR DESCRIPTION
This one drops the dependency on lodash entirely, resolving some open @dependabot alerts