### PR TITLE
Bump to maykin-python3-saml patch release

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -314,7 +314,7 @@ maykin-2fa==1.0.0
     # via -r requirements/base.in
 maykin-json-logic-py==0.13.0
     # via -r requirements/base.in
-maykin-python3-saml==1.16.0.post2
+maykin-python3-saml==1.16.1
     # via django-digid-eherkenning
 mozilla-django-oidc==4.0.0
     # via mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -580,7 +580,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post2
+maykin-python3-saml==1.16.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -658,7 +658,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-python3-saml==1.16.0.post2
+maykin-python3-saml==1.16.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -479,7 +479,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post2
+maykin-python3-saml==1.16.1
     # via
     #   -r requirements/base.txt
     #   django-digid-eherkenning


### PR DESCRIPTION
Closes #4079

The patch is in our fork of python3-saml - this now uses `requests` to retrieve the metadata instead of `urllib.request`.