### PR TITLE
Fix late `lambda` binding bugs

### DIFF
--- a/src/openforms/forms/tasks.py
+++ b/src/openforms/forms/tasks.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 from datetime import timedelta
+from functools import partial
 
 from django.db import DatabaseError, transaction
 from django.db.utils import IntegrityError
@@ -160,7 +161,7 @@ def activate_forms():
                     extra={"pk": form.pk},
                 )
             else:
-                transaction.on_commit(lambda: logevent.form_activated(form))
+                transaction.on_commit(partial(logevent.form_activated, form))
 
 
 @app.task()
@@ -186,4 +187,4 @@ def deactivate_forms():
                 )
 
             else:
-                transaction.on_commit(lambda: logevent.form_deactivated(form))
+                transaction.on_commit(partial(logevent.form_deactivated, form))

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from dataclasses import dataclass
+from functools import partial
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -283,7 +284,7 @@ class StufZDSRegistration(BasePlugin):
             zaak_data.update({"betalings_indicatie": payment_status})
 
             execute_unless_result_exists(
-                lambda: client.create_zaak(zaak_id, zaak_data, LangInjection()),
+                partial(client.create_zaak, zaak_id, zaak_data, LangInjection()),
                 submission,
                 "intermediate.zaak_created",
                 default=False,
@@ -298,7 +299,9 @@ class StufZDSRegistration(BasePlugin):
             )
             submission_report = SubmissionReport.objects.get(submission=submission)
             execute_unless_result_exists(
-                lambda: client.create_zaak_document(zaak_id, doc_id, submission_report),
+                partial(
+                    client.create_zaak_document, zaak_id, doc_id, submission_report
+                ),
                 submission,
                 "intermediate.documents_created.pdf-report",
                 default=False,
@@ -313,8 +316,11 @@ class StufZDSRegistration(BasePlugin):
                     default="",
                 )
                 execute_unless_result_exists(
-                    lambda: client.create_zaak_attachment(
-                        zaak_id, attachment_doc_id, attachment
+                    partial(
+                        client.create_zaak_attachment,
+                        zaak_id,
+                        attachment_doc_id,
+                        attachment,
                     ),
                     submission,
                     f"intermediate.documents_created.{attachment.id}",


### PR DESCRIPTION
Follow up https://github.com/open-formulieren/open-forms/pull/4211:

- The form logevent is an actual bug, but not that big of a deal so not really worth a test
- The zds registration is actually fine (as the callback gets called immediately afterwards) but let's stick to the best practice 