### PR TITLE
[#3855] Catch errors when DMN plugin is not working

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -1,3 +1,5 @@
+@use 'microscope-sass/lib/bem';
+
 @import '@fortawesome/fontawesome-free/scss/fontawesome';
 @import '@fortawesome/fontawesome-free/scss/v4-shims.scss';
 @import '@fortawesome/fontawesome-free/scss/brands';
@@ -224,5 +226,9 @@ div.flatpickr-calendar.open {
 .form-row {
   .form-builder__container {
     color: var(--body-fg);
+  }
+
+  @include bem.modifier('no-bottom-line') {
+    border-bottom: 0;
   }
 }


### PR DESCRIPTION
Fixes #3855 
![Screenshot from 2024-02-20 11-48-07](https://github.com/open-formulieren/open-forms/assets/19154114/ea88895a-d110-4b6f-ad94-bba3532ef03d)

Maybe the plugin ID field should be kept out of the boundary so that the user can select a different plugin in case of errors. Or they can just create a new action and delete the one with errors?