### PR TITLE
Bump maykin-python3-saml and django-digid-eherkenning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,8 +77,10 @@ click-repl==0.2.0
     # via celery
 cryptography==42.0.2
     # via
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect2==0.4.1
@@ -161,7 +163,7 @@ django-csp-reports==1.8.1
     # via -r requirements/base.in
 django-decorator-include==3.0
     # via -r requirements/base.in
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via -r requirements/base.in
 django-filter==23.2
     # via -r requirements/base.in
@@ -308,7 +310,7 @@ maykin-django-two-factor-auth[phonenumbers]==2.0.4
     # via -r requirements/base.in
 maykin-json-logic-py==0.13.0
     # via -r requirements/base.in
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via django-digid-eherkenning
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db
@@ -362,7 +364,6 @@ pyopenssl==24.0.0
     # via
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via weasyprint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -145,8 +145,10 @@ cryptography==42.0.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect==1.1.0
@@ -262,7 +264,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -568,7 +570,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -709,7 +711,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -165,8 +165,10 @@ cryptography==42.0.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect==1.1.0
@@ -293,7 +295,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -647,7 +649,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -826,7 +828,6 @@ pyopenssl==24.0.0
     #   -r requirements/ci.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -114,8 +114,10 @@ click-repl==0.2.0
 cryptography==42.0.2
     # via
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   django-simple-certmanager
     #   josepy
+    #   maykin-python3-saml
     #   mozilla-django-oidc
     #   pyopenssl
 cssselect2==0.4.1
@@ -228,7 +230,7 @@ django-decorator-include==3.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-digid-eherkenning==0.11.0
+django-digid-eherkenning==0.12.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -471,7 +473,7 @@ maykin-json-logic-py==0.13.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-maykin-python3-saml==1.16.0.post1
+maykin-python3-saml==1.16.1
     # via
     #   -r requirements/base.txt
     #   django-digid-eherkenning
@@ -573,7 +575,6 @@ pyopenssl==24.0.0
     #   -r requirements/base.txt
     #   django-simple-certmanager
     #   josepy
-    #   maykin-python3-saml
     #   zgw-consumers
 pyphen==0.10.0
     # via


### PR DESCRIPTION
django-digid-eherkenning bump is required because of the updated maykin-python3-saml version which contains a necessary bugfix.

Backport-of: #4087