### PR TITLE
[#4191] Add missing required `aoaIdentificatie` field to ZGW registration

### DIFF
--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -217,6 +217,10 @@ class ZGWRegistration(BasePlugin):
         else:
             rol_data["betrokkeneType"] = "natuurlijk_persoon"
 
+        if verblijfsadres := betrokkene_identificatie.get("verblijfsadres"):
+            # GH-4191: Required, can currently be empty.
+            verblijfsadres["aoaIdentificatie"] = ""
+
         with (
             get_documents_client(zgw) as documents_client,
             get_zaken_client(zgw) as zaken_client,

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -350,7 +350,10 @@ class ZGWBackendTests(TestCase):
                     "inpBsn": "111222333",
                     "voorvoegselGeslachtsnaam": "de",
                     "geslachtsnaam": "Bar",
-                    "verblijfsadres": {"aoaPostcode": "1000 AA"},
+                    "verblijfsadres": {
+                        "aoaPostcode": "1000 AA",
+                        "aoaIdentificatie": "",
+                    },
                     "voorletters": "J.W.",
                     "geslachtsaanduiding": "m",
                 },
@@ -566,7 +569,10 @@ class ZGWBackendTests(TestCase):
                     "vestigingsNummer": "87654321",
                     "innNnpId": "12345678",
                     "statutaireNaam": "ACME",
-                    "verblijfsadres": {"aoaPostcode": "1000 AA"},
+                    "verblijfsadres": {
+                        "aoaPostcode": "1000 AA",
+                        "aoaIdentificatie": "",
+                    },
                 },
             )
 
@@ -843,7 +849,10 @@ class ZGWBackendTests(TestCase):
                     "handelsnaam": "ACME",
                     "innNnpId": "12345678",
                     "statutaireNaam": "ACME",
-                    "verblijfsadres": {"aoaPostcode": "1000 AA"},
+                    "verblijfsadres": {
+                        "aoaPostcode": "1000 AA",
+                        "aoaIdentificatie": "",
+                    },
                 },
             )
 


### PR DESCRIPTION
Fixes #4191