### PR TITLE
Upgrade to django-simple-certmanager 2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -372,7 +372,6 @@ pyopenssl==24.0.0
     # via
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.14.0
     # via weasyprint
 pypng==0.20220715.0
@@ -529,7 +528,7 @@ xmltodict==0.12.0
     # via -r requirements/base.in
 zeep==4.2.1
     # via -r requirements/base.in
-zgw-consumers==0.30.0
+zgw-consumers==0.31.0
     # via -r requirements/base.in
 zopfli==0.2.3
     # via fonttools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,7 +50,6 @@ celery-once==3.0.1
     # via -r requirements/base.in
 certifi==2023.7.22
     # via
-    #   django-simple-certmanager
     #   elastic-apm
     #   requests
     #   self-certifi
@@ -197,7 +196,7 @@ django-sendfile2==0.7.0
     # via django-privates
 django-sessionprofile==2.0.0
     # via django-digid-eherkenning
-django-simple-certmanager==1.4.1
+django-simple-certmanager==2.0.0
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
@@ -371,7 +370,6 @@ pyjwt==2.6.0
     # via gemma-zds-client
 pyopenssl==24.0.0
     # via
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
     #   zgw-consumers

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -736,7 +736,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.14.0
     # via
     #   -c requirements/base.txt
@@ -1078,7 +1077,7 @@ zeep==4.2.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-zgw-consumers[testutils]==0.30.0
+zgw-consumers[testutils]==0.31.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -93,7 +93,6 @@ certifi==2023.7.22
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-simple-certmanager
     #   elastic-apm
     #   requests
     #   self-certifi
@@ -340,7 +339,7 @@ django-sessionprofile==2.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-django-simple-certmanager[testutils]==1.4.1
+django-simple-certmanager[testutils]==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -735,7 +734,6 @@ pyopenssl==24.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
     #   zgw-consumers

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -852,7 +852,6 @@ pyopenssl==24.0.0
     #   -r requirements/ci.txt
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.14.0
     # via
     #   -c requirements/ci.txt
@@ -1266,7 +1265,7 @@ zeep==4.2.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-zgw-consumers[testutils]==0.30.0
+zgw-consumers[testutils]==0.31.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -107,7 +107,6 @@ certifi==2023.7.22
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-simple-certmanager
     #   elastic-apm
     #   requests
     #   self-certifi
@@ -377,7 +376,7 @@ django-sessionprofile==2.0.0
     #   django-digid-eherkenning
 django-silk==5.1.0
     # via -r requirements/dev.in
-django-simple-certmanager[testutils]==1.4.1
+django-simple-certmanager[testutils]==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -851,7 +850,6 @@ pyopenssl==24.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
     #   zgw-consumers

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -74,7 +74,6 @@ celery-once==3.0.1
 certifi==2023.7.22
     # via
     #   -r requirements/base.txt
-    #   django-simple-certmanager
     #   elastic-apm
     #   requests
     #   self-certifi
@@ -296,7 +295,7 @@ django-sessionprofile==2.0.0
     # via
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-django-simple-certmanager==1.4.1
+django-simple-certmanager==2.0.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -591,7 +590,6 @@ pyjwt==2.6.0
 pyopenssl==24.0.0
     # via
     #   -r requirements/base.txt
-    #   django-simple-certmanager
     #   josepy
     #   webauthn
     #   zgw-consumers

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -592,7 +592,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   josepy
     #   webauthn
-    #   zgw-consumers
 pyphen==0.14.0
     # via
     #   -r requirements/base.txt
@@ -832,7 +831,7 @@ zeep==4.2.1
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-zgw-consumers==0.30.0
+zgw-consumers==0.31.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt


### PR DESCRIPTION
Closes #3931

This drops the dependency on PyOpenSSL on our end