### PR TITLE
Feature/update formio builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.18.3",
+        "@open-formulieren/formio-builder": "^0.19.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@storybook/jest": "^0.2.3",
@@ -2833,18 +2833,6 @@
         "stylis": "4.2.0"
       }
     },
-    "node_modules/@emotion/css": {
-      "version": "11.11.2",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.11.2.tgz",
-      "integrity": "sha512-VJxe1ucoMYMS7DkiMdC2T7PWNbrEI0a39YRiyDvK2qq4lXwjRbVP/z4lpG+odCsRzadlR+1ywwrTzhdm5HNdew==",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.11.0",
-        "@emotion/cache": "^11.11.0",
-        "@emotion/serialize": "^1.1.2",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1"
-      }
-    },
     "node_modules/@emotion/hash": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
@@ -4591,12 +4579,11 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.18.4.tgz",
-      "integrity": "sha512-Qs7WuyGSFs75f/xvEMDbvWR+Bau8U+KSzhLab+2woVeZWh7Z5ixZkfnnBHn3siENH6DpQD6X7IbEJktbc7W4lw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.19.1.tgz",
+      "integrity": "sha512-fTH385DYWq4CLZVKm0PdR/z6jDPhHqDzlihLcT5YN3DsC4W7J6Ia23fuzbVCSCxSiPq6H3ukmxGfsj39mvIUgg==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
-        "@emotion/css": "^11.11.2",
         "@floating-ui/react": "^0.26.4",
         "@open-formulieren/ckeditor5-build-classic": "^1.0.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
@@ -28341,18 +28328,6 @@
         "stylis": "4.2.0"
       }
     },
-    "@emotion/css": {
-      "version": "11.11.2",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.11.2.tgz",
-      "integrity": "sha512-VJxe1ucoMYMS7DkiMdC2T7PWNbrEI0a39YRiyDvK2qq4lXwjRbVP/z4lpG+odCsRzadlR+1ywwrTzhdm5HNdew==",
-      "requires": {
-        "@emotion/babel-plugin": "^11.11.0",
-        "@emotion/cache": "^11.11.0",
-        "@emotion/serialize": "^1.1.2",
-        "@emotion/sheet": "^1.2.2",
-        "@emotion/utils": "^1.2.1"
-      }
-    },
     "@emotion/hash": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
@@ -29587,12 +29562,11 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.18.4.tgz",
-      "integrity": "sha512-Qs7WuyGSFs75f/xvEMDbvWR+Bau8U+KSzhLab+2woVeZWh7Z5ixZkfnnBHn3siENH6DpQD6X7IbEJktbc7W4lw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.19.1.tgz",
+      "integrity": "sha512-fTH385DYWq4CLZVKm0PdR/z6jDPhHqDzlihLcT5YN3DsC4W7J6Ia23fuzbVCSCxSiPq6H3ukmxGfsj39mvIUgg==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
-        "@emotion/css": "^11.11.2",
         "@floating-ui/react": "^0.26.4",
         "@open-formulieren/ckeditor5-build-classic": "^1.0.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.18.3",
+    "@open-formulieren/formio-builder": "^0.19.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@storybook/jest": "^0.2.3",

--- a/src/openforms/forms/tasks.py
+++ b/src/openforms/forms/tasks.py
@@ -58,8 +58,8 @@ def detect_formiojs_configuration_snake_case(
         return
 
     config_now = copy.deepcopy(fd.configuration)
-    remove_key_from_dict(config_now, "time_24hr")
-    remove_key_from_dict(config_now, "invalid_time")
+    for key in ["time_24hr", "invalid_time", "invalid_date", "invalid_datetime"]:
+        remove_key_from_dict(config_now, key)
     camelized_config = camelize(config_now)
 
     if config_now != camelized_config:

--- a/src/openforms/scss/screen.scss
+++ b/src/openforms/scss/screen.scss
@@ -1,6 +1,8 @@
 // design tokens
 @import '@open-formulieren/design-tokens/dist/index.css';
 
+@import '@open-formulieren/formio-builder/css/index';
+
 @import '../ui/static/ui/scss/settings';
 @import './vendor';
 @import './components';


### PR DESCRIPTION
Required for #3964 and #4158

**Changes**

Updates to the latest feature release of formio-builder

* Addresses the sass toolchain change
* Includes the ability to clear the Radio component default value
* Supports `invalid_date` and `invalid_datetime` (custom) error message keys for date/datetime components
* Simple conditionals (in the advanced tab) for client-side logic now properly set boolean values when the trigger component is a checkbox, removing the need for a workaround in the backend

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
