### PR TITLE
Update some dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -64,7 +64,7 @@ charset-normalizer==2.0.2
     # via requests
 clamd==1.0.2
     # via -r requirements/base.in
-click==8.0.3
+click==8.1.7
     # via
     #   celery
     #   click-didyoumean
@@ -207,7 +207,7 @@ django-solo==2.1.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
-django-timeline-logger==3.0.0
+django-timeline-logger==4.0.0
     # via -r requirements/base.in
 django-tinymce==3.6.1
     # via -r requirements/base.in
@@ -291,7 +291,7 @@ jsonschema==4.17.3
     #   openapi-spec-validator
 jsonschema-spec==0.1.6
     # via openapi-spec-validator
-kombu==5.2.3
+kombu==5.2.4
     # via celery
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
@@ -374,7 +374,7 @@ pypng==0.20220715.0
     # via qrcode
 pyrsistent==0.17.3
     # via jsonschema
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   django-camunda
     #   django-relativedelta

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -117,7 +117,7 @@ clamd==1.0.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-click==8.0.3
+click==8.1.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -353,7 +353,7 @@ django-solo==2.1.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
-django-timeline-logger==3.0.0
+django-timeline-logger==4.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -541,7 +541,7 @@ jsonschema-spec==0.1.6
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   openapi-spec-validator
-kombu==5.2.3
+kombu==5.2.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -751,7 +751,7 @@ pyrsistent==0.17.3
     #   jsonschema
 pytest==7.4.0
     # via -r requirements/test-tools.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -131,7 +131,7 @@ clamd==1.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-click==8.0.3
+click==8.1.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -390,7 +390,7 @@ django-solo==2.1.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
-django-timeline-logger==3.0.0
+django-timeline-logger==4.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -613,7 +613,7 @@ jsonschema-spec==0.1.6
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   openapi-spec-validator
-kombu==5.2.3
+kombu==5.2.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -871,7 +871,7 @@ pytest==7.4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -95,7 +95,7 @@ clamd==1.0.2
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-click==8.0.3
+click==8.1.7
     # via
     #   -r requirements/base.txt
     #   celery
@@ -308,7 +308,7 @@ django-solo==2.1.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
-django-timeline-logger==3.0.0
+django-timeline-logger==4.0.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -446,7 +446,7 @@ jsonschema-spec==0.1.6
     # via
     #   -r requirements/base.txt
     #   openapi-spec-validator
-kombu==5.2.3
+kombu==5.2.4
     # via
     #   -r requirements/base.txt
     #   celery
@@ -599,7 +599,7 @@ pyrsistent==0.17.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   django-camunda


### PR DESCRIPTION
Updated celery and its dependencies. `django-yubin` is currently blocking the latest Updated `django-timeline-logger`, should remove the `pkg_resources` startup import