### PR TITLE
:alien: [#3049] Ensure the data-theme attribute is set

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,3 +4,7 @@
 <link rel="stylesheet" href="./static/admin/css/forms.css" />
 <link rel="stylesheet" href="./static/admin/css/widgets.css" />
 <link rel="stylesheet" href="./static/admin/css/admin-index.css" />
+
+<script defer>
+  document.documentElement.dataset.theme = 'auto';
+</script>


### PR DESCRIPTION
Set to auto so that the browser preferences and storybooks default dark/light mode tool (hopefully) work out of the box without requiring an explicit theme switcher.