### PR TITLE
:arrow_up: Bump to formio-builder 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.17.0",
+        "@open-formulieren/formio-builder": "^0.18.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@storybook/jest": "^0.2.3",
@@ -4586,9 +4586,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.17.0.tgz",
-      "integrity": "sha512-AUaiSfHSvQc/QCJvOjKZ7rUreCJFe+Bgc3t9hDNXkMXaxuk42a0XtzjFWWnDR6Q4jD13WAHvBl+BGrqMljU3UQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.18.0.tgz",
+      "integrity": "sha512-opM0RixEbWBmLKdT7IA7G5CPl/UE4+GGahPfOxF+H7diEt8uvElT0lyWf+eyfVU2/eZ9kHz5RrTb5iCzyq4toQ==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",
@@ -29944,9 +29944,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.17.0.tgz",
-      "integrity": "sha512-AUaiSfHSvQc/QCJvOjKZ7rUreCJFe+Bgc3t9hDNXkMXaxuk42a0XtzjFWWnDR6Q4jD13WAHvBl+BGrqMljU3UQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.18.0.tgz",
+      "integrity": "sha512-opM0RixEbWBmLKdT7IA7G5CPl/UE4+GGahPfOxF+H7diEt8uvElT0lyWf+eyfVU2/eZ9kHz5RrTb5iCzyq4toQ==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@emotion/css": "^11.11.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.17.0",
+    "@open-formulieren/formio-builder": "^0.18.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@storybook/jest": "^0.2.3",


### PR DESCRIPTION
Closes #3943
Closes open-formulieren/open-forms-sdk#483

This release contains the necessary fixes/features for the related tickets.