### PR TITLE
:mute: Mute logging during test runs in CI

### DIFF
--- a/src/openforms/conf/ci.py
+++ b/src/openforms/conf/ci.py
@@ -24,6 +24,7 @@ os.environ.setdefault("SECRET_KEY", "dummy")
 os.environ.setdefault("LOG_REQUESTS", "no")
 
 from .base import *  # noqa isort:skip
+from .utils import mute_logging  # noqa isort:skip
 
 CACHES.update(
     {
@@ -35,15 +36,7 @@ CACHES.update(
 )
 
 # shut up logging
-LOGGING["loggers"].update(
-    {
-        "openforms.api.exception_handling": {
-            "handlers": ["console"],
-            "level": "CRITICAL",
-            "propagate": False,
-        },
-    }
-)
+mute_logging(LOGGING)
 
 # don't spend time on password hashing in tests/user factories
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.UnsaltedMD5PasswordHasher"]


### PR DESCRIPTION
CI is showing irrelevant logs, making it harder to debug actual test failures.