### PR TITLE
Use the plugin appointment ID instead of our internal DB pk

### DIFF
--- a/src/openforms/appointments/renderer.py
+++ b/src/openforms/appointments/renderer.py
@@ -45,8 +45,9 @@ class AppointmentRenderer(Renderer):
         )
         plugin = get_plugin(plugin=appointment.plugin)
 
+        identifier: str = self.submission.appointment_info.appointment_id
         ctx = {
-            "appointment": plugin.get_appointment_details(appointment.pk),
+            "appointment": plugin.get_appointment_details(identifier),
             "contact_details": self.get_children(),  # todo: a bit of a wart
         }
         return render_to_string(template_name, ctx)


### PR DESCRIPTION
Closes #4103

Appointment details were being retrieved using our internal database primary key, but that looks up records from the appointment system that are unlikely to match with the actual appointment ID recorded for a given appointment.