### PR TITLE
:sparkles: [#3977] Add submission context to formio data serializer

### DIFF
--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -57,7 +57,11 @@ class CompletionValidationSerializer(serializers.Serializer):
             assert step.form_step
             components = step.form_step.form_definition.configuration["components"]
 
-            step_data_serializer = build_serializer(components, data=data)
+            step_data_serializer = build_serializer(
+                components,
+                data=data,
+                context={"submission": submission},
+            )
             if not step_data_serializer.is_valid():
                 errors = step_data_serializer.errors
 

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -80,6 +80,22 @@ class SingleTextFieldTests(ValidationsTestCase):
             expected_ui_error="Huisnummertoevoeging mag enkel alfanumerieke karaketers zijn.",
         )
 
+    def test_kvk_number_validation_plugin(self):
+        component: Component = {
+            "type": "textfield",
+            "key": "chamberOfCommerce",
+            "label": "KVK nummer",
+            "validate": {
+                "plugins": ["kvk-kvkNumber"],
+            },
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="aaaa",  # deliberate to trigger the non-network validation
+            expected_ui_error="Waarde moet numeriek zijn.",
+        )
+
 
 class SingleEmailTests(ValidationsTestCase):
     def test_required_field(self):


### PR DESCRIPTION
Part of #3977
Part of #72 

So that the plugin validators can run in the context of the provided submission and not crash.