### PR TITLE
Fix date validation crash

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import datetime
 from typing import Protocol
 
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
@@ -13,7 +13,7 @@ from openforms.authentication.constants import AuthAttribute
 from openforms.config.models import GlobalConfiguration
 from openforms.submissions.models import Submission
 from openforms.typing import DataMapping
-from openforms.utils.date import format_date_value
+from openforms.utils.date import datetime_in_amsterdam, format_date_value
 from openforms.utils.validators import BSNValidator
 from openforms.validations.service import PluginValidator
 
@@ -82,10 +82,15 @@ class Date(BasePlugin[DateComponent]):
         required = validate.get("required", False)
         date_picker = component.get("datePicker") or {}
         validators = []
+
         if min_date := date_picker.get("minDate"):
-            validators.append(MinValueValidator(date.fromisoformat(min_date)))
+            min_value = datetime_in_amsterdam(datetime.fromisoformat(min_date)).date()
+            validators.append(MinValueValidator(min_value))
+
         if max_date := date_picker.get("maxDate"):
-            validators.append(MaxValueValidator(date.fromisoformat(max_date)))
+            max_value = datetime_in_amsterdam(datetime.fromisoformat(max_date)).date()
+            validators.append(MaxValueValidator(max_value))
+
         base = FormioDateField(
             required=required,
             allow_null=not required,

--- a/src/openforms/formio/tests/validation/test_date.py
+++ b/src/openforms/formio/tests/validation/test_date.py
@@ -1,5 +1,10 @@
 from django.test import SimpleTestCase, tag
+from django.utils import timezone
 
+from openforms.submissions.models import Submission
+
+from ...datastructures import FormioConfigurationWrapper
+from ...dynamic_config import rewrite_formio_components
 from ...typing import DateComponent
 from .helpers import extract_error, validate_formio_data
 
@@ -54,6 +59,48 @@ class DateFieldValidationTests(SimpleTestCase):
                 self.assertIn(component["key"], errors)
                 error = extract_error(errors, component["key"])
                 self.assertEqual(error.code, error_code)
+
+    @tag("gh-4172")
+    def test_min_max_can_be_datetimes(self):
+        # Our dynamic logic that calculates dates/datetimes is shared between date
+        # and datetime components, so it produces datetime strings (!)
+        component: DateComponent = {
+            "type": "date",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": False},
+            "openForms": {
+                "minDate": {
+                    "mode": "future",
+                    "includeToday": True,
+                },
+            },
+        }
+        submission = Submission()  # this test is not supposed to hit the DB
+        config_wraper = FormioConfigurationWrapper(
+            configuration={"components": [component]}
+        )
+        config_wraper = rewrite_formio_components(
+            config_wraper,
+            submission=submission,
+            data={"now": timezone.now()},
+        )
+
+        updated_component = config_wraper["foo"]
+        # check that rewrite_formio_components behaved as expected
+        assert "datePicker" in updated_component
+        assert "minDate" in updated_component["datePicker"]
+
+        with self.subTest("valid value"):
+            today = timezone.now().date().isoformat()
+            is_valid, _ = validate_formio_data(component, {"foo": today})
+
+            self.assertTrue(is_valid)
+
+        with self.subTest("invalid value"):
+            is_valid, _ = validate_formio_data(component, {"foo": "2020-01-01"})
+
+            self.assertFalse(is_valid)
 
     @tag("gh-4068")
     def test_empty_default_value(self):

--- a/src/openforms/formio/typing/dates.py
+++ b/src/openforms/formio/typing/dates.py
@@ -22,5 +22,9 @@ class DateConstraintConfiguration(TypedDict):
 
 
 class DatePickerConfig(TypedDict):
+    # NOTE: these strings can be a date (YYYY-MM-DD) or datetime (YYYY-MM-DDTHH:mm:ss)
+    # ISO-8601 string! Even the date component uses datetimes under the hood because
+    # Javascript only has a Date type that covers both, and that leaks into our form
+    # builder and backend logic doing dynamic things.
     minDate: str | None
     maxDate: str | None

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -74,6 +74,8 @@ def parse_time(value: str) -> None | time:
 
 
 def datetime_in_amsterdam(value: datetime) -> datetime:
+    if timezone.is_naive(value):
+        return value
     return timezone.make_naive(value, timezone=TIMEZONE_AMS)
 
 


### PR DESCRIPTION
Fixes #4172

Requires a patch in the SDK too for the fixed value validation, but the existing PR will be split for that.