### PR TITLE
 [#4031] Set geometry as part of the JSON Schema 

### DIFF
--- a/src/openforms/contrib/objects_api/clients/objecttypes.py
+++ b/src/openforms/contrib/objects_api/clients/objecttypes.py
@@ -43,6 +43,14 @@ class ObjecttypesClient(NLXClient):
             page_size=page_size,
         )
 
+    def get_objecttype(
+        self,
+        objecttype_uuid: str | UUID,
+    ) -> dict[str, Any]:
+        response = self.get(f"objecttypes/{objecttype_uuid}")
+        response.raise_for_status()
+        return response.json()
+
     def list_objecttype_versions(
         self,
         objecttype_uuid: str | UUID,

--- a/src/openforms/contrib/objects_api/helpers.py
+++ b/src/openforms/contrib/objects_api/helpers.py
@@ -7,10 +7,11 @@ def prepare_data_for_registration(
     record_data: dict[str, Any],
     objecttype: str,
     objecttype_version: int,
+    geometry_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Prepare the submission data for sending it to the Objects API."""
 
-    return {
+    data = {
         "type": objecttype,
         "record": {
             "typeVersion": objecttype_version,
@@ -18,3 +19,7 @@ def prepare_data_for_registration(
             "startAt": get_today(),
         },
     }
+    if geometry_data is not None:
+        data["record"]["geometry"] = geometry_data
+
+    return data

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -56,7 +56,6 @@ const ObjectsApiOptionsFormFields = ({index, name, schema, formData, onChange}) 
         draft.version = realVersion;
         if (realVersion === 2) {
           draft.variablesMapping = [];
-          draft.geometryVariableKey = '';
         } else {
           delete draft.variablesMapping;
         }

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
@@ -6,7 +6,6 @@ import {FormattedMessage} from 'react-intl';
  *
  * @typedef {{
  *   variablesMapping: {variableKey: string, targetPath: string[]}[],
- *   geometryVariableKey: string,
  * }} ObjectsAPIV2Options
  *
  * @param {Object} p
@@ -15,18 +14,6 @@ import {FormattedMessage} from 'react-intl';
  * @returns {JSX.Element} - The summary, represented as the parts of the target path separated by '>'
  */
 const ObjectsApiSummaryHandler = ({variable, backendOptions}) => {
-  const geometryVariableKey = backendOptions.geometryVariableKey;
-
-  if (geometryVariableKey === variable.key) {
-    return (
-      <FormattedMessage
-        description="'Mapped to geometry' registration summary message"
-        defaultMessage="Mapped to the {geometryPath} attribute"
-        values={{geometryPath: <code>record.geometry</code>}}
-      />
-    );
-  }
-
   const variableMapping = backendOptions.variablesMapping.find(
     mapping => mapping.variableKey === variable.key
   );

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -25,7 +25,6 @@ import {asJsonSchema} from './utils';
  *   objecttype: string;
  *   objecttypeVersion: number;
  *   variablesMapping: {variableKey: string, targetPath: string[]}[];
- *   geometryVariableKey: string;
  * }} ObjectsAPIRegistrationBackendOptions
  *
  * @param {Object} p
@@ -39,12 +38,9 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
   const {values: backendOptions, getFieldProps, setFieldValue} = useFormikContext();
 
   /** @type {ObjectsAPIRegistrationBackendOptions} */
-  const {objecttype, objecttypeVersion, geometryVariableKey, variablesMapping, version} =
-    backendOptions;
+  const {objecttype, objecttypeVersion, variablesMapping, version} = backendOptions;
 
   if (version !== 2) throw new Error('Not supported, must be config version 2.');
-
-  const isGeometry = geometryVariableKey === variable.key;
 
   // get the index of our variable in the mapping, if it exists
   let index = variablesMapping.findIndex(
@@ -117,33 +113,6 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
       </FormRow>
       <FormRow>
         <Field
-          label={
-            <FormattedMessage
-              defaultMessage="Map to geometry field"
-              description="'Map to geometry field' checkbox label"
-            />
-          }
-          helpText={
-            <FormattedMessage
-              description="'Map to geometry field' checkbox help text"
-              defaultMessage="Whether to map this variable to the {geometryPath} attribute"
-              values={{geometryPath: <code>record.geometry</code>}}
-            />
-          }
-          name="geometryVariableKey"
-          disabled={!!mappedVariable.targetPath}
-        >
-          <Checkbox
-            checked={isGeometry}
-            onChange={event => {
-              const newValue = event.target.checked ? variable.key : undefined;
-              setFieldValue('geometryVariableKey', newValue);
-            }}
-          />
-        </Field>
-      </FormRow>
-      <FormRow>
-        <Field
           name={`${namePrefix}.targetPath`}
           label={
             <FormattedMessage
@@ -151,14 +120,12 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
               description="'JSON Schema target' label"
             />
           }
-          disabled={isGeometry}
         >
           <TargetPathSelect
             name={`${namePrefix}.targetPath`}
             index={index}
             choices={choices}
             mappedVariable={mappedVariable}
-            disabled={isGeometry}
           />
         </Field>
       </FormRow>

--- a/src/openforms/registrations/contrib/objects_api/api/views.py
+++ b/src/openforms/registrations/contrib/objects_api/api/views.py
@@ -87,9 +87,21 @@ class TargetPathsListView(views.APIView):
 
         with get_objecttypes_client() as client:
 
-            json_schema = client.get_objecttype_version(
+            allow_geometry = client.get_objecttype(objecttype_uuid).get(
+                "allowGeometry", True
+            )
+
+            _json_schema = client.get_objecttype_version(
                 objecttype_uuid, input_serializer.validated_data["objecttype_version"]
             )["jsonSchema"]
+
+        json_schema = {
+            "type": "object",
+            "properties": {"data": {"type": "object", "properties": _json_schema}},
+        }
+
+        if allow_geometry:
+            json_schema["properties"]["geometry"] = {"type": "object"}
 
         return_data = [
             {

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -150,23 +150,13 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         required=False,
     )
 
-    # As `record.geometry` is outside `record.data`, we special case this attribute:
-    geometry_variable_key = FormioVariableKeyField(
-        label=_("geometry variable"),
-        help_text=_(
-            "The 'dotted' path to a form variable key that should be mapped to the `record.geometry` attribute."
-        ),
-        required=False,
-        allow_blank=True,
-    )
-
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         v1_only_fields = {
             "productaanvraag_type",
             "content_json",
             "payment_status_update_json",
         }
-        v2_only_fields = {"variables_mapping", "geometry_variable_key"}
+        v2_only_fields = {"variables_mapping"}
 
         version = get_from_serializer_data_or_instance("version", attrs, self)
 

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -101,40 +101,43 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
             "variables_mapping": [
                 # fmt: off
                 {
+                    "variable_key": "location",
+                    "target_path": ["geometry"],
+                },
+                {
                     "variable_key": "age",
-                    "target_path": ["age"],
+                    "target_path": ["data", "age"],
                 },
                 {
                     "variable_key": "lastname",
-                    "target_path": ["name", "last.name"]
+                    "target_path": ["data", "name", "last.name"]
                 },
                 {
                     "variable_key": "now",
-                    "target_path": ["submission_date"],
+                    "target_path": ["data", "submission_date"],
                 },
                 {
                     "variable_key": "pdf_url",
-                    "target_path": ["submission_pdf_url"],
+                    "target_path": ["data", "submission_pdf_url"],
                 },
                 {
                     "variable_key": "csv_url",
-                    "target_path": ["submission_csv_url"],
+                    "target_path": ["data", "submission_csv_url"],
                 },
                 {
                     "variable_key": "payment_completed",
-                    "target_path": ["submission_payment_completed"],
+                    "target_path": ["data", "submission_payment_completed"],
                 },
                 {
                     "variable_key": "payment_amount",
-                    "target_path": ["submission_payment_amount"],
+                    "target_path": ["data", "submission_payment_amount"],
                 },
                 {
                     "variable_key": "payment_public_order_ids",
-                    "target_path": ["submission_payment_public_ids"],
+                    "target_path": ["data", "submission_payment_public_ids"],
                 },
                 # fmt: on
             ],
-            "geometry_variable_key": "location",
         }
 
         plugin = ObjectsAPIRegistration(PLUGIN_IDENTIFIER)
@@ -213,11 +216,11 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 # fmt: off
                 {
                     "variable_key": "single_file",
-                    "target_path": ["single_file"],
+                    "target_path": ["data", "single_file"],
                 },
                 {
                     "variable_key": "multiple_files",
-                    "target_path": ["multiple_files"]
+                    "target_path": ["data", "multiple_files"]
                 },
                 # fmt: on
             ],
@@ -275,7 +278,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 # fmt: off
                 {
                     "variable_key": "location",
-                    "target_path": ["pointCoordinates"],
+                    "target_path": ["data", "pointCoordinates"],
                 },
                 # fmt: on
             ],

--- a/src/openforms/registrations/contrib/objects_api/tests/test_update_payment_status_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_update_payment_status_v2.py
@@ -115,40 +115,43 @@ class ObjectsAPIPaymentStatusUpdateV2Tests(OFVCRMixin, TestCase):
             "variables_mapping": [
                 # fmt: off
                 {
+                    "variable_key": "location",
+                    "target_path": ["geometry"],
+                },
+                {
                     "variable_key": "age",
-                    "target_path": ["age"],
+                    "target_path": ["data", "age"],
                 },
                 {
                     "variable_key": "lastname",
-                    "target_path": ["name", "last.name"]
+                    "target_path": ["data", "name", "last.name"]
                 },
                 {
                     "variable_key": "now",
-                    "target_path": ["submission_date"],
+                    "target_path": ["data", "submission_date"],
                 },
                 {
                     "variable_key": "pdf_url",
-                    "target_path": ["submission_pdf_url"],
+                    "target_path": ["data", "submission_pdf_url"],
                 },
                 {
                     "variable_key": "csv_url",
-                    "target_path": ["submission_csv_url"],
+                    "target_path": ["data", "submission_csv_url"],
                 },
                 {
                     "variable_key": "payment_completed",
-                    "target_path": ["submission_payment_completed"],
+                    "target_path": ["data", "submission_payment_completed"],
                 },
                 {
                     "variable_key": "payment_amount",
-                    "target_path": ["nested", "submission_payment_amount"],
+                    "target_path": ["data", "nested", "submission_payment_amount"],
                 },
                 {
                     "variable_key": "payment_public_order_ids",
-                    "target_path": ["submission_payment_public_ids"],
+                    "target_path": ["data", "submission_payment_public_ids"],
                 },
                 # fmt: on
             ],
-            "geometry_variable_key": "location",
         }
 
         SubmissionPaymentFactory.create(

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -30,7 +30,6 @@ class ObjecttypeVariableMapping(TypedDict):
 class RegistrationOptionsV2(_BaseRegistrationOptions, total=False):
     version: Required[Literal[2]]
     variables_mapping: Required[list[ObjecttypeVariableMapping]]
-    geometry_variable_key: str
 
 
 RegistrationOptions: TypeAlias = RegistrationOptionsV1 | RegistrationOptionsV2


### PR DESCRIPTION
This turns out to be to hard to implement, as nesting the JSON Schema under

`{"type": "object", "properties": {"data": data_json_schema}}`

leads to unexpected issues (`data_json_schema` can have "meta" attributes, such as `$id`, `$schema` that needs to be handled).

All references also need to be updated, to account for the initial `/data/` path bit. So I'm closing this for now.