### PR TITLE
Bump to the latest factory-boy version

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -437,12 +437,12 @@ face==20.1.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   glom
-factory-boy==3.0.1
+factory-boy==3.3.0
     # via
     #   -r requirements/test-tools.in
     #   django-simple-certmanager
     #   zgw-consumers
-faker==7.0.1
+faker==23.1.0
     # via
     #   factory-boy
     #   zgw-consumers
@@ -954,8 +954,6 @@ tblib==1.7.0
     # via -r requirements/test-tools.in
 testfixtures==6.17.1
     # via -r requirements/test-tools.in
-text-unidecode==1.3
-    # via faker
 tinycss2==1.1.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -479,13 +479,13 @@ face==20.1.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   glom
-factory-boy==3.0.1
+factory-boy==3.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-simple-certmanager
     #   zgw-consumers
-faker==7.0.1
+faker==23.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1120,11 +1120,6 @@ testfixtures==6.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-text-unidecode==1.3
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   faker
 tinycss2==1.1.0
     # via
     #   -c requirements/ci.txt

--- a/src/openforms/payments/tests/factories.py
+++ b/src/openforms/payments/tests/factories.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import patch
 
 import factory
+import faker
 
 from openforms.config.models import GlobalConfiguration
 from openforms.submissions.tests.factories import SubmissionFactory
@@ -18,11 +19,13 @@ def mocked_create_public_order_id_for(
         payment.public_order_id = extracted
         return
 
+    fake = faker.Faker()
+
     with patch(
         "openforms.payments.models.GlobalConfiguration.get_solo",
         return_value=GlobalConfiguration(),
     ):
-        pk = factory.Faker("random_int").generate() if not create else None
+        pk = fake.random_int() if not create else None
         payment.public_order_id = SubmissionPaymentManager.create_public_order_id_for(
             payment, pk=pk
         )

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.translation import get_language
 
 import factory
+import faker
 import magic
 from glom import PathAccessError, glom
 
@@ -336,7 +337,8 @@ class SubmissionFileAttachmentFactory(factory.django.DjangoModelFactory):
 
         # this is no longer a field on the model, but we still want to use the form/sub-variable generating machinery below
         if form_key is None:
-            form_key = factory.Faker("slug").generate()
+            fake = faker.Faker()
+            form_key = fake.slug()
 
         submission = file_attachment.submission_step.submission
         form_variable = submission.form.formvariable_set.filter(key=form_key).first()


### PR DESCRIPTION
Part of #3049

3.0 didn't officially support django 3.2 even. 3.3 explicitly provides support up until django 4.1, but likely 4.2 will also work.

This could potentially address some aspects of fd0c764c15312d07edae1d63ef129a41eb608148