### PR TITLE
Fixed log output suppression when running tests locally

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -435,7 +435,7 @@ LOGGING = {
     "loggers": {
         "openforms": {
             "handlers": ["project"] if not LOG_STDOUT else ["console"],
-            "level": "DEBUG",
+            "level": "INFO",
             "propagate": True,
         },
         "stuf": {
@@ -455,7 +455,7 @@ LOGGING = {
         },
         "mozilla_django_oidc": {
             "handlers": ["project"] if not LOG_STDOUT else ["console"],
-            "level": "DEBUG",
+            "level": "INFO",
         },
         "log_outgoing_requests": {
             "handlers": (

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -386,9 +386,6 @@ LOGGING = {
         },
         "timestamped": {"format": "%(asctime)s %(levelname)s %(name)s  %(message)s"},
         "simple": {"format": "%(levelname)s  %(message)s"},
-        "performance": {
-            "format": "%(asctime)s %(process)d | %(thread)d | %(message)s",
-        },
         "outgoing_requests": {"()": HttpFormatter},
     },
     "filters": {
@@ -422,14 +419,6 @@ LOGGING = {
             "class": "logging.handlers.RotatingFileHandler",
             "filename": os.path.join(LOGGING_DIR, "openforms.log"),
             "formatter": "verbose",
-            "maxBytes": 1024 * 1024 * 10,  # 10 MB
-            "backupCount": 10,
-        },
-        "performance": {
-            "level": "INFO",
-            "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(LOGGING_DIR, "performance.log"),
-            "formatter": "performance",
             "maxBytes": 1024 * 1024 * 10,  # 10 MB
             "backupCount": 10,
         },

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -25,6 +25,7 @@ os.environ.setdefault("SDK_RELEASE", "latest")
 # otherwise the test suite is flaky due to logging config lookups to the DB in
 # non-DB test cases
 os.environ.setdefault("LOG_REQUESTS", "no")
+os.environ.setdefault("LOG_STDOUT", "1")
 os.environ.setdefault("VCR_RECORD_MODE", "once")
 
 from .base import *  # noqa isort:skip
@@ -40,24 +41,14 @@ SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
 LOGGING["loggers"].update(
     {
-        "openforms": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-            "propagate": True,
-        },
-        "stuf": {
-            "handlers": ["console"],
-            "level": "DEBUG",
-            "propagate": True,
-        },
         "django": {
             "handlers": ["console"],
             "level": "DEBUG",
-            "propagate": True,
+            "propagate": False,
         },
         "django.db.backends": {
             "handlers": ["django"],
-            "level": "DEBUG",
+            "level": "INFO",
             "propagate": False,
         },
         #
@@ -72,7 +63,7 @@ LOGGING["loggers"].update(
         "weasyprint": {
             "handlers": ["console"],
             "level": "DEBUG",
-            "propagate": True,
+            "propagate": False,
         },
     }
 )

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -60,11 +60,6 @@ LOGGING["loggers"].update(
             "level": "DEBUG",
             "propagate": False,
         },
-        "performance": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": True,
-        },
         #
         # See: https://code.djangoproject.com/ticket/30554
         # Autoreload logs excessively, turn it down a bit.

--- a/src/openforms/conf/local_example.py
+++ b/src/openforms/conf/local_example.py
@@ -4,8 +4,8 @@
 import os
 import sys
 
-from .dev import LOGGING as _LOGGING
-from .utils import config
+from .dev import LOGGING
+from .utils import config, mute_logging
 
 # Configure your database via the DB_* envvars in .env, see also dotenv.example file.
 
@@ -21,14 +21,14 @@ if "test" in sys.argv:
 
     # Silence logging during testing
     # if "VERBOSE" not in os.environ:
-    #     LOGGING = None
+    #     mute_logging(LOGGING)
 
 
 if "CELERY_TASK_ALWAYS_EAGER" in os.environ:
     CELERY_TASK_ALWAYS_EAGER = True
 
 if log_level := os.environ.get("LOG_LEVEL"):
-    for logger in _LOGGING["loggers"].values():
+    for logger in LOGGING["loggers"].values():
         logger["level"] = log_level
 
 # make the language code configurable via envvars

--- a/src/openforms/conf/local_example.py
+++ b/src/openforms/conf/local_example.py
@@ -24,19 +24,29 @@ if "test" in sys.argv:
     #     mute_logging(LOGGING)
 
 
-if "CELERY_TASK_ALWAYS_EAGER" in os.environ:
+# run celery tasks so submissions get processed in dev server
+# Ceveat emptor: this breaks test isolation and breaks a few tests in the suite
+if config("CELERY_TASK_ALWAYS_EAGER", default=False):
     CELERY_TASK_ALWAYS_EAGER = True
+
+#
+# LOGGING
+#
+
+# Log DB queries to file and console
+# LOGGING["loggers"]["django.db.backends"] = {
+#     "handlers": ["django", "console"],
+#     "level": "DEBUG",
+#     "propagate": False,
+# }
 
 if log_level := os.environ.get("LOG_LEVEL"):
     for logger in LOGGING["loggers"].values():
         logger["level"] = log_level
+
 
 # make the language code configurable via envvars
 LANGUAGE_CODE = config("LANGUAGE_CODE", "nl")
 
 # allow SPA dev server and API on different ports
 # CORS_ALLOW_ALL_ORIGINS = True
-
-# run celery tasks so submissions get processed in dev server
-# Ceveat emptor: this breaks test isolation and breaks a few tests in the suite
-# CELERY_TASK_ALWAYS_EAGER = True

--- a/src/openforms/conf/utils.py
+++ b/src/openforms/conf/utils.py
@@ -111,3 +111,23 @@ def get_sentry_integrations() -> list:
         extra.append(celery.CeleryIntegration())
 
     return [*default, *extra]
+
+
+def mute_logging(config: dict) -> None:  # pragma: no cover
+    """
+    Disable (console) output from logging.
+
+    :arg config: The logging config, typically the django LOGGING setting.
+    """
+
+    # set up the null handler for all loggers so that nothing gets emitted
+    for logger in config["loggers"].values():
+        logger["handlers"] = ["null"]
+
+    # some tooling logs to a logger which isn't defined, and that ends up in the root
+    # logger -> add one so that we can mute that output too.
+    config["loggers"].update(
+        {
+            "": {"handlers": ["null"], "level": "CRITICAL", "propagate": False},
+        }
+    )

--- a/src/openforms/registrations/tests/test_pre_registration.py
+++ b/src/openforms/registrations/tests/test_pre_registration.py
@@ -14,6 +14,7 @@ from openforms.registrations.tasks import register_submission
 from openforms.submissions.constants import PostSubmissionEvents
 from openforms.submissions.tasks.registration import pre_registration
 from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.utils.tests.logging import ensure_logger_level
 
 
 class PreRegistrationTests(TestCase):
@@ -272,6 +273,7 @@ class PreRegistrationTests(TestCase):
             patch(
                 "openforms.registrations.contrib.zgw_apis.plugin.ZGWRegistration.pre_register_submission"
             ) as mock_pre_register,
+            ensure_logger_level("DEBUG"),
             self.assertLogs(level="DEBUG") as logs,
         ):
             pre_registration(submission.id, PostSubmissionEvents.on_retry)

--- a/src/openforms/registrations/tests/test_registration_hook.py
+++ b/src/openforms/registrations/tests/test_registration_hook.py
@@ -19,6 +19,7 @@ from openforms.forms.models import FormRegistrationBackend
 from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.constants import PostSubmissionEvents, RegistrationStatuses
 from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.utils.tests.logging import ensure_logger_level
 
 from ..base import BasePlugin
 from ..exceptions import RegistrationFailed
@@ -286,6 +287,7 @@ class RegistrationHookTests(TestCase):
 
             with self.subTest("on retry"):
                 with (
+                    ensure_logger_level("DEBUG"),
                     self.assertRaises(RegistrationFailed),
                     self.assertLogs(level="DEBUG") as logs,
                 ):

--- a/src/openforms/submissions/tests/test_post_submission_event.py
+++ b/src/openforms/submissions/tests/test_post_submission_event.py
@@ -16,6 +16,7 @@ from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
 from openforms.forms.tests.factories import FormDefinitionFactory
 from openforms.payments.constants import PaymentStatus
 from openforms.payments.tests.factories import SubmissionPaymentFactory
+from openforms.utils.tests.logging import ensure_logger_level
 
 from ..constants import PostSubmissionEvents
 from ..models import SubmissionReport
@@ -1058,6 +1059,7 @@ class PaymentFlowTests(TestCase):
                 "openforms.registrations.tasks.GlobalConfiguration.get_solo",
                 return_value=GlobalConfiguration(wait_for_payment_to_register=True),
             ),
+            ensure_logger_level("DEBUG"),
             LogCapture() as logs,
         ):
             on_post_submission_event(submission.id, PostSubmissionEvents.on_completion)

--- a/src/openforms/utils/tests/logging.py
+++ b/src/openforms/utils/tests/logging.py
@@ -1,4 +1,6 @@
 import logging
+from contextlib import contextmanager
+from typing import Iterator
 
 from django.test.utils import TestContextDecorator
 
@@ -9,3 +11,23 @@ class disable_logging(TestContextDecorator):
 
     def disable(self):
         logging.disable(logging.NOTSET)
+
+
+@contextmanager
+def ensure_logger_level(level: str = "INFO", name="openforms") -> Iterator[None]:
+    """
+    Set the (minimum) level for a given logger.
+
+    Base or individual settings may tweak the log level to reduce the overload for the
+    developer, but this affects tests that verify that log records are "written" by
+    application code for a certain log level.
+
+    This context manager allows you to pin the log level for a given text, irrespective
+    of individual preferences/developer settings.
+    """
+    logger = logging.getLogger(name)
+    original_level = logger.getEffectiveLevel()
+
+    logger.setLevel(logging._nameToLevel[level])
+    yield
+    logger.setLevel(original_level)


### PR DESCRIPTION
My console was littered with distracting log output from exceptions here and there. I managed to trace down the root cause to:

* missing root logger configuration
* the `dev.py` settings adding additional loggers that are not present in `ci.py` (nor `base.py`)

For this I did some clean up/added some helpers:

* Remove the unused performance logging
* Rely on the standard envvar mechanism to set the `handler` in dev to file or console output (`LOG_STDOUT` setting)
* Tweaked the log levels a bit for loggers that are too chatty (DEBUG -> INFO)
* Updated local example to mute logging locally entirely.