### PR TITLE
Delete the 'save and add another' button

### DIFF
--- a/src/openforms/js/components/admin/forms/ActionButton.js
+++ b/src/openforms/js/components/admin/forms/ActionButton.js
@@ -24,15 +24,6 @@ const SubmitAction = props => {
   return <ActionButton name="_save" text={btnText} {...props} />;
 };
 
-const AddAnotherAction = props => {
-  const intl = useIntl();
-  const btnText = intl.formatMessage({
-    description: 'Admin save and add another submit button',
-    defaultMessage: 'Save and add another',
-  });
-  return <ActionButton name="_addanother" text={btnText} {...props} />;
-};
-
 const ContinueEditingAction = props => {
   const intl = useIntl();
   const btnText = intl.formatMessage({
@@ -43,4 +34,4 @@ const ContinueEditingAction = props => {
 };
 
 export default ActionButton;
-export {ActionButton, SubmitAction, AddAnotherAction, ContinueEditingAction};
+export {ActionButton, SubmitAction, ContinueEditingAction};

--- a/src/openforms/js/components/admin/forms/ActionButton.mdx
+++ b/src/openforms/js/components/admin/forms/ActionButton.mdx
@@ -1,6 +1,6 @@
 import {ArgTypes, Canvas, Meta} from '@storybook/addon-docs';
 
-import {ActionButton, AddAnotherAction, ContinueEditingAction, SubmitAction} from './ActionButton';
+import {ActionButton, ContinueEditingAction, SubmitAction} from './ActionButton';
 import * as ActionButtonStories from './ActionButton.stories';
 
 <Meta of={ActionButtonStories} />
@@ -20,10 +20,6 @@ The default Django admin action buttons
 ### Submit
 
 <Canvas of={ActionButtonStories.SubmitActionStory} />
-
-### Save and add another
-
-<Canvas of={ActionButtonStories.AddAnotherActionStory} />
 
 ### Save and edit
 

--- a/src/openforms/js/components/admin/forms/ActionButton.stories.js
+++ b/src/openforms/js/components/admin/forms/ActionButton.stories.js
@@ -1,4 +1,4 @@
-import {ActionButton, AddAnotherAction, ContinueEditingAction, SubmitAction} from './ActionButton';
+import {ActionButton, ContinueEditingAction, SubmitAction} from './ActionButton';
 
 export default {
   title: 'Admin/Django/ActionButton',
@@ -17,11 +17,6 @@ export const ActionButtonDefault = {
 export const SubmitActionStory = {
   name: 'SubmitAction',
   render: () => <SubmitAction />,
-};
-
-export const AddAnotherActionStory = {
-  name: 'AddAnotherAction',
-  render: () => <AddAnotherAction />,
 };
 
 export const ContinueEditingActionStory = {

--- a/src/openforms/js/components/admin/forms/SubmitRow.js
+++ b/src/openforms/js/components/admin/forms/SubmitRow.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {AddAnotherAction, ContinueEditingAction, SubmitAction} from './ActionButton';
+import {ContinueEditingAction, SubmitAction} from './ActionButton';
 
 const SubmitRow = ({
   onSubmit,
@@ -25,7 +25,6 @@ const SubmitRow = ({
       {children ?? (
         <>
           <SubmitAction className={isDefault ? 'default' : ''} onClick={onSubmitClick} />
-          <AddAnotherAction onClick={onSubmitClick} />
           <ContinueEditingAction onClick={onSubmitClick} />
         </>
       )}


### PR DESCRIPTION
Closes #4000

Checked that this was not used in other screens - all other SubmitRow usage explicitly specifies the children so this button is effectively unused.

This only affects the React code, the standard Django pages remain unchanged.