### PR TITLE
[#3855] Retrieve variables from decision definitions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -86,9 +86,7 @@ cryptography==42.0.2
 cssselect2==0.7.0
     # via weasyprint
 defusedxml==0.7.1
-    # via
-    #   -r requirements/base.in
-    #   django-camunda
+    # via -r requirements/base.in
 django==3.2.24
     # via
     #   -r requirements/base.in
@@ -142,7 +140,7 @@ django-autoslug==1.9.9
     # via -r requirements/base.in
 django-axes[ipware]==6.0.5
     # via -r requirements/base.in
-django-camunda==0.13.0
+django-camunda==0.14.0
     # via -r requirements/base.in
 django-capture-tag==1.0
     # via -r requirements/base.in
@@ -300,6 +298,7 @@ lazy-object-proxy==1.9.0
 lxml==4.9.1
     # via
     #   -r requirements/base.in
+    #   django-camunda
     #   django-digid-eherkenning
     #   mail-cleaner
     #   maykin-python3-saml

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -165,7 +165,6 @@ defusedxml==0.7.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-camunda
 django==3.2.24
     # via
     #   -c requirements/base.txt
@@ -230,7 +229,7 @@ django-axes[ipware]==6.0.5
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-axes
-django-camunda==0.13.0
+django-camunda==0.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -556,6 +555,7 @@ lxml==4.9.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-camunda
     #   django-digid-eherkenning
     #   mail-cleaner
     #   maykin-python3-saml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -188,7 +188,6 @@ defusedxml==0.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-camunda
 django==3.2.24
     # via
     #   -c requirements/ci.txt
@@ -257,7 +256,7 @@ django-axes[ipware]==6.0.5
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-axes
-django-camunda==0.13.0
+django-camunda==0.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -628,6 +627,7 @@ lxml==4.9.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-camunda
     #   django-digid-eherkenning
     #   mail-cleaner
     #   maykin-python3-saml

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -130,7 +130,6 @@ defusedxml==0.7.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-    #   django-camunda
 django==3.2.24
     # via
     #   -c requirements/base.in
@@ -195,7 +194,7 @@ django-axes[ipware]==6.0.5
     #   -c requirements/base.in
     #   -r requirements/base.txt
     #   django-axes
-django-camunda==0.13.0
+django-camunda==0.14.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -459,6 +458,7 @@ lxml==4.9.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
+    #   django-camunda
     #   django-digid-eherkenning
     #   mail-cleaner
     #   maykin-python3-saml

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -690,6 +690,80 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+  /api/v2/dmn/decision-definitions/inputs-outputs:
+    get:
+      operationId: dmn_decision_definitions_inputs_outputs_retrieve
+      summary: Retrieve the decision definition input/output clauses
+      parameters:
+      - in: query
+        name: definition
+        schema:
+          type: string
+        description: Identifier of the definition to retrieve available versions for.
+        required: true
+      - in: query
+        name: engine
+        schema:
+          type: string
+          enum:
+          - camunda7
+        description: Identifier of the decision engine to query. Note that some engines
+          may be disabled at runtime.
+        required: true
+      - in: query
+        name: version
+        schema:
+          type: string
+      tags:
+      - dmn
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionDefinitionIntrospectionResult'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/dmn/decision-definitions/versions:
     get:
       operationId: dmn_decision_definitions_versions_list
@@ -6868,6 +6942,79 @@ components:
       required:
       - id
       - label
+    DecisionDefinitionInput:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the decision table input.
+        label:
+          type: string
+          description: Short description of the input.
+        expression:
+          type: string
+          description: Specifies how the value of the input clause is generated. It
+            usually simple references a variable which is available during the evaluation.
+        typeRef:
+          allOf:
+          - $ref: '#/components/schemas/TypeRefEnum'
+          description: |-
+            The type of the input expression after being evaluated.
+
+            * `string` - string
+            * `integer` - integer
+            * `long` - long
+            * `boolean` - boolean
+            * `date` - date
+            * `double` - double
+      required:
+      - expression
+      - id
+      - label
+      - typeRef
+    DecisionDefinitionIntrospectionResult:
+      type: object
+      properties:
+        inputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DecisionDefinitionInput'
+        outputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DecisionDefinitionOutput'
+      required:
+      - inputs
+      - outputs
+    DecisionDefinitionOutput:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the decision table output.
+        label:
+          type: string
+          description: Short description of the output.
+        name:
+          type: string
+          description: Used to reference the value of the output.
+        typeRef:
+          allOf:
+          - $ref: '#/components/schemas/TypeRefEnum'
+          description: |-
+            The type of the output clause.
+
+            * `string` - string
+            * `integer` - integer
+            * `long` - long
+            * `boolean` - boolean
+            * `date` - date
+            * `double` - double
+      required:
+      - id
+      - label
+      - name
+      - typeRef
     DecisionDefinitionVersion:
       type: object
       properties:
@@ -9636,6 +9783,22 @@ components:
           format: date-time
       required:
       - time
+    TypeRefEnum:
+      enum:
+      - string
+      - integer
+      - long
+      - boolean
+      - date
+      - double
+      type: string
+      description: |-
+        * `string` - string
+        * `integer` - integer
+        * `long` - long
+        * `boolean` - boolean
+        * `date` - date
+        * `double` - double
     UsedInForm:
       type: object
       properties:

--- a/src/openforms/dmn/api/constants.py
+++ b/src/openforms/dmn/api/constants.py
@@ -1,0 +1,11 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class DMNTypes(models.TextChoices):
+    string = "string", _("string")
+    integer = "integer", _("integer")
+    long = "long", _("long")
+    boolean = "boolean", _("boolean")
+    date = "date", _("date")
+    double = "double", _("double")

--- a/src/openforms/dmn/api/serializers.py
+++ b/src/openforms/dmn/api/serializers.py
@@ -4,6 +4,8 @@ from rest_framework import serializers
 
 from openforms.plugins.api.serializers import PluginBaseSerializer
 
+from .constants import DMNTypes
+
 
 class DecisionPluginSerializer(PluginBaseSerializer):
     pass
@@ -41,3 +43,45 @@ class DecisionDefinitionXMLSerializer(serializers.Serializer):
         label=_("DMN XML"),
         help_text=_("If no XML can be obtained, the value will be an empty string."),
     )
+
+
+class DecisionDefinitionInputSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        label=_("ID"), help_text=_("Unique identifier of the decision table input.")
+    )
+    label = serializers.CharField(
+        label=_("label"), help_text=_("Short description of the input.")
+    )
+    expression = serializers.CharField(
+        label=_("expression"),
+        help_text=_(
+            "Specifies how the value of the input clause is generated. "
+            "It usually simple references a variable which is available during the evaluation."
+        ),
+    )
+    type_ref = serializers.ChoiceField(
+        choices=DMNTypes.choices,
+        help_text=_("The type of the input expression after being evaluated."),
+    )
+
+
+class DecisionDefinitionOutputSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        label=_("ID"), help_text=_("Unique identifier of the decision table output.")
+    )
+    label = serializers.CharField(
+        label=_("label"), help_text=_("Short description of the output.")
+    )
+    name = serializers.CharField(
+        label=_("name"),
+        help_text=_("Used to reference the value of the output."),
+    )
+    type_ref = serializers.ChoiceField(
+        choices=DMNTypes.choices,
+        help_text=_("The type of the output clause."),
+    )
+
+
+class DecisionDefinitionIntrospectionResultSerializer(serializers.Serializer):
+    inputs = DecisionDefinitionInputSerializer(many=True)
+    outputs = DecisionDefinitionOutputSerializer(many=True)

--- a/src/openforms/dmn/api/urls.py
+++ b/src/openforms/dmn/api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    DecisionDefinitionInputOutputView,
     DecisionDefinitionListView,
     DecisionDefinitionVersionListView,
     DecisionDefinitionXMLView,
@@ -23,5 +24,10 @@ urlpatterns = [
         "decision-definitions/xml",
         DecisionDefinitionXMLView.as_view(),
         name="dmn-definition-xml",
+    ),
+    path(
+        "decision-definitions/inputs-outputs",
+        DecisionDefinitionInputOutputView.as_view(),
+        name="dmn-definition-inputs-outputs",
     ),
 ]

--- a/src/openforms/dmn/base.py
+++ b/src/openforms/dmn/base.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from django_camunda.dmn.datastructures import DMNIntrospectionResult
+
 from openforms.plugins.plugin import AbstractBasePlugin
 
 
@@ -65,3 +67,16 @@ class BasePlugin(ABC, AbstractBasePlugin):
         If this is not available, return an empty string.
         """
         return ""
+
+    def get_decision_definition_parameters(
+        self, definition_id: str, version: str = ""
+    ) -> DMNIntrospectionResult | None:
+        """
+        Return the input/output clauses for a given decision definition (version).
+
+        An input clause defines the id, label, expression and type of a decision table input. It is represented by an
+        input element inside a decisionTable XML element.
+        An output clause defines the id, label, name and type of a decision table output. It is represented by an
+        output element inside a decisionTable XML element.
+        """
+        return None

--- a/src/openforms/dmn/base.py
+++ b/src/openforms/dmn/base.py
@@ -2,9 +2,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
-from django_camunda.dmn.datastructures import DMNIntrospectionResult
-
 from openforms.plugins.plugin import AbstractBasePlugin
+
+from .types import DMNInputOutput
 
 
 @dataclass
@@ -68,9 +68,10 @@ class BasePlugin(ABC, AbstractBasePlugin):
         """
         return ""
 
+    @abstractmethod
     def get_decision_definition_parameters(
         self, definition_id: str, version: str = ""
-    ) -> DMNIntrospectionResult | None:
+    ) -> DMNInputOutput:
         """
         Return the input/output clauses for a given decision definition (version).
 
@@ -79,4 +80,4 @@ class BasePlugin(ABC, AbstractBasePlugin):
         An output clause defines the id, label, name and type of a decision table output. It is represented by an
         output element inside a decisionTable XML element.
         """
-        return None
+        ...

--- a/src/openforms/dmn/contrib/camunda/plugin.py
+++ b/src/openforms/dmn/contrib/camunda/plugin.py
@@ -8,6 +8,8 @@ import requests
 import simplejson  # dependency pulled in via mail-parser...
 from django_camunda.client import Camunda, get_client
 from django_camunda.dmn import evaluate_dmn
+from django_camunda.dmn.datastructures import DMNIntrospectionResult
+from django_camunda.dmn.parser import Parser
 
 from ...base import BasePlugin, DecisionDefinition, DecisionDefinitionVersion
 from ...registry import register
@@ -122,3 +124,12 @@ class Plugin(BasePlugin):
 
     def check_config(self):
         check_config(self)
+
+    def get_decision_definition_parameters(
+        self, definition_id: str, version: str = ""
+    ) -> DMNIntrospectionResult:
+        xml_doc = self.get_definition_xml(definition_id, version)
+
+        parser = Parser(xml=xml_doc.encode("utf-8"))
+
+        return parser.extract_parameters(definition_id)

--- a/src/openforms/dmn/contrib/camunda/plugin.py
+++ b/src/openforms/dmn/contrib/camunda/plugin.py
@@ -7,9 +7,8 @@ from django.utils.translation import gettext_lazy as _
 import requests
 import simplejson  # dependency pulled in via mail-parser...
 from django_camunda.client import Camunda, get_client
-from django_camunda.dmn import evaluate_dmn
+from django_camunda.dmn import evaluate_dmn, get_dmn_parser
 from django_camunda.dmn.datastructures import DMNIntrospectionResult
-from django_camunda.dmn.parser import Parser
 
 from ...base import BasePlugin, DecisionDefinition, DecisionDefinitionVersion
 from ...registry import register
@@ -128,8 +127,9 @@ class Plugin(BasePlugin):
     def get_decision_definition_parameters(
         self, definition_id: str, version: str = ""
     ) -> DMNIntrospectionResult:
-        xml_doc = self.get_definition_xml(definition_id, version)
-
-        parser = Parser(xml=xml_doc.encode("utf-8"))
-
+        with get_client() as client:
+            camunda_id = _get_decision_definition_id(client, definition_id, version)
+            parser = get_dmn_parser(
+                dmn_key=definition_id, dmn_id=camunda_id, client=client
+            )
         return parser.extract_parameters(definition_id)

--- a/src/openforms/dmn/contrib/camunda/tests/test_plugin.py
+++ b/src/openforms/dmn/contrib/camunda/tests/test_plugin.py
@@ -150,3 +150,40 @@ class CamundaDMNTests(TestCase):
                 capture.records[1].msg,
                 "Could not decode JSON data in error response body",
             )
+
+    def test_get_inputs_outputs(self):
+        params = plugin.get_decision_definition_parameters(
+            "invoiceClassification", version="1"
+        )
+
+        inputs = params.inputs
+        outputs = params.outputs
+
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs[0]["label"], "Invoice Amount")
+        self.assertEqual(inputs[0]["expression"], "amount")
+        self.assertEqual(inputs[1]["label"], "Invoice Category")
+        self.assertEqual(inputs[1]["expression"], "invoiceCategory")
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0]["label"], "Classification")
+        self.assertEqual(outputs[0]["name"], "invoiceClassification")
+
+    def test_get_inputs_outputs_table_with_dependency(self):
+        # This decision ID depends on the invoiceClassification table
+        params = plugin.get_decision_definition_parameters(
+            "invoice-assign-approver", version="1"
+        )
+
+        inputs = params.inputs
+        outputs = params.outputs
+
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs[0]["label"], "Invoice Amount")
+        self.assertEqual(inputs[0]["expression"], "amount")
+        self.assertEqual(inputs[1]["label"], "Invoice Category")
+        self.assertEqual(inputs[1]["expression"], "invoiceCategory")
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0]["label"], "Approver Group")
+        self.assertEqual(outputs[0]["name"], "result")

--- a/src/openforms/dmn/tests/test_api.py
+++ b/src/openforms/dmn/tests/test_api.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-from django_camunda.dmn.datastructures import DMNIntrospectionResult
-from django_camunda.dmn.types import DMNInputParameter, DMNOutputParameter
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -11,6 +9,7 @@ from openforms.api.tests.utils import APITestAssertions
 
 from ..base import BasePlugin, DecisionDefinition, DecisionDefinitionVersion
 from ..registry import Registry
+from ..types import DMNInputOutput
 
 register = Registry()
 
@@ -33,37 +32,37 @@ class TestPlugin(BasePlugin):
     @staticmethod
     def get_decision_definition_parameters(
         self, definition_id: str, version: str = ""
-    ) -> DMNIntrospectionResult:
-        return DMNIntrospectionResult(
-            inputs=[
-                DMNInputParameter(
-                    id="clause1",
-                    label="Invoice Amount",
-                    expression="amount",
-                    type_ref="double",
-                ),
-                DMNInputParameter(
-                    id="InputClause_15qmk0v",
-                    label="Invoice Category",
-                    expression="invoiceCategory",
-                    type_ref="string",
-                ),
+    ) -> DMNInputOutput:
+        return {
+            "inputs": [
+                {
+                    "id": "clause1",
+                    "label": "Invoice Amount",
+                    "expression": "amount",
+                    "type_ref": "double",
+                },
+                {
+                    "id": "InputClause_15qmk0v",
+                    "label": "Invoice Category",
+                    "expression": "invoiceCategory",
+                    "type_ref": "string",
+                },
             ],
-            outputs=[
-                DMNOutputParameter(
-                    id="clause3",
-                    label="Classification",
-                    name="invoiceClassification",
-                    type_ref="string",
-                ),
-                DMNOutputParameter(
-                    id="OutputClause_1cthd0w",
-                    label="Approver Group",
-                    name="result",
-                    type_ref="string",
-                ),
+            "outputs": [
+                {
+                    "id": "clause3",
+                    "label": "Classification",
+                    "name": "invoiceClassification",
+                    "type_ref": "string",
+                },
+                {
+                    "id": "OutputClause_1cthd0w",
+                    "label": "Approver Group",
+                    "name": "result",
+                    "type_ref": "string",
+                },
             ],
-        )
+        }
 
     @staticmethod
     def evaluate(

--- a/src/openforms/dmn/tests/test_management_commands.py
+++ b/src/openforms/dmn/tests/test_management_commands.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from ..base import BasePlugin, DecisionDefinition, DecisionDefinitionVersion
 from ..management.commands.dmn_evaluate import input_variable
 from ..registry import Registry
+from ..types import DMNInputOutput, GenericInputOutput
 
 register = Registry()
 
@@ -20,6 +21,12 @@ class Plugin1(BasePlugin):
     @staticmethod
     def evaluate(*args, **kwargs):
         pass
+
+    @staticmethod
+    def get_decision_definition_parameters(
+        definition_id: str, version: str = ""
+    ) -> DMNInputOutput:
+        return GenericInputOutput(inputs=[], outputs=[])
 
 
 @register("plugin2")
@@ -39,6 +46,12 @@ class Plugin2(BasePlugin):
 
     @staticmethod
     def evaluate(*args, **kwargs):
+        pass
+
+    @staticmethod
+    def get_decision_definition_parameters(
+        definition_id: str, version: str = ""
+    ) -> DMNInputOutput:
         pass
 
 

--- a/src/openforms/dmn/tests/test_registry.py
+++ b/src/openforms/dmn/tests/test_registry.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from ..base import BasePlugin, DecisionDefinition
 from ..registry import Registry
+from ..types import DMNInputOutput, GenericInputOutput
 
 register = Registry()
 
@@ -17,6 +18,12 @@ class TestPlugin(BasePlugin):
         definition_id, *, version: str = "", input_values: dict[str, int]
     ) -> dict[str, int]:
         return {"sum": sum([input_values["a"], input_values["b"]])}
+
+    @staticmethod
+    def get_decision_definition_parameters(
+        definition_id: str, version: str = ""
+    ) -> DMNInputOutput:
+        return GenericInputOutput(inputs=[], outputs=[])
 
 
 class RegistryTests(TestCase):

--- a/src/openforms/dmn/types.py
+++ b/src/openforms/dmn/types.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class DMNInputParameter(Protocol):
+    expression: str
+    label: str
+
+
+class DMNOutputParameter(Protocol):
+    name: str
+    label: str
+
+
+class DMNInputOutput(Protocol):
+    inputs: list[DMNInputParameter]
+    outputs: list[DMNOutputParameter]
+
+
+@dataclass
+class GenericInputOutput:
+    inputs: list[DMNInputParameter]
+    outputs: list[DMNOutputParameter]


### PR DESCRIPTION
Fixes #3855 (partially)

Backend part to get input/output "variables" from DMN decision definitions