### PR TITLE
Bump maykin-python3-saml and django-digid-eherkenning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -74,8 +74,10 @@ click-repl==0.2.0
     # via celery
 cryptography==42.0.5
     # via
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect2==0.7.0
@@ -152,7 +154,7 @@ django-csp-reports==1.8.1
     # via -r requirements/base.in
 django-decorator-include==3.0
     # via -r requirements/base.in
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via -r requirements/base.in
 django-filter==23.2
     # via -r requirements/base.in
@@ -305,7 +307,7 @@ maykin-django-two-factor-auth[phonenumbers]==2.0.4
     # via -r requirements/base.in
 maykin-json-logic-py==0.13.0
     # via -r requirements/base.in
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via django-digid-eherkenning
 mozilla-django-oidc==3.0.0
     # via mozilla-django-oidc-db
@@ -360,7 +362,6 @@ pyopenssl==24.0.0
     # via
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via weasyprint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -139,8 +139,10 @@ cryptography==42.0.5
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect==1.1.0
@@ -250,7 +252,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -563,7 +565,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -708,7 +710,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -159,8 +159,10 @@ cryptography==42.0.5
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect==1.1.0
@@ -281,7 +283,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -645,7 +647,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -828,7 +830,6 @@ pyopenssl==24.0.0
     #   -r requirements/ci.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -109,8 +109,10 @@ click-repl==0.2.0
 cryptography==42.0.5
     # via
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect2==0.7.0
@@ -217,7 +219,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -466,7 +468,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via
     #   -r requirements/base.txt
     #   django-digid-eherkenning
@@ -571,7 +573,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via


### PR DESCRIPTION
django-digid-eherkenning bump is required because of the updated maykin-python3-saml version which contains a necessary bugfix.

Backport-of: #4087