### PR TITLE
⬆️ Update dependencies to drop `setuptools`

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -44,7 +44,7 @@ You will also need the following operating-system libraries:
 .. _Python: https://www.python.org/
 .. _Django framework: https://www.djangoproject.com/
 .. _Virtualenv: https://virtualenv.pypa.io/en/stable/
-.. _Pip: https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date
+.. _Pip: https://pip.pypa.io/en/stable/installation/
 .. _PostgreSQL: https://www.postgresql.org
 .. _Node.js: http://nodejs.org/
 .. _nvm: https://github.com/nvm-sh/nvm

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -45,7 +45,6 @@ django-capture-tag
 django-colorfield
 django-cookie-consent
 django-cors-headers
-django-decorator-include
 django-digid-eherkenning
 django-hijack
 django-jsonform

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,7 @@ bleach[css] >= 5
 celery ~= 5.0
 celery-once
 defusedxml
+frozendict
 furl
 glom
 maykin-json-logic-py
@@ -33,10 +34,6 @@ tabulate
 typing-extensions
 weasyprint
 zeep
-# Pinned setuptools to a version lower than 58 to allow pyzmail36 to be
-# installed, as required by django-yubin.
-setuptools
-frozendict
 
 # Framework libraries
 django ~= 4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -100,7 +100,6 @@ django==4.2.11
     #   django-cors-headers
     #   django-csp
     #   django-csp-reports
-    #   django-decorator-include
     #   django-digid-eherkenning
     #   django-filter
     #   django-formtools
@@ -155,8 +154,6 @@ django-cors-headers==3.11.0
 django-csp==3.7
     # via -r requirements/base.in
 django-csp-reports==1.8.1
-    # via -r requirements/base.in
-django-decorator-include==3.0
     # via -r requirements/base.in
 django-digid-eherkenning==0.12.0
     # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -140,7 +140,7 @@ django-appconf==1.0.4
     #   django-timeline-logger
 django-autoslug==1.9.9
     # via -r requirements/base.in
-django-axes[ipware]==6.0.5
+django-axes[ipware]==6.4.0
     # via -r requirements/base.in
 django-camunda==0.14.0
     # via -r requirements/base.in
@@ -278,7 +278,7 @@ isodate==0.6.1
     #   maykin-json-logic-py
     #   maykin-python3-saml
     #   zeep
-josepy==1.8.0
+josepy==1.14.0
     # via mozilla-django-oidc
 jq==1.3.0
     # via -r requirements/base.in
@@ -529,10 +529,3 @@ zgw-consumers==0.32.0
     # via -r requirements/base.in
 zopfli==0.2.3
     # via fonttools
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==65.6.3
-    # via
-    #   -r requirements/base.in
-    #   django-axes
-    #   josepy

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -226,7 +226,7 @@ django-autoslug==1.9.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-axes[ipware]==6.0.5
+django-axes[ipware]==6.4.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -515,7 +515,7 @@ isort==5.10.1
     # via -r requirements/test-tools.in
 jinja2==3.1.3
     # via sphinx
-josepy==1.8.0
+josepy==1.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1082,11 +1082,3 @@ zopfli==0.2.3
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   fonttools
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==65.6.3
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   django-axes
-    #   josepy

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -179,7 +179,6 @@ django==4.2.11
     #   django-cors-headers
     #   django-csp
     #   django-csp-reports
-    #   django-decorator-include
     #   django-digid-eherkenning
     #   django-filter
     #   django-formtools
@@ -256,10 +255,6 @@ django-csp==3.7
     #   -c requirements/base.txt
     #   -r requirements/base.txt
 django-csp-reports==1.8.1
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-django-decorator-include==3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -203,7 +203,6 @@ django==4.2.11
     #   django-csp
     #   django-csp-reports
     #   django-debug-toolbar
-    #   django-decorator-include
     #   django-digid-eherkenning
     #   django-extensions
     #   django-filter
@@ -288,10 +287,6 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
-django-decorator-include==3.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
 django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -253,7 +253,7 @@ django-autoslug==1.9.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-axes[ipware]==6.0.5
+django-axes[ipware]==6.4.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -587,7 +587,7 @@ jinja2==3.1.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   sphinx
-josepy==1.8.0
+josepy==1.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1275,9 +1275,4 @@ zopfli==0.2.3
 pip==23.3.1
     # via pip-tools
 setuptools==65.6.3
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   django-axes
-    #   josepy
-    #   pip-tools
+    # via pip-tools

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -144,7 +144,6 @@ django==4.2.11
     #   django-cors-headers
     #   django-csp
     #   django-csp-reports
-    #   django-decorator-include
     #   django-digid-eherkenning
     #   django-filter
     #   django-formtools
@@ -221,10 +220,6 @@ django-csp==3.7
     #   -c requirements/base.in
     #   -r requirements/base.txt
 django-csp-reports==1.8.1
-    # via
-    #   -c requirements/base.in
-    #   -r requirements/base.txt
-django-decorator-include==3.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -191,7 +191,7 @@ django-autoslug==1.9.9
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-axes[ipware]==6.0.5
+django-axes[ipware]==6.4.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -424,7 +424,7 @@ isodate==0.6.1
     #   maykin-json-logic-py
     #   maykin-python3-saml
     #   zeep
-josepy==1.8.0
+josepy==1.14.0
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc
@@ -836,11 +836,3 @@ zopfli==0.2.3
     # via
     #   -r requirements/base.txt
     #   fonttools
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==65.6.3
-    # via
-    #   -c requirements/base.in
-    #   -r requirements/base.txt
-    #   django-axes
-    #   josepy

--- a/src/openforms/admin/urls.py
+++ b/src/openforms/admin/urls.py
@@ -3,12 +3,12 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import views as auth_views
 from django.urls import include, path
 
-from decorator_include import decorator_include
 from maykin_2fa import monkeypatch_admin
 from maykin_2fa.urls import urlpatterns, webauthn_urlpatterns
 from mozilla_django_oidc_db.views import AdminLoginFailure
 
 from openforms.emails.admin import EmailTestAdminView
+from openforms.utils.urls import decorator_include
 
 from .views import AdminLoginRedirectView, ClassicAdminLoginView
 

--- a/src/openforms/api/urls.py
+++ b/src/openforms/api/urls.py
@@ -1,7 +1,6 @@
 from django.urls import include, path
 from django.views.generic import RedirectView
 
-from decorator_include import decorator_include
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularJSONAPIView,
@@ -25,6 +24,7 @@ from openforms.services.api.viewsets import ServiceViewSet
 from openforms.submissions.api.viewsets import SubmissionStepViewSet, SubmissionViewSet
 from openforms.utils.decorators import never_cache
 from openforms.utils.json_logic.api.views import GenerateLogicDescriptionView
+from openforms.utils.urls import decorator_include
 from openforms.variables.api.viewsets import ServiceFetchConfigurationViewSet
 
 from .views import PingView


### PR DESCRIPTION
This is an experiment to see which dependencies relies on `pkg_resources` and does not use `setuptools` as a dependency. In Python 3.12, `setuptools` is no longer installed by default in venvs, and people used to rely on that to use `pkg_resources` (installed along with `setuptools`) to get the version of a package. By updating the last dependencies that used to rely on this (`django-axes` and `josepy`), setuptools will no longer be present, and I can then see what packages fail:
- [x] `zds_client`: imported by `zgw_consumers`. It is planned to drop support for `zds_client` in `zgw_consumers`, however it is more work than I expected. Fixed by: https://github.com/open-formulieren/open-forms/pull/4059
- [x] `decorator_include`: unmaintained, we should find a replacement: https://github.com/open-formulieren/open-forms/pull/4083