### PR TITLE
Upgrade dependencies to lower startup time

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -371,7 +371,7 @@ pyopenssl==24.0.0
     #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
-pyphen==0.10.0
+pyphen==0.14.0
     # via weasyprint
 pyrsistent==0.17.3
     # via jsonschema
@@ -380,7 +380,7 @@ python-dateutil==2.8.1
     #   django-camunda
     #   django-relativedelta
     #   o365
-python-decouple==3.3
+python-decouple==3.8
     # via -r requirements/base.in
 python-dotenv==0.14.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -734,7 +734,7 @@ pyopenssl==24.0.0
     #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
-pyphen==0.10.0
+pyphen==0.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -757,7 +757,7 @@ python-dateutil==2.8.1
     #   faker
     #   freezegun
     #   o365
-python-decouple==3.3
+python-decouple==3.8
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -206,6 +206,7 @@ django==3.2.24
     #   django-debug-toolbar
     #   django-decorator-include
     #   django-digid-eherkenning
+    #   django-extensions
     #   django-filter
     #   django-formtools
     #   django-hijack
@@ -296,7 +297,7 @@ django-digid-eherkenning==0.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-extensions==3.0.7
+django-extensions==3.2.3
     # via -r requirements/dev.in
 django-filter==23.2
     # via
@@ -374,7 +375,7 @@ django-sessionprofile==2.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-django-silk==5.0.1
+django-silk==5.1.0
     # via -r requirements/dev.in
 django-simple-certmanager[testutils]==1.4.1
     # via
@@ -591,7 +592,6 @@ jinja2==3.1.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-silk
     #   sphinx
 josepy==1.8.0
     # via
@@ -850,7 +850,7 @@ pyopenssl==24.0.0
     #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
-pyphen==0.10.0
+pyphen==0.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -874,11 +874,10 @@ python-dateutil==2.8.1
     #   -r requirements/ci.txt
     #   django-camunda
     #   django-relativedelta
-    #   django-silk
     #   faker
     #   freezegun
     #   o365
-python-decouple==3.3
+python-decouple==3.8
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -897,7 +896,6 @@ pytz==2022.2.1
     #   babel
     #   celery
     #   django
-    #   django-silk
     #   django-yubin
     #   djangorestframework
     #   flower
@@ -939,7 +937,6 @@ requests==2.31.0
     #   django-camunda
     #   django-log-outgoing-requests
     #   django-rosetta
-    #   django-silk
     #   gemma-zds-client
     #   jsonschema-spec
     #   maykin-python3-saml

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -589,7 +589,7 @@ pyopenssl==24.0.0
     #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
-pyphen==0.10.0
+pyphen==0.14.0
     # via
     #   -r requirements/base.txt
     #   weasyprint
@@ -603,7 +603,7 @@ python-dateutil==2.8.1
     #   django-camunda
     #   django-relativedelta
     #   o365
-python-decouple==3.3
+python-decouple==3.8
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt


### PR DESCRIPTION
`pkg_resources` still gets imported at startup, I will try to figure out where so that it can be reduced. Current import graph:

![image](https://github.com/open-formulieren/open-forms/assets/65306057/61cc186e-3078-4e7e-b004-a8f315bd56fc)

---

- I also made a PR @ `weasyprint` to reduce the import time by 0.4s, hopefully will get accepted.
- `O365` takes 0.2s because of `bs4`. One solution would be to import the module in the client class instead of at the module level