### PR TITLE
[#4158] Add missing English translation for `invalid_time`

### DIFF
--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -35,5 +35,6 @@
   "maxFileSizeMessage": "The maximum file size is {{maxFileSize}}.",
   "The uploaded file is not of an allowed type. It must be: {{ pattern }}.": "The uploaded file is not of an allowed type. It must be: {{ pattern }}.",
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} or {{ lastLabel }}",
+  "invalid_time": "Only times between {{ minTime }} and {{ maxTime }} are allowed.",
   "": ""
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -401,7 +401,5 @@
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} of {{ lastLabel }}",
   "Note that any family member without a BSN will not be displayed.": "Let op, gezinsleden zonder BSN worden niet getoond.",
   "invalidDatetime": "Ongeldige datum/tijd",
-  "maxDatetime": "De opgegeven datum/tijd liggen te ver in de toekomst.",
-  "minDatetime": "De opgegeven datum/tijd liggen te ver in het verleden.",
   "": ""
 }


### PR DESCRIPTION
Also remove unused Dutch translations

Closes #4158

**Changes**

`invalid_time` is not defined by Formio, so the missing English translation would result in the bare key being displayed

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
