### PR TITLE
End to end tests for input validation

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -57,6 +57,17 @@ if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
 
+def _normalize_pattern(pattern: str) -> str:
+    """
+    Normalize a regex pattern so that it matches from beginning to the end of the value.
+    """
+    if not pattern.startswith("^"):
+        pattern = f"^{pattern}"
+    if not pattern.endswith("$"):
+        pattern = f"{pattern}$"
+    return pattern
+
+
 @register("default")
 class Default(BasePlugin):
     """
@@ -88,7 +99,7 @@ class TextField(BasePlugin[TextFieldComponent]):
         if pattern := validate.get("pattern"):
             validators.append(
                 RegexValidator(
-                    pattern,
+                    _normalize_pattern(pattern),
                     message=_("This value does not match the required pattern."),
                 )
             )
@@ -167,7 +178,7 @@ class PhoneNumber(BasePlugin):
         if pattern := validate.get("pattern"):
             validators.append(
                 RegexValidator(
-                    pattern,
+                    _normalize_pattern(pattern),
                     message=_("This value does not match the required pattern."),
                 )
             )

--- a/src/openforms/formio/tests/validation/test_textfield.py
+++ b/src/openforms/formio/tests/validation/test_textfield.py
@@ -63,6 +63,22 @@ class TextFieldValidationTests(SimpleTestCase):
         error = extract_error(errors, "houseNumber")
         self.assertEqual(error.code, "invalid")
 
+    @tag("gh-3977")
+    def test_textfield_regex_housenumber_addition(self):
+        component: TextFieldComponent = {
+            "type": "textfield",
+            "key": "houseNumberAddition",
+            "label": "House number",
+            "validate": {"pattern": r"^[a-zA-Z0-9]{1,4}$"},
+        }
+        data: JSONValue = {"houseNumberAddition": "<div>injection</div>"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = extract_error(errors, "houseNumberAddition")
+        self.assertEqual(error.code, "invalid")
+
     def test_multiple(self):
         component: TextFieldComponent = {
             "type": "textfield",

--- a/src/openforms/tests/e2e/input_validation_base.py
+++ b/src/openforms/tests/e2e/input_validation_base.py
@@ -1,0 +1,142 @@
+from typing import TypedDict
+
+from django.test import override_settings, tag
+from django.urls import reverse
+
+from asgiref.sync import async_to_sync
+from furl import furl
+from playwright.async_api import expect
+from rest_framework import status
+from typing_extensions import NotRequired, Unpack
+
+from openforms.formio.typing import Component
+from openforms.forms.models import Form
+from openforms.forms.tests.factories import (
+    FormDefinitionFactory,
+    FormFactory,
+    FormStepFactory,
+)
+from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.submissions.tests.mixins import SubmissionsMixin
+from openforms.typing import JSONValue
+
+from .base import E2ETestCase, browser_page
+
+
+def create_form(component: Component) -> Form:
+    _test_name = f"{component['type']} - {component['label']}"[:50]
+    form_definition = FormDefinitionFactory.create(
+        name=_test_name,
+        configuration={"components": [component]},
+    )
+    form = FormFactory.create(
+        name=_test_name,
+        product=None,
+        category=None,
+        registration_backend=None,
+        translation_enabled=False,  # force Dutch
+        ask_privacy_consent=False,
+        ask_statement_of_truth=False,
+    )
+    FormStepFactory.create(
+        form=form, form_definition=form_definition, next_text="Volgende"
+    )
+    return form
+
+
+class ValidationKwargs(TypedDict):
+    api_value: NotRequired[JSONValue]
+
+
+@tag("e2e-validation")
+# allow all origins, since we don't know exactly the generated live server port number
+@override_settings(CORS_ALLOW_ALL_ORIGINS=True)
+class ValidationsTestCase(SubmissionsMixin, E2ETestCase):
+
+    def assertValidationIsAligned(
+        self,
+        component: Component,
+        ui_input: str | int | float,
+        expected_ui_error: str,
+        **kwargs: Unpack[ValidationKwargs],
+    ):
+        """
+        Check a component and ensure frontend and backend validation are aligned.
+
+        When the frontend validation rejects a user input, the backend must do so
+        accordingly. This does not necessarily apply the other way around - the frontend
+        cannot handle array/null datatypes etc. so the backend may be stricter to some
+        extent.
+
+        :arg component: Given the component definition, create a form instance and use
+          this for both the end-to-end test with playwright and the django test client
+          assertions to check for validation issues.
+        :arg ui_input: Input to enter in the field with playwright.
+        :arg expected_ui_error: Content of the validation error to be expected in the
+          playwright test.
+        """
+        form = create_form(component)
+
+        with self.subTest("frontend validation"):
+            self._assertFrontendValidation(
+                form, component["label"], str(ui_input), expected_ui_error
+            )
+
+        with self.subTest("backend validation"):
+            api_value = kwargs.pop("api_value", ui_input)
+            self._assertBackendValidation(form, component["key"], api_value)
+
+    @async_to_sync()
+    async def _assertFrontendValidation(
+        self,
+        form: Form,
+        label: str,
+        ui_input: str,
+        expected_ui_error: str,
+    ):
+        frontend_path = reverse("forms:form-detail", kwargs={"slug": form.slug})
+        url = str(furl(self.live_server_url) / frontend_path)
+
+        async with browser_page() as page:
+            await page.goto(url)
+            await page.get_by_role("button", name="Formulier starten").click()
+
+            # fill in the test input
+            await page.get_by_label(label, exact=True).fill(ui_input)
+
+            # try to submit the step which should be invalid, so we expect this to
+            # render the error message.
+            await page.get_by_role("button", name="Volgende").click()
+
+            await expect(page.get_by_text(expected_ui_error)).to_be_visible()
+
+    def _assertBackendValidation(self, form: Form, key: str, value: JSONValue):
+        submission = SubmissionFactory.create(form=form)
+        step = form.formstep_set.get()
+        self._add_submission_to_session(submission)
+
+        step_endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": step.uuid,
+            },
+        )
+        body = {"data": {key: value}}
+        response = self.client.put(step_endpoint, body, content_type="application/json")
+        assert response.status_code in [201, 200]
+
+        # try to complete the submission, this is expected to fail
+        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(
+            endpoint,
+            data={"privacyPolicyAccepted": True},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        invalid_params = response.json()["invalidParams"]
+        expected_name = f"steps.0.data.{key}"
+        names = [param["name"] for param in invalid_params]
+        self.assertIn(expected_name, names)

--- a/src/openforms/tests/e2e/input_validation_base.py
+++ b/src/openforms/tests/e2e/input_validation_base.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from asgiref.sync import async_to_sync
 from furl import furl
-from playwright.async_api import expect
+from playwright.async_api import Page, expect
 from rest_framework import status
 from typing_extensions import NotRequired, Unpack
 
@@ -86,6 +86,9 @@ class ValidationsTestCase(SubmissionsMixin, E2ETestCase):
             api_value = kwargs.pop("api_value", ui_input)
             self._assertBackendValidation(form, component["key"], api_value)
 
+    def _locate_input(self, page: Page, label: str):
+        return page.get_by_label(label, exact=True)
+
     @async_to_sync()
     async def _assertFrontendValidation(
         self,
@@ -102,7 +105,7 @@ class ValidationsTestCase(SubmissionsMixin, E2ETestCase):
             await page.get_by_role("button", name="Formulier starten").click()
 
             # fill in the test input
-            await page.get_by_label(label, exact=True).fill(ui_input)
+            await self._locate_input(page, label).fill(ui_input)
 
             # try to submit the step which should be invalid, so we expect this to
             # render the error message.

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -1,0 +1,154 @@
+"""
+Test that the input validation performed on the backend matches the one on the frontend.
+
+The frontend/formio validation implementation is leading here.
+
+Note that the actual test input/output is defined in the YAML-files in the
+input_validation subdirectory.
+"""
+
+from pathlib import Path
+
+from openforms.formio.typing import Component
+
+from .input_validation_base import ValidationsTestCase
+
+TEST_CASES = (Path(__file__).parent / "input_validation").resolve()
+
+
+class SingleTextFieldTests(ValidationsTestCase):
+
+    def test_required_field(self):
+        component: Component = {
+            "type": "textfield",
+            "key": "requiredTextField",
+            "label": "Required text field",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            expected_ui_error="Het verplichte veld Required text field is niet ingevuld.",
+        )
+
+    def test_max_length(self):
+        component: Component = {
+            "type": "textfield",
+            "key": "maxLengthTextField",
+            "label": "Max length 3",
+            "validate": {"maxLength": 3},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="too long",
+            expected_ui_error="Er zijn teveel karakters opgegeven.",
+        )
+
+    def test_regex_huisletter(self):
+        component: Component = {
+            "type": "textfield",
+            "key": "houseLetter",
+            "label": "Huisletter",
+            "validate": {"pattern": "[a-zA-Z]"},
+            "errors": {"pattern": "Huisletter moet een letter zijn."},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="<h2>test</h2>",
+            expected_ui_error="Huisletter moet een letter zijn.",
+        )
+
+    def test_regex_house_number_addition(self):
+        component: Component = {
+            "type": "textfield",
+            "key": "houseNumberAddition",
+            "label": "Toevoeging huisnummer",
+            "validate": {"pattern": "[a-zA-Z0-9]{1,4}"},
+            "errors": {
+                "pattern": "Huisnummertoevoeging mag enkel alfanumerieke karaketers zijn."
+            },
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="<h1>test</h1>",
+            expected_ui_error="Huisnummertoevoeging mag enkel alfanumerieke karaketers zijn.",
+        )
+
+
+class SingleEmailTests(ValidationsTestCase):
+    def test_required_field(self):
+        component: Component = {
+            "type": "email",
+            "key": "requiredEmail",
+            "label": "Required email",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            expected_ui_error="Het verplichte veld Required email is niet ingevuld.",
+        )
+
+    def test_email_format(self):
+        component: Component = {
+            "type": "email",
+            "key": "email",
+            "label": "E-mailadres",
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="invalid",
+            expected_ui_error="Ongeldig e-mailadres",
+        )
+
+
+class SingleNumberTests(ValidationsTestCase):
+
+    def test_required_field(self):
+        component: Component = {
+            "type": "number",
+            "key": "requiredNumber",
+            "label": "Required number",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            api_value=None,
+            expected_ui_error="Het verplichte veld Required number is niet ingevuld.",
+        )
+
+    def test_min_value(self):
+        component: Component = {
+            "type": "number",
+            "key": "minValue",
+            "label": "Minimum value",
+            "validate": {"min": 3},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input=2,
+            expected_ui_error="De waarde moet 3 of groter zijn.",
+        )
+
+    def test_max_value(self):
+        component: Component = {
+            "type": "number",
+            "key": "maxValue",
+            "label": "Maximum value",
+            "validate": {"max": 42},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input=50,
+            expected_ui_error="De waarde moet 42 of kleiner zijn.",
+        )


### PR DESCRIPTION
Closes #3977
Depends on #4010

Adds tests to lock in the parity between frontend and backend behaviour.