### PR TITLE
:lock: Obfuscate incorrect password in Axes logs

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -645,6 +645,9 @@ AXES_IPWARE_PROXY_COUNT = NUM_PROXIES - 1 if NUM_PROXIES else None
 AXES_LOCKOUT_TEMPLATE = "account_blocked.html"
 AXES_LOCKOUT_PARAMETERS = [["ip_address", "user_agent", "username"]]
 AXES_BEHIND_REVERSE_PROXY = IS_HTTPS
+# By default, Axes obfuscates values for formfields named "password", but the admin
+# interface login formfield name is "auth-password", so we want to obfuscate that
+AXES_SENSITIVE_PARAMETERS = ["auth-password"]  # nosec
 
 # The default meta precedence order
 IPWARE_META_PRECEDENCE_ORDER = (


### PR DESCRIPTION
From: https://github.com/maykinmedia/open-inwoner/pull/1053#discussion_r1503072563