### PR TITLE
Disable sending hidden fields to objects API

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -613,6 +613,7 @@ MAX_UNTRUSTED_JSON_PARSE_SIZE = config(
 )  # 1mb in bytes
 # Perform HTML escaping on user's data-input
 ESCAPE_REGISTRATION_OUTPUT = config("ESCAPE_REGISTRATION_OUTPUT", default=False)
+DISABLE_SENDING_HIDDEN_FIELDS = config("DISABLE_SENDING_HIDDEN_FIELDS", default=False)
 
 
 ##############################

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Callable, Iterator
 
+from django.conf import settings
 from django.urls import reverse
 from django.utils.html import format_html_join
 from django.utils.safestring import SafeString, mark_safe
@@ -35,7 +36,10 @@ class ContainerMixin:
         # class.
         # In registration mode, we need to treat layout/container nodes as visible so
         # that their children are emitted too.
-        if self.mode in {RenderModes.export, RenderModes.registration}:
+        visible_modes = {RenderModes.export, RenderModes.registration}
+        if settings.DISABLE_SENDING_HIDDEN_FIELDS:
+            visible_modes.remove(RenderModes.registration)
+        if self.mode in visible_modes:
             return True
 
         # We only pass the step data, since frontend logic only has access to the current step data.

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -2,6 +2,8 @@ import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal
 
+from django.conf import settings
+
 from glom import Path, assign, glom
 
 from openforms.submissions.models import SubmissionStep
@@ -117,7 +119,10 @@ class ComponentNode(Node):
 
         # everything is emitted in export mode to get consistent columns
         # the same happens with the registration in order to include hidden fields as well
-        if self.mode in {RenderModes.export, RenderModes.registration}:
+        visible_modes = {RenderModes.export, RenderModes.registration}
+        if settings.DISABLE_SENDING_HIDDEN_FIELDS:
+            visible_modes.remove(RenderModes.registration)
+        if self.mode in visible_modes:
             return True
 
         # explicitly hidden components never show up. Note that this property can be set

--- a/src/openforms/registrations/contrib/objects_api/tests/test_template.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_template.py
@@ -402,3 +402,94 @@ class JSONTemplatingRegressionTests(SubmissionsMixin, TestCase):
                 },
             },
         )
+
+    @tag("dh-673", "gh-4140")
+    @override_settings(DISABLE_SENDING_HIDDEN_FIELDS=True)
+    def test_opt_out_of_sending_hidden_fields(self):
+        submission = SubmissionFactory.from_components(
+            components_list=[
+                {
+                    "type": "radio",
+                    "key": "radio",
+                    "label": "Radio",
+                    "values": [
+                        {"label": "1", "value": "1"},
+                        {"label": "2", "value": "2"},
+                    ],
+                    "defaultValue": None,
+                    "validate": {"required": True},
+                    "openForms": {"dataSrc": "manual"},
+                },
+                {
+                    "type": "textfield",
+                    "key": "tekstveld",
+                    "label": "Tekstveld",
+                    "hidden": True,
+                    "validate": {"required": True},
+                    "conditional": {"eq": "1", "show": True, "when": "radio"},
+                    "defaultValue": None,
+                    "clearOnHide": True,
+                },
+                {
+                    "type": "currency",
+                    "currency": "EUR",
+                    "key": "bedrag",
+                    "label": "Bedrag",
+                    "hidden": True,
+                    "validate": {"required": True},
+                    "conditional": {"eq": "1", "show": True, "when": "radio"},
+                    "defaultValue": None,
+                    "clearOnHide": True,
+                },
+            ],
+            with_report=True,
+            submitted_data={"radio": "2"},
+            form_definition_kwargs={"slug": "stepwithnulls"},
+        )
+        config = ObjectsAPIConfig(
+            objects_service=ServiceFactory.build(),
+            drc_service=ServiceFactory.build(),
+            content_json="{% json_summary %}",
+        )
+        plugin = ObjectsAPIRegistration(PLUGIN_IDENTIFIER)
+        prefix = "openforms.registrations.contrib.objects_api"
+
+        with (
+            patch(
+                f"{prefix}.models.ObjectsAPIConfig.get_solo",
+                return_value=config,
+            ),
+            patch(f"{prefix}.plugin.get_objects_client") as mock_objects_client,
+        ):
+            _objects_client = mock_objects_client.return_value.__enter__.return_value
+            _objects_client.create_object.return_value = {"dummy": "response"}
+
+            plugin.register_submission(
+                submission,
+                {
+                    "version": 1,
+                    "objecttype": "https://objecttypen.nl/api/v1/objecttypes/1",
+                    "objecttype_version": 300,
+                    # skip document uploads
+                    "informatieobjecttype_submission_report": "",
+                    "upload_submission_csv": False,
+                    "informatieobjecttype_attachment": "",
+                },
+            )
+
+        _objects_client.create_object.mock_assert_called_once()
+        _objects_client.create_object.call_args
+        record_data = _objects_client.create_object.call_args[1]["object_data"][
+            "record"
+        ]["data"]
+        # for missing values, the empty value (depending on component type) must be used
+        # Note that the input data was validated against the hidden/visible and
+        # clearOnHide state - absence of the data implies that the component was not
+        # visible and its data was cleared (otherwise the value *would* have been sent
+        # along and be present).
+        self.assertEqual(
+            record_data,
+            {
+                "stepwithnulls": {"radio": "2"},
+            },
+        )


### PR DESCRIPTION
Closes #4140

Enabling the envvar DISABLE_SENDING_HIDDEN_FIELDS opts out of the bugfix that sends hidden fields to the objects API registration backend, restoring the old (but broken) behaviour. This buys organizations time to update their json schemas.

This fix will only be present in Open Forms 2.6.3+, newer versions enforce the earlier bugfix behaviour.