### PR TITLE
Increase the number of docs linkcheck retries

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,8 @@ html_css_files = [
 
 todo_include_todos = True
 
+linkcheck_retries = 3
+
 linkcheck_ignore = [
     r"urn:*",
     r"https?://.*\.gemeente.nl",


### PR DESCRIPTION
Default is 1. This might help with the docs test failures