### PR TITLE
:zap: [#4229] Cache KVKRemoteValidator result to speed up validation

### DIFF
--- a/src/openforms/contrib/kvk/tests/files/vcr_cassettes/KvKRemoteValidatorTestCase/KvKRemoteValidatorTestCase.test_branchNumber_validator.yaml
+++ b/src/openforms/contrib/kvk/tests/files/vcr_cassettes/KvKRemoteValidatorTestCase/KvKRemoteValidatorTestCase.test_branchNumber_validator.yaml
@@ -36,7 +36,7 @@ interactions:
       Content-Type:
       - application/hal+json
       Date:
-      - Thu, 21 Mar 2024 14:00:37 GMT
+      - Fri, 03 May 2024 08:31:08 GMT
       Feature-Policy:
       - '''none'''
       Keep-Alive:
@@ -89,7 +89,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2024 14:00:37 GMT
+      - Fri, 03 May 2024 08:31:08 GMT
       Feature-Policy:
       - '''none'''
       Keep-Alive:

--- a/src/openforms/contrib/kvk/tests/files/vcr_cassettes/KvKRemoteValidatorTestCase/KvKRemoteValidatorTestCase.test_kvkNumber_validator.yaml
+++ b/src/openforms/contrib/kvk/tests/files/vcr_cassettes/KvKRemoteValidatorTestCase/KvKRemoteValidatorTestCase.test_kvkNumber_validator.yaml
@@ -18,10 +18,10 @@ interactions:
     uri: https://api.kvk.nl/test/api/v2/zoeken?kvkNummer=69599084
   response:
     body:
-      string: '{"pagina":1,"resultatenPerPagina":10,"totaal":2,"resultaten":[{"kvkNummer":"69599084","vestigingsnummer":"000038509504","naam":"Test
+      string: '{"pagina":1,"resultatenPerPagina":10,"totaal":2,"resultaten":[{"kvkNummer":"69599084","vestigingsnummer":"000038509520","naam":"Test
+        EMZ Nevenvestiging Govert","adres":{"binnenlandsAdres":{"type":"bezoekadres","straatnaam":"Geneinde","plaats":"Maastricht"}},"type":"nevenvestiging","_links":{"basisprofiel":{"href":"https://api.kvk.nl/test/api/v1/basisprofielen/69599084"},"vestigingsprofiel":{"href":"https://api.kvk.nl/test/api/v1/vestigingsprofielen/000038509520"}}},{"kvkNummer":"69599084","vestigingsnummer":"000038509504","naam":"Test
         EMZ Dagobert","adres":{"binnenlandsAdres":{"type":"bezoekadres","straatnaam":"Abebe
-        Bikilalaan","plaats":"Amsterdam"}},"type":"hoofdvestiging","_links":{"basisprofiel":{"href":"https://api.kvk.nl/test/api/v1/basisprofielen/69599084"},"vestigingsprofiel":{"href":"https://api.kvk.nl/test/api/v1/vestigingsprofielen/000038509504"}}},{"kvkNummer":"69599084","vestigingsnummer":"000038509520","naam":"Test
-        EMZ Nevenvestiging Govert","adres":{"binnenlandsAdres":{"type":"bezoekadres","straatnaam":"Geneinde","plaats":"Maastricht"}},"type":"nevenvestiging","_links":{"basisprofiel":{"href":"https://api.kvk.nl/test/api/v1/basisprofielen/69599084"},"vestigingsprofiel":{"href":"https://api.kvk.nl/test/api/v1/vestigingsprofielen/000038509520"}}}],"_links":{"self":{"href":"https://api.kvk.nl/test/api/v2/zoeken?kvknummer=69599084&pagina=1&resultatenperpagina=10"}}}'
+        Bikilalaan","plaats":"Amsterdam"}},"type":"hoofdvestiging","_links":{"basisprofiel":{"href":"https://api.kvk.nl/test/api/v1/basisprofielen/69599084"},"vestigingsprofiel":{"href":"https://api.kvk.nl/test/api/v1/vestigingsprofielen/000038509504"}}}],"_links":{"self":{"href":"https://api.kvk.nl/test/api/v2/zoeken?kvknummer=69599084&pagina=1&resultatenperpagina=10"}}}'
     headers:
       API-Version:
       - 2.0.0
@@ -38,7 +38,7 @@ interactions:
       Content-Type:
       - application/hal+json
       Date:
-      - Thu, 21 Mar 2024 14:00:37 GMT
+      - Fri, 03 May 2024 08:31:08 GMT
       Feature-Policy:
       - '''none'''
       Keep-Alive:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2024 14:00:37 GMT
+      - Fri, 03 May 2024 08:31:08 GMT
       Feature-Policy:
       - '''none'''
       Keep-Alive:

--- a/src/openforms/contrib/kvk/tests/files/vcr_cassettes/KvKRemoteValidatorTestCase/KvKRemoteValidatorTestCase.test_rsin_validator.yaml
+++ b/src/openforms/contrib/kvk/tests/files/vcr_cassettes/KvKRemoteValidatorTestCase/KvKRemoteValidatorTestCase.test_rsin_validator.yaml
@@ -15,6 +15,61 @@ interactions:
       apikey:
       - l7xx1f2691f2520d487b902f4e0b57a0b197
     method: GET
+    uri: https://api.kvk.nl/test/api/v2/zoeken?rsin=992760562
+  response:
+    body:
+      string: '{"pagina":1,"resultatenPerPagina":10,"totaal":1,"resultaten":[{"kvkNummer":"90001354","rsin":"992760562","vestigingsnummer":"990000541921","naam":"Grand
+        Joyflex B.V.","adres":{"binnenlandsAdres":{"type":"postadres","plaats":"Sterksel"}},"type":"hoofdvestiging","_links":{"basisprofiel":{"href":"https://api.kvk.nl/test/api/v1/basisprofielen/90001354"},"vestigingsprofiel":{"href":"https://api.kvk.nl/test/api/v1/vestigingsprofielen/990000541921"}}}],"_links":{"self":{"href":"https://api.kvk.nl/test/api/v2/zoeken?rsin=992760562&pagina=1&resultatenperpagina=10"}}}'
+    headers:
+      API-Version:
+      - 2.0.0
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '300'
+      Content-Security-Policy:
+      - frame-ancestors 'none', default-src 'none'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Fri, 03 May 2024 08:31:09 GMT
+      Feature-Policy:
+      - '''none'''
+      Keep-Alive:
+      - timeout=60
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - unknown
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      strict-transport-security:
+      - max-age=157680000 ; includeSubDomains
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/hal+json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/hal+json
+      User-Agent:
+      - python-requests/2.31.0
+      apikey:
+      - l7xx1f2691f2520d487b902f4e0b57a0b197
+    method: GET
     uri: https://api.kvk.nl/test/api/v2/zoeken?rsin=123456782
   response:
     body:
@@ -34,7 +89,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2024 14:00:37 GMT
+      - Fri, 03 May 2024 08:31:09 GMT
       Feature-Policy:
       - '''none'''
       Keep-Alive:

--- a/src/openforms/contrib/kvk/tests/test_validators.py
+++ b/src/openforms/contrib/kvk/tests/test_validators.py
@@ -1,12 +1,16 @@
 from functools import partial
 
 from django.core.exceptions import ValidationError
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from django.utils.translation import gettext as _
 
+import requests_mock
+from freezegun import freeze_time
 from privates.test import temp_private_root
 
 from openforms.submissions.models import Submission
+from openforms.tests.utils import NOOP_CACHES
+from openforms.utils.tests.cache import clear_caches
 from openforms.utils.tests.vcr import OFVCRMixin
 
 from ..validators import (
@@ -49,6 +53,7 @@ class KvKValidatorTestCase(SimpleTestCase):
             validate_branchNumber("11223-445566")
 
 
+@override_settings(CACHES=NOOP_CACHES)
 @temp_private_root()
 class KvKRemoteValidatorTestCase(OFVCRMixin, KVKTestMixin, SimpleTestCase):
     VCR_TEST_FILES = TEST_FILES
@@ -76,11 +81,10 @@ class KvKRemoteValidatorTestCase(OFVCRMixin, KVKTestMixin, SimpleTestCase):
             validator("bork")
 
     def test_rsin_validator(self):
-        # kvk test environment does not provide an example of valid rsin numbers so we
-        # only test against the invalid one
-        # https://developers.kvk.nl/documentation/testing
-
         validator = partial(KVKRSINRemoteValidator("id"), submission=Submission())
+
+        # valid rsin
+        validator("992760562")
 
         # invalid rsin(404)
         with self.assertRaisesMessage(
@@ -119,3 +123,107 @@ class KvKRemoteValidatorTestCase(OFVCRMixin, KVKTestMixin, SimpleTestCase):
             ValidationError, _("Expected a numerical value.")
         ):
             validator("bork")
+
+
+class KvKRemoteValidatorCachingTestCase(KVKTestMixin, SimpleTestCase):
+    # Rather than using VCR, we use requests mock because we don't check the contents
+    # of the responses (they are not relevant for the behaviour being tested).
+    # So, instead we use requests-mock and check the amount of calls made.
+
+    def setUp(self):
+        super().setUp()
+
+        self.addCleanup(clear_caches)
+        clear_caches()
+
+        self.mocker = requests_mock.Mocker()
+        self.addCleanup(self.mocker.stop)
+        self.mocker.start()
+        self.mocker.get(requests_mock.ANY, json={"resultaten": ["MOCK"]})
+
+    def assertNumRequests(self, expected: int):
+        num_requests = len(self.mocker.request_history)
+        self.assertEqual(
+            num_requests,
+            expected,
+            f"Expected {expected} requests, got {num_requests} instead.",
+        )
+
+    def test_kvkNumber_validator_caching(self):
+        # valid-existing kvkNummer
+        validator = partial(KVKNumberRemoteValidator("id"), submission=Submission())
+
+        with freeze_time("2024-01-01T12:00:00"):
+            self.assertNumRequests(0)
+
+            validator("69599084")
+
+            self.assertNumRequests(1)
+
+            validator("69599084")
+
+            # No additional request has been made because the result was cached
+            self.assertNumRequests(1)
+
+            validator("68727720")
+
+            # validate with different KVK number should trigger new request
+            self.assertNumRequests(2)
+
+        with freeze_time("2024-01-01T12:05:01"):
+            validator("69599084")
+
+        # Request is made, because cached result is timed out
+        self.assertNumRequests(3)
+
+    def test_rsin_validator_caching(self):
+        validator = partial(KVKRSINRemoteValidator("id"), submission=Submission())
+
+        with freeze_time("2024-01-01T12:00:00"):
+            self.assertNumRequests(0)
+
+            validator("992760562")
+
+            self.assertNumRequests(1)
+
+            validator("992760562")
+
+            # No additional request has been made because the result was cached
+            self.assertNumRequests(1)
+
+            validator("858311537")
+
+            # validate with different RSIN should trigger new request
+            self.assertNumRequests(2)
+
+        with freeze_time("2024-01-01T12:05:01"):
+            validator("992760562")
+
+        # Request is made, because cached result is timed out
+        self.assertNumRequests(3)
+
+    def test_branchNumber_validator_caching(self):
+        validator = partial(KVKBranchNumberRemoteValidator(""), submission=Submission())
+
+        with freeze_time("2024-01-01T12:00:00"):
+            self.assertNumRequests(0)
+
+            validator("990000541921")
+
+            self.assertNumRequests(1)
+
+            validator("990000541921")
+
+            # No additional request has been made because the result was cached
+            self.assertNumRequests(1)
+
+            validator("990000216645")
+
+            # validate with different branchnumber should trigger new request
+            self.assertNumRequests(2)
+
+        with freeze_time("2024-01-01T12:05:01"):
+            validator("990000541921")
+
+        # Request is made, because cached result is timed out
+        self.assertNumRequests(3)


### PR DESCRIPTION
Closes #4229 

**Changes**

* Cache the result of KVK search in the KVKRemoteValidatorMixin
* Add missing VCR cassette for valid RSIN

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page -> no, caching is applied in the validator and not on the KVKClient level
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
