### PR TITLE
✅ Import weasyprint early and increase hypothesis deadline

### DIFF
--- a/src/openforms/conf/ci.py
+++ b/src/openforms/conf/ci.py
@@ -11,6 +11,9 @@ import warnings
 # preventing flakiness in hypothesis tests that hit this code path.
 import idna  # noqa: F401
 
+# Heavy imports, can interfere with some tests making use of hypothesis' deadline:
+import weasyprint  # noqa: F401
+
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
 # Do not log requests in CI/tests:

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -640,7 +640,7 @@ class PDFSubmissionReportTests(HypothesisTestCase):
             alphabet=st.characters(blacklist_characters="\x00", codec="utf-8"),
         )
     )
-    @settings(deadline=500)
+    @settings(deadline=2000)
     def test_names_do_not_break_pdf_saving_to_disk(self, form_name):
         report = SubmissionReportFactory.create(submission__form__name=form_name)
         report.generate_submission_report_pdf()


### PR DESCRIPTION
weasyprint can take some extra time loading fonts when special characters need to be rendered. This isn't a big concern as realistically users will not create forms with such characters