### PR TITLE
Catch migration crashes because of broken configuration

### DIFF
--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -6,6 +6,7 @@ component definitions are rewritten to be compatible with the current code.
 """
 
 import json
+import logging
 from typing import Protocol, cast
 
 from glom import assign, glom
@@ -15,6 +16,8 @@ from openforms.typing import JSONObject
 
 from .datastructures import FormioConfigurationWrapper
 from .typing import Component
+
+logger = logging.getLogger(__name__)
 
 
 class ComponentConverter(Protocol):
@@ -189,6 +192,14 @@ def convert_simple_conditionals(configuration: JSONObject) -> bool:
             continue
 
         assert "conditional" in component
+
+        if comparison_component_key not in config:
+            logger.warning(
+                "Couldn't locate component with key %s in configuration %r",
+                comparison_component_key,
+                configuration,
+            )
+            continue
 
         comparison_component = config[comparison_component_key]
         eq = component["conditional"].get("eq")

--- a/src/openforms/formio/tests/test_simple_conditionals_converter.py
+++ b/src/openforms/formio/tests/test_simple_conditionals_converter.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase, tag
 
+from openforms.formio.typing import EditGridComponent
 from openforms.typing import JSONObject
 
 from ..migration_converters import convert_simple_conditionals
@@ -58,6 +59,38 @@ class RegressionTests(SimpleTestCase):
                 }
             ]
         }
+
+        try:
+            convert_simple_conditionals(configuration)
+        except Exception as exc:
+            raise self.failureException("Unexpected crash") from exc
+
+    @tag("gh-4247")
+    def test_broken_references(self):
+        # A conditional can just have a broken reference completely, nothing we can do...
+        editgrid: EditGridComponent = {
+            "type": "editgrid",
+            "key": "medebewonerHGroep",
+            "label": "Broken editgrid",
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "grOntvangenHuur",
+                    "label": "Text field",
+                },
+                {
+                    "type": "textfield",
+                    "key": "periodeHuur",
+                    "label": "Text field",
+                    "conditional": {  # type: ignore
+                        "eq": "whatever",
+                        "show": True,
+                        "when": "medebewonerHGroep.ontvangenHuur",
+                    },
+                },
+            ],
+        }
+        configuration: JSONObject = {"components": [editgrid]}
 
         try:
             convert_simple_conditionals(configuration)


### PR DESCRIPTION
Closes #4247

Through manual editing or form changes without matching logic updates, the formio configuration itself may end up in a broken state, which crashes our data migration trying to process it.

**Changes**

* Added test case with broken formio configuration
* Added robustness to prevent migration crashes

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
