### PR TITLE
Add setting & support redirecting to OpenID Connect identity provider

### DIFF
--- a/docs/configuration/general/oidc.rst
+++ b/docs/configuration/general/oidc.rst
@@ -86,3 +86,6 @@ Klik tot slot rechtsonder op **Opslaan**.
 Je kan vervolgens het makkelijkst testen of alles werkt door in een incognitoscherm
 naar ``https://open-formulieren.gemeente.nl/admin/`` te navigeren en op 
 *Inloggen met organisatieaccount* te klikken.
+
+.. note:: We raden aan om Open Formulieren te deployen met de ``USE_OIDC_FOR_ADMIN_LOGIN=1``
+   environment variabele zodat je meteen omgeleid wordt naar de OpenID Connect Provider.

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -260,6 +260,11 @@ Other settings
   Docker images. The value is used to know which SDK JS/CSS files to include on the form
   detail page.
 
+* ``USE_OIDC_FOR_ADMIN_LOGIN``: If enabled, the admin login page will automatically
+  redirect to the OpenID Connect provider. You typically want to enable this if you
+  enable :ref:`Organization accounts <configuration_authentication_oidc>`. Defaults
+  to ``False``.
+
 * ``SESSION_EXPIRE_AT_BROWSER_CLOSE``: Controls if sessions expire at browser close.
   This applies to both the session of end-users filling out forms and staff using the
   administrative interface. Enabling this forces users to log in every time they open

--- a/src/openforms/accounts/tests/test_hijacking.py
+++ b/src/openforms/accounts/tests/test_hijacking.py
@@ -14,7 +14,10 @@ from openforms.logging.models import TimelineLogProxy
 from .factories import StaffUserFactory, SuperUserFactory
 
 
-@override_settings(MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS=[])  # enforce MFA
+@override_settings(
+    USE_OIDC_FOR_ADMIN_LOGIN=False,
+    MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS=[],  # enforce MFA
+)
 class HijackTests(WebTest):
     csrf_checks = False
 
@@ -26,7 +29,7 @@ class HijackTests(WebTest):
         return response
 
     def _login_with_mfa(self, user):
-        login_page = self.app.get(reverse("admin:login"))
+        login_page = self.app.get(reverse("admin:login"), auto_follow=True)
         login_page.form["auth-username"] = user.username
         login_page.form["auth-password"] = "secret"
         token_page = login_page.form.submit()

--- a/src/openforms/accounts/tests/test_oidc.py
+++ b/src/openforms/accounts/tests/test_oidc.py
@@ -17,7 +17,7 @@ class OIDCLoginButtonTestCase(WebTest):
         return_value=OpenIDConnectConfig(enabled=False),
     )
     def test_oidc_button_disabled(self, mock_get_solo):
-        response = self.app.get(reverse("admin:login"))
+        response = self.app.get(reverse("admin-mfa-login"))
 
         oidc_login_link = response.html.find(
             "a", string=_("Login with organization account")
@@ -36,7 +36,7 @@ class OIDCLoginButtonTestCase(WebTest):
         ),
     )
     def test_oidc_button_enabled(self, mock_get_solo):
-        response = self.app.get(reverse("admin:login"))
+        response = self.app.get(reverse("admin-mfa-login"))
 
         oidc_login_link = response.html.find(
             "a", string=_("Login with organization account")

--- a/src/openforms/accounts/tests/test_user_preferences.py
+++ b/src/openforms/accounts/tests/test_user_preferences.py
@@ -21,7 +21,7 @@ class AccessControlTests(WebTest):
         expected_redirect = furl(reverse("admin:login")).set(
             {"next": str(self.admin_url)}
         )
-        self.assertRedirects(response, str(expected_redirect))
+        self.assertRedirects(response, str(expected_redirect), target_status_code=302)
 
     def test_non_staff_user(self):
         user = UserFactory.create(is_staff=False, is_superuser=False)
@@ -31,7 +31,7 @@ class AccessControlTests(WebTest):
         expected_redirect = furl(reverse("admin:login")).set(
             {"next": str(self.admin_url)}
         )
-        self.assertRedirects(response, str(expected_redirect))
+        self.assertRedirects(response, str(expected_redirect), target_status_code=302)
 
     def test_superuser_but_not_staff(self):
         user = SuperUserFactory.create(is_staff=False)
@@ -41,7 +41,7 @@ class AccessControlTests(WebTest):
         expected_redirect = furl(reverse("admin:login")).set(
             {"next": str(self.admin_url)}
         )
-        self.assertRedirects(response, str(expected_redirect))
+        self.assertRedirects(response, str(expected_redirect), target_status_code=302)
 
     def test_staff_users(self):
         for is_superuser in (False, True):

--- a/src/openforms/admin/tests/test_admin_login.py
+++ b/src/openforms/admin/tests/test_admin_login.py
@@ -1,0 +1,135 @@
+"""
+Tests for the possible admin login flows.
+"""
+
+from unittest.mock import patch
+
+from django.test import override_settings
+from django.urls import reverse, reverse_lazy
+
+from django_webtest import WebTest
+from maykin_2fa.test import disable_admin_mfa
+from mozilla_django_oidc_db.models import OpenIDConnectConfig
+
+from openforms.accounts.tests.factories import SuperUserFactory
+
+LOGIN_URL = reverse_lazy("admin:login")
+
+
+@disable_admin_mfa()
+@override_settings(USE_OIDC_FOR_ADMIN_LOGIN=False)
+class ClassicLoginTests(WebTest):
+
+    def test_admin_login_without_next_param(self):
+        user = SuperUserFactory.create()
+        login_page = self.app.get(LOGIN_URL, auto_follow=True)
+
+        self.assertEqual(login_page.request.path, reverse("admin-mfa-login"))
+
+        with self.subTest("login flow"):
+            form = login_page.forms["login-form"]
+
+            form["auth-username"] = user.username
+            form["auth-password"] = "secret"
+
+            admin_index = form.submit().follow()
+            self.assertEqual(admin_index.request.path, "/admin/")
+
+    def test_admin_login_with_next_param(self):
+        user = SuperUserFactory.create()
+        login_page = self.app.get(
+            LOGIN_URL, {"next": "/admin/accounts/user/"}, auto_follow=True
+        )
+
+        self.assertEqual(login_page.request.path, reverse("admin-mfa-login"))
+
+        with self.subTest("login flow"):
+            form = login_page.forms["login-form"]
+
+            form["auth-username"] = user.username
+            form["auth-password"] = "secret"
+
+            admin_index = form.submit().follow()
+            self.assertEqual(admin_index.request.path, "/admin/accounts/user/")
+
+    def test_admin_login_with_evil_next_param(self):
+        user = SuperUserFactory.create()
+        login_page = self.app.get(
+            LOGIN_URL, {"next": "https://evil.com"}, auto_follow=True
+        )
+
+        self.assertEqual(login_page.request.path, reverse("admin-mfa-login"))
+
+        with self.subTest("login flow"):
+            form = login_page.forms["login-form"]
+
+            form["auth-username"] = user.username
+            form["auth-password"] = "secret"
+
+            admin_index = form.submit().follow()
+            self.assertEqual(admin_index.request.path, "/admin/")
+
+
+@disable_admin_mfa()
+@override_settings(USE_OIDC_FOR_ADMIN_LOGIN=True)
+class OIDCLoginTests(WebTest):
+
+    def setUp(self):
+        super().setUp()
+
+        patcher = patch(
+            "mozilla_django_oidc_db.mixins.OpenIDConnectConfig.get_solo",
+            return_value=OpenIDConnectConfig(
+                enabled=True,
+                oidc_op_authorization_endpoint="https://oidc.example.com/",
+            ),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_admin_login_without_next_param(self):
+        login_page = self.app.get(LOGIN_URL).follow()
+
+        self.assertEqual(login_page.status_code, 302)
+        self.assertTrue(
+            login_page.headers["Location"].startswith("https://oidc.example.com/")
+        )
+        self.assertEqual(self.app.session["oidc_login_next"], "/admin/")
+
+    def test_admin_login_with_next_param(self):
+        login_page = self.app.get(LOGIN_URL, {"next": "/admin/accounts/user/"}).follow()
+
+        self.assertEqual(login_page.status_code, 302)
+        self.assertTrue(
+            login_page.headers["Location"].startswith("https://oidc.example.com/")
+        )
+        self.assertEqual(self.app.session["oidc_login_next"], "/admin/accounts/user/")
+
+
+@disable_admin_mfa()
+class AlreadyLoggedInTests(WebTest):
+
+    def test_admin_login_without_next_param(self):
+        user = SuperUserFactory.create()
+
+        login_page = self.app.get(LOGIN_URL, user=user)
+
+        self.assertRedirects(login_page, "/admin/", fetch_redirect_response=False)
+
+    def test_admin_login_with_next_param(self):
+        user = SuperUserFactory.create()
+
+        login_page = self.app.get(
+            LOGIN_URL, {"next": "/admin/accounts/user/"}, user=user
+        )
+
+        self.assertRedirects(
+            login_page, "/admin/accounts/user/", fetch_redirect_response=False
+        )
+
+    def test_admin_login_with_evil_next_param(self):
+        user = SuperUserFactory.create()
+
+        login_page = self.app.get(LOGIN_URL, {"next": "https://evil.com"}, user=user)
+
+        self.assertRedirects(login_page, "/admin/", fetch_redirect_response=False)

--- a/src/openforms/admin/urls.py
+++ b/src/openforms/admin/urls.py
@@ -6,12 +6,11 @@ from django.urls import include, path
 from decorator_include import decorator_include
 from maykin_2fa import monkeypatch_admin
 from maykin_2fa.urls import urlpatterns, webauthn_urlpatterns
-from maykin_2fa.views import AdminLoginView
 from mozilla_django_oidc_db.views import AdminLoginFailure
 
 from openforms.emails.admin import EmailTestAdminView
 
-from .views import AdminLoginRedirectView
+from .views import AdminLoginRedirectView, ClassicAdminLoginView
 
 # Configure admin
 monkeypatch_admin()
@@ -43,7 +42,7 @@ urlpatterns = [
     # Custom views on top of maykin-2fa even for OIDC redirect if staff users are not
     # authenticated.
     path("login/", AdminLoginRedirectView.as_view()),  # dispatcher
-    path("classic-login/", AdminLoginView.as_view(), name="admin-mfa-login"),
+    path("classic-login/", ClassicAdminLoginView.as_view(), name="admin-mfa-login"),
     # Use custom login views for the admin + support hardware tokens
     path("", include((urlpatterns, "maykin_2fa"))),
     path("", include((webauthn_urlpatterns, "two_factor"))),

--- a/src/openforms/admin/urls.py
+++ b/src/openforms/admin/urls.py
@@ -6,9 +6,12 @@ from django.urls import include, path
 from decorator_include import decorator_include
 from maykin_2fa import monkeypatch_admin
 from maykin_2fa.urls import urlpatterns, webauthn_urlpatterns
+from maykin_2fa.views import AdminLoginView
 from mozilla_django_oidc_db.views import AdminLoginFailure
 
 from openforms.emails.admin import EmailTestAdminView
+
+from .views import AdminLoginRedirectView
 
 # Configure admin
 monkeypatch_admin()
@@ -39,7 +42,8 @@ urlpatterns = [
     path("login/failure/", AdminLoginFailure.as_view(), name="admin-oidc-error"),
     # Custom views on top of maykin-2fa even for OIDC redirect if staff users are not
     # authenticated.
-    # TODO
+    path("login/", AdminLoginRedirectView.as_view()),  # dispatcher
+    path("classic-login/", AdminLoginView.as_view(), name="admin-mfa-login"),
     # Use custom login views for the admin + support hardware tokens
     path("", include((urlpatterns, "maykin_2fa"))),
     path("", include((webauthn_urlpatterns, "two_factor"))),

--- a/src/openforms/admin/urls.py
+++ b/src/openforms/admin/urls.py
@@ -37,6 +37,9 @@ urlpatterns = [
         ),
     ),
     path("login/failure/", AdminLoginFailure.as_view(), name="admin-oidc-error"),
+    # Custom views on top of maykin-2fa even for OIDC redirect if staff users are not
+    # authenticated.
+    # TODO
     # Use custom login views for the admin + support hardware tokens
     path("", include((urlpatterns, "maykin_2fa"))),
     path("", include((webauthn_urlpatterns, "two_factor"))),

--- a/src/openforms/admin/views.py
+++ b/src/openforms/admin/views.py
@@ -7,6 +7,16 @@ from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import RedirectView
 
+from maykin_2fa.views import AdminLoginView
+
+
+class ClassicAdminLoginView(AdminLoginView):
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form, **kwargs)
+        redirect_to = self.request.GET.get(self.redirect_field_name, "")
+        context.setdefault(self.redirect_field_name, redirect_to)
+        return context
+
 
 class AdminLoginRedirectView(RedirectView):
     permanent = False

--- a/src/openforms/admin/views.py
+++ b/src/openforms/admin/views.py
@@ -1,0 +1,34 @@
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.shortcuts import resolve_url
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.generic import RedirectView
+
+
+class AdminLoginRedirectView(RedirectView):
+    permanent = False
+
+    def get_redirect_url(self, *args, **kwargs) -> str:
+        default = reverse("admin:index")
+        redirect_to = self.request.GET.get(REDIRECT_FIELD_NAME, default)
+        url_is_safe = url_has_allowed_host_and_scheme(
+            url=redirect_to,
+            allowed_hosts={self.request.get_host()},
+            require_https=self.request.is_secure(),
+        )
+        redirect_to = redirect_to if url_is_safe else default
+
+        # user already logged in and MFA verified -> send to the final destination
+        if self.request.user.is_authenticated and self.request.user.is_verified():
+            return redirect_to
+
+        redirect_to_name = (
+            "oidc_authentication_init"
+            if settings.USE_OIDC_FOR_ADMIN_LOGIN
+            else "admin-mfa-login"
+        )
+        query = urlencode({REDIRECT_FIELD_NAME: redirect_to}, safe="/")
+        return f"{resolve_url(redirect_to_name)}?{query}"

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -513,6 +513,9 @@ LOGIN_URL = reverse_lazy("admin:login")
 LOGIN_REDIRECT_URL = reverse_lazy("admin:index")
 LOGOUT_REDIRECT_URL = reverse_lazy("admin:index")
 
+# Custom setting
+USE_OIDC_FOR_ADMIN_LOGIN = config("USE_OIDC_FOR_ADMIN_LOGIN", default=False)
+
 #
 # SECURITY settings
 #

--- a/src/openforms/emails/tests/test_check_email.py
+++ b/src/openforms/emails/tests/test_check_email.py
@@ -179,13 +179,13 @@ class CheckEmailSettingsAdminViewTest(WebTestPyQueryMixin, WebTest):
 
         with self.subTest("anon"):
             response = self.app.get(url, status=302)  # to login
-            self.assertRedirects(response, redirect_url)
+            self.assertRedirects(response, redirect_url, target_status_code=302)
 
         with self.subTest("user"):
             user = UserFactory()
             self.app.set_user(user)
             response = self.app.get(url, status=302)  # to login
-            self.assertRedirects(response, redirect_url)
+            self.assertRedirects(response, redirect_url, target_status_code=302)
 
         with self.subTest("staff"):
             user = StaffUserFactory()

--- a/src/openforms/submissions/tests/test_attachment_download_view.py
+++ b/src/openforms/submissions/tests/test_attachment_download_view.py
@@ -178,7 +178,7 @@ class PermissionTests(AuthAssertMixin, WebTest):
 
         response = self.app.get(url)
 
-        self.assertLoginRequired(response, url)
+        self.assertLoginRequired(response, str(url), target_status_code=302)
 
     def test_insufficient_permissions(self):
         submission_file_attachment = SubmissionFileAttachmentFactory.create(

--- a/src/openforms/tests/e2e/base.py
+++ b/src/openforms/tests/e2e/base.py
@@ -55,7 +55,7 @@ async def browser_page():
 @override_settings(ALLOWED_HOSTS=["*"])
 class E2ETestCase(StaticLiveServerTestCase):
     async def _admin_login(self, page: Page) -> None:
-        login_url = furl(self.live_server_url) / reverse("admin:login")
+        login_url = furl(self.live_server_url) / reverse("admin-mfa-login")
         await page.goto(str(login_url))
         await page.get_by_label("Username").fill("admin")
         await page.get_by_label("Password").fill("e2tests")

--- a/src/openforms/utils/tests/test_urls.py
+++ b/src/openforms/utils/tests/test_urls.py
@@ -154,7 +154,7 @@ class IsAdminRequestTest(TestCase):
         Test for requests directly hitting admin URLs.
         """
         factory = RequestFactory()
-        request = factory.get(reverse("admin:login"))
+        request = factory.get(reverse("admin-mfa-login"))
 
         result = is_admin_request(request)
 


### PR DESCRIPTION
Closes #3695

* Added & documented setting to automatically do OIDC authenticate endpoint redirect
* Broke up classic username/password login screen to use different URL
* `/admin/login/` now redirects to either classic login or OIDC provider depending on value of setting