### PR TITLE
:arrow_up: Bump django-digid-eherkenning and python3-saml

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,8 +78,10 @@ click-repl==0.2.0
     # via celery
 cryptography==42.0.4
     # via
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
     #   webauthn
@@ -156,7 +158,7 @@ django-csp-reports==1.8.1
     # via -r requirements/base.in
 django-decorator-include==3.0
     # via -r requirements/base.in
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via -r requirements/base.in
 django-filter==23.2
     # via -r requirements/base.in
@@ -312,7 +314,7 @@ maykin-2fa==1.0.0
     # via -r requirements/base.in
 maykin-json-logic-py==0.13.0
     # via -r requirements/base.in
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.0.post2
     # via django-digid-eherkenning
 mozilla-django-oidc==4.0.0
     # via mozilla-django-oidc-db
@@ -365,7 +367,6 @@ pyopenssl==24.0.0
     # via
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
 pyphen==0.14.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -149,8 +149,10 @@ cryptography==42.0.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
     #   webauthn
@@ -261,7 +263,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -583,7 +585,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.0.post2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -729,7 +731,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
 pyphen==0.14.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -169,8 +169,10 @@ cryptography==42.0.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
     #   webauthn
@@ -290,7 +292,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -661,7 +663,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.0.post2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -845,7 +847,6 @@ pyopenssl==24.0.0
     #   -r requirements/ci.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
 pyphen==0.14.0

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -117,8 +117,10 @@ click-repl==0.2.0
 cryptography==42.0.4
     # via
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
     #   webauthn
@@ -226,7 +228,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -480,7 +482,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.0.post2
     # via
     #   -r requirements/base.txt
     #   django-digid-eherkenning
@@ -584,7 +586,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   webauthn
     #   zgw-consumers
 pyphen==0.14.0


### PR DESCRIPTION
The new versions no longer depend on PyOpenSSL