### PR TITLE
Django 4.2 upgrade preparations - debug toolbar changes

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -10,6 +10,5 @@ django-rosetta
 
 # Debug tooling
 django-debug-toolbar
-ddt-api-calls
 django-extensions
 django-silk

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -286,7 +286,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-debug-toolbar==3.2.1
+django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
 django-decorator-include==3.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -184,8 +184,6 @@ cssselect2==0.7.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-ddt-api-calls==0.3.2
-    # via -r requirements/dev.in
 defusedxml==0.7.1
     # via
     #   -c requirements/ci.txt
@@ -197,7 +195,6 @@ django==3.2.24
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   ddt-api-calls
     #   django-admin-index
     #   django-appconf
     #   django-axes
@@ -939,7 +936,6 @@ requests==2.31.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   ape-pie
-    #   ddt-api-calls
     #   django-camunda
     #   django-log-outgoing-requests
     #   django-rosetta
@@ -966,7 +962,6 @@ requests-mock==1.8.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   ddt-api-calls
     #   zgw-consumers
 requests-oauthlib==1.3.0
     # via

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -99,26 +99,9 @@ CACHES.update(
 ELASTIC_APM["DEBUG"] = config("DISABLE_APM_IN_DEV", default=True)
 
 # Django debug toolbar
-INSTALLED_APPS += ["debug_toolbar", "ddt_api_calls"]
+INSTALLED_APPS += ["debug_toolbar"]
 MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 INTERNAL_IPS = ("127.0.0.1",)
-DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}
-DEBUG_TOOLBAR_PANELS = [
-    "debug_toolbar.panels.versions.VersionsPanel",
-    "debug_toolbar.panels.timer.TimerPanel",
-    "debug_toolbar.panels.settings.SettingsPanel",
-    "debug_toolbar.panels.headers.HeadersPanel",
-    "debug_toolbar.panels.request.RequestPanel",
-    "debug_toolbar.panels.sql.SQLPanel",
-    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
-    "debug_toolbar.panels.templates.TemplatesPanel",
-    "debug_toolbar.panels.cache.CachePanel",
-    "debug_toolbar.panels.signals.SignalsPanel",
-    "debug_toolbar.panels.logging.LoggingPanel",
-    "debug_toolbar.panels.redirects.RedirectsPanel",
-    "debug_toolbar.panels.profiling.ProfilingPanel",
-    "ddt_api_calls.panels.APICallsPanel",
-]
 
 # Django extensions
 INSTALLED_APPS += ["django_extensions"]


### PR DESCRIPTION
Part of #3049

* Drop ddt-api-calls toolbar panel
* Upgrade django-debug-toolbar itself to a version that supports both 3.2 and 4.2
* Removed obsoleted settings/configuration