### PR TITLE
Handle object types with no geometry allowed

### DIFF
--- a/src/openforms/contrib/objects_api/clients/objecttypes.py
+++ b/src/openforms/contrib/objects_api/clients/objecttypes.py
@@ -43,6 +43,14 @@ class ObjecttypesClient(NLXClient):
             page_size=page_size,
         )
 
+    def get_objecttype(
+        self,
+        objecttype_uuid: str | UUID,
+    ) -> dict[str, Any]:
+        response = self.get(f"objecttypes/{objecttype_uuid}")
+        response.raise_for_status()
+        return response.json()
+
     def list_objecttype_versions(
         self,
         objecttype_uuid: str | UUID,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -66,7 +66,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
 
   const {
     loading,
-    value: targetPaths,
+    value: objecttypeVersionInfo,
     error,
   } = useAsync(
     async () => {
@@ -82,12 +82,16 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
     []
   );
 
-  const getTargetPath = pathSegment => targetPaths.find(t => isEqual(t.targetPath, pathSegment));
+  const getTargetPath = pathSegment =>
+    objecttypeVersionInfo.targetPaths.find(t => isEqual(t.targetPath, pathSegment));
 
   const choices =
     loading || error
       ? LOADING_OPTION
-      : targetPaths.map(t => [JSON.stringify(t.targetPath), <TargetPathDisplay target={t} />]);
+      : objecttypeVersionInfo.targetPaths.map(t => [
+          JSON.stringify(t.targetPath),
+          <TargetPathDisplay target={t} />,
+        ]);
 
   if (error)
     return (
@@ -115,33 +119,35 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
           />
         </Field>
       </FormRow>
-      <FormRow>
-        <Field
-          label={
-            <FormattedMessage
-              defaultMessage="Map to geometry field"
-              description="'Map to geometry field' checkbox label"
+      {objecttypeVersionInfo && objecttypeVersionInfo.allowGeometry && (
+        <FormRow>
+          <Field
+            label={
+              <FormattedMessage
+                defaultMessage="Map to geometry field"
+                description="'Map to geometry field' checkbox label"
+              />
+            }
+            helpText={
+              <FormattedMessage
+                description="'Map to geometry field' checkbox help text"
+                defaultMessage="Whether to map this variable to the {geometryPath} attribute"
+                values={{geometryPath: <code>record.geometry</code>}}
+              />
+            }
+            name="geometryVariableKey"
+            disabled={!!mappedVariable.targetPath}
+          >
+            <Checkbox
+              checked={isGeometry}
+              onChange={event => {
+                const newValue = event.target.checked ? variable.key : undefined;
+                setFieldValue('geometryVariableKey', newValue);
+              }}
             />
-          }
-          helpText={
-            <FormattedMessage
-              description="'Map to geometry field' checkbox help text"
-              defaultMessage="Whether to map this variable to the {geometryPath} attribute"
-              values={{geometryPath: <code>record.geometry</code>}}
-            />
-          }
-          name="geometryVariableKey"
-          disabled={!!mappedVariable.targetPath}
-        >
-          <Checkbox
-            checked={isGeometry}
-            onChange={event => {
-              const newValue = event.target.checked ? variable.key : undefined;
-              setFieldValue('geometryVariableKey', newValue);
-            }}
-          />
-        </Field>
-      </FormRow>
+          </Field>
+        </FormRow>
+      )}
       <FormRow>
         <Field
           name={`${namePrefix}.targetPath`}

--- a/src/openforms/registrations/contrib/objects_api/api/serializers.py
+++ b/src/openforms/registrations/contrib/objects_api/api/serializers.py
@@ -43,7 +43,21 @@ class TargetPathsSerializer(serializers.Serializer):
     )
 
 
-class TargetPathsInputSerializer(serializers.Serializer):
+class ObjecttypeVersionTargetPathsSerializer(serializers.Serializer):
+    allow_geometry = serializers.BooleanField(
+        label=_("allow geometry"),
+        help_text=_(
+            "Whether this object type allows the geometry attribute to be filled."
+        ),
+    )
+    target_paths = TargetPathsSerializer(
+        many=True,
+        label=_("target paths"),
+        help_text=_("The list of available target paths."),
+    )
+
+
+class ObjecttypeVersionTargetPathsInputSerializer(serializers.Serializer):
     objecttype_url = serializers.URLField(
         label=_("objecttype url"), help_text=("The URL of the objecttype.")
     )

--- a/src/openforms/registrations/contrib/objects_api/api/urls.py
+++ b/src/openforms/registrations/contrib/objects_api/api/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 
-from .views import ObjecttypesListView, ObjecttypeVersionsListView, TargetPathsListView
+from .views import (
+    ObjecttypesListView,
+    ObjecttypeVersionsListView,
+    ObjecttypeVersionTargetPathsListView,
+)
 
 app_name = "objects_api"
 
@@ -17,7 +21,7 @@ urlpatterns = [
     ),
     path(
         "target-paths",
-        TargetPathsListView.as_view(),
+        ObjecttypeVersionTargetPathsListView.as_view(),
         name="target-paths",
     ),
 ]


### PR DESCRIPTION
I will probably close this PR at some point, as I think it's better to handle it as sergei said:

> instead of handling the mapping as everything inside `data` and special casing `geometry`, can't we just implicitly add the `data` path prefix to everything so then you get a list of targets:
> - `geometry`
> - `data.firstName`
> - `data.lastName`
> - `data.country`
> but the end user never needs to worry about the `data.` prefix
> (of course keeping the types in mind here)
> the reason I'm asking this is also because you can have a second map in the form which goes to `data.additionalGeometry`, and that thing also needs to be pre-processed to produce geo-json

With this solution in my mind, we would just have to remove `geometry` if `allowGeometry` is `False` in the objecttypes API