### PR TITLE
[#3881] Update variables in reusable form definitions

### DIFF
--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -27,7 +27,7 @@ from openforms.variables.constants import FormVariableSources
 
 from ..messages import add_success_message
 from ..models import Form, FormDefinition, FormStep, FormVersion
-from ..tasks import recouple_submission_variables_to_form_variables
+from ..tasks import on_variables_bulk_update_event
 from ..utils import export_form, import_form
 from .datastructures import FormVariableWrapper
 from .documentation import get_admin_fields_markdown
@@ -553,7 +553,7 @@ class FormViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        recouple_submission_variables_to_form_variables.delay(form.id)
+        on_variables_bulk_update_event(form.id)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/src/openforms/forms/tasks.py
+++ b/src/openforms/forms/tasks.py
@@ -6,12 +6,33 @@ from django.db import DatabaseError, transaction
 from django.db.utils import IntegrityError
 from django.utils import timezone
 
+from celery import chain
 from djangorestframework_camel_case.util import camelize
+
+from openforms.variables.constants import FormVariableSources
 
 from ..celery import app
 from .models import Form
 
 logger = logging.getLogger(__name__)
+
+
+def on_variables_bulk_update_event(form_id: int) -> None:
+    """
+    Celery chain of tasks to execute on a bulk update of variables event.
+    """
+    repopulate_reusable_definition_variables_task = (
+        repopulate_reusable_definition_variables_to_form_variables.si(form_id)
+    )
+    recouple_submission_variables_task = (
+        recouple_submission_variables_to_form_variables.si(form_id)
+    )
+
+    actions_chain = chain(
+        repopulate_reusable_definition_variables_task,
+        recouple_submission_variables_task,
+    )
+    actions_chain.delay()
 
 
 @app.task(ignore_result=True)
@@ -85,6 +106,33 @@ def recouple_submission_variables_to_form_variables(form_id: int) -> None:
         # Issue #1970: If the form is saved again from the form editor while this task was running, the form variables
         # retrieved don't exist anymore. Another task will be scheduled from the endpoint, so nothing more to do here.
         logger.info("Form variables were updated while this task was runnning.")
+
+
+@app.task(ignore_result=True)
+@transaction.atomic()
+def repopulate_reusable_definition_variables_to_form_variables(form_id: int) -> None:
+    """Fix inconsistencies created by updating a re-usable form definition which is used in other forms.
+
+    When the FormVariable bulk create/update endpoint is called, all existing FormVariable related to the form are
+    deleted and new are created. If there are any form definitions which are reusable, we want to update all the forms
+    which are also using these FormDefinitions (concerning the FormVariables). This task updates the FormVariables
+    of each related form in the database, by replacing the old state with the newly derived set of form variables.
+    """
+    from .models import FormDefinition, FormVariable  # due to circular import
+
+    fds = FormDefinition.objects.filter(formstep__form=form_id, is_reusable=True)
+
+    other_forms = Form.objects.filter(formstep__form_definition__in=fds).exclude(
+        id=form_id
+    )
+
+    # delete the existing form variables, we will re-create them
+    FormVariable.objects.filter(
+        form__in=other_forms, source=FormVariableSources.component
+    ).delete()
+
+    for form in other_forms:
+        FormVariable.objects.create_for_form(form)
 
 
 @app.task()


### PR DESCRIPTION
Fixes #3881 