### PR TITLE
Fix migration crash because of particular key-structure with repeating groups

### DIFF
--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -84,8 +84,20 @@ class FormioConfigurationWrapper:
         return self._cached_component_map
 
     def __iter__(self) -> Iterator[Component]:
+        """
+        Yield the components in the configuration by looping over this object.
+
+        Each (unique) component is guaranteed to be yielded only once, even though
+        it may be present multiple times in the internal datastructures.
+        """
+        seen = set()
         for component in self.component_map.values():
+            # dicts are not hashable, the memory address is a stable reference
+            component_id = id(component)
+            if component_id in seen:
+                continue
             yield component
+            seen.add(component_id)
 
     def __contains__(self, key: str) -> bool:
         return key in self.component_map

--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -188,15 +188,28 @@ def convert_simple_conditionals(configuration: JSONObject) -> bool:
         ):
             continue
 
+        assert "conditional" in component
+
         comparison_component = config[comparison_component_key]
+        eq = component["conditional"].get("eq")
+        if eq is None:
+            continue
+
         if comparison_component["type"] in ["number", "currency"]:
-            component["conditional"]["eq"] = json.loads(component["conditional"]["eq"])
+            # only strings can be loaded
+            if not isinstance(eq, str):
+                continue
+            component["conditional"]["eq"] = json.loads(eq)
             config_modified = True
 
         if comparison_component["type"] == "checkbox":
-            component["conditional"]["eq"] = {"true": True, "false": False}.get(
-                component["conditional"]["eq"], False
-            )
+            if isinstance(eq, bool):
+                continue
+
+            component["conditional"]["eq"] = {
+                "true": True,
+                "false": False,
+            }.get(eq, False)
             config_modified = True
 
     return config_modified

--- a/src/openforms/formio/tests/test_simple_conditionals_converter.py
+++ b/src/openforms/formio/tests/test_simple_conditionals_converter.py
@@ -1,0 +1,65 @@
+from django.test import SimpleTestCase, tag
+
+from openforms.typing import JSONObject
+
+from ..migration_converters import convert_simple_conditionals
+
+
+class RegressionTests(SimpleTestCase):
+
+    @tag("gh-4247")
+    def test_editgrid_reference(self):
+        configuration: JSONObject = {
+            "components": [
+                {
+                    "type": "editgrid",
+                    "key": "ingeschrevenOnderneming",
+                    "label": "Gegevens onderneming",
+                    "components": [
+                        {
+                            "type": "radio",
+                            "key": "rechtsvorm",
+                            "label": "Wat is de rechtsvorm van uw onderneming?",
+                            "values": [
+                                {
+                                    "label": "Eenmanszaak / ZZP",
+                                    "value": "EENMANSZAAK_ZZP",
+                                },
+                                {
+                                    "label": "Vennootschap Onder Firma (VOF)",
+                                    "value": "VENNOOTSCHAP_ONDER_FIRMA_VOF",
+                                },
+                                {
+                                    "label": "Commanditaire Vennootschap (CV)",
+                                    "value": "COMMANDITAIRE_VENNOOTSCHAP_CV",
+                                },
+                                {
+                                    "label": "Besloten Vennootschap (BV)",
+                                    "value": "BESLOTEN_VENNOOTSCHAP_BV",
+                                },
+                                {"label": "Maatschap", "value": "MAATSCHAP"},
+                                {
+                                    "label": "Stichting (met winstoogmerk)",
+                                    "value": "STICHTING_MET_WINSTOOGMERK",
+                                },
+                            ],
+                        },
+                        {
+                            "type": "number",
+                            "key": "aantalVennoten",
+                            "label": "Hoeveel vennoten heeft uw onderneming?",
+                            "conditional": {
+                                "eq": "VENNOOTSCHAP_ONDER_FIRMA_VOF",
+                                "show": True,
+                                "when": "ingeschrevenOnderneming.rechtsvorm",
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+        try:
+            convert_simple_conditionals(configuration)
+        except Exception as exc:
+            raise self.failureException("Unexpected crash") from exc

--- a/src/openforms/formio/typing/__init__.py
+++ b/src/openforms/formio/typing/__init__.py
@@ -6,7 +6,7 @@ Formio components are JSON blobs adhering to a formio-specific schema. We define
 (parts of) the schema.
 """
 
-from .base import Component, OptionDict
+from .base import Component, FormioConfiguration, OptionDict
 from .custom import DateComponent
 from .vanilla import (
     Column,
@@ -26,6 +26,7 @@ __all__ = [
     # base
     "Component",
     "OptionDict",
+    "FormioConfiguration",
     # standard
     "TextFieldComponent",
     "DateComponent",

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -87,3 +87,7 @@ class Component(TypedDict):
     prefill: NotRequired[PrefillConfiguration]
     openForms: NotRequired[OpenFormsConfig]
     autocomplete: NotRequired[str]
+
+
+class FormioConfiguration(TypedDict):
+    components: list[Component]

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -10,13 +10,15 @@ from openforms.utils.glom import _glom_path_to_str
 from openforms.variables.constants import DEFAULT_INITIAL_VALUE, FormVariableDataTypes
 
 from .constants import COMPONENT_DATATYPES
-from .typing import Column, ColumnsComponent, Component
+from .typing import Column, ColumnsComponent, Component, FormioConfiguration
 
 logger = logging.getLogger(__name__)
 
 # XXX: we should probably be able to narrow this in Python 3.11 with non-total typed
 # dicts.
-ComponentLike: TypeAlias = JSONObject | Component | ColumnsComponent | Column
+ComponentLike: TypeAlias = (
+    FormioConfiguration | JSONObject | Component | ColumnsComponent | Column
+)
 
 
 def _is_column_component(component: ComponentLike) -> TypeGuard[ColumnsComponent]:

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -1256,6 +1256,17 @@ class ImportExportTests(TestCase):
                                     },
                                 ],
                             },
+                            {
+                                "key": "textArea8",
+                                "type": "textarea",
+                                "label": "Text Area 8",
+                                "conditional": {
+                                    "eq": 0,
+                                    "show": True,
+                                    "when": "number",
+                                },
+                                "clearOnHide": True,
+                            },
                         ]
                     },
                     "name": "A definition",
@@ -1285,3 +1296,4 @@ class ImportExportTests(TestCase):
         self.assertIsInstance(
             fixed_components[9]["components"][0]["conditional"]["eq"], int
         )
+        self.assertIsInstance(fixed_components[10]["conditional"]["eq"], int)


### PR DESCRIPTION
Closes #4247

**Changes**

* Added regression test
* Added some more type defs for Formio data structures (less squigly lines in my editor..., I may end up regretting this)
* Fixed/added edit grid namespacing in the component map so that these lookups work as expected

This only makes it possibly to process form configurations, data handling (and consequently server-side `is_visible_in_frontend` for components inside repeating groups) is still not solved, nor is server-side logic actions to target individual items inside a repeating group.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
