### PR TITLE
[#3688] Refactor Objects API plugin to allow for v2

### DIFF
--- a/src/openforms/contrib/objects_api/helpers.py
+++ b/src/openforms/contrib/objects_api/helpers.py
@@ -1,41 +1,20 @@
-from typing import TypedDict
+from typing import Any
 
-from openforms.contrib.zgw.clients.utils import (  # TODO: should be moved somewhere more generic?
-    get_today,
-)
-from openforms.registrations.constants import REGISTRATION_ATTRIBUTE
-from openforms.submissions.mapping import MappingConfig, apply_data_mapping
-from openforms.submissions.models import Submission
-
-from .rendering import render_to_json
-
-
-class PrepareOptions(TypedDict):
-    content_json: str  # Django template syntax
-    objecttype: str  # URL to the objecttype in the Objecttypes API
-    objecttype_version: int
+from openforms.utils.date import get_today
 
 
 def prepare_data_for_registration(
-    submission: Submission,
-    context: dict,
-    options: PrepareOptions,
-    object_mapping: MappingConfig,
-) -> dict:
-    # Prepare the submission data for sending it to the Objects API. This requires
-    # rendering the configured JSON template and running some basic checks for
-    # security and validity, before throwing it over the fence to the Objects API.
+    record_data: dict[str, Any],
+    objecttype: str,
+    objecttype_version: int,
+) -> dict[str, Any]:
+    """Prepare the submission data for sending it to the Objects API."""
 
-    record_data = render_to_json(options["content_json"], context)
-
-    object_data = {
-        "type": options["objecttype"],
+    return {
+        "type": objecttype,
         "record": {
-            "typeVersion": options["objecttype_version"],
+            "typeVersion": objecttype_version,
             "data": record_data,
             "startAt": get_today(),
         },
     }
-    apply_data_mapping(submission, object_mapping, REGISTRATION_ATTRIBUTE, object_data)
-
-    return object_data

--- a/src/openforms/contrib/zgw/clients/documenten.py
+++ b/src/openforms/contrib/zgw/clients/documenten.py
@@ -6,8 +6,7 @@ from django.core.files.base import ContentFile
 from zgw_consumers.nlx import NLXClient
 
 from openforms.translations.utils import to_iso639_2b
-
-from .utils import get_today
+from openforms.utils.date import get_today
 
 DocumentStatus: TypeAlias = Literal[
     "in_bewerking",

--- a/src/openforms/contrib/zgw/clients/utils.py
+++ b/src/openforms/contrib/zgw/clients/utils.py
@@ -1,8 +1,0 @@
-from django.utils import timezone
-
-from openforms.utils.date import datetime_in_amsterdam
-
-
-def get_today() -> str:
-    now = datetime_in_amsterdam(timezone.now())
-    return now.date().isoformat()

--- a/src/openforms/contrib/zgw/clients/zaken.py
+++ b/src/openforms/contrib/zgw/clients/zaken.py
@@ -5,8 +5,9 @@ from django.utils import timezone
 from furl import furl
 from zgw_consumers.nlx import NLXClient
 
+from openforms.utils.date import get_today
+
 from .catalogi import CatalogiClient
-from .utils import get_today
 
 logger = logging.getLogger(__name__)
 

--- a/src/openforms/registrations/contrib/objects_api/models.py
+++ b/src/openforms/registrations/contrib/objects_api/models.py
@@ -172,6 +172,7 @@ class ObjectsAPIConfig(SingletonModel):
             )
 
     def apply_defaults_to(self, options):
+        options.setdefault("version", 1)
         options.setdefault("objecttype", self.objecttype)
         options.setdefault("objecttype_version", self.objecttype_version)
         options.setdefault("productaanvraag_type", self.productaanvraag_type)

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -5,42 +5,27 @@ from typing import Any
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from openforms.contrib.objects_api.helpers import prepare_data_for_registration
-from openforms.contrib.objects_api.rendering import render_to_json
-from openforms.contrib.zgw.clients import DocumentenClient
-from openforms.contrib.zgw.clients.utils import get_today
-from openforms.contrib.zgw.service import (
-    create_attachment_document,
-    create_csv_document,
-    create_report_document,
-)
+from typing_extensions import override
+
 from openforms.registrations.utils import execute_unless_result_exists
-from openforms.submissions.exports import create_submission_export
-from openforms.submissions.mapping import SKIP, FieldConf
-from openforms.submissions.models import Submission, SubmissionReport
-from openforms.variables.utils import get_variables_for_context
+from openforms.submissions.models import Submission
+from openforms.utils.date import get_today
 
 from ...base import BasePlugin
-from ...constants import RegistrationAttribute
 from ...registry import register
 from .checks import check_config
-from .client import get_documents_client, get_objects_client
+from .client import get_objects_client
 from .config import ObjectsAPIOptionsSerializer
 from .models import ObjectsAPIConfig
-from .utils import get_payment_context_data
+from .submission_registration import HANDLER_MAPPING
+from .typing import RegistrationOptions
 
 PLUGIN_IDENTIFIER = "objects_api"
 
 logger = logging.getLogger(__name__)
 
 
-def _point_coordinate(value):
-    if not value or not isinstance(value, list) or len(value) != 2:
-        return SKIP
-    return {"type": "Point", "coordinates": [value[0], value[1]]}
-
-
-def build_options(plugin_options: dict, key_mapping: dict) -> dict:
+def build_options(plugin_options: RegistrationOptions, key_mapping: dict) -> dict:
     """
     Construct options from plugin options dict, allowing renaming of keys
     """
@@ -57,105 +42,29 @@ class ObjectsAPIRegistration(BasePlugin):
     verbose_name = _("Objects API registration")
     configuration_options = ObjectsAPIOptionsSerializer
 
-    object_mapping = {
-        "record.geometry": FieldConf(
-            RegistrationAttribute.locatie_coordinaat, transform=_point_coordinate
-        ),
-    }
-
+    @override
     def register_submission(
-        self, submission: Submission, options: dict
+        self, submission: Submission, options: RegistrationOptions
     ) -> dict[str, Any]:
-        """Register a submission using the ObjectsAPI backend
+        """Register a submission using the Objects API backend.
 
         The creation of submission documents (report, attachment, csv) makes use of ZGW
         service functions (e.g. :func:`create_report_document`) and involves a mapping
         (and in some cases renaming) of variables which would otherwise not be
         accessible from here. For example, 'vertrouwelijkheidaanduiding' must be named
         'doc_vertrouwelijkheidaanduiding' because this is what the ZGW service functions
-        use."""
+        use.
+        """
+
         config = ObjectsAPIConfig.get_solo()
         assert isinstance(config, ObjectsAPIConfig)
         config.apply_defaults_to(options)
 
-        # Prepare all documents to relate to the Objects API record
-        with get_documents_client() as documents_client:
-            # Create the document for the PDF summary
-            submission_report = SubmissionReport.objects.get(submission=submission)
-            submission_report_options = build_options(
-                options,
-                {
-                    "informatieobjecttype": "informatieobjecttype_submission_report",
-                    "organisatie_rsin": "organisatie_rsin",
-                    "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
-                },
-            )
+        handler = HANDLER_MAPPING[options["version"]]
 
-            document = create_report_document(
-                client=documents_client,
-                name=submission.form.admin_name,
-                submission_report=submission_report,
-                options=submission_report_options,
-                language=submission_report.submission.language_code,
-            )
-
-            # Register the attachments
-            # TODO turn attachments into dictionary when giving users more options then
-            # just urls.
-            attachments = []
-            for attachment in submission.attachments:
-                attachment_options = build_options(
-                    options,
-                    {
-                        "informatieobjecttype": "informatieobjecttype_attachment",  # Different IOT than for the report
-                        "organisatie_rsin": "organisatie_rsin",
-                        "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
-                    },
-                )
-
-                component_overwrites = {
-                    "doc_vertrouwelijkheidaanduiding": attachment.doc_vertrouwelijkheidaanduiding,
-                    "titel": attachment.titel,
-                    "organisatie_rsin": attachment.bronorganisatie,
-                    "informatieobjecttype": attachment.informatieobjecttype,
-                }
-
-                for key, value in component_overwrites.items():
-                    if value:
-                        attachment_options[key] = value
-
-                attachment_document = create_attachment_document(
-                    client=documents_client,
-                    name=submission.form.admin_name,
-                    submission_attachment=attachment,
-                    options=attachment_options,
-                    language=attachment.submission_step.submission.language_code,  # assume same as submission
-                )
-                attachments.append(attachment_document["url"])
-
-            # Create the CSV submission export, if requested.
-            # If no CSV is being uploaded, then `assert csv_url == ""` applies.
-            csv_url = register_submission_csv(submission, options, documents_client)
-
-        context = {
-            "_submission": submission,
-            "productaanvraag_type": options["productaanvraag_type"],
-            "payment": get_payment_context_data(submission),
-            "variables": get_variables_for_context(submission),
-            # Github issue #661, nested for namespacing note: other templates and context expose all submission
-            # variables in the top level namespace, but that is due for refactor
-            "submission": {
-                "public_reference": submission.public_registration_reference,
-                "kenmerk": str(submission.uuid),
-                "language_code": submission.language_code,
-                "uploaded_attachment_urls": attachments,
-                "pdf_url": document["url"],
-                "csv_url": csv_url,
-            },
-        }
-
-        object_data = prepare_data_for_registration(
-            submission, context, options, self.object_mapping
+        object_data = handler.get_object_data(
+            submission=submission,
+            options=options,
         )
 
         with get_objects_client() as objects_client:
@@ -167,9 +76,11 @@ class ObjectsAPIRegistration(BasePlugin):
 
         return response
 
+    @override
     def check_config(self):
         check_config()
 
+    @override
     def get_config_actions(self):
         return [
             (
@@ -181,13 +92,17 @@ class ObjectsAPIRegistration(BasePlugin):
             ),
         ]
 
+    @override
     def get_custom_templatetags_libraries(self) -> list[str]:
         prefix = "openforms.registrations.contrib.objects_api.templatetags.registrations.contrib"
         return [
             f"{prefix}.objects_api.json_tags",
         ]
 
-    def update_payment_status(self, submission: "Submission", options: dict) -> None:
+    @override
+    def update_payment_status(
+        self, submission: Submission, options: RegistrationOptions
+    ) -> None:
         config = ObjectsAPIConfig.get_solo()
         assert isinstance(config, ObjectsAPIConfig)
         config.apply_defaults_to(options)
@@ -198,17 +113,14 @@ class ObjectsAPIRegistration(BasePlugin):
             )
             return
 
-        context = {
-            "variables": get_variables_for_context(submission),
-            "payment": get_payment_context_data(submission),
-        }
-
-        updated_record_data = render_to_json(
-            options["payment_status_update_json"], context
+        handler = HANDLER_MAPPING[options["version"]]
+        updated_object_data = handler.get_update_payment_status_data(
+            submission, options
         )
+
         updated_object_data = {
             "record": {
-                "data": updated_record_data,
+                "data": updated_object_data,
                 "startAt": get_today(),
             },
         }
@@ -221,37 +133,3 @@ class ObjectsAPIRegistration(BasePlugin):
                 headers={"Content-Crs": "EPSG:4326"},
             )
             response.raise_for_status()
-
-
-def register_submission_csv(
-    submission: Submission,
-    options: dict,
-    documents_client: DocumentenClient,
-) -> str:
-    if not options.get("upload_submission_csv", False):
-        return ""
-
-    if not options["informatieobjecttype_submission_csv"]:
-        return ""
-
-    submission_csv_options = build_options(
-        options,
-        {
-            "informatieobjecttype": "informatieobjecttype_submission_csv",
-            "organisatie_rsin": "organisatie_rsin",
-            "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
-            "auteur": "auteur",
-        },
-    )
-    qs = Submission.objects.filter(pk=submission.pk).select_related("auth_info")
-    submission_csv = create_submission_export(qs).export("csv")  # type: ignore
-
-    submission_csv_document = create_csv_document(
-        client=documents_client,
-        name=f"{submission.form.admin_name} (csv)",
-        csv_data=submission_csv,
-        options=submission_csv_options,
-        language=submission.language_code,
-    )
-
-    return submission_csv_document["url"]

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -48,12 +48,8 @@ class ObjectsAPIRegistration(BasePlugin):
     ) -> dict[str, Any]:
         """Register a submission using the Objects API backend.
 
-        The creation of submission documents (report, attachment, csv) makes use of ZGW
-        service functions (e.g. :func:`create_report_document`) and involves a mapping
-        (and in some cases renaming) of variables which would otherwise not be
-        accessible from here. For example, 'vertrouwelijkheidaanduiding' must be named
-        'doc_vertrouwelijkheidaanduiding' because this is what the ZGW service functions
-        use.
+        Depending on the options version (legacy or mapped variables), the payload
+        will be created differently. The actual logic lives in the ``submission_registration`` submodule.
         """
 
         config = ObjectsAPIConfig.get_solo()

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -43,7 +43,7 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
     """Provide the registration data for legacy (v1) registration options, using JSON templates."""
 
     @staticmethod
-    def _point_coordinate(value):
+    def _point_coordinate(value: Any) -> dict[str, Any] | object:
         if not value or not isinstance(value, list) or len(value) != 2:
             return SKIP
         return {"type": "Point", "coordinates": [value[0], value[1]]}

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -1,0 +1,233 @@
+from typing import Any, Protocol, TypeVar, cast
+
+from typing_extensions import override
+
+from openforms.contrib.objects_api.helpers import prepare_data_for_registration
+from openforms.contrib.objects_api.rendering import render_to_json
+from openforms.contrib.zgw.service import (
+    create_attachment_document,
+    create_csv_document,
+    create_report_document,
+)
+from openforms.submissions.exports import create_submission_export
+from openforms.submissions.mapping import SKIP, FieldConf, apply_data_mapping
+from openforms.submissions.models import Submission, SubmissionReport
+from openforms.variables.utils import get_variables_for_context
+
+from ...constants import REGISTRATION_ATTRIBUTE, RegistrationAttribute
+from .client import DocumentenClient, get_documents_client
+from .typing import ConfigVersion, RegistrationOptionsV1, RegistrationOptionsV2
+
+OptionsT = TypeVar(
+    "OptionsT", RegistrationOptionsV1, RegistrationOptionsV2, contravariant=True
+)
+
+
+class ObjectsAPIRegistrationHandler(Protocol[OptionsT]):
+    """Provide the registration data to be sent to the Objects API."""
+
+    def get_object_data(
+        self,
+        submission: Submission,
+        options: OptionsT,
+    ) -> dict[str, Any]:
+        """Get the object data payload to be sent to the Objects API."""
+        ...
+
+    def get_update_payment_status_data(
+        self, submission: Submission, options: OptionsT
+    ) -> dict[str, Any]: ...
+
+
+class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
+    """Provide the registration data for legacy (v1) registration options, using JSON templates."""
+
+    @staticmethod
+    def _point_coordinate(value):
+        if not value or not isinstance(value, list) or len(value) != 2:
+            return SKIP
+        return {"type": "Point", "coordinates": [value[0], value[1]]}
+
+    @staticmethod
+    def get_payment_context_data(submission: Submission) -> dict[str, Any]:
+        return {
+            "completed": submission.payment_user_has_paid,
+            "amount": str(submission.payments.sum_amount()),
+            "public_order_ids": submission.payments.get_completed_public_order_ids(),
+        }
+
+    @staticmethod
+    def build_options(plugin_options: RegistrationOptionsV1, key_mapping: dict) -> dict:
+        """
+        Construct options from plugin options dict, allowing renaming of keys
+        """
+        options = {
+            new_key: plugin_options[key_in_opts]
+            for new_key, key_in_opts in key_mapping.items()
+            if key_in_opts in plugin_options
+        }
+        return options
+
+    def register_submission_csv(
+        self,
+        submission: Submission,
+        options: RegistrationOptionsV1,
+        documents_client: DocumentenClient,
+    ) -> str:
+        if not options.get("upload_submission_csv", False):
+            return ""
+
+        if not options["informatieobjecttype_submission_csv"]:
+            return ""
+
+        submission_csv_options = self.build_options(
+            options,
+            {
+                "informatieobjecttype": "informatieobjecttype_submission_csv",
+                "organisatie_rsin": "organisatie_rsin",
+                "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
+                "auteur": "auteur",
+            },
+        )
+        qs = Submission.objects.filter(pk=submission.pk).select_related("auth_info")
+        submission_csv = create_submission_export(qs).export("csv")  # type: ignore
+
+        submission_csv_document = create_csv_document(
+            client=documents_client,
+            name=f"{submission.form.admin_name} (csv)",
+            csv_data=submission_csv,
+            options=submission_csv_options,
+            language=submission.language_code,
+        )
+
+        return submission_csv_document["url"]
+
+    @override
+    def get_object_data(
+        self,
+        submission: Submission,
+        options: RegistrationOptionsV1,
+    ) -> dict[str, Any]:
+        """Get the object data payload to be sent to the Objects API.
+
+        The creation of submission documents (report, attachment, csv) makes use of ZGW
+        service functions (e.g. :func:`create_report_document`) and involves a mapping
+        (and in some cases renaming) of variables which would otherwise not be
+        accessible from here. For example, 'vertrouwelijkheidaanduiding' must be named
+        'doc_vertrouwelijkheidaanduiding' because this is what the ZGW service functions
+        use.
+        """
+
+        # Prepare all documents to relate to the Objects API record
+        with get_documents_client() as documents_client:
+            # Create the document for the PDF summary
+            submission_report = SubmissionReport.objects.get(submission=submission)
+            submission_report_options = self.build_options(
+                options,
+                {
+                    "informatieobjecttype": "informatieobjecttype_submission_report",
+                    "organisatie_rsin": "organisatie_rsin",
+                    "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
+                },
+            )
+
+            report_document = create_report_document(
+                client=documents_client,
+                name=submission.form.admin_name,
+                submission_report=submission_report,
+                options=submission_report_options,
+                language=submission_report.submission.language_code,
+            )
+
+            # Register the attachments
+            # TODO turn attachments into dictionary when giving users more options then
+            # just urls.
+            attachment_urls: list[str] = []
+            for attachment in submission.attachments:
+                attachment_options = self.build_options(
+                    options,
+                    {
+                        "informatieobjecttype": "informatieobjecttype_attachment",  # Different IOT than for the report
+                        "organisatie_rsin": "organisatie_rsin",
+                        "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
+                    },
+                )
+
+                component_overwrites = {
+                    "doc_vertrouwelijkheidaanduiding": attachment.doc_vertrouwelijkheidaanduiding,
+                    "titel": attachment.titel,
+                    "organisatie_rsin": attachment.bronorganisatie,
+                    "informatieobjecttype": attachment.informatieobjecttype,
+                }
+
+                for key, value in component_overwrites.items():
+                    if value:
+                        attachment_options[key] = value
+
+                attachment_document = create_attachment_document(
+                    client=documents_client,
+                    name=submission.form.admin_name,
+                    submission_attachment=attachment,
+                    options=attachment_options,
+                    language=attachment.submission_step.submission.language_code,  # assume same as submission
+                )
+                attachment_urls.append(attachment_document["url"])
+
+            # Create the CSV submission export, if requested.
+            # If no CSV is being uploaded, then `assert csv_url == ""` applies.
+            csv_url = self.register_submission_csv(
+                submission, options, documents_client
+            )
+
+        context = {
+            "_submission": submission,
+            "productaanvraag_type": options["productaanvraag_type"],
+            "payment": self.get_payment_context_data(submission),
+            "variables": get_variables_for_context(submission),
+            # Github issue #661, nested for namespacing note: other templates and context expose all submission
+            # variables in the top level namespace, but that is due for refactor
+            "submission": {
+                "public_reference": submission.public_registration_reference,
+                "kenmerk": str(submission.uuid),
+                "language_code": submission.language_code,
+                "uploaded_attachment_urls": attachment_urls,
+                "pdf_url": report_document["url"],
+                "csv_url": csv_url,
+            },
+        }
+
+        object_mapping = {
+            "record.geometry": FieldConf(
+                RegistrationAttribute.locatie_coordinaat,
+                transform=self._point_coordinate,
+            ),
+        }
+
+        record_data = cast(
+            dict[str, Any], render_to_json(options["content_json"], context)
+        )
+        object_data = prepare_data_for_registration(
+            record_data=record_data,
+            objecttype=options["objecttype"],
+            objecttype_version=options["objecttype_version"],
+        )
+        object_data = apply_data_mapping(
+            submission, object_mapping, REGISTRATION_ATTRIBUTE, object_data
+        )
+        return object_data
+
+    @override
+    def get_update_payment_status_data(
+        self, submission: Submission, options: RegistrationOptionsV1
+    ) -> dict[str, Any]:
+        context = {
+            "variables": get_variables_for_context(submission),
+            "payment": self.get_payment_context_data(submission),
+        }
+
+        return render_to_json(options["payment_status_update_json"], context)
+
+
+HANDLER_MAPPING: dict[ConfigVersion, ObjectsAPIRegistrationHandler[Any]] = {
+    1: ObjectsAPIV1Handler(),
+}

--- a/src/openforms/registrations/contrib/objects_api/tests/test_template.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_template.py
@@ -55,11 +55,11 @@ class JSONTemplatingTests(TestCase):
                 return_value=config,
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_report_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_report_document",
                 return_value={"url": "http://oz.nl/pdf-report"},
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_attachment_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_attachment_document",
                 return_value={"url": "http://oz.nl/attachment-url"},
             ),
         ):
@@ -156,19 +156,19 @@ class JSONTemplatingTests(TestCase):
                 return_value=config,
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_report_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_report_document",
                 return_value={"url": "http://oz.nl/pdf-report"},
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_attachment_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_attachment_document",
                 return_value={"url": "http://oz.nl/attachment-url"},
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_submission_export",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_submission_export",
                 return_value=tablib.Dataset(),
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_csv_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_csv_document",
                 return_value={"url": "http://oz.nl/csv-report"},
             ),
         ):
@@ -264,7 +264,7 @@ class JSONTemplatingTests(TestCase):
                 return_value=config,
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_report_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_report_document",
                 return_value={"url": "http://of.nl/pdf-report"},
             ),
         ):
@@ -295,7 +295,7 @@ class JSONTemplatingTests(TestCase):
                 return_value=config,
             ),
             patch(
-                "openforms.registrations.contrib.objects_api.plugin.create_report_document",
+                "openforms.registrations.contrib.objects_api.submission_registration.create_report_document",
                 return_value={"url": "http://of.nl/pdf-report"},
             ),
         ):

--- a/src/openforms/registrations/contrib/objects_api/tests/test_utils.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_utils.py
@@ -7,7 +7,8 @@ from openforms.payments.constants import PaymentStatus
 from openforms.payments.tests.factories import SubmissionPaymentFactory
 from openforms.submissions.tests.factories import SubmissionFactory
 
-from ..utils import get_payment_context_data, html_escape_json
+from ..submission_registration import ObjectsAPIV1Handler
+from ..utils import html_escape_json
 
 
 class EscapeHTMLTests(TestCase):
@@ -76,7 +77,7 @@ class EscapeHTMLTests(TestCase):
             amount=1_000,
         )
 
-        context_data = get_payment_context_data(payment.submission)
+        context_data = ObjectsAPIV1Handler.get_payment_context_data(payment.submission)
 
         self.assertEqual("1000.00", context_data["amount"])
 
@@ -85,7 +86,7 @@ class EscapeHTMLTests(TestCase):
             amount=3.1415926535,
         )
 
-        context_data = get_payment_context_data(payment.submission)
+        context_data = ObjectsAPIV1Handler.get_payment_context_data(payment.submission)
 
         self.assertEqual("3.14", context_data["amount"])
 
@@ -104,7 +105,10 @@ class EscapeHTMLTests(TestCase):
         )
 
         rendered_json = render_to_json(
-            template, context={"payment": get_payment_context_data(submission)}
+            template,
+            context={
+                "payment": ObjectsAPIV1Handler.get_payment_context_data(submission)
+            },
         )
 
         self.assertEqual(

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -1,0 +1,36 @@
+from typing import Literal, TypeAlias, TypedDict
+
+from typing_extensions import Required
+
+ConfigVersion: TypeAlias = Literal[1, 2]
+
+
+class _BaseRegistrationOptions(TypedDict, total=False):
+    objecttype: Required[str]
+    objecttype_version: Required[int]
+    productaanvraag_type: str
+    informatieobjecttype_submission_report: str
+    upload_submission_csv: bool
+    informatieobjecttype_submission_csv: str
+    informatieobjecttype_attachment: str
+    organisatie_rsin: str
+
+
+class RegistrationOptionsV1(_BaseRegistrationOptions, total=False):
+    version: Required[Literal[1]]
+    content_json: str
+    payment_status_update_json: str
+
+
+class ObjecttypeVariableMapping(TypedDict):
+    variable_key: str
+    target_path: list[str]
+
+
+class RegistrationOptionsV2(_BaseRegistrationOptions):
+    version: Literal[2]
+    variables_mapping: list[ObjecttypeVariableMapping]
+
+
+RegistrationOptions: TypeAlias = RegistrationOptionsV1 | RegistrationOptionsV2
+"""The Objects API registration options (either V1 or V2)."""

--- a/src/openforms/registrations/contrib/objects_api/utils.py
+++ b/src/openforms/registrations/contrib/objects_api/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from django.utils.html import escape
 
@@ -21,11 +21,3 @@ def html_escape_json(value: T) -> T:
         case _:
             # nothing to do, return unmodified
             return value
-
-
-def get_payment_context_data(submission) -> dict[str, Any]:
-    return {
-        "completed": submission.payment_user_has_paid,
-        "amount": str(submission.payments.sum_amount()),
-        "public_order_ids": submission.payments.get_completed_public_order_ids(),
-    }

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -14,6 +14,7 @@ from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 from openforms.api.fields import PrimaryKeyRelatedAsChoicesField
 from openforms.config.data import Action
 from openforms.contrib.objects_api.helpers import prepare_data_for_registration
+from openforms.contrib.objects_api.rendering import render_to_json
 from openforms.contrib.zgw.clients.catalogi import omschrijving_matcher
 from openforms.contrib.zgw.service import (
     create_attachment_document,
@@ -640,8 +641,15 @@ class ZGWRegistration(BasePlugin):
             },
         }
 
+        record_data = render_to_json(options["content_json"], context)
         object_data = prepare_data_for_registration(
-            submission, context, options, object_mapping
+            record_data=record_data,
+            objecttype=options["objecttype"],
+            objecttype_version=options["objecttype_version"],
+        )
+
+        apply_data_mapping(
+            submission, object_mapping, REGISTRATION_ATTRIBUTE, object_data
         )
 
         with get_objects_client() as objects_client:

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -75,3 +75,8 @@ def parse_time(value: str) -> None | time:
 
 def datetime_in_amsterdam(value: datetime) -> datetime:
     return timezone.make_naive(value, timezone=TIMEZONE_AMS)
+
+
+def get_today() -> str:
+    now = datetime_in_amsterdam(timezone.now())
+    return now.date().isoformat()


### PR DESCRIPTION
Part of #3688.

# PR summary

This PR refactors the Objects API registration backend to split the registration logic depending on whether the registration options are v1 (legacy way, with the JSON templates) or v2 (with variables mapped individually):
- Added a `typing` module to provide TypedDicts for the options.
- Moved all the business logic in the `register_submission` method to the `submission_registration` module. A `Protocol` is defined, and an implementation for the V1 logic is provided (V2 is for another PR). This protocol is responsible for providing the object data JSON payload to be sent to the API. The `ObjectsAPIV1Handler` implements this protocol for V1, and all the utility functions that where in the plugin module are now set as staticmethods for clarity (i.e. to do some "namespacing").
- The registration plugin then instantiates the correct handler depending on V1 or V2, and simply grabs the record data to be sent.
- Some cleanups (the `get_today` function was moved to `openforms.utils.date`)

---

This also raises the question of how the record data will be generated for v2:
- we currently have control over the mapping of the variables, but v1 also allows registering more things (`bsn`, `uploaded_attachments_urls`, etc).
For reference, the default template looks like:
```jinja
{
  "data": {% json_summary %},
  "type": "{{ productaanvraag_type }}",
  "bsn": "{{ variables.auth_bsn }}",
  "pdf_url": "{{ submission.pdf_url }}",
  "attachments": {% uploaded_attachment_urls %},
  "submission_id": "{{ submission.kenmerk }}",
  "language_code": "{{ submission.language_code }}"
}
```
The idea would be to have the `variable_mapping` configuration translated to a JSON object that would fit in `"data"`. But the user has then no control over the rest, as he can't provide a JSON template anymore. In a follow up PR, this will probably be implemented in a way where registration backends can provide custom submission variables. For instance with the Objects API backend, a variable `pdf_url` of type `string` will be provided, and the end user will be able to map it to a specific JSON Schema target, the same way it is done currently for existing variables (so most probably a new tab in the variables tab will appear). This is still TBD.