### PR TITLE
[#4101] Disable "Show form" button if form not active

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -14,6 +14,7 @@ from openforms.api.utils import underscore_to_camel
 from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.payments.admin import PaymentBackendChoiceFieldMixin
 from openforms.registrations.admin import RegistrationBackendFieldMixin
+from openforms.typing import StrOrPromise
 from openforms.utils.expressions import FirstNotBlank
 
 from ..models import Category, Form, FormDefinition, FormStep
@@ -235,12 +236,14 @@ class FormAdmin(
         )
 
     @admin.display(description=_("Actions"))
-    def get_object_actions(self, obj) -> str:
-        links = ((obj.get_absolute_url(), _("Show form")),)
+    def get_object_actions(self, obj: Form) -> str:
+        links: list[tuple[str, StrOrPromise]] = []
+        if obj.active:
+            links.append((obj.get_absolute_url(), _("Show form")))
         return format_html_join(" | ", '<a href="{}" target="_blank">{}</a>', links)
 
     @admin.display(description=_("name"), ordering="anno_name")
-    def anno_name(self, obj) -> str:
+    def anno_name(self, obj: Form) -> str:
         return obj.admin_name
 
     def get_form(self, request, *args, **kwargs):

--- a/src/openforms/js/components/admin/form_design/FormObjectTools.js
+++ b/src/openforms/js/components/admin/form_design/FormObjectTools.js
@@ -1,11 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 
-const FormObjectTools = ({isLoading, formUrl, historyUrl}) => {
+const FormObjectTools = ({isLoading, isActive, formUrl, historyUrl}) => {
   /* TODO The buttons are disabled if the form page is still loading. Interrupting the fetch of form data
     raises an error which is displayed as 'The form is invalid. Please correct the errors below.'.
      */
+  const intl = useIntl();
+  const showFormStyling = !isActive
+    ? {cursor: 'not-allowed', textDecoration: 'none', background: '#555'}
+    : {};
+
   return (
     <div className="form-object-tools">
       <ul
@@ -15,7 +20,21 @@ const FormObjectTools = ({isLoading, formUrl, historyUrl}) => {
       >
         {formUrl ? (
           <li>
-            <a target="_blank" href={formUrl} className="historylink">
+            <a
+              title={
+                !isActive
+                  ? intl.formatMessage({
+                      defaultMessage: 'The form is not active',
+                      description: 'Show form button disabled title',
+                    })
+                  : undefined
+              }
+              target={isActive ? '_blank' : '_self'}
+              href={isActive ? formUrl : '#'}
+              aria-disabled={!isActive ? true : undefined}
+              style={showFormStyling}
+              className="historylink"
+            >
               <FormattedMessage defaultMessage="Show form" description="Show form button" />
             </a>
           </li>
@@ -32,6 +51,7 @@ const FormObjectTools = ({isLoading, formUrl, historyUrl}) => {
 
 FormObjectTools.propTypes = {
   isLoading: PropTypes.bool.isRequired,
+  isActive: PropTypes.bool.isRequired,
   historyUrl: PropTypes.string.isRequired,
   formUrl: PropTypes.string.isRequired,
 };

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1227,7 +1227,12 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
 
   return (
     <ValidationErrorsProvider errors={state.validationErrors}>
-      <FormObjectTools isLoading={loading} historyUrl={formHistoryUrl} formUrl={formUrl} />
+      <FormObjectTools
+        isLoading={loading}
+        isActive={state.form.active}
+        historyUrl={formHistoryUrl}
+        formUrl={formUrl}
+      />
 
       <h1>
         <FormattedMessage defaultMessage="Change form" description="Change form page title" />


### PR DESCRIPTION
Fixes #4101

Using `pointer-events: none;` prevents `title` from showing on hoover, and using a top level `span` element with a `title` didn't help either :/