### PR TITLE
:sparkles: Hide OAS fields in zgw consumers admin

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -981,6 +981,8 @@ ZGW_CONSUMERS_TEST_SCHEMA_DIRS = [
     os.path.join(BASE_DIR, "src/openforms/contrib/haal_centraal/tests/files"),
 ]
 
+ZGW_CONSUMERS_IGNORE_OAS_FIELDS = True
+
 #
 # Django Solo
 #


### PR DESCRIPTION
**Changes**

Since zgw-consumers 0.32.0, the OAS fields are not used anymore by the library. They can be removed from the UI through a setting before being dropped entirely.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
