### PR TITLE
[#3688] Add implementation of the Objects API mapping editor

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -3353,6 +3353,12 @@
       "value": "Authorised person"
     }
   ],
+  "cK2O6E": [
+    {
+      "type": 0,
+      "value": "Something went wrong when fetching the available target paths"
+    }
+  ],
   "cQvPLh": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -391,6 +391,12 @@
       "value": "CSS class"
     }
   ],
+  "3z1hhJ": [
+    {
+      "type": 0,
+      "value": "Toggle JSON Schema"
+    }
+  ],
   "4/cCvG": [
     {
       "type": 0,
@@ -721,6 +727,12 @@
     {
       "type": 0,
       "value": "Maximum date"
+    }
+  ],
+  "7Vx5It": [
+    {
+      "type": 0,
+      "value": "No compatible registration backend configured."
     }
   ],
   "7X6yT4": [
@@ -1331,6 +1343,18 @@
       "value": "The values that can be picked for this field. Values are the text that is submitted with the form data. Labels are the text next to radio buttons, checkboxes and options in dropdowns."
     }
   ],
+  "DRidde": [
+    {
+      "type": 0,
+      "value": "Could not retrieve the decision definitions IDs/versions. Is the selected DMN plugin running and properly configured?"
+    }
+  ],
+  "DaxIUG": [
+    {
+      "type": 0,
+      "value": "Variable key"
+    }
+  ],
   "DcI1VF": [
     {
       "type": 0,
@@ -1847,16 +1871,16 @@
       "value": "The data entered in this component will be removed in accordance with the privacy settings."
     }
   ],
-  "JN1BvY": [
-    {
-      "type": 0,
-      "value": "Add another"
-    }
-  ],
   "JRGs/Q": [
     {
       "type": 0,
       "value": "Expand/collapse JsonLogic"
+    }
+  ],
+  "JXcHQ2": [
+    {
+      "type": 0,
+      "value": "Not yet configured"
     }
   ],
   "JZRX+C": [
@@ -3955,6 +3979,12 @@
       "value": "Values"
     }
   ],
+  "j5KpZP": [
+    {
+      "type": 0,
+      "value": "loading..."
+    }
+  ],
   "j7rEgn": [
     {
       "type": 0,
@@ -4669,6 +4699,12 @@
       "value": "'Add another' text"
     }
   ],
+  "rkzjK3": [
+    {
+      "type": 0,
+      "value": "JSON Schema target"
+    }
+  ],
   "rzGuvz": [
     {
       "type": 0,
@@ -5093,6 +5129,34 @@
     {
       "type": 0,
       "value": "Objects API - objecttype"
+    }
+  ],
+  "y4U0aW": [
+    {
+      "options": {
+        "other": {
+          "value": [
+            {
+              "type": 1,
+              "value": "path"
+            }
+          ]
+        },
+        "true": {
+          "value": [
+            {
+              "type": 1,
+              "value": "path"
+            },
+            {
+              "type": 0,
+              "value": " (required)"
+            }
+          ]
+        }
+      },
+      "type": 5,
+      "value": "required"
     }
   ],
   "yCogwi": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -3354,6 +3354,12 @@
       "value": "Gemachtigde"
     }
   ],
+  "cK2O6E": [
+    {
+      "type": 0,
+      "value": "Something went wrong when fetching the available target paths"
+    }
+  ],
   "cQvPLh": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -391,6 +391,12 @@
       "value": "Weergavestijl"
     }
   ],
+  "3z1hhJ": [
+    {
+      "type": 0,
+      "value": "Toggle JSON Schema"
+    }
+  ],
   "4/cCvG": [
     {
       "type": 0,
@@ -721,6 +727,12 @@
     {
       "type": 0,
       "value": "Maximale datum"
+    }
+  ],
+  "7Vx5It": [
+    {
+      "type": 0,
+      "value": "No compatible registration backend configured."
     }
   ],
   "7X6yT4": [
@@ -1335,6 +1347,18 @@
       "value": "De mogelijke keuzeopties voor dit veld. De waarden worden in de formuliergegevens opgeslagen. De labels zijn de teksten die aan de gebruiker getoond worden."
     }
   ],
+  "DRidde": [
+    {
+      "type": 0,
+      "value": "Could not retrieve the decision definitions IDs/versions. Is the selected DMN plugin running and properly configured?"
+    }
+  ],
+  "DaxIUG": [
+    {
+      "type": 0,
+      "value": "Variable key"
+    }
+  ],
   "DcI1VF": [
     {
       "type": 0,
@@ -1851,16 +1875,16 @@
       "value": "Gegevens opgevoerd in dit component worden geschoond volgens de privacy-instellingen."
     }
   ],
-  "JN1BvY": [
-    {
-      "type": 0,
-      "value": "Nog één toevoegen"
-    }
-  ],
   "JRGs/Q": [
     {
       "type": 0,
       "value": "Klap JsonLogic-expressie in/uit"
+    }
+  ],
+  "JXcHQ2": [
+    {
+      "type": 0,
+      "value": "Not yet configured"
     }
   ],
   "JZRX+C": [
@@ -3931,7 +3955,7 @@
   "iq0ppL": [
     {
       "type": 0,
-      "value": "[EXPERIMENTEEL] Gebruik de nieuwe afspraakformulierenimplementatie."
+      "value": "Bij het inschakelen van de afsprakenmodus doorloopt de gebruiker een vaste flow."
     }
   ],
   "iqAbXt": [
@@ -3954,6 +3978,12 @@
     {
       "type": 0,
       "value": "Waarden"
+    }
+  ],
+  "j5KpZP": [
+    {
+      "type": 0,
+      "value": "loading..."
     }
   ],
   "j7rEgn": [
@@ -4671,6 +4701,12 @@
       "value": "'Groep toevoegen'-tekst"
     }
   ],
+  "rkzjK3": [
+    {
+      "type": 0,
+      "value": "JSON Schema target"
+    }
+  ],
   "rzGuvz": [
     {
       "type": 0,
@@ -5095,6 +5131,34 @@
     {
       "type": 0,
       "value": "Objecten API - objecttype"
+    }
+  ],
+  "y4U0aW": [
+    {
+      "options": {
+        "other": {
+          "value": [
+            {
+              "type": 1,
+              "value": "path"
+            }
+          ]
+        },
+        "true": {
+          "value": [
+            {
+              "type": 1,
+              "value": "path"
+            },
+            {
+              "type": 0,
+              "value": " (required)"
+            }
+          ]
+        }
+      },
+      "type": 5,
+      "value": "required"
     }
   ],
   "yCogwi": [

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -7,7 +7,7 @@ const FeatureFlagsContext = React.createContext({});
 FeatureFlagsContext.displayName = 'FeatureFlagsContext';
 
 const FormContext = React.createContext({
-  form: {url: ''},
+  form: {url: '', uuid: ''},
   components: {},
   formSteps: [],
   formDefinitions: [],

--- a/src/openforms/js/components/admin/form_design/constants.js
+++ b/src/openforms/js/components/admin/form_design/constants.js
@@ -3,6 +3,8 @@ export const FORM_DEFINITIONS_ENDPOINT = '/api/v2/form-definitions';
 export const REGISTRATION_BACKENDS_ENDPOINT = '/api/v2/registration/plugins';
 export const REGISTRATION_OBJECTTYPES_ENDPOINT =
   '/api/v2/registration/plugins/objects-api/object-types';
+export const REGISTRATION_OBJECTS_TARGET_PATHS =
+  '/api/v2/registration/plugins/objects-api/target-paths';
 export const AUTH_PLUGINS_ENDPOINT = '/api/v2/authentication/plugins';
 export const PREFILL_PLUGINS_ENDPOINT = '/api/v2/prefill/plugins';
 export const DMN_PLUGINS_ENDPOINT = '/api/v2/dmn/plugins';

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1435,6 +1435,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
                     payload: {key, propertyName, propertyValue},
                   })
                 }
+                onFieldChange={onFieldChange}
               />
             </TabPanel>
           )}

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1214,7 +1214,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
 
       <FormContext.Provider
         value={{
-          form: {url: state.form.url},
+          form: {url: state.form.url, uuid: state.form.uuid},
           components: availableComponents,
           formSteps: state.formSteps,
           formDefinitions: state.formDefinitions,

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -12,7 +12,6 @@ import ZGWOptionsForm from './zgw';
  *   form?: React.FC,
  *   uiSchema?: Object,
  *   configurableFromVariables?: boolean | (options: Object) => boolean,
- *   formVariableConfigured: (variable: Object, options: Object) => boolean,
  *   summaryHandler?: React.FC
  * }} BackendInfo
  * A map of backend ID to components for the (advanced) option forms.
@@ -27,8 +26,6 @@ export const BACKEND_OPTIONS_FORMS = {
     form: ObjectsApiOptionsForm,
     onStepEdit: null,
     configurableFromVariables: options => options.version === 2,
-    formVariableConfigured: (variable, options) =>
-      options.variablesMapping.some(mapping => mapping.variableKey === variable.key),
     summaryHandler: ObjectsApiSummaryHandler,
     variableConfigurationEditor: ObjectsApiVariableConfigurationEditor,
   },

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -13,6 +13,7 @@ import ZGWOptionsForm from './zgw';
  *   uiSchema?: Object,
  *   configurableFromVariables?: boolean | (options: Object) => boolean,
  *   summaryHandler?: React.FC
+ *   variableConfigurationEditor?: React.FC
  * }} BackendInfo
  * A map of backend ID to components for the (advanced) option forms.
  * @type {{[key: string]: BackendInfo}}

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -4,6 +4,7 @@ import CamundaOptionsForm from './camunda';
 import {onCamundaStepEdit, onZGWStepEdit} from './handlers';
 import ObjectsApiOptionsForm from './objectsapi/ObjectsApiOptionsForm';
 import ObjectsApiSummaryHandler from './objectsapi/ObjectsApiSummaryHandler';
+import ObjectsApiVariableConfigurationEditor from './objectsapi/ObjectsApiVariableConfigurationEditor';
 import ZGWOptionsForm from './zgw';
 
 /**
@@ -11,7 +12,7 @@ import ZGWOptionsForm from './zgw';
  *   form?: React.FC,
  *   uiSchema?: Object,
  *   configurableFromVariables?: boolean | (options: Object) => boolean,
- *   formVariableConfigured: (variableKey: string, options: Object) => boolean,
+ *   formVariableConfigured: (variable: Object, options: Object) => boolean,
  *   summaryHandler?: React.FC
  * }} BackendInfo
  * A map of backend ID to components for the (advanced) option forms.
@@ -26,9 +27,10 @@ export const BACKEND_OPTIONS_FORMS = {
     form: ObjectsApiOptionsForm,
     onStepEdit: null,
     configurableFromVariables: options => options.version === 2,
-    formVariableConfigured: (variableKey, options) =>
-      options.variablesMapping.some(mapping => mapping.variableKey === variableKey),
+    formVariableConfigured: (variable, options) =>
+      options.variablesMapping.some(mapping => mapping.variableKey === variable.key),
     summaryHandler: ObjectsApiSummaryHandler,
+    variableConfigurationEditor: ObjectsApiVariableConfigurationEditor,
   },
   email: {
     uiSchema: {

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeSelect.js
@@ -1,10 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {useEffect} from 'react';
 
-import Select from 'components/admin/forms/Select';
-
-// TODO: properly translate this
-const LOADING_OPTION = [['...', 'loading...']];
+import Select, {LOADING_OPTION} from 'components/admin/forms/Select';
 
 const ObjectTypeSelect = ({availableObjectTypesState, objecttype, onChange}) => {
   const {loading, availableObjecttypes, error} = availableObjectTypesState;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeVersionSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectTypeVersionSelect.js
@@ -2,11 +2,8 @@ import PropTypes from 'prop-types';
 import React, {useEffect} from 'react';
 import useAsync from 'react-use/esm/useAsync';
 
-import Select from 'components/admin/forms/Select';
+import Select, {LOADING_OPTION} from 'components/admin/forms/Select';
 import {get} from 'utils/fetch';
-
-// TODO: properly translate this
-const LOADING_OPTION = [['...', 'loading...']];
 
 const getObjecttypeVersionsEndpoint = objecttype => {
   const bits = [

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -32,14 +32,20 @@ const ObjectsApiOptionsFormFields = ({index, name, schema, formData, onChange}) 
   const {version = 1} = formData;
 
   const changeVersion = v => {
-    if (v === 1) {
+    const realVersion = v + 1;
+    if (realVersion === 2) {
       const confirmV2Switch = window.confirm(v2SwitchMessage);
       if (!confirmV2Switch) return;
     }
 
     onChange(
       produce(formData, draft => {
-        draft.version = v + 1;
+        draft.version = realVersion;
+        if (realVersion === 2) {
+          draft.variablesMapping = [];
+        } else {
+          delete draft.variablesMapping;
+        }
         delete draft.contentJson;
         delete draft.paymentStatusUpdateJson;
       })

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.mdx
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.mdx
@@ -8,7 +8,9 @@ import * as ObjectsApiOptionsFormFieldsStories from './ObjectsApiOptionsFormFiel
 # Objects API Registration
 
 Here we can set up the registration backend for Objects APIs. The Objecttype and corresponding
-versions are fetched from the API.
+versions are fetched from the API. When using the _Variables Mapping_ configuration mode, the
+mapping between variables and Objecttype targets is configured in the
+[_Variables_ tab](/story/form-design-variables-editor--with-objects-api-registration-backends).
 
 <Canvas of={ObjectsApiOptionsFormFieldsStories.Default} />
 

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
@@ -8,14 +8,14 @@ import React from 'react';
  * }} ObjectsAPIV2Options
  *
  * @param {Object} p
- * @param {string} p.variableKey - The current variable key
+ * @param {string} p.variable - The current variable
  * @param {ObjectsAPIV2Options} p.backendOptions - The Objects API Options (guaranteed to be v2)
  * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
  */
-const ObjectsApiSummaryHandler = ({variableKey, backendOptions}) => {
+const ObjectsApiSummaryHandler = ({variable, backendOptions}) => {
   // Guaranteed to exist:
   const variableMapping = backendOptions.variablesMapping.find(
-    mapping => mapping.variableKey === variableKey
+    mapping => mapping.variableKey === variable.key
   );
 
   return variableMapping.targetPath

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 
 /**
  * Returns the Objects API Registration summary for a specific variable. This only applies to V2 Options
@@ -13,10 +14,18 @@ import React from 'react';
  * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
  */
 const ObjectsApiSummaryHandler = ({variable, backendOptions}) => {
-  // Guaranteed to exist:
   const variableMapping = backendOptions.variablesMapping.find(
     mapping => mapping.variableKey === variable.key
   );
+
+  if (!variableMapping) {
+    return (
+      <FormattedMessage
+        description="'Not yet configured' registration summary message"
+        defaultMessage="Not yet configured"
+      />
+    );
+  }
 
   return variableMapping.targetPath
     .map(p => <code>{p}</code>)

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
@@ -11,7 +11,7 @@ import {FormattedMessage} from 'react-intl';
  * @param {Object} p
  * @param {string} p.variable - The current variable
  * @param {ObjectsAPIV2Options} p.backendOptions - The Objects API Options (guaranteed to be v2)
- * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
+ * @returns {JSX.Element} - The summary, represented as the parts of the target path separated by '>'
  */
 const ObjectsApiSummaryHandler = ({variable, backendOptions}) => {
   const variableMapping = backendOptions.variablesMapping.find(

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -1,5 +1,6 @@
 import {FieldArray, useFormikContext} from 'formik';
 import isEqual from 'lodash/isEqual';
+import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useAsync, useToggle} from 'react-use';
@@ -135,6 +136,12 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
   );
 };
 
+ObjectsApiVariableConfigurationEditor.propTypes = {
+  variable: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
 const TargetPathSelect = ({name, index, choices}) => {
   const {getFieldProps, setFieldValue} = useFormikContext();
   const props = getFieldProps(name);
@@ -163,6 +170,12 @@ const TargetPathSelect = ({name, index, choices}) => {
   );
 };
 
+TargetPathSelect.propTypes = {
+  name: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
+  choices: PropTypes.array.isRequired,
+};
+
 const TargetPathDisplay = ({target}) => {
   const path = target.targetPath.join(' > ');
   return (
@@ -172,6 +185,13 @@ const TargetPathDisplay = ({target}) => {
       values={{path, required: target.isRequired}}
     />
   );
+};
+
+TargetPathDisplay.propTypes = {
+  target: PropTypes.shape({
+    targetPath: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }).isRequired,
+  isRequired: PropTypes.bool.isRequired,
 };
 
 export default ObjectsApiVariableConfigurationEditor;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -28,13 +28,13 @@ import {asJsonSchema} from './utils';
  *
  * @param {Object} p
  * @param {Object} p.variable - The current variable
- * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
+ * @returns {JSX.Element} - The configuration form for the Objects API
  */
 const ObjectsApiVariableConfigurationEditor = ({variable}) => {
   const {csrftoken} = useContext(APIContext);
 
   const [jsonSchemaVisible, toggleJsonSchemaVisible] = useToggle(false);
-  const {values: backendOptions, getFieldProps, setFieldValue} = useFormikContext();
+  const {values: backendOptions, getFieldProps} = useFormikContext();
 
   /** @type {ObjectsAPIRegistrationBackendOptions} */
   const {objecttype, objecttypeVersion, variablesMapping, version} = backendOptions;
@@ -191,6 +191,7 @@ TargetPathSelect.propTypes = {
   name: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   choices: PropTypes.array.isRequired,
+  mappedVariable: PropTypes.object.isRequired,
 };
 
 const TargetPathDisplay = ({target}) => {
@@ -207,8 +208,8 @@ const TargetPathDisplay = ({target}) => {
 TargetPathDisplay.propTypes = {
   target: PropTypes.shape({
     targetPath: PropTypes.arrayOf(PropTypes.string).isRequired,
+    isRequired: PropTypes.bool.isRequired,
   }).isRequired,
-  isRequired: PropTypes.bool.isRequired,
 };
 
 export default ObjectsApiVariableConfigurationEditor;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -1,49 +1,120 @@
-import React from 'react';
+import {Form, Formik} from 'formik';
+import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
+import {useAsync} from 'react-use';
 
+import {FormContext} from 'components/admin/form_design/Context';
 import Select from 'components/admin/forms/Select';
+import {get} from 'utils/fetch';
+
+// TODO: properly translate this
+const LOADING_OPTION = [['...', 'loading...']];
 
 /**
  * Returns the Objects API Configuration editor modal for a specific variable. This only applies to V2 Options
  *
  * @typedef {{
- *   variablesMapping: {variableKey: string, targetPath: string[]}[]
- * }} ObjectsAPIV2Options
+ *   backend: string;
+ *   key: string;
+ *   name: string;
+ *   options: {
+ *     variablesMapping: {variableKey: string, targetPath: string[]}[]
+ *   }
+ * }} ObjectsAPIRegistrationBackend
  *
  * @param {Object} p
- * @param {string} p.variable - The current variable
- * @param {ObjectsAPIV2Options} p.backendOptions - The Objects API Options (guaranteed to be v2)
+ * @param {Object} p.variable - The current variable
+ * @param {ObjectsAPIRegistrationBackend} p.backend - The Objects API registration backend (options guaranteed to be v2)
  * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
  */
-const ObjectsApiVariableConfigurationEditor = ({variable, backendOptions}) => {
+const ObjectsApiVariableConfigurationEditor = ({variable, backend}) => {
+  const {
+    form: {uuid},
+  } = useContext(FormContext);
+
+  const {
+    loading,
+    value: targetPaths,
+    error,
+  } = useAsync(async () => {
+    const response = await get('/api/v2/registration/plugins/objects-api/target-paths', {
+      backendKey: backend.key,
+      formUuid: uuid,
+      variableKey: variable.key,
+    });
+
+    if (!response.ok) {
+      throw new Error('Loading available target paths failed');
+    }
+
+    return response.data;
+  }, []);
+
+  const choices =
+    loading || error
+      ? LOADING_OPTION
+      : targetPaths.map(t => [t.targetPath, t.targetPath.join(' > ')]);
+
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>
-            <FormattedMessage defaultMessage="Variable name" description="'Variable name' label" />
-          </th>
-          <th>
-            <FormattedMessage defaultMessage="Variable key" description="'Variable key' label" />
-          </th>
-          <th>
-            <FormattedMessage
-              defaultMessage="JSON Schema target"
-              description="'JSON Schema target' label"
-            />
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{variable.name}</td>
-          <td>{variable.key}</td>
-          <td>
-            <Select choices={[['test', 'test']]} />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <Formik
+      initialValues={{
+        targetPath:
+          backend.options.variablesMapping.find(mapping => mapping.variableKey === variable.key)
+            .targetPath || '',
+      }}
+    >
+      {formik => (
+        <Form>
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  <FormattedMessage
+                    defaultMessage="Variable name"
+                    description="'Variable name' label"
+                  />
+                </th>
+                <th>
+                  <FormattedMessage
+                    defaultMessage="Variable key"
+                    description="'Variable key' label"
+                  />
+                </th>
+                <th>
+                  <FormattedMessage
+                    defaultMessage="JSON Schema target"
+                    description="'JSON Schema target' label"
+                  />
+                </th>
+                <th>
+                  <FormattedMessage
+                    defaultMessage="JSON Schema info"
+                    description="'JSON Schema info' label"
+                  />
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{variable.name}</td>
+                <td>{variable.key}</td>
+                <td>
+                  <Select
+                    id="targetPath"
+                    name="targetPath"
+                    choices={choices}
+                    {...formik.getFieldProps('targetPath')}
+                  />
+                </td>
+                <td>
+                  <pre>{JSON.stringify({}, null, 2)}</pre>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </Form>
+      )}
+    </Formik>
   );
 };
 

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -85,10 +85,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
   const choices =
     loading || error
       ? LOADING_OPTION
-      : targetPaths.map(t => [
-          JSON.stringify(t.targetPath),
-          `${t.targetPath.join(' > ')}${t.required ? ' (required)' : ''}`,
-        ]);
+      : targetPaths.map(t => [JSON.stringify(t.targetPath), <TargetPathDisplay target={t} />]);
 
   return (
     <Fieldset>
@@ -141,7 +138,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
 const TargetPathSelect = ({name, index, choices}) => {
   const {getFieldProps, setFieldValue} = useFormikContext();
   const props = getFieldProps(name);
-  console.log(props, choices);
+
   return (
     <FieldArray
       name="variablesMapping"
@@ -162,6 +159,17 @@ const TargetPathSelect = ({name, index, choices}) => {
           }}
         />
       )}
+    />
+  );
+};
+
+const TargetPathDisplay = ({target}) => {
+  const path = target.targetPath.join(' > ');
+  return (
+    <FormattedMessage
+      description="Representation of a JSON Schema target path"
+      defaultMessage="{required, select, true {{path} (required)} other {{path}}}"
+      values={{path, required: target.isRequired}}
     />
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -1,10 +1,11 @@
 import {Form, Formik} from 'formik';
 import isEqual from 'lodash/isEqual';
-import React, {useContext} from 'react';
+import React, {useContext, useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useAsync} from 'react-use';
 
 import {FormContext} from 'components/admin/form_design/Context';
+import {REGISTRATION_OBJECTS_TARGET_PATHS} from 'components/admin/form_design/constants';
 import Select, {LOADING_OPTION} from 'components/admin/forms/Select';
 import {get} from 'utils/fetch';
 
@@ -23,12 +24,21 @@ import {get} from 'utils/fetch';
  * @param {Object} p
  * @param {Object} p.variable - The current variable
  * @param {ObjectsAPIRegistrationBackend} p.backend - The Objects API registration backend (options guaranteed to be v2)
+ * @param {ObjectsAPIRegistrationBackend} p.setGetOptions - A callback to register the function that will return the edited options
  * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
  */
-const ObjectsApiVariableConfigurationEditor = ({variable, backend}) => {
+const ObjectsApiVariableConfigurationEditor = ({variable, backend, setGetOptions}) => {
   const {
     form: {uuid},
   } = useContext(FormContext);
+
+  const getOptions = () => {
+    return backend.options;
+  };
+
+  useEffect(() => {
+    setGetOptions(() => getOptions);
+  }, []);
 
   const {
     loading,
@@ -36,7 +46,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable, backend}) => {
     error,
   } = useAsync(
     async () => {
-      const response = await get('/api/v2/registration/plugins/objects-api/target-paths', {
+      const response = await get(REGISTRATION_OBJECTS_TARGET_PATHS, {
         backendKey: backend.key,
         formUuid: uuid,
         variableKey: variable.key,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -71,10 +71,6 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
         variableJsonSchema: asJsonSchema(variable),
       });
 
-      if (!response.ok) {
-        throw new Error('Loading available target paths failed');
-      }
-
       return response.data;
     },
     // Load only once:

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import Select from 'components/admin/forms/Select';
+
+/**
+ * Returns the Objects API Configuration editor modal for a specific variable. This only applies to V2 Options
+ *
+ * @typedef {{
+ *   variablesMapping: {variableKey: string, targetPath: string[]}[]
+ * }} ObjectsAPIV2Options
+ *
+ * @param {Object} p
+ * @param {string} p.variable - The current variable
+ * @param {ObjectsAPIV2Options} p.backendOptions - The Objects API Options (guaranteed to be v2)
+ * @returns {JSX.Element} - The summary, represented as a the parts of the target path separated by '>'
+ */
+const ObjectsApiVariableConfigurationEditor = ({variable, backendOptions}) => {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <FormattedMessage defaultMessage="Variable name" description="'Variable name' label" />
+          </th>
+          <th>
+            <FormattedMessage defaultMessage="Variable key" description="'Variable key' label" />
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="JSON Schema target"
+              description="'JSON Schema target' label"
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{variable.name}</td>
+          <td>{variable.key}</td>
+          <td>
+            <Select choices={[['test', 'test']]} />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+export default ObjectsApiVariableConfigurationEditor;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -12,6 +12,7 @@ import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
 import {TextInput} from 'components/admin/forms/Inputs';
 import Select, {LOADING_OPTION} from 'components/admin/forms/Select';
+import ErrorMessage from 'components/errors/ErrorMessage';
 import {post} from 'utils/fetch';
 
 import {asJsonSchema} from './utils';
@@ -86,6 +87,16 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
     loading || error
       ? LOADING_OPTION
       : targetPaths.map(t => [JSON.stringify(t.targetPath), <TargetPathDisplay target={t} />]);
+
+  if (error)
+    return (
+      <ErrorMessage>
+        <FormattedMessage
+          description="Objects API variable registration configuration API error"
+          defaultMessage="Something went wrong when fetching the available target paths"
+        />
+      </ErrorMessage>
+    );
 
   return (
     <Fieldset>

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -2,10 +2,13 @@ import {Form, Formik} from 'formik';
 import isEqual from 'lodash/isEqual';
 import React, {useContext, useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
-import {useAsync} from 'react-use';
+import {useAsync, useToggle} from 'react-use';
 
 import {FormContext} from 'components/admin/form_design/Context';
 import {REGISTRATION_OBJECTS_TARGET_PATHS} from 'components/admin/form_design/constants';
+import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
 import Select, {LOADING_OPTION} from 'components/admin/forms/Select';
 import {get} from 'utils/fetch';
 
@@ -31,6 +34,8 @@ const ObjectsApiVariableConfigurationEditor = ({variable, backend, setGetOptions
   const {
     form: {uuid},
   } = useContext(FormContext);
+
+  const [jsonSchemaVisible, toggleJsonSchemaVisible] = useToggle(false);
 
   const getOptions = () => {
     return backend.options;
@@ -87,57 +92,56 @@ const ObjectsApiVariableConfigurationEditor = ({variable, backend, setGetOptions
     >
       {formik => (
         <Form>
-          <table>
-            <thead>
-              <tr>
-                <th>
+          <Fieldset>
+            <FormRow>
+              <Field
+                name="name"
+                label={
                   <FormattedMessage
-                    defaultMessage="Variable name"
-                    description="'Variable name' label"
-                  />
-                </th>
-                <th>
-                  <FormattedMessage
-                    defaultMessage="Variable key"
                     description="'Variable key' label"
+                    defaultMessage="Variable key"
                   />
-                </th>
-                <th>
+                }
+              >
+                <div className="readonly">{variable.key}</div>
+              </Field>
+            </FormRow>
+            <FormRow>
+              <Field
+                name="targetPath"
+                htmlFor="targetPath"
+                label={
                   <FormattedMessage
                     defaultMessage="JSON Schema target"
                     description="'JSON Schema target' label"
                   />
-                </th>
-                <th>
-                  <FormattedMessage
-                    defaultMessage="JSON Schema info"
-                    description="'JSON Schema info' label"
-                  />
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{variable.name}</td>
-                <td>{variable.key}</td>
-                <td>
-                  <Select
-                    id="targetPath"
-                    name="targetPath"
-                    choices={choices}
-                    {...formik.getFieldProps('targetPath')}
-                  />
-                </td>
-                <td>
-                  <pre>
-                    {loading
-                      ? 'N/A'
-                      : JSON.stringify(getTargetPath(formik.values.targetPath).jsonSchema, null, 2)}
-                  </pre>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                }
+              >
+                <Select
+                  id="targetPath"
+                  name="targetPath"
+                  allowBlank
+                  choices={choices}
+                  {...formik.getFieldProps('targetPath')}
+                />
+              </Field>
+            </FormRow>
+            <div style={{marginTop: '1em'}}>
+              <a href="#" onClick={e => e.preventDefault() || toggleJsonSchemaVisible()}>
+                <FormattedMessage
+                  description="Objects API variable configuration editor JSON Schema visibility toggle"
+                  defaultMessage="Toggle JSON Schema"
+                />
+              </a>
+              {jsonSchemaVisible && (
+                <pre>
+                  {loading || !formik.values.targetPath
+                    ? 'N/A'
+                    : JSON.stringify(getTargetPath(formik.values.targetPath).jsonSchema, null, 2)}
+                </pre>
+              )}
+            </div>
+          </Fieldset>
         </Form>
       )}
     </Formik>

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -22,5 +22,5 @@ export const mockObjecttypesError = () =>
 
 export const mockTargetPathsGet = paths =>
   rest.get(`${BASE_URL}/api/v2/registration/plugins/objects-api/target-paths`, (req, res, ctx) => {
-    return res(ctx.json(paths.map(path => ({targetPath: path}))));
+    return res(ctx.json(paths));
   });

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -20,7 +20,7 @@ export const mockObjecttypesError = () =>
     return res(ctx.status(500));
   });
 
-export const mockTargetPathsGet = paths =>
-  rest.get(`${BASE_URL}/api/v2/registration/plugins/objects-api/target-paths`, (req, res, ctx) => {
+export const mockTargetPathsPost = paths =>
+  rest.post(`${BASE_URL}/api/v2/registration/plugins/objects-api/target-paths`, (req, res, ctx) => {
     return res(ctx.json(paths));
   });

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -19,3 +19,8 @@ export const mockObjecttypesError = () =>
   rest.all('*', (req, res, ctx) => {
     return res(ctx.status(500));
   });
+
+export const mockTargetPathsGet = paths =>
+  rest.get(`${BASE_URL}/api/v2/registration/plugins/objects-api/target-paths`, (req, res, ctx) => {
+    return res(ctx.json(paths.map(path => ({targetPath: path}))));
+  });

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/utils.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/utils.js
@@ -30,4 +30,33 @@ const getErrorMarkup = errorMessages => {
   );
 };
 
-export {getErrorMarkup, getFieldErrors};
+const VARIABLE_TYPE_MAP = {
+  boolean: 'boolean',
+  int: 'integer',
+  float: 'number',
+  object: 'object',
+  array: 'array',
+  string: 'string',
+};
+
+const FORMAT_TYPE_MAP = {
+  datetime: 'date-time',
+  time: 'time',
+  date: 'date',
+};
+
+/**
+ * Return a JSON Schema definition matching the provided variable.
+ * @param {Object} variable - The current variable
+ * @returns {Object} - The JSON Schema
+ */
+const asJsonSchema = variable => {
+  if (VARIABLE_TYPE_MAP.hasOwnProperty(variable.dataType))
+    return {type: VARIABLE_TYPE_MAP[variable.dataType]};
+  return {
+    type: 'string',
+    format: FORMAT_TYPE_MAP[variable.dataType],
+  };
+};
+
+export {getErrorMarkup, getFieldErrors, asJsonSchema};

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -1,6 +1,6 @@
 import {FeatureFlagsContext, FormContext} from 'components/admin/form_design/Context';
 
-import {APIContext, FormLogicContext} from './Context';
+import {FormLogicContext} from './Context';
 
 export const FeatureFlagsDecorator = Story => (
   <FeatureFlagsContext.Provider value={{}}>

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -1,6 +1,6 @@
 import {FeatureFlagsContext, FormContext} from 'components/admin/form_design/Context';
 
-import {FormLogicContext} from './Context';
+import {APIContext, FormLogicContext} from './Context';
 
 export const FeatureFlagsDecorator = Story => (
   <FeatureFlagsContext.Provider value={{}}>

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -22,6 +22,7 @@ export const FormLogicDecorator = (Story, {args}) => (
 export const FormDecorator = (Story, {args}) => (
   <FormContext.Provider
     value={{
+      form: args.form || {},
       formSteps: args.availableFormSteps || [],
       staticVariables: args.availableStaticVariables || [],
       formVariables: args.availableFormVariables || [],

--- a/src/openforms/js/components/admin/form_design/variables/StaticData.js
+++ b/src/openforms/js/components/admin/form_design/variables/StaticData.js
@@ -4,7 +4,7 @@ import {FormattedMessage} from 'react-intl';
 import {FormContext} from 'components/admin/form_design/Context';
 import {ChangelistTableWrapper, HeadColumn} from 'components/admin/tables';
 
-import RegistrationsSummary from './registration';
+import RegistrationSummaryList from './registration';
 
 const StaticData = ({onFieldChange}) => {
   const formContext = useContext(FormContext);
@@ -48,7 +48,7 @@ const StaticData = ({onFieldChange}) => {
               <td>{item.name}</td>
               <td>{item.key}</td>
               <td>
-                <RegistrationsSummary variable={item} onFieldChange={onFieldChange} />
+                <RegistrationSummaryList variable={item} onFieldChange={onFieldChange} />
               </td>
               <td>{item.dataType}</td>
             </tr>

--- a/src/openforms/js/components/admin/form_design/variables/StaticData.js
+++ b/src/openforms/js/components/admin/form_design/variables/StaticData.js
@@ -4,7 +4,9 @@ import {FormattedMessage} from 'react-intl';
 import {FormContext} from 'components/admin/form_design/Context';
 import {ChangelistTableWrapper, HeadColumn} from 'components/admin/tables';
 
-const StaticData = () => {
+import RegistrationsSummary from './registration';
+
+const StaticData = ({onFieldChange}) => {
   const formContext = useContext(FormContext);
   const staticData = formContext.staticVariables;
 
@@ -16,6 +18,14 @@ const StaticData = () => {
       />
       <HeadColumn
         content={<FormattedMessage defaultMessage="Key" description="Variable table key title" />}
+      />
+      <HeadColumn
+        content={
+          <FormattedMessage
+            defaultMessage="Registration"
+            description="Variable table registration title"
+          />
+        }
       />
       <HeadColumn
         content={
@@ -37,6 +47,9 @@ const StaticData = () => {
               <td />
               <td>{item.name}</td>
               <td>{item.key}</td>
+              <td>
+                <RegistrationsSummary variable={item} onFieldChange={onFieldChange} />
+              </td>
               <td>{item.dataType}</td>
             </tr>
           );

--- a/src/openforms/js/components/admin/form_design/variables/UserDefinedVariables.js
+++ b/src/openforms/js/components/admin/form_design/variables/UserDefinedVariables.js
@@ -5,7 +5,7 @@ import ButtonContainer from 'components/admin/forms/ButtonContainer';
 
 import VariablesTable from './VariablesTable';
 
-const UserDefinedVariables = ({variables, onAdd, onChange, onDelete}) => {
+const UserDefinedVariables = ({variables, onAdd, onDelete, onChange, onFieldChange}) => {
   const intl = useIntl();
 
   const onAddUserDefinedVar = event => {
@@ -30,8 +30,9 @@ const UserDefinedVariables = ({variables, onAdd, onChange, onDelete}) => {
       <VariablesTable
         variables={variables}
         editable={true}
-        onChange={onChange}
         onDelete={onDelete}
+        onChange={onChange}
+        onFieldChange={onFieldChange}
       />
       <ButtonContainer onClick={onAddUserDefinedVar}>
         <FormattedMessage

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
@@ -63,7 +63,7 @@ const VariablesEditor = ({variables, onAdd, onDelete, onChange, onFieldChange}) 
             />
           </TabPanel>
           <TabPanel>
-            <StaticData />
+            <StaticData onFieldChange={onFieldChange} />
           </TabPanel>
         </Tabs>
       </div>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
@@ -11,7 +11,7 @@ import VariablesTable from './VariablesTable';
 import {VARIABLE_SOURCES} from './constants';
 import {variableHasErrors} from './utils';
 
-const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
+const VariablesEditor = ({variables, onAdd, onDelete, onChange, onFieldChange}) => {
   const userDefinedVariables = variables.filter(
     variable => variable.source === VARIABLE_SOURCES.userDefined
   );
@@ -51,7 +51,7 @@ const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
           </TabList>
 
           <TabPanel>
-            <VariablesTable variables={componentVariables} />
+            <VariablesTable variables={componentVariables} onFieldChange={onFieldChange} />
           </TabPanel>
           <TabPanel>
             <UserDefinedVariables
@@ -59,6 +59,7 @@ const VariablesEditor = ({variables, onAdd, onChange, onDelete}) => {
               onAdd={onAdd}
               onDelete={onDelete}
               onChange={onChange}
+              onFieldChange={onFieldChange}
             />
           </TabPanel>
           <TabPanel>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -71,7 +71,8 @@ export const WithObjectsAPIRegistrationBackends = {
   args: {
     registrationBackends: [
       {
-        key: 'objects_api',
+        backend: 'objects_api',
+        key: 'objects_api_1',
         name: 'Example Objects API reg.',
         options: {
           version: 2,
@@ -91,7 +92,8 @@ export const WithObjectsAPIRegistrationBackends = {
         },
       },
       {
-        key: 'objects_api',
+        backend: 'objects_api',
+        key: 'objects_api_2',
         name: 'Other Objects API registration with a long name',
         options: {
           version: 2,
@@ -107,7 +109,8 @@ export const WithObjectsAPIRegistrationBackends = {
         },
       },
       {
-        key: 'objects_api',
+        backend: 'objects_api',
+        key: 'objects_api_3',
         name: "Shouldn't display!",
         options: {
           version: 1,
@@ -127,12 +130,12 @@ export const WithObjectsAPIRegistrationBackends = {
         mockTargetPathsPost([
           {
             targetPath: ['path', 'to.the', 'target'],
-            required: true,
+            isRequired: true,
             jsonSchema: {type: 'string'},
           },
           {
             targetPath: ['other', 'path'],
-            required: false,
+            isRequired: false,
             jsonSchema: {type: 'object', properties: {a: {type: 'string'}}, required: ['a']},
           },
         ]),

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -108,8 +108,16 @@ export const WithObjectsAPIRegistrationBackends = {
     msw: {
       handlers: [
         mockTargetPathsGet([
-          ['path', 'to.the', 'target'],
-          ['other', 'path'],
+          {
+            targetPath: ['path', 'to.the', 'target'],
+            required: true,
+            jsonSchema: {type: 'string'},
+          },
+          {
+            targetPath: ['other', 'path'],
+            required: false,
+            jsonSchema: {type: 'object', properties: {a: {type: 'string'}}, required: ['a']},
+          },
         ]),
       ],
     },

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -1,4 +1,4 @@
-import {mockTargetPathsGet} from 'components/admin/form_design/registrations/objectsapi/mocks';
+import {mockTargetPathsPost} from 'components/admin/form_design/registrations/objectsapi/mocks';
 
 import {FormDecorator} from '../story-decorators';
 import VariablesEditor from './VariablesEditor';
@@ -8,9 +8,6 @@ export default {
   component: VariablesEditor,
   decorators: [FormDecorator],
   args: {
-    form: {
-      uuid: '36612390',
-    },
     variables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
@@ -88,7 +85,7 @@ export const WithObjectsAPIRegistrationBackends = {
             },
             {
               variableKey: 'userDefined',
-              targetPath: ['path'],
+              targetPath: ['other', 'path'],
             },
           ],
         },
@@ -127,7 +124,7 @@ export const WithObjectsAPIRegistrationBackends = {
   parameters: {
     msw: {
       handlers: [
-        mockTargetPathsGet([
+        mockTargetPathsPost([
           {
             targetPath: ['path', 'to.the', 'target'],
             required: true,

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -1,3 +1,5 @@
+import {mockTargetPathsGet} from 'components/admin/form_design/registrations/objectsapi/mocks';
+
 import {FormDecorator} from '../story-decorators';
 import VariablesEditor from './VariablesEditor';
 
@@ -6,6 +8,9 @@ export default {
   component: VariablesEditor,
   decorators: [FormDecorator],
   args: {
+    form: {
+      uuid: '36612390',
+    },
     variables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
@@ -38,6 +43,18 @@ export default {
         initialValue: [],
       },
     ],
+  },
+  argTypes: {
+    onChange: {action: true},
+    onAdd: {action: true},
+    onDelete: {action: true},
+  },
+};
+
+export const Default = {};
+
+export const WithObjectsAPIRegistrationBackends = {
+  args: {
     registrationBackends: [
       {
         key: 'objects_api',
@@ -87,11 +104,14 @@ export default {
       },
     ],
   },
-  argTypes: {
-    onChange: {action: true},
-    onAdd: {action: true},
-    onDelete: {action: true},
+  parameters: {
+    msw: {
+      handlers: [
+        mockTargetPathsGet([
+          ['path', 'to.the', 'target'],
+          ['other', 'path'],
+        ]),
+      ],
+    },
   },
 };
-
-export const Default = {};

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -103,6 +103,9 @@ export const WithObjectsAPIRegistrationBackends = {
         },
       },
     ],
+    onFieldChange: data => {
+      console.log(data);
+    },
   },
   parameters: {
     msw: {

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -43,6 +43,23 @@ export default {
         initialValue: [],
       },
     ],
+    availableStaticVariables: [
+      {
+        form: null,
+        formDefinition: null,
+        name: 'Now',
+        key: 'now',
+        source: '',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataType: 'datetime',
+        dataFormat: '',
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: '2024-02-27T16:44:22.170405Z',
+      },
+    ],
   },
   argTypes: {
     onChange: {action: true},

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -99,10 +99,7 @@ const VariableRow = ({index, variable}) => {
         )}
       </td>
       <td>
-        <RegistrationsSummary
-          variableKey={variable.key}
-          registrationBackends={registrationBackends}
-        />
+        <RegistrationsSummary variable={variable} registrationBackends={registrationBackends} />
       </td>
       <td>{variable.dataType}</td>
       <td>
@@ -216,10 +213,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
         </Field>
       </td>
       <td>
-        <RegistrationsSummary
-          variableKey={variable.key}
-          registrationBackends={registrationBackends}
-        />
+        <RegistrationsSummary variable={variable} registrationBackends={registrationBackends} />
       </td>
       <td>
         <Field name="dataType" errors={variable.errors?.dataType}>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -66,10 +66,9 @@ Td.propTypes = {
   fieldName: PropTypes.string.isRequired,
 };
 
-const VariableRow = ({index, variable}) => {
+const VariableRow = ({index, variable, onFieldChange}) => {
   const intl = useIntl();
   const formContext = useContext(FormContext);
-
   const formSteps = formContext.formSteps;
 
   const getFormDefinitionName = formDefinition => {
@@ -98,7 +97,7 @@ const VariableRow = ({index, variable}) => {
         )}
       </td>
       <td>
-        <RegistrationsSummary variable={variable} />
+        <RegistrationsSummary variable={variable} onFieldChange={onFieldChange} />
       </td>
       <td>{variable.dataType}</td>
       <td>
@@ -109,7 +108,7 @@ const VariableRow = ({index, variable}) => {
   );
 };
 
-const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
+const EditableVariableRow = ({index, variable, onDelete, onChange, onFieldChange}) => {
   const intl = useIntl();
   const deleteConfirmMessage = intl.formatMessage({
     description: 'User defined variable deletion confirm message',
@@ -211,7 +210,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
         </Field>
       </td>
       <td>
-        <RegistrationsSummary variable={variable} />
+        <RegistrationsSummary variable={variable} onFieldChange={onFieldChange} />
       </td>
       <td>
         <Field name="dataType" errors={variable.errors?.dataType}>
@@ -251,7 +250,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
   );
 };
 
-const VariablesTable = ({variables, editable, onChange, onDelete}) => {
+const VariablesTable = ({variables, editable, onDelete, onChange, onFieldChange}) => {
   const headColumns = (
     <>
       <HeadColumn content="" />
@@ -339,11 +338,17 @@ const VariablesTable = ({variables, editable, onChange, onDelete}) => {
               key={`${variable.key}-${index}`}
               index={index}
               variable={variable}
-              onChange={onChange}
               onDelete={onDelete}
+              onChange={onChange}
+              onFieldChange={onFieldChange}
             />
           ) : (
-            <VariableRow key={`${variable.key}-${index}`} index={index} variable={variable} />
+            <VariableRow
+              key={`${variable.key}-${index}`}
+              index={index}
+              variable={variable}
+              onFieldChange={onFieldChange}
+            />
           )
         )}
       </ChangelistTableWrapper>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -71,7 +71,6 @@ const VariableRow = ({index, variable}) => {
   const formContext = useContext(FormContext);
 
   const formSteps = formContext.formSteps;
-  const registrationBackends = formContext.registrationBackends;
 
   const getFormDefinitionName = formDefinition => {
     for (const step of formSteps) {
@@ -99,7 +98,7 @@ const VariableRow = ({index, variable}) => {
         )}
       </td>
       <td>
-        <RegistrationsSummary variable={variable} registrationBackends={registrationBackends} />
+        <RegistrationsSummary variable={variable} />
       </td>
       <td>{variable.dataType}</td>
       <td>
@@ -119,7 +118,6 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
 
   const formContext = useContext(FormContext);
 
-  const registrationBackends = formContext.registrationBackends;
   const {availablePrefillPlugins} = formContext.plugins;
   const prefillPluginChoices = availablePrefillPlugins.map(plugin => [plugin.id, plugin.label]);
   const [prefillAttributeChoices, setPrefillAttributeChoices] = useState([]);
@@ -213,7 +211,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange}) => {
         </Field>
       </td>
       <td>
-        <RegistrationsSummary variable={variable} registrationBackends={registrationBackends} />
+        <RegistrationsSummary variable={variable} />
       </td>
       <td>
         <Field name="dataType" errors={variable.errors?.dataType}>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -15,7 +15,7 @@ import {ChangelistTableWrapper, HeadColumn} from 'components/admin/tables';
 import {get} from 'utils/fetch';
 
 import {DATATYPES_CHOICES, IDENTIFIER_ROLE_CHOICES} from './constants';
-import RegistrationsSummary from './registration';
+import RegistrationSummaryList from './registration';
 import Variable from './types';
 import {variableHasErrors} from './utils';
 
@@ -97,7 +97,7 @@ const VariableRow = ({index, variable, onFieldChange}) => {
         )}
       </td>
       <td>
-        <RegistrationsSummary variable={variable} onFieldChange={onFieldChange} />
+        <RegistrationSummaryList variable={variable} onFieldChange={onFieldChange} />
       </td>
       <td>{variable.dataType}</td>
       <td>
@@ -210,7 +210,7 @@ const EditableVariableRow = ({index, variable, onDelete, onChange, onFieldChange
         </Field>
       </td>
       <td>
-        <RegistrationsSummary variable={variable} onFieldChange={onFieldChange} />
+        <RegistrationSummaryList variable={variable} onFieldChange={onFieldChange} />
       </td>
       <td>
         <Field name="dataType" errors={variable.errors?.dataType}>

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -103,7 +103,7 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
   const summaries = [];
 
   for (const [backendIndex, backend] of registrationBackends.entries()) {
-    const backendInfo = BACKEND_OPTIONS_FORMS[backend.key];
+    const backendInfo = BACKEND_OPTIONS_FORMS[backend.backend];
 
     // Check if the registration backend can be configured from the variables tab...
     const configurableFromVariables = backendInfo.configurableFromVariables;
@@ -115,10 +115,8 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
       continue;
 
     // These components are guaranteed to exist if `configurableFromVariables` is true:
-    const SummaryHandler = BACKEND_OPTIONS_FORMS[backend.key].summaryHandler;
-    const VariableConfigurationEditor =
-      BACKEND_OPTIONS_FORMS[backend.key].variableConfigurationEditor;
-
+    const SummaryHandler = backendInfo.summaryHandler;
+    const VariableConfigurationEditor = backendInfo.variableConfigurationEditor;
     summaries.push({
       name: backend.name,
       variable,

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -1,6 +1,6 @@
 import {produce} from 'immer';
 import React, {useContext, useState} from 'react';
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import FAIcon from 'components/admin/FAIcon';
 import {FormContext} from 'components/admin/form_design/Context';
@@ -139,6 +139,15 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
       getOptions,
       onChange: onFieldChange,
     });
+  }
+
+  if (!summaries.length) {
+    return (
+      <FormattedMessage
+        description="Registration summary no registration backend fallback message"
+        defaultMessage="No compatible registration backend configured."
+      />
+    );
   }
 
   return (

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -62,7 +62,9 @@ const RegistrationSummary = ({
           initialValues={backend.options}
           onSubmit={(values, actions) => {
             const updatedBackend = {...backend, options: values};
-            onChange({target: `form.registrationBackend.${backendIndex}`, value: updatedBackend});
+            onChange({
+              target: {name: `form.registrationBackends.${backendIndex}`, value: updatedBackend},
+            });
             actions.setSubmitting(false);
             setModalOpen(false);
           }}

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -1,19 +1,30 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import FAIcon from 'components/admin/FAIcon';
 import {BACKEND_OPTIONS_FORMS} from 'components/admin/form_design/registrations';
+import {SubmitAction} from 'components/admin/forms/ActionButton';
 import ButtonContainer from 'components/admin/forms/ButtonContainer';
+import SubmitRow from 'components/admin/forms/SubmitRow';
+import {FormModal} from 'components/admin/modals';
 
 /**
  *
  * @param {Object} p
  * @param {string} p.name - The name of the current registration backend
- * @param {JSX.Element} p.registrationSummary - The rendered summary of the registration backend for a specific variable
+ * @param {Object} p.variable - The current variable
+ * @param {JSX.Element} p.registrationSummary - The rendered summary of the registration backend for the current variable
+ * @param {JSX.Element} p.variableConfigurationEditor - The rendered configuration editor for the current variable
  * @returns {JSX.Element} - The rendered summary, containing the backend name, summary and edit icon
  */
-const RegistrationSummary = ({name, registrationSummary}) => {
+const RegistrationSummary = ({
+  name,
+  variable,
+  registrationSummary,
+  variableConfigurationEditor,
+}) => {
   const intl = useIntl();
+  const [modalOpen, setModalOpen] = useState(false);
 
   return (
     <>
@@ -29,11 +40,27 @@ const RegistrationSummary = ({name, registrationSummary}) => {
               description: "'Edit variable registration' icon label",
             })}
             extraClassname="fa-lg actions__action"
-            onClick={() => {}}
+            onClick={() => setModalOpen(!modalOpen)}
           />
         </span>
       </div>
       <div>{registrationSummary}</div>
+      <FormModal
+        title={`'${variable.name}' registration configuration for '${name}'`}
+        isOpen={modalOpen}
+        closeModal={() => setModalOpen(false)}
+      >
+        {variableConfigurationEditor}
+        <SubmitRow>
+          <SubmitAction
+            text={intl.formatMessage({
+              defaultMessage: 'Save',
+              description: "Variable registration configuration editor 'Save' button label",
+            })}
+            onClick={() => {}}
+          />
+        </SubmitRow>
+      </FormModal>
     </>
   );
 };
@@ -44,11 +71,11 @@ const RegistrationSummary = ({name, registrationSummary}) => {
  * @typedef {{key: string, name: string, options: {[key: string]: any}}} RegistrationBackend
  *
  * @param {Object} p
- * @param {string} p.variableKey - The current variable
+ * @param {Object} p.variable - The current variable
  * @param {RegistrationBackend[]} p.registrationBackends - The form's registration backends
  * @returns {JSX.Element} - A <ul> list of summaries
  */
-const RegistrationsSummary = ({variableKey, registrationBackends}) => {
+const RegistrationsSummary = ({variable, registrationBackends}) => {
   const summaries = [];
   let canConfigureBackend = false;
 
@@ -65,16 +92,22 @@ const RegistrationsSummary = ({variableKey, registrationBackends}) => {
       continue;
 
     // ... if it is the case, check if the variable is already configured:
-    const formVariableConfigured = backendInfo.formVariableConfigured(variableKey, backend.options);
+    const formVariableConfigured = backendInfo.formVariableConfigured(variable, backend.options);
     if (formVariableConfigured) {
-      // a summary handler is guaranteed to exist if `configurableFromVariables` is true:
+      // These components are guaranteed to exist if `configurableFromVariables` is true:
       const SummaryHandler = BACKEND_OPTIONS_FORMS[backend.key].summaryHandler;
-      const registrationSummary = (
-        <SummaryHandler variableKey={variableKey} backendOptions={backend.options} />
-      );
+      const VariableConfigurationEditor =
+        BACKEND_OPTIONS_FORMS[backend.key].variableConfigurationEditor;
+
       summaries.push({
         name: backend.name,
-        registrationSummary: registrationSummary,
+        variable,
+        registrationSummary: (
+          <SummaryHandler variable={variable} backendOptions={backend.options} />
+        ),
+        variableConfigurationEditor: (
+          <VariableConfigurationEditor variable={variable} backendOptions={backend.options} />
+        ),
       });
     } else {
       canConfigureBackend = true;

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -1,12 +1,11 @@
 import {produce} from 'immer';
 import React, {useContext, useState} from 'react';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {useIntl} from 'react-intl';
 
 import FAIcon from 'components/admin/FAIcon';
 import {FormContext} from 'components/admin/form_design/Context';
 import {BACKEND_OPTIONS_FORMS} from 'components/admin/form_design/registrations';
 import {SubmitAction} from 'components/admin/forms/ActionButton';
-import ButtonContainer from 'components/admin/forms/ButtonContainer';
 import SubmitRow from 'components/admin/forms/SubmitRow';
 import {FormModal} from 'components/admin/modals';
 
@@ -104,7 +103,6 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
   const registrationBackends = formContext.registrationBackends;
 
   const summaries = [];
-  let canConfigureBackend = false;
 
   for (const [backendIndex, backend] of registrationBackends.entries()) {
     const backendInfo = BACKEND_OPTIONS_FORMS[backend.key];
@@ -118,37 +116,29 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
     )
       continue;
 
-    // ... if it is the case, check if the variable is already configured:
-    const formVariableConfigured = backendInfo.formVariableConfigured(variable, backend.options);
-    if (formVariableConfigured) {
-      // These components are guaranteed to exist if `configurableFromVariables` is true:
-      const SummaryHandler = BACKEND_OPTIONS_FORMS[backend.key].summaryHandler;
-      const VariableConfigurationEditor =
-        BACKEND_OPTIONS_FORMS[backend.key].variableConfigurationEditor;
+    // These components are guaranteed to exist if `configurableFromVariables` is true:
+    const SummaryHandler = BACKEND_OPTIONS_FORMS[backend.key].summaryHandler;
+    const VariableConfigurationEditor =
+      BACKEND_OPTIONS_FORMS[backend.key].variableConfigurationEditor;
 
-      const [getOptions, setGetOptions] = useState();
+    const [getOptions, setGetOptions] = useState();
 
-      summaries.push({
-        name: backend.name,
-        variable,
-        backend,
-        backendIndex,
-        registrationSummary: (
-          <SummaryHandler variable={variable} backendOptions={backend.options} />
-        ),
-        variableConfigurationEditor: (
-          <VariableConfigurationEditor
-            variable={variable}
-            backend={backend}
-            setGetOptions={setGetOptions}
-          />
-        ),
-        getOptions,
-        onChange: onFieldChange,
-      });
-    } else {
-      canConfigureBackend = true;
-    }
+    summaries.push({
+      name: backend.name,
+      variable,
+      backend,
+      backendIndex,
+      registrationSummary: <SummaryHandler variable={variable} backendOptions={backend.options} />,
+      variableConfigurationEditor: (
+        <VariableConfigurationEditor
+          variable={variable}
+          backend={backend}
+          setGetOptions={setGetOptions}
+        />
+      ),
+      getOptions,
+      onChange: onFieldChange,
+    });
   }
 
   return (
@@ -160,14 +150,6 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
           </li>
         ))}
       </ul>
-      {canConfigureBackend && (
-        <ButtonContainer>
-          <FormattedMessage
-            defaultMessage="Add another"
-            description="Registrations column 'Add another' label"
-          />
-        </ButtonContainer>
-      )}
     </>
   );
 };

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -1,7 +1,8 @@
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import FAIcon from 'components/admin/FAIcon';
+import {FormContext} from 'components/admin/form_design/Context';
 import {BACKEND_OPTIONS_FORMS} from 'components/admin/form_design/registrations';
 import {SubmitAction} from 'components/admin/forms/ActionButton';
 import ButtonContainer from 'components/admin/forms/ButtonContainer';
@@ -72,10 +73,14 @@ const RegistrationSummary = ({
  *
  * @param {Object} p
  * @param {Object} p.variable - The current variable
- * @param {RegistrationBackend[]} p.registrationBackends - The form's registration backends
  * @returns {JSX.Element} - A <ul> list of summaries
  */
-const RegistrationsSummary = ({variable, registrationBackends}) => {
+const RegistrationsSummary = ({variable}) => {
+  const formContext = useContext(FormContext);
+
+  /** @type {RegistrationBackend[]} */
+  const registrationBackends = formContext.registrationBackends;
+
   const summaries = [];
   let canConfigureBackend = false;
 
@@ -105,8 +110,9 @@ const RegistrationsSummary = ({variable, registrationBackends}) => {
         registrationSummary: (
           <SummaryHandler variable={variable} backendOptions={backend.options} />
         ),
+        // TODO 'backend' for all others?
         variableConfigurationEditor: (
-          <VariableConfigurationEditor variable={variable} backendOptions={backend.options} />
+          <VariableConfigurationEditor variable={variable} backend={backend} />
         ),
       });
     } else {

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummary.js
@@ -1,4 +1,5 @@
 import {Formik} from 'formik';
+import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -85,6 +86,16 @@ const RegistrationSummary = ({
   );
 };
 
+RegistrationSummary.propTypes = {
+  name: PropTypes.string.isRequired,
+  variable: PropTypes.object.isRequired,
+  backend: PropTypes.object.isRequired,
+  backendIndex: PropTypes.number,
+  registrationSummary: PropTypes.element.isRequired,
+  variableConfigurationEditor: PropTypes.element.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
 /**
  * Returns a list of summaries for each registration backend
  *
@@ -148,6 +159,11 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
       </ul>
     </>
   );
+};
+
+RegistrationsSummary.propTypes = {
+  variable: PropTypes.object.isRequired,
+  onFieldChange: PropTypes.func.isRequired,
 };
 
 export default RegistrationsSummary;

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
@@ -92,7 +92,7 @@ RegistrationSummary.propTypes = {
   name: PropTypes.string.isRequired,
   variable: PropTypes.object.isRequired,
   backend: PropTypes.object.isRequired,
-  backendIndex: PropTypes.number,
+  backendIndex: PropTypes.number.isRequired,
   registrationSummary: PropTypes.element.isRequired,
   variableConfigurationEditor: PropTypes.element.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -107,7 +107,7 @@ RegistrationSummary.propTypes = {
  * @param {Object} p.variable - The current variable
  * @returns {JSX.Element} - A <ul> list of summaries
  */
-const RegistrationsSummary = ({variable, onFieldChange}) => {
+const RegistrationsSummaryList = ({variable, onFieldChange}) => {
   const formContext = useContext(FormContext);
 
   /** @type {RegistrationBackend[]} */
@@ -163,9 +163,9 @@ const RegistrationsSummary = ({variable, onFieldChange}) => {
   );
 };
 
-RegistrationsSummary.propTypes = {
+RegistrationsSummaryList.propTypes = {
   variable: PropTypes.object.isRequired,
   onFieldChange: PropTypes.func.isRequired,
 };
 
-export default RegistrationsSummary;
+export default RegistrationsSummaryList;

--- a/src/openforms/js/components/admin/form_design/variables/registration/index.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/index.js
@@ -1,3 +1,3 @@
-import RegistrationsSummary from './RegistrationsSummary';
+import RegistrationsSummaryList from './RegistrationsSummaryList';
 
-export default RegistrationsSummary;
+export default RegistrationsSummaryList;

--- a/src/openforms/js/components/admin/forms/Select.js
+++ b/src/openforms/js/components/admin/forms/Select.js
@@ -1,10 +1,16 @@
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import {PrefixContext} from './Context';
 
-const BLANK_OPTION = ['', '------'];
+const BLANK_OPTION = [['', '------']];
+export const LOADING_OPTION = [
+  [
+    '...',
+    <FormattedMessage defaultMessage="loading..." description="Loading select option label" />,
+  ],
+];
 
 const Select = ({
   name = 'select',
@@ -25,7 +31,7 @@ const Select = ({
 
   const prefix = useContext(PrefixContext);
   name = prefix ? `${prefix}-${name}` : name;
-  const options = allowBlank ? [BLANK_OPTION].concat(choices) : choices;
+  const options = allowBlank ? BLANK_OPTION.concat(choices) : choices;
 
   extraProps.value = extraProps.value || '';
 

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1574,6 +1574,11 @@
     "description": "JSON editor: complex value representation",
     "originalDefault": "(complex value)"
   },
+  "cK2O6E": {
+    "defaultMessage": "Something went wrong when fetching the available target paths",
+    "description": "Objects API variable registration configuration API error",
+    "originalDefault": "Something went wrong when fetching the available target paths"
+  },
   "cUVVbl": {
     "defaultMessage": "is greater than or equal to",
     "description": "\">=\" operator description",

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -164,6 +164,11 @@
     "description": "Form askStatementOfTruth field label",
     "originalDefault": "Ask statement of truth"
   },
+  "3z1hhJ": {
+    "defaultMessage": "Toggle JSON Schema",
+    "description": "Objects API variable configuration editor JSON Schema visibility toggle",
+    "originalDefault": "Toggle JSON Schema"
+  },
   "41hfj4": {
     "defaultMessage": "Which ZGW API group to use.",
     "description": "ZGW API group selection",
@@ -298,6 +303,11 @@
     "defaultMessage": "Unique identifier for the form",
     "description": "Form ID field help text",
     "originalDefault": "Unique identifier for the form"
+  },
+  "7Vx5It": {
+    "defaultMessage": "No compatible registration backend configured.",
+    "description": "Registration summary no registration backend fallback message",
+    "originalDefault": "No compatible registration backend configured."
   },
   "7X6yT4": {
     "defaultMessage": "You are modifying an existing form definition! This change affects <link>{count, plural, one {# form} other {# forms} }</link>",
@@ -553,6 +563,16 @@
     "defaultMessage": "Move down",
     "description": "Move down icon title",
     "originalDefault": "Move down"
+  },
+  "DRidde": {
+    "defaultMessage": "Could not retrieve the decision definitions IDs/versions. Is the selected DMN plugin running and properly configured?",
+    "description": "Admin error for API error when configuring Camunda actions",
+    "originalDefault": "Could not retrieve the decision definitions IDs/versions. Is the selected DMN plugin running and properly configured?"
+  },
+  "DaxIUG": {
+    "defaultMessage": "Variable key",
+    "description": "'Variable key' label",
+    "originalDefault": "Variable key"
   },
   "DcI1VF": {
     "defaultMessage": "Session expired",
@@ -829,15 +849,15 @@
     "description": "Modal title API call failed with HTTP 401",
     "originalDefault": "Authentication failure"
   },
-  "JN1BvY": {
-    "defaultMessage": "Add another",
-    "description": "Registrations column 'Add another' label",
-    "originalDefault": "Add another"
-  },
   "JRGs/Q": {
     "defaultMessage": "Expand/collapse JsonLogic",
     "description": "Expand/collapse logic expression icon title",
     "originalDefault": "Expand/collapse JsonLogic"
+  },
+  "JXcHQ2": {
+    "defaultMessage": "Not yet configured",
+    "description": "'Not yet configured' registration summary message",
+    "originalDefault": "Not yet configured"
   },
   "JZRX+C": {
     "defaultMessage": "Successful Submissions Removal Limit",
@@ -1834,6 +1854,11 @@
     "description": "form step label in nav",
     "originalDefault": "{name} [new]"
   },
+  "j5KpZP": {
+    "defaultMessage": "loading...",
+    "description": "Loading select option label",
+    "originalDefault": "loading..."
+  },
   "j7rEgn": {
     "defaultMessage": "Submission report PDF informatieobjecttype",
     "description": "Objects API registration options \"Submission report PDF informatieobjecttype\" label",
@@ -2184,6 +2209,11 @@
     "description": "Session expiry notice - API call failed with 401",
     "originalDefault": "Sorry, we couldn't do that because you are logged out - this may be because your session expired."
   },
+  "rkzjK3": {
+    "defaultMessage": "JSON Schema target",
+    "description": "'JSON Schema target' label",
+    "originalDefault": "JSON Schema target"
+  },
   "rzGuvz": {
     "defaultMessage": "(not configured yet)",
     "description": "DMN evaluation not configured yet message",
@@ -2373,6 +2403,11 @@
     "defaultMessage": "Objects API - objecttype",
     "description": "URL to the OBJECT TYPE for the \"Product Request\" in the Object Types API. The object type must contain the following attributes: 1) submission_id 2) type (the type of the \"Product Request\") 3) data (submitted form data).",
     "originalDefault": "Objects API - objecttype"
+  },
+  "y4U0aW": {
+    "defaultMessage": "{required, select, true {{path} (required)} other {{path}}}",
+    "description": "Representation of a JSON Schema target path",
+    "originalDefault": "{required, select, true {{path} (required)} other {{path}}}"
   },
   "yCogwi": {
     "defaultMessage": "Select definition",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1587,6 +1587,11 @@
     "description": "JSON editor: complex value representation",
     "originalDefault": "(complex value)"
   },
+  "cK2O6E": {
+    "defaultMessage": "Something went wrong when fetching the available target paths",
+    "description": "Objects API variable registration configuration API error",
+    "originalDefault": "Something went wrong when fetching the available target paths"
+  },
   "cUVVbl": {
     "defaultMessage": "is groter dan of gelijk aan",
     "description": "\">=\" operator description",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -165,6 +165,11 @@
     "description": "Form askStatementOfTruth field label",
     "originalDefault": "Ask statement of truth"
   },
+  "3z1hhJ": {
+    "defaultMessage": "Toggle JSON Schema",
+    "description": "Objects API variable configuration editor JSON Schema visibility toggle",
+    "originalDefault": "Toggle JSON Schema"
+  },
   "41hfj4": {
     "defaultMessage": "Welke ZGW APIs-groep gebruikt moet worden.",
     "description": "ZGW API group selection",
@@ -301,6 +306,11 @@
     "defaultMessage": "Globaal uniek ID voor het formulier",
     "description": "Form ID field help text",
     "originalDefault": "Unique identifier for the form"
+  },
+  "7Vx5It": {
+    "defaultMessage": "No compatible registration backend configured.",
+    "description": "Registration summary no registration backend fallback message",
+    "originalDefault": "No compatible registration backend configured."
   },
   "7X6yT4": {
     "defaultMessage": "U bewerkt een bestaande set van formuliervelden! Deze wijziging heeft effect op <link>{count, plural, one {# formulier} other {# formulieren} }</link>.",
@@ -558,6 +568,16 @@
     "defaultMessage": "Verplaats omlaag",
     "description": "Move down icon title",
     "originalDefault": "Move down"
+  },
+  "DRidde": {
+    "defaultMessage": "Could not retrieve the decision definitions IDs/versions. Is the selected DMN plugin running and properly configured?",
+    "description": "Admin error for API error when configuring Camunda actions",
+    "originalDefault": "Could not retrieve the decision definitions IDs/versions. Is the selected DMN plugin running and properly configured?"
+  },
+  "DaxIUG": {
+    "defaultMessage": "Variable key",
+    "description": "'Variable key' label",
+    "originalDefault": "Variable key"
   },
   "DcI1VF": {
     "defaultMessage": "Sessie vervallen",
@@ -835,15 +855,15 @@
     "description": "Modal title API call failed with HTTP 401",
     "originalDefault": "Authentication failure"
   },
-  "JN1BvY": {
-    "defaultMessage": "Nog één toevoegen",
-    "description": "Registrations column 'Add another' label",
-    "originalDefault": "Add another"
-  },
   "JRGs/Q": {
     "defaultMessage": "Klap JsonLogic-expressie in/uit",
     "description": "Expand/collapse logic expression icon title",
     "originalDefault": "Expand/collapse JsonLogic"
+  },
+  "JXcHQ2": {
+    "defaultMessage": "Not yet configured",
+    "description": "'Not yet configured' registration summary message",
+    "originalDefault": "Not yet configured"
   },
   "JZRX+C": {
     "defaultMessage": "bewaartermijn voor voltooide inzendingen.",
@@ -1848,6 +1868,11 @@
     "description": "form step label in nav",
     "originalDefault": "{name} [new]"
   },
+  "j5KpZP": {
+    "defaultMessage": "loading...",
+    "description": "Loading select option label",
+    "originalDefault": "loading..."
+  },
   "j7rEgn": {
     "defaultMessage": "Submission report PDF informatieobjecttype",
     "description": "Objects API registration options \"Submission report PDF informatieobjecttype\" label",
@@ -2199,6 +2224,11 @@
     "description": "Session expiry notice - API call failed with 401",
     "originalDefault": "Sorry, we couldn't do that because you are logged out - this may be because your session expired."
   },
+  "rkzjK3": {
+    "defaultMessage": "JSON Schema target",
+    "description": "'JSON Schema target' label",
+    "originalDefault": "JSON Schema target"
+  },
   "rzGuvz": {
     "defaultMessage": "(nog niet ingesteld)",
     "description": "DMN evaluation not configured yet message",
@@ -2389,6 +2419,11 @@
     "defaultMessage": "Objecten API - objecttype",
     "description": "URL to the OBJECT TYPE for the \"Product Request\" in the Object Types API. The object type must contain the following attributes: 1) submission_id 2) type (the type of the \"Product Request\") 3) data (submitted form data).",
     "originalDefault": "Objects API - objecttype"
+  },
+  "y4U0aW": {
+    "defaultMessage": "{required, select, true {{path} (required)} other {{path}}}",
+    "description": "Representation of a JSON Schema target path",
+    "originalDefault": "{required, select, true {{path} (required)} other {{path}}}"
   },
   "yCogwi": {
     "defaultMessage": "Formulierdefinitie selecteren",


### PR DESCRIPTION
Part of #3688

Relies on https://github.com/open-formulieren/open-forms/pull/3925 for the API request.

# PR Summary

This PR builds on top of a previous one, where the "registration summary" was displayed, but nothing would happen when you tried editing the configuration:

![image](https://github.com/open-formulieren/open-forms/assets/65306057/5c5b0756-266b-4471-8811-4d2dbca46ecb)

To do so, the `RegistrationSummary` component (responsible for displaying the summary shown above) was tweaked to display a `FormModal`. Inside this modal:
- the variable configuration editor is rendered in a generic way (the `RegistrationSummary` doesn't know anything about it). This will allow other registration backends to provide their own edit form in the future.
- a submit button that will update the options of the matching reg. backend.
- this modal makes use of a Formik form, and the actual configuration editor form can make use of the formik context to edit the options.

For the Objects API, the actual form is defined in the `ObjectsApiVariableConfigurationEditor` component:

![image](https://github.com/open-formulieren/open-forms/assets/65306057/c65b6136-0df0-4b7a-8d0c-4c232830010f)

- Unfortunately, I have to pass the `onFieldChange` callback all the way down to allow backend options to be edited.
- The logic is a bit complex, because we have to handle both edits to an existing mapping and configuring a new variable.
- The target dropdown is also tricky to handle: options values for the select component need to be strings, so the best way we can do this is using `JSON.stringify/parse` to be sure it translates to string and back to an actual value without any collisions.
- If the select is set to the empty option (`----`), it means the variable will remain unmapped. This logic can be found in `TargetPathSelect` component, where we make use of formik's array helpers.

---

This PR also fixes quite some issues not directly related:
- the `LOADING_OPTION` is now properly translated
- When switching from v1 to v2, we make sure an empty `variablesMapping` array is set to avoid errors
- In various components, the complete backend/variable data is passed to props, instead of specific attributes (e.g. `variableKey` -> `variable`)
- Simplified the summary logic: instead of displaying a _Add another_ button, every backend summary is displayed (and they can display a fallback message if it is not yet configured)
- Added the registration column for static variables
- Fixed a crash where the wrong attribute was used to determine the backend conf

---

What remains and will be tackled in another PR:
- Updating the variables mapping array when the name (and thus the key) of a variable changes. Currently, you will see it gets out of sync when you change the name of a user defined variable. Same goes for the component variables when they are edited in the form builder (for this, I will make use of the [`onStepEdit` ](https://github.com/open-formulieren/open-forms/pull/3917/files#diff-2b49dda99f17cba3438b72ce1b13790be227ea434e1307275b6976b9a77375a6R28), however I still need to figure out a way for user defined variables where no such logic is currently defined).
- ~~Error handling if the API request to fetch the compatible target paths fails~~ Done
- Mapping a component variable inside `record.geometry`: the current implementation only allows mapping variables to a target in the `record.data` attribute on the Objects API side. However, it is possible, with the `apply_data_mapping` functionality in the backend, to map a component variable to the geometry attribute. This will need special casing unfortunately.
- Only display targets not yet mapped? 