### PR TITLE
Fix incorrect components context in component select dropdowns

### DIFF
--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -152,7 +152,7 @@ class WebformBuilder extends WebformBuilderFormio {
             uniquifyKey={uniquifyKey}
             supportedLanguageCodes={LANGUAGES}
             richTextColors={RICH_TEXT_COLORS}
-            getFormComponents={() => parent.formioContainer}
+            getFormComponents={() => this.webform.components}
             getValidatorPlugins={getValidatorPlugins}
             getRegistrationAttributes={getRegistrationAttributes}
             getPrefillPlugins={getPrefillPlugins}


### PR DESCRIPTION
Closes #3921

Needs backporting to 2.5.x, but not earlier.