### PR TITLE
Remove defusedxml.lxml usage from dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -89,8 +89,6 @@ defusedxml==0.7.1
     # via
     #   -r requirements/base.in
     #   django-camunda
-    #   django-digid-eherkenning
-    #   maykin-python3-saml
 django==3.2.24
     # via
     #   -r requirements/base.in
@@ -160,7 +158,7 @@ django-csp-reports==1.8.1
     # via -r requirements/base.in
 django-decorator-include==3.0
     # via -r requirements/base.in
-django-digid-eherkenning==0.10.0
+django-digid-eherkenning==0.11.0
     # via -r requirements/base.in
 django-filter==23.2
     # via -r requirements/base.in
@@ -315,7 +313,7 @@ maykin-2fa==1.0.0
     # via -r requirements/base.in
 maykin-json-logic-py==0.13.0
     # via -r requirements/base.in
-maykin-python3-saml==1.14.0.post0
+maykin-python3-saml==1.16.0.post1
     # via django-digid-eherkenning
 mozilla-django-oidc==4.0.0
     # via mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -166,8 +166,6 @@ defusedxml==0.7.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-camunda
-    #   django-digid-eherkenning
-    #   maykin-python3-saml
 django==3.2.24
     # via
     #   -c requirements/base.txt
@@ -264,7 +262,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.10.0
+django-digid-eherkenning==0.11.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -585,7 +583,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-python3-saml==1.14.0.post0
+maykin-python3-saml==1.16.0.post1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -189,8 +189,6 @@ defusedxml==0.7.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-camunda
-    #   django-digid-eherkenning
-    #   maykin-python3-saml
 django==3.2.24
     # via
     #   -c requirements/ci.txt
@@ -293,7 +291,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.10.0
+django-digid-eherkenning==0.11.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -663,7 +661,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-python3-saml==1.14.0.post0
+maykin-python3-saml==1.16.0.post1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -131,8 +131,6 @@ defusedxml==0.7.1
     #   -c requirements/base.in
     #   -r requirements/base.txt
     #   django-camunda
-    #   django-digid-eherkenning
-    #   maykin-python3-saml
 django==3.2.24
     # via
     #   -c requirements/base.in
@@ -229,7 +227,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-digid-eherkenning==0.10.0
+django-digid-eherkenning==0.11.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -482,7 +480,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-maykin-python3-saml==1.14.0.post0
+maykin-python3-saml==1.16.0.post1
     # via
     #   -r requirements/base.txt
     #   django-digid-eherkenning


### PR DESCRIPTION
Closes #1052

The final dependency (django-camunda) will be upgraded through #3886, which results in us only using defusedxml to defuse the standard library. This is still necessary because xmltodict uses xml.sax/expat as it only supports `defusedexpat` rather than `defusedxml`.