### PR TITLE
[#72] Backend validation of remaining components

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -314,3 +314,45 @@ class BSN(BasePlugin[Component]):
 class AddressNL(BasePlugin):
 
     formatter = AddressNLFormatter
+
+
+@register("iban")
+class Iban(BasePlugin):
+    formatter = DefaultFormatter
+
+    def build_serializer_field(
+        self, component: Component
+    ) -> serializers.CharField | serializers.ListField:
+        multiple = component.get("multiple", False)
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+        base = serializers.CharField(required=required, allow_blank=not required)
+        return serializers.ListField(child=base) if multiple else base
+
+
+@register("licenseplate")
+class LicensePlate(BasePlugin):
+    formatter = DefaultFormatter
+
+    def build_serializer_field(self, component: Component) -> serializers.CharField:
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+
+        extra = {}
+        validators = []
+        # adding in the validator is more explicit than changing to serialiers.RegexField,
+        # which essentially does the same.
+        if pattern := validate.get("pattern"):
+            validators.append(
+                RegexValidator(
+                    _normalize_pattern(pattern),
+                    message=_("This value does not match the required pattern."),
+                )
+            )
+
+        if validators:
+            extra["validators"] = validators
+
+        return serializers.CharField(
+            required=required, allow_blank=not required, **extra
+        )

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -20,6 +20,7 @@ from openforms.validations.service import PluginValidator
 from ..dynamic_config.date import mutate as mutate_min_max_validation
 from ..formatters.custom import (
     AddressNLFormatter,
+    CosignFormatter,
     DateFormatter,
     DateTimeFormatter,
     MapFormatter,
@@ -356,3 +357,14 @@ class LicensePlate(BasePlugin):
         return serializers.CharField(
             required=required, allow_blank=not required, **extra
         )
+
+
+@register("cosign")
+class Cosign(BasePlugin):
+    formatter = CosignFormatter
+
+    def build_serializer_field(self, component: Component) -> serializers.EmailField:
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+
+        return serializers.EmailField(required=required, allow_blank=not required)

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -374,6 +374,15 @@ class Number(BasePlugin):
 class Password(BasePlugin):
     formatter = PasswordFormatter
 
+    def build_serializer_field(
+        self, component: Component
+    ) -> serializers.CharField | serializers.ListField:
+        multiple = component.get("multiple", False)
+        validate = component.get("validate", {})
+        required = validate.get("required", False)
+        base = serializers.CharField(required=required, allow_blank=not required)
+        return serializers.ListField(child=base) if multiple else base
+
 
 def validate_required_checkbox(value: bool) -> None:
     """

--- a/src/openforms/formio/formatters/custom.py
+++ b/src/openforms/formio/formatters/custom.py
@@ -37,3 +37,8 @@ class AddressNLFormatter(FormatterBase):
         return format_html(
             "{postcode} {houseNumber}{houseLetter} {houseNumberAddition}", **value
         ).strip()
+
+
+class CosignFormatter(FormatterBase):
+    def format(self, component: Component, value: str) -> str:
+        return str(value)

--- a/src/openforms/formio/tests/validation/test_cosign.py
+++ b/src/openforms/formio/tests/validation/test_cosign.py
@@ -1,0 +1,48 @@
+from django.test import SimpleTestCase
+
+
+from openforms.typing import JSONValue
+
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class CosignValidationTests(SimpleTestCase):
+    def test_cosign_required_validation(self):
+        component: Component = {
+            "type": "cosign",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": ""}, "blank"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_cosign_pattern_validation(self):
+        component: Component = {
+            "type": "cosign",
+            "key": "foo",
+            "label": "Test",
+        }
+        data: JSONValue = {"foo": "invalid-email"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "invalid")

--- a/src/openforms/formio/tests/validation/test_cosign.py
+++ b/src/openforms/formio/tests/validation/test_cosign.py
@@ -1,15 +1,28 @@
 from django.test import SimpleTestCase
 
-
 from openforms.typing import JSONValue
-
 
 from ...typing import Component
 from .helpers import extract_error, validate_formio_data
 
 
 class CosignValidationTests(SimpleTestCase):
-    def test_cosign_required_validation(self):
+    def test_valid_required_cosign(self):
+        component: Component = {
+            "type": "cosign",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": True},
+        }
+
+        data: JSONValue = {"foo": "user@example.com"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_invalid_required_cosign(self):
         component: Component = {
             "type": "cosign",
             "key": "foo",
@@ -32,12 +45,29 @@ class CosignValidationTests(SimpleTestCase):
                 error = extract_error(errors, component["key"])
                 self.assertEqual(error.code, error_code)
 
-    def test_cosign_pattern_validation(self):
+    def test_valid_non_required_cosign(self):
         component: Component = {
             "type": "cosign",
             "key": "foo",
             "label": "Test",
+            "validate": {"required": False},
         }
+
+        data: JSONValue = {"foo": "user@example.com"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_invalid_non_required_cosign(self):
+        component: Component = {
+            "type": "cosign",
+            "key": "foo",
+            "label": "Test",
+            "validate": {"required": False},
+        }
+
         data: JSONValue = {"foo": "invalid-email"}
 
         is_valid, errors = validate_formio_data(component, data)

--- a/src/openforms/formio/tests/validation/test_iban.py
+++ b/src/openforms/formio/tests/validation/test_iban.py
@@ -7,8 +7,36 @@ from .helpers import extract_error, validate_formio_data
 
 
 class IbanFieldValidationTests(SimpleTestCase):
+    def test_valid_required_ibanfield(self):
+        component: Component = {
+            "type": "iban",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+        }
 
-    def test_ibanfield_required_validation(self):
+        data: JSONValue = {"foo": "NL56 INGB 0705 0051 00"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_valid_non_required_ibanfield(self):
+        component: Component = {
+            "type": "iban",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": False},
+        }
+        data: JSONValue = {"foo": ""}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_invalid_required_ibanfield(self):
         component: Component = {
             "type": "iban",
             "key": "foo",
@@ -30,13 +58,31 @@ class IbanFieldValidationTests(SimpleTestCase):
                 error = extract_error(errors, component["key"])
                 self.assertEqual(error.code, error_code)
 
-    def test_multiple(self):
+    def test_multiple_enabled(self):
+        component: Component = {
+            "type": "iban",
+            "key": "foo",
+            "label": "Test",
+            "multiple": True,
+        }
+
+        data: JSONValue = {
+            "foo": [" RO09 BCYP 0000 1112 3456 5678", "RO09 BCYP 0000 0012 3456 7890"]
+        }
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_multiple_disabled(self):
         component: Component = {
             "type": "iban",
             "key": "foo",
             "label": "Test",
             "multiple": False,
         }
+
         data: JSONValue = {
             "foo": [" RO09 BCYP 0000 1112 3456 5678", "RO09 BCYP 0000 0012 3456 7890"]
         }

--- a/src/openforms/formio/tests/validation/test_iban.py
+++ b/src/openforms/formio/tests/validation/test_iban.py
@@ -1,0 +1,49 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class IbanFieldValidationTests(SimpleTestCase):
+
+    def test_ibanfield_required_validation(self):
+        component: Component = {
+            "type": "iban",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_multiple(self):
+        component: Component = {
+            "type": "iban",
+            "key": "foo",
+            "label": "Test",
+            "multiple": False,
+        }
+        data: JSONValue = {
+            "foo": [" RO09 BCYP 0000 1112 3456 5678", "RO09 BCYP 0000 0012 3456 7890"]
+        }
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "invalid")

--- a/src/openforms/formio/tests/validation/test_licenseplate.py
+++ b/src/openforms/formio/tests/validation/test_licenseplate.py
@@ -8,16 +8,56 @@ from .helpers import extract_error, validate_formio_data
 
 class LicenseplateFieldValidationTests(SimpleTestCase):
 
-    def test_licenseplatefield_required_validation(self):
+    def test_valid_non_required_licenseplatefield(self):
         component: Component = {
             "type": "licenseplate",
             "key": "foo",
             "label": "Foo",
-            "validate": {"required": True},
+            "validate": {
+                "required": False,
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
+            },
+        }
+
+        data: JSONValue = {"foo": "1-AAA-BB"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_valid_required_licenseplatefield(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {
+                "required": True,
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
+            },
+        }
+
+        data: JSONValue = {"foo": "1-AAA-BB"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_invalid_required_licenseplatefield(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {
+                "required": True,
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
+            },
         }
 
         invalid_values = [
             ({}, "required"),
+            ({"foo": "wrong input"}, "invalid"),
             ({"foo": None}, "null"),
         ]
 
@@ -30,15 +70,58 @@ class LicenseplateFieldValidationTests(SimpleTestCase):
                 error = extract_error(errors, component["key"])
                 self.assertEqual(error.code, error_code)
 
-    def test_licenseplate_pattern_validation(self):
+    def test_invalid_non_required_licenseplatefield(self):
         component: Component = {
             "type": "licenseplate",
             "key": "foo",
             "label": "Foo",
             "validate": {
-                "pattern": r"^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$",
+                "required": False,
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
             },
         }
+
+        invalid_values = [
+            ({"foo": "AAAA-8-A"}, "invalid"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_valid_licenseplatefield_pattern(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
+            },
+        }
+
+        data: JSONValue = {"foo": "1-AAA-BB"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_invalid_licenseplatefield_pattern(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
+            },
+        }
+
         data: JSONValue = {"foo": "1-AAA-2222"}
 
         is_valid, errors = validate_formio_data(component, data)

--- a/src/openforms/formio/tests/validation/test_licenseplate.py
+++ b/src/openforms/formio/tests/validation/test_licenseplate.py
@@ -1,0 +1,49 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class LicenseplateFieldValidationTests(SimpleTestCase):
+
+    def test_licenseplatefield_required_validation(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_licenseplate_pattern_validation(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {
+                "pattern": r"^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$",
+            },
+        }
+        data: JSONValue = {"foo": "1-AAA-2222"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "invalid")

--- a/src/openforms/formio/tests/validation/test_password.py
+++ b/src/openforms/formio/tests/validation/test_password.py
@@ -1,0 +1,47 @@
+from django.test import SimpleTestCase
+
+from openforms.typing import JSONValue
+
+from ...typing import Component
+from .helpers import extract_error, validate_formio_data
+
+
+class PasswordFieldValidationTests(SimpleTestCase):
+
+    def test_passwordfield_required_validation(self):
+        component: Component = {
+            "type": "password",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": None}, "null"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_multiple(self):
+        component: Component = {
+            "type": "password",
+            "key": "foo",
+            "label": "Test",
+            "multiple": False,
+        }
+        data: JSONValue = {"foo": ["ghwgG22", "TRshhe33j"]}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        self.assertIn(component["key"], errors)
+        error = extract_error(errors, component["key"])
+        self.assertEqual(error.code, "invalid")

--- a/src/openforms/formio/tests/validation/test_password.py
+++ b/src/openforms/formio/tests/validation/test_password.py
@@ -7,8 +7,22 @@ from .helpers import extract_error, validate_formio_data
 
 
 class PasswordFieldValidationTests(SimpleTestCase):
+    def test_valid_required_passwordfield(self):
+        component: Component = {
+            "type": "password",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+        }
 
-    def test_passwordfield_required_validation(self):
+        data: JSONValue = {"foo": "test"}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_invalid_required_passwordfield(self):
         component: Component = {
             "type": "password",
             "key": "foo",
@@ -30,13 +44,29 @@ class PasswordFieldValidationTests(SimpleTestCase):
                 error = extract_error(errors, component["key"])
                 self.assertEqual(error.code, error_code)
 
-    def test_multiple(self):
+    def test_multiple_enabled(self):
         component: Component = {
             "type": "password",
             "key": "foo",
-            "label": "Test",
+            "label": "Foo",
+            "multiple": True,
+        }
+
+        data: JSONValue = {"foo": ["ghwgG22", "TRshhe33j"]}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+        self.assertDictEqual(errors, {})
+
+    def test_multiple_disabled(self):
+        component: Component = {
+            "type": "password",
+            "key": "foo",
+            "label": "Foo",
             "multiple": False,
         }
+
         data: JSONValue = {"foo": ["ghwgG22", "TRshhe33j"]}
 
         is_valid, errors = validate_formio_data(component, data)

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -26,6 +26,8 @@ class Validate(TypedDict, total=False):
     pattern: str
     min: int | float
     max: int | float
+    minTime: str
+    maxTime: str
     plugins: list[str]
 
 

--- a/src/openforms/formio/typing/custom.py
+++ b/src/openforms/formio/typing/custom.py
@@ -1,8 +1,9 @@
 from typing_extensions import NotRequired
 
 from .base import Component
-from .dates import DatePickerConfig
+from .dates import DatePickerConfig, DatePickerCustomOptions
 
 
 class DateComponent(Component):
     datePicker: NotRequired[DatePickerConfig]
+    customOptions: NotRequired[DatePickerCustomOptions]

--- a/src/openforms/formio/typing/dates.py
+++ b/src/openforms/formio/typing/dates.py
@@ -21,10 +21,21 @@ class DateConstraintConfiguration(TypedDict):
     operator: NotRequired[Literal["add", "subtract"] | None]
 
 
+class DatePickerCustomOptions(TypedDict):
+    allowInvalidPreload: NotRequired[bool]
+
+
 class DatePickerConfig(TypedDict):
     # NOTE: these strings can be a date (YYYY-MM-DD) or datetime (YYYY-MM-DDTHH:mm:ss)
     # ISO-8601 string! Even the date component uses datetimes under the hood because
     # Javascript only has a Date type that covers both, and that leaks into our form
     # builder and backend logic doing dynamic things.
+    showWeeks: NotRequired[bool]
+    startingDay: NotRequired[Literal[0, 1, 2, 3, 4, 5, 6]]
+    initDate: NotRequired[str]
+    minMode: NotRequired[Literal["day", "month", "year"]]
+    maxMode: NotRequired[Literal["day", "month", "year"]]
+    yearRows: NotRequired[int]
+    yearColumns: NotRequired[int]
     minDate: str | None
     maxDate: str | None

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -248,7 +248,10 @@ class SingleBSNTests(ValidationsTestCase):
 
 class SingleDateTests(ValidationsTestCase):
 
-    async def apply_ui_input(self, page: Page, label: str, ui_input: str = "") -> None:
+    async def apply_ui_input(
+        self, page: Page, label: str, ui_input: str | int | float = ""
+    ) -> None:
+        assert isinstance(ui_input, str)
         # fix the input resolution because the formio datepicker is not accessible
         label_node = page.get_by_text(label, exact=True)
         label_parent = label_node.locator("xpath=../..")
@@ -261,10 +264,6 @@ class SingleDateTests(ValidationsTestCase):
             "key": "requiredDate",
             "label": "Required date field",
             "validate": {"required": True},
-            "datepickerMode": "day",
-            "enableDate": True,
-            "enableTime": False,
-            "format": "dd-MM-yyyy",
             "datePicker": {
                 "showWeeks": True,
                 "startingDay": 0,
@@ -293,10 +292,6 @@ class SingleDateTests(ValidationsTestCase):
             "openForms": {
                 "minDate": {"mode": "fixedValue"},
             },
-            "datepickerMode": "day",
-            "enableDate": True,
-            "enableTime": False,
-            "format": "dd-MM-yyyy",
             "datePicker": {
                 "showWeeks": True,
                 "startingDay": 0,
@@ -326,10 +321,6 @@ class SingleDateTests(ValidationsTestCase):
             "openForms": {
                 "maxDate": {"mode": "fixedValue"},
             },
-            "datepickerMode": "day",
-            "enableDate": True,
-            "enableTime": False,
-            "format": "dd-MM-yyyy",
             "datePicker": {
                 "showWeeks": True,
                 "startingDay": 0,
@@ -571,4 +562,98 @@ class SingleTimeTests(ValidationsTestCase):
             component,
             ui_input="15:00",
             expected_ui_error="Alleen tijden tussen 20:00 en 04:00 zijn toegestaan.",
+        )
+
+
+class SingleIbanTests(ValidationsTestCase):
+    def test_required_field(self):
+        component: Component = {
+            "type": "iban",
+            "key": "requiredIban",
+            "label": "Required iban",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            expected_ui_error="Het verplichte veld Required iban is niet ingevuld.",
+        )
+
+
+class SingleLicenseplateTests(ValidationsTestCase):
+    def test_required_field(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "requiredLicenseplate",
+            "label": "Required licenseplate",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            expected_ui_error="Het verplichte veld Required licenseplate is niet ingevuld.",
+        )
+
+    def test_regex_pattern(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "requiredLicenseplate",
+            "label": "Required licenseplate",
+            "validate": {
+                "pattern": r"^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$"
+            },
+            "errors": {"pattern": "Ongeldig Nederlands kenteken"},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="<h2>test</h2>",
+            expected_ui_error="Ongeldig Nederlands kenteken",
+        )
+
+
+class SinglePasswordTests(ValidationsTestCase):
+    def test_required_field(self):
+        component: Component = {
+            "type": "password",
+            "key": "requiredPassword",
+            "label": "Required password",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            expected_ui_error="Het verplichte veld Required password is niet ingevuld.",
+        )
+
+
+class SingleCosignTests(ValidationsTestCase):
+    def test_required_field(self):
+        component: Component = {
+            "type": "cosign",
+            "key": "requiredCosign",
+            "label": "Required cosign",
+            "validate": {"required": True},
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="",
+            expected_ui_error="Het verplichte veld Required cosign is niet ingevuld.",
+        )
+
+    def test_cosign_format(self):
+        component: Component = {
+            "type": "cosign",
+            "key": "cosign",
+            "label": "Cosign",
+        }
+
+        self.assertValidationIsAligned(
+            component,
+            ui_input="invalid",
+            expected_ui_error="Ongeldig e-mailadres",
         )


### PR DESCRIPTION
Partly closes #72 

This PR handles the following components, the rest of them are handled by PR #4029

- datetime
- file
- selectboxes
- iban
- licenseplate
- npFamilyMembers
- addressNL
- co-sign v1
- co-sign v2
- password