### PR TITLE
Implement formio form-to-serializer translation

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -221,6 +221,33 @@ class NPFamilyMembers(BasePlugin):
             ]
 
 
+@register("bsn")
+class BSN(BasePlugin):
+    formatter = TextFieldFormatter
+
+    def build_serializer_field(
+        self, component: Component
+    ) -> serializers.CharField | serializers.ListField:
+        multiple = component.get("multiple", False)
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+
+        if validate.get("plugins", []):
+            raise NotImplementedError("Plugin validators not supported yet.")
+
+        # dynamically add in more kwargs based on the component configuration
+        extra = {}
+        # maxLength because of the usage in appointments, even though our form builder
+        # does not expose it. See `openforms.appointments.contrib.qmatic.constants`.
+        if (max_length := validate.get("maxLength")) is not None:
+            extra["max_length"] = max_length
+
+        base = serializers.CharField(
+            required=required, allow_blank=not required, allow_null=False, **extra
+        )
+        return serializers.ListField(child=base) if multiple else base
+
+
 @register("addressNL")
 class AddressNL(BasePlugin):
 

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1,9 +1,12 @@
 import logging
+from datetime import date
 from typing import Protocol
 
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
+from rest_framework import serializers
 from rest_framework.request import Request
 
 from openforms.authentication.constants import AuthAttribute
@@ -49,6 +52,32 @@ class Date(BasePlugin[DateComponent]):
         ``src/openforms/js/components/form/date.js`` for the various configurable options.
         """
         mutate_min_max_validation(component, data)
+
+    def build_serializer_field(
+        self, component: DateComponent
+    ) -> serializers.DateField | serializers.ListField:
+        """
+        Accept date values.
+
+        Additional validation is taken from the datePicker configuration, which is also
+        set dynamically through our own backend (see :meth:`mutate_config_dynamically`).
+        """
+        # relevant validators: required, datePicker.minDate and datePicker.maxDdate
+        multiple = component.get("multiple", False)
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+        date_picker = component.get("datePicker") or {}
+        validators = []
+        if min_date := date_picker.get("minDate"):
+            validators.append(MinValueValidator(date.fromisoformat(min_date)))
+        if max_date := date_picker.get("maxDate"):
+            validators.append(MaxValueValidator(date.fromisoformat(max_date)))
+        base = serializers.DateField(
+            required=required,
+            allow_null=not required,
+            validators=validators,
+        )
+        return serializers.ListField(child=base) if multiple else base
 
 
 @register("datetime")

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -300,6 +300,26 @@ class Radio(BasePlugin[RadioComponent]):
             return
         translate_options(options, language_code, enabled)
 
+    def build_serializer_field(
+        self, component: RadioComponent
+    ) -> serializers.ChoiceField:
+        """
+        Convert a radio component to a serializer field.
+
+        A radio component allows only a single value to be selected, but selecting a
+        value may not be required. The available choices are taken from the ``values``
+        key, which may be set dynamically (see :meth:`mutate_config_dynamically`).
+        """
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+        choices = [(value["value"], value["label"]) for value in component["values"]]
+        return serializers.ChoiceField(
+            choices=choices,
+            required=required,
+            allow_blank=not required,
+            allow_null=not required,
+        )
+
 
 @register("signature")
 class Signature(BasePlugin):

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -206,6 +206,30 @@ class TextArea(BasePlugin):
 class Number(BasePlugin):
     formatter = NumberFormatter
 
+    def build_serializer_field(
+        self, component: Component
+    ) -> serializers.FloatField | serializers.ListField:
+        # new builder no longer exposes this, but existing forms may have multiple set
+        multiple = component.get("multiple", False)
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+
+        if validate.get("plugins", []):
+            raise NotImplementedError("Plugin validators not supported yet.")
+
+        extra = {}
+        if max_value := validate.get("max"):
+            extra["max_value"] = max_value
+        if min_value := validate.get("min"):
+            extra["min_value"] = min_value
+
+        base = serializers.FloatField(
+            required=required,
+            allow_null=not required,
+            **extra,
+        )
+        return serializers.ListField(child=base) if multiple else base
+
 
 @register("password")
 class Password(BasePlugin):

--- a/src/openforms/formio/serializers.py
+++ b/src/openforms/formio/serializers.py
@@ -1,0 +1,71 @@
+"""
+Dynamically build serializers for Formio component trees.
+
+The reference implementation for the validation behaviour is the JS implementation of
+Formio.js 4.13.x:
+https://github.com/formio/formio.js/blob/4.13.x/src/validator/Validator.js.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+from glom import assign
+from rest_framework import serializers
+
+from .typing import Component
+from .utils import iter_components
+
+if TYPE_CHECKING:
+    from .registry import ComponentRegistry
+
+
+FieldOrNestedFields: TypeAlias = serializers.Field | dict[str, "FieldOrNestedFields"]
+
+
+def dict_to_serializer(
+    fields: dict[str, FieldOrNestedFields], **kwargs
+) -> serializers.Serializer:
+    """
+    Recursively convert a mapping of field names to a serializer instance.
+
+    Keys are the names of the serializer fields to use, while the values can be
+    serializer field instances or nested mappings. Nested mappings result in nested
+    serializers.
+    """
+    serializer = serializers.Serializer(**kwargs)
+
+    for bit, field in fields.items():
+        match field:
+            case dict() as nested_fields:
+                # we do not pass **kwwargs to nested serializers, as this should only
+                # be provided to the top-level serializer. The context/data is then
+                # shared through all children by DRF.
+                serializer.fields[bit] = dict_to_serializer(nested_fields)
+            # treat default case as a serializer field
+            case _:
+                serializer.fields[bit] = field
+
+    return serializer
+
+
+def build_serializer(
+    components: list[Component], register: ComponentRegistry, **kwargs
+) -> serializers.Serializer:
+    """
+    Translate a sequence of Formio.js component definitions into a serializer.
+
+    This recursively builds up the serializer fields for each (nested) component and
+    puts them into a serializer instance ready for validation.
+    """
+    fields: dict[str, FieldOrNestedFields] = {}
+
+    # TODO: check that editgrid nested components are not yielded here!
+    for component in iter_components(
+        {"components": components}, recurse_into_editgrid=False
+    ):
+        field = register.build_serializer_field(component)
+        assign(obj=fields, path=component["key"], val=field, missing=dict)
+
+    serializer = dict_to_serializer(fields, **kwargs)
+    return serializer

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -25,7 +25,8 @@ from .dynamic_config import (
     rewrite_formio_components,
     rewrite_formio_components_for_request,
 )
-from .registry import register
+from .registry import ComponentRegistry, register
+from .serializers import build_serializer as _build_serializer
 from .typing import Component
 from .utils import iter_components, iterate_data_with_components, recursive_apply
 from .validation import validate_formio_data
@@ -42,6 +43,7 @@ __all__ = [
     "iterate_data_with_components",
     "validate_formio_data",
     "recursive_apply",
+    "build_serializer",
 ]
 
 
@@ -105,3 +107,9 @@ def get_dynamic_configuration(
     # as checkboxes/dropdowns/radios/...
     inject_prefill(config_wrapper, submission)
     return config_wrapper
+
+
+def build_serializer(
+    components: list[Component], _register: ComponentRegistry | None = None, **kwargs
+):
+    return _build_serializer(components, register=_register or register, **kwargs)

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -112,4 +112,10 @@ def get_dynamic_configuration(
 def build_serializer(
     components: list[Component], _register: ComponentRegistry | None = None, **kwargs
 ):
+    """
+    Translate a sequence of Formio.js component definitions into a serializer.
+
+    This recursively builds up the serializer fields for each (nested) component and
+    puts them into a serializer instance ready for validation.
+    """
     return _build_serializer(components, register=_register or register, **kwargs)

--- a/src/openforms/formio/tests/search_strategies.py
+++ b/src/openforms/formio/tests/search_strategies.py
@@ -29,7 +29,7 @@ def formio_key():
     data structure empty strings are used as keys:
     ``{"foo": {"": {"": {"bar": $value}}}}``
 
-    See :func:`openforms.forms.models.form_variable.variable_key_validator` for the
+    See :func:`openforms.formio.validators.variable_key_validator` for the
     validator implementation.
 
     This strategy differs slightly from the validator - it will generate keys with a

--- a/src/openforms/formio/tests/test_search_strategies.py
+++ b/src/openforms/formio/tests/test_search_strategies.py
@@ -3,8 +3,6 @@ from django.test import SimpleTestCase
 
 from hypothesis import given, settings
 
-from openforms.forms.models.form_variable import variable_key_validator
-
 from ..typing import (
     ColumnsComponent,
     Component,
@@ -13,6 +11,7 @@ from ..typing import (
     SelectBoxesComponent,
     SelectComponent,
 )
+from ..validators import variable_key_validator
 from .search_strategies import (
     address_nl_component,
     bsn_component,

--- a/src/openforms/formio/tests/test_validation.py
+++ b/src/openforms/formio/tests/test_validation.py
@@ -2,36 +2,33 @@ from django.test import SimpleTestCase
 
 from rest_framework.serializers import ValidationError
 
-from ..validation import validate_formio_data
+from openforms.typing import JSONObject, JSONValue
+
+from ..service import build_serializer
+from ..typing import Component, RadioComponent, TextFieldComponent
 
 
-class FormioValidationTests(SimpleTestCase):
-    def test_textfield_required_validation(self):
-        component = {"type": "textfield", "key": "foo", "validate": {"required": True}}
+def validate_formio_data(components: list[Component], data: JSONValue) -> None:
+    serializer = build_serializer(components=components, data=data)
+    serializer.is_valid(raise_exception=True)
 
-        invalid_values = [
-            {},
-            {"foo": ""},
-            {"foo": None},
-        ]
 
-        for data in invalid_values:
-            with self.subTest(data=data):
-                with self.assertRaises(ValidationError) as exc_detail:
-                    validate_formio_data([component], data)
+class GenericValidationTests(SimpleTestCase):
+    """
+    Test some generic validation behaviours using anecdotal examples.
 
-                self.assertEqual(exc_detail.exception.detail["0"].code, "required")  # type: ignore
-
-    def test_textfield_max_length(self):
-        component = {"type": "textfield", "key": "foo", "validate": {"maxLength": 3}}
-
-        with self.assertRaises(ValidationError) as exc_detail:
-            validate_formio_data([component], {"foo": "barbaz"})
-
-        self.assertEqual(exc_detail.exception.detail["0"].code, "max_length")  # type: ignore
+    Tests in this class are aimed towards some patterns, but use specific component
+    types as an easy-to-follow-and-debug example. Full coverage needs to be guaranteed
+    through the YAML-based tests or component-type specific test cases like below.
+    """
 
     def test_component_without_validate_information(self):
-        component = {"type": "radio", "key": "radio", "values": []}
+        component: RadioComponent = {
+            "type": "radio",
+            "key": "radio",
+            "label": "Test",
+            "values": [],
+        }
 
         try:
             validate_formio_data([component], {"radio": ""})
@@ -39,3 +36,69 @@ class FormioValidationTests(SimpleTestCase):
             raise self.failureException(
                 "Expected component to pass validation"
             ) from exc
+
+    def test_multiple_respected(self):
+        """
+        Test that component ``multiple: true`` is correctly validated.
+
+        Many components support multiple, but not all of them. The value data structure
+        changes for multiple, and the invalid param names should change accordingly.
+        """
+        component: TextFieldComponent = {
+            "type": "textfield",
+            "key": "textMultiple",
+            "label": "Text multiple",
+            "multiple": True,
+            "validate": {
+                "required": True,
+                "maxLength": 3,
+            },
+        }
+        data: JSONObject = {
+            "textMultiple": [
+                "ok",
+                "not okay",
+                "",
+            ],
+        }
+
+        with self.assertRaises(ValidationError) as exc_context:
+            validate_formio_data([component], data)
+
+        detail = exc_context.exception.detail
+        assert isinstance(detail, dict)
+        assert "textMultiple" in detail
+        nested = detail["textMultiple"]
+        assert isinstance(nested, dict)
+
+        self.assertEqual(list(nested.keys()), [1, 2])
+
+        with self.subTest("Error for item at index 1"):
+            self.assertEqual(len(errors := nested[1]), 1)
+            self.assertEqual(errors[0].code, "max_length")  # type: ignore
+
+        with self.subTest("Error for item at index 2"):
+            self.assertEqual(len(errors := nested[2]), 1)
+            self.assertEqual(errors[0].code, "blank")  # type: ignore
+
+    def test_key_with_nested_structure(self):
+        component: Component = {
+            "type": "textfield",
+            "key": "parent.nested",
+            "label": "Special key",
+            "validate": {
+                "maxLength": 2,
+            },
+        }
+        data: JSONObject = {"parent": {"nested": "foo"}}
+
+        with self.assertRaises(ValidationError) as exc_context:
+            validate_formio_data([component], data)
+
+        detail = exc_context.exception.detail
+        assert isinstance(detail, dict)
+        assert "parent" in detail
+        self.assertIn("parent", detail)
+        self.assertIn("nested", detail["parent"])
+        err_code = detail["parent"]["nested"][0].code
+        self.assertEqual(err_code, "max_length")

--- a/src/openforms/formio/tests/validation/helpers.py
+++ b/src/openforms/formio/tests/validation/helpers.py
@@ -1,0 +1,21 @@
+from rest_framework.utils.serializer_helpers import ReturnDict
+
+from openforms.typing import JSONValue
+
+from ...service import build_serializer
+from ...typing import Component
+
+
+def validate_formio_data(
+    component: Component, data: JSONValue
+) -> tuple[bool, ReturnDict]:
+    """
+    Dynamically build the serializer, validate it and return the status.
+    """
+    serializer = build_serializer(components=[component], data=data)
+    is_valid = serializer.is_valid(raise_exception=False)
+    return is_valid, serializer.errors
+
+
+def extract_error(errors: ReturnDict, key: str, index: int = 0):
+    return errors[key][index]

--- a/src/openforms/formio/tests/validation/test_bsn.py
+++ b/src/openforms/formio/tests/validation/test_bsn.py
@@ -1,0 +1,51 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class BSNValidationTests(SimpleTestCase):
+
+    def test_bsn_field_required_validation(self):
+        component: Component = {
+            "type": "bsn",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": ""}, "blank"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_maxlength(self):
+        component: Component = {
+            "type": "bsn",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True, "maxLength": 5},
+        }
+        data: JSONValue = {"foo": "123456"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = extract_error(errors, "foo")
+        self.assertEqual(error.code, "max_length")
+
+    # TODO
+    # def test_elfproef(self):
+    #     pass

--- a/src/openforms/formio/tests/validation/test_date.py
+++ b/src/openforms/formio/tests/validation/test_date.py
@@ -1,0 +1,56 @@
+from django.test import SimpleTestCase
+
+from ...typing import DateComponent
+from .helpers import extract_error, validate_formio_data
+
+
+class DateFieldValidationTests(SimpleTestCase):
+
+    def test_datefield_required_validation(self):
+        component: DateComponent = {
+            "type": "date",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+            "datePicker": None,
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_min_max_date(self):
+        component: DateComponent = {
+            "type": "date",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": False},
+            "datePicker": {
+                "minDate": "2024-03-10",
+                "maxDate": "2025-03-10",
+            },
+        }
+
+        invalid_values = [
+            ({"foo": "2023-01-01"}, "min_value"),
+            ({"foo": "2025-12-30"}, "max_value"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)

--- a/src/openforms/formio/tests/validation/test_editgrid.py
+++ b/src/openforms/formio/tests/validation/test_editgrid.py
@@ -1,0 +1,163 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONObject
+
+from ...service import build_serializer
+from ...typing import EditGridComponent
+from .helpers import validate_formio_data
+
+
+class EditGridValidationTests(SimpleTestCase):
+    """
+    Test validations on the edit grid and its nested components.
+    """
+
+    def test_nested_fields_are_validated(self):
+        component: EditGridComponent = {
+            "type": "editgrid",
+            "key": "parent",
+            "label": "Repeating group",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "nested",
+                    "label": "Nested text field",
+                    "validate": {
+                        "required": True,
+                    },
+                }
+            ],
+        }
+        data: JSONObject = {
+            "parent": [
+                {
+                    "nested": "foo",
+                },
+                {
+                    "nested": "",
+                },
+                {},
+            ],
+        }
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+
+        assert isinstance(errors, dict)
+        assert "parent" in errors
+        nested = errors["parent"]
+        assert isinstance(nested, dict)
+
+        with self.subTest("Item at index 0"):
+            self.assertNotIn(0, nested)
+
+        with self.subTest("Item at index 1"):
+            self.assertIn(1, nested)
+            _errors = nested[1]
+            self.assertIsInstance(_errors, dict)
+            self.assertIn("nested", _errors)
+            self.assertEqual(len(_errors["nested"]), 1)
+            self.assertEqual(_errors["nested"][0].code, "blank")
+
+        with self.subTest("Item at index 2"):
+            self.assertIn(2, nested)
+            _errors = nested[2]
+            self.assertIsInstance(_errors, dict)
+            self.assertIn("nested", _errors)
+            self.assertEqual(len(_errors["nested"]), 1)
+            self.assertEqual(_errors["nested"][0].code, "required")
+
+    def test_editgrids_own_validations(self):
+        component: EditGridComponent = {
+            "type": "editgrid",
+            "key": "parent",
+            "label": "Repeating group",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "nested",
+                    "label": "Nested text field",
+                }
+            ],
+            "validate": {
+                "required": True,
+                "maxLength": 2,
+            },
+        }
+
+        with self.subTest("Required values missing"):
+            data: JSONObject = {}
+
+            is_valid, errors = validate_formio_data(component, data)
+
+            self.assertFalse(is_valid)
+
+            assert isinstance(errors, dict)
+            assert "parent" in errors
+            nested = errors["parent"]
+
+            self.assertIsInstance(nested, list)
+            err_code = nested[0].code
+            self.assertEqual(err_code, "required")
+
+        with self.subTest("Max length exceeded"):
+            data: JSONObject = {
+                "parent": [
+                    {"nested": "foo"},
+                    {"nested": "bar"},
+                    {"nested": "bax"},
+                ]
+            }
+
+            is_valid, errors = validate_formio_data(component, data)
+
+            self.assertFalse(is_valid)
+
+            assert isinstance(errors, dict)
+            assert "parent" in errors
+            nested = errors["parent"]
+
+            self.assertIsInstance(nested, list)
+            err_code = nested[0].code
+            self.assertEqual(err_code, "max_length")
+
+    def test_valid_configuration_nested_field_not_present_in_top_level_serializer(self):
+        """
+        Test that the nested components in edit grid are not processed in a generic way.
+
+        They are a blueprint for items in an array, so when iterating over all
+        components (recursively), they may not show up as standalone components.
+        """
+        component: EditGridComponent = {
+            "type": "editgrid",
+            "key": "toplevel",
+            "label": "Repeating group",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "nested",
+                    "label": "Required textfield",
+                    "validate": {"required": True},
+                }
+            ],
+        }
+        data: JSONObject = {
+            "toplevel": [{"nested": "i am valid"}],
+        }
+
+        serializer = build_serializer(components=[component], data=data)
+
+        with self.subTest("serializer validity"):
+            self.assertTrue(serializer.is_valid())
+
+        top_level_fields = serializer.fields
+        with self.subTest("top level fields"):
+            self.assertIn("toplevel", top_level_fields)
+            self.assertNotIn("nested", top_level_fields)
+
+        with self.subTest("nested fields"):
+            nested_fields = top_level_fields["toplevel"].child.fields  # type: ignore
+
+            self.assertIn("nested", nested_fields)
+            self.assertNotIn("toplevel", nested_fields)

--- a/src/openforms/formio/tests/validation/test_email.py
+++ b/src/openforms/formio/tests/validation/test_email.py
@@ -1,0 +1,61 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class EmailValidationTests(SimpleTestCase):
+    def test_email_required_validation(self):
+        component: Component = {
+            "type": "email",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": ""}, "blank"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_email_pattern_validation(self):
+        component: Component = {
+            "type": "email",
+            "key": "foo",
+            "label": "Test",
+        }
+        data: JSONValue = {"foo": "invalid-email"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "invalid")
+
+    def test_maxlength(self):
+        component: Component = {
+            "type": "email",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"maxLength": 10},
+        }
+        data: JSONValue = {"foo": "foobar@example.com"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = extract_error(errors, "foo")
+        self.assertEqual(error.code, "max_length")

--- a/src/openforms/formio/tests/validation/test_generic.py
+++ b/src/openforms/formio/tests/validation/test_generic.py
@@ -1,0 +1,23 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import validate_formio_data
+
+
+class FallbackBehaviourTests(SimpleTestCase):
+
+    def test_unknown_component_passthrough(self):
+        # TODO: this should *not* pass when all components are implemented, it's a
+        # temporary compatibility layer
+        component: Component = {
+            "type": "unknown-i-do-not-exist",
+            "key": "foo",
+            "label": "Fallback",
+        }
+        data: JSONValue = {"value": ["weird", {"data": "structure"}]}
+
+        is_valid, _ = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)

--- a/src/openforms/formio/tests/validation/test_number.py
+++ b/src/openforms/formio/tests/validation/test_number.py
@@ -1,0 +1,47 @@
+from django.test import SimpleTestCase
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class NumberValidationTests(SimpleTestCase):
+    def test_number_min_value(self):
+        component: Component = {
+            "type": "number",
+            "key": "foo",
+            "label": "Test",
+            "validate": {
+                "min": -3.5,
+            },
+        }
+
+        is_valid, errors = validate_formio_data(component, {"foo": -5.2})
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "min_value")
+
+    def test_number_min_value_with_non_required_value(self):
+        component: Component = {
+            "type": "number",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"max": 10},
+        }
+
+        is_valid, _ = validate_formio_data(component, {})
+
+        self.assertTrue(is_valid)
+
+    def test_zero_is_accepted(self):
+        component: Component = {
+            "type": "number",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        is_valid, _ = validate_formio_data(component, {"foo": 0})
+
+        self.assertTrue(is_valid)

--- a/src/openforms/formio/tests/validation/test_phonenumber.py
+++ b/src/openforms/formio/tests/validation/test_phonenumber.py
@@ -1,0 +1,69 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class PhoneNumberValidationTests(SimpleTestCase):
+    def test_phonenumber_required_validation(self):
+        component: Component = {
+            "type": "phoneNumber",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": ""}, "blank"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_pattern_validation(self):
+        component: Component = {
+            "type": "phoneNumber",
+            "key": "foo",
+            "label": "Test",
+            "validate": {
+                "required": True,
+                "pattern": r"06[ -]?[\d ]+",  # only allow mobile numbers
+            },
+        }
+        data: JSONValue = {"foo": "020-123 456"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "invalid")
+
+    def test_phonenumber_maxlength(self):
+        component: Component = {
+            "type": "phoneNumber",
+            "key": "foo",
+            "label": "Test",
+            "validate": {
+                "required": True,
+                "maxLength": 8,
+            },
+        }
+        data: JSONValue = {"foo": "020123456"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "max_length")

--- a/src/openforms/formio/tests/validation/test_textfield.py
+++ b/src/openforms/formio/tests/validation/test_textfield.py
@@ -1,0 +1,62 @@
+from django.test import SimpleTestCase, tag
+
+from openforms.typing import JSONValue
+
+from ...typing import TextFieldComponent
+from .helpers import extract_error, validate_formio_data
+
+
+class TextFieldValidationTests(SimpleTestCase):
+    def test_textfield_required_validation(self):
+        component: TextFieldComponent = {
+            "type": "textfield",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": ""}, "blank"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_textfield_max_length(self):
+        component: TextFieldComponent = {
+            "type": "textfield",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"maxLength": 3},
+        }
+
+        is_valid, errors = validate_formio_data(component, {"foo": "barbaz"})
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "max_length")
+
+    @tag("gh-3977")
+    def test_textfield_regex_housenumber(self):
+        component: TextFieldComponent = {
+            "type": "textfield",
+            "key": "houseNumber",
+            "label": "House number",
+            "validate": {"pattern": r"[0-9]{1,5}"},
+        }
+        data: JSONValue = {"houseNumber": "<div>injection</div>"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = extract_error(errors, "houseNumber")
+        self.assertEqual(error.code, "invalid")

--- a/src/openforms/formio/tests/validation/test_textfield.py
+++ b/src/openforms/formio/tests/validation/test_textfield.py
@@ -60,3 +60,22 @@ class TextFieldValidationTests(SimpleTestCase):
         self.assertFalse(is_valid)
         error = extract_error(errors, "houseNumber")
         self.assertEqual(error.code, "invalid")
+
+    def test_multiple(self):
+        component: TextFieldComponent = {
+            "type": "textfield",
+            "key": "numbers",
+            "label": "House number",
+            "multiple": True,
+            "validate": {"pattern": r"\d+"},
+        }
+        data: JSONValue = {"numbers": ["42", "notnumber"]}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = errors["numbers"][1][0]
+        self.assertEqual(error.code, "invalid")
+
+        with self.subTest("valid item"):
+            self.assertNotIn(0, errors["numbers"])


### PR DESCRIPTION
Partly closes #3977

This PR implements the conversion layer from a formio form definition (as a sequence of components) to a DRF serializer, where each component is translated into a serializer field (or nested serializer).

Each field is then capable/responsible of validating the user input, effectively running the formio validation server-side.

A future PR will be hook this up into our submissions/appointment serializers.