### PR TITLE
[#4197] Fix late binding bug when resizing multiple images

### DIFF
--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -173,7 +173,9 @@ def validate_uploads(submission_step: SubmissionStep, data: dict | None) -> None
         raise ValidationError(validation_errors)
 
 
-def attach_uploads_to_submission_step(submission_step: SubmissionStep) -> list:
+def attach_uploads_to_submission_step(
+    submission_step: SubmissionStep,
+) -> list[tuple[SubmissionFileAttachment, bool]]:
     # circular import
     from .tasks import resize_submission_attachment
 

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -257,7 +257,7 @@ def attach_uploads_to_submission_step(submission_step: SubmissionStep) -> list:
             # NOTE there is a possible race-condition if user completes a submission before this resize task is done
             # see https://github.com/open-formulieren/open-forms/issues/507
             transaction.on_commit(
-                lambda: resize_submission_attachment.delay(attachment.id, resize_size)
+                resize_submission_attachment.si(attachment.id, resize_size).delay
             )
 
     return result

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -5,6 +5,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
+from functools import partial
 from typing import Iterable, Iterator
 from urllib.parse import urlparse
 
@@ -259,7 +260,7 @@ def attach_uploads_to_submission_step(
             # NOTE there is a possible race-condition if user completes a submission before this resize task is done
             # see https://github.com/open-formulieren/open-forms/issues/507
             transaction.on_commit(
-                resize_submission_attachment.si(attachment.id, resize_size).delay
+                partial(resize_submission_attachment.delay, attachment.id, resize_size)
             )
 
     return result


### PR DESCRIPTION
Fixes #4197.

I got curious and saw that `ruff check --select B023 src/` ([doc](https://docs.astral.sh/ruff/rules/function-uses-loop-variable/)) caught this issue and a couple more, so I'll provide a follow up PR with more fixes.