### PR TITLE
 [#4302] Add cosign information for Objects API registration 

### DIFF
--- a/docs/manual/templates.rst
+++ b/docs/manual/templates.rst
@@ -556,6 +556,10 @@ Variabele                              Beschrijving
 ``{{ payment.completed }}``            Indicatie of de betaling voltooid is.
 ``{{ payment.amount }}``               Bedrag dat betaald moet worden.
 ``{{ payment.public_order_ids }}``     Lijst van bestelling IDs die naar de externe betaalprovider meegestuurd zijn.
+``{{ cosign_data.date }}``             De datum waarop de inzending mede is ondertekend.
+``{{ cosign_data.bsn }}``              Het BSN van de medeondertekenaar, indien beschikbaar.
+``{{ cosign_data.kvk }}``              Het KvK van de medeondertekenaar, indien beschikbaar.
+``{{ cosign_data.pseudo }}``           Het pseudo van de medeondertekenaar, indien beschikbaar.
 =====================================  ===========================================================================
 
 
@@ -576,7 +580,11 @@ Voorbeeld
            "attachments": {% uploaded_attachment_urls %},
            "submission_id": "{{ submission.kenmerk }}",
            "language_code": "{{ submission.language_code }}",
-           "public_reference": "{{ submission.public_reference }}"
+           "public_reference": "{{ submission.public_reference }}",
+           {% if cosign_data %}
+           "cosign_date": "{{ cosign_data.date.isoformat }}",
+           "cosign_bsn": "{{ cosign_data.bsn }}"
+           {% endif %}
          }
 
    .. tab:: Resultaat
@@ -594,5 +602,7 @@ Voorbeeld
            "attachments": ["http://some-url.nl/to/attachment1", "http://some-url.nl/to/attachment2"],
            "submission_id": "c305a56f-c56c-49bc-9d94-3e301d0b8bf8",
            "language_code": "nl",
-           "public_reference": "OF-12345"
+           "public_reference": "OF-12345",
+           "cosign_date": "2024-01-01T12:00:00.037672+00:00",
+           "cosign_bsn": "123456783"
          }

--- a/src/openforms/authentication/service.py
+++ b/src/openforms/authentication/service.py
@@ -1,4 +1,5 @@
-from .constants import FORM_AUTH_SESSION_KEY
+from .constants import FORM_AUTH_SESSION_KEY, AuthAttribute
+from .typing import BaseAuth
 from .utils import (
     is_authenticated_with_an_allowed_plugin,
     is_authenticated_with_plugin,
@@ -7,6 +8,8 @@ from .utils import (
 
 __all__ = [
     "FORM_AUTH_SESSION_KEY",
+    "AuthAttribute",
+    "BaseAuth",
     "store_auth_details",
     "is_authenticated_with_plugin",
     "is_authenticated_with_an_allowed_plugin",

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -2,6 +2,7 @@ import logging
 
 from django.core.exceptions import PermissionDenied
 from django.dispatch import Signal, receiver
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework.request import Request
@@ -142,4 +143,5 @@ def set_cosign_data_on_submission(
     form_auth = request.session.get(FORM_AUTH_SESSION_KEY)
 
     instance.co_sign_data = form_auth
+    instance.co_sign_data["cosign_date"] = timezone.localtime().isoformat()
     instance.save()

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -143,5 +143,5 @@ def set_cosign_data_on_submission(
     form_auth = request.session.get(FORM_AUTH_SESSION_KEY)
 
     instance.co_sign_data = form_auth
-    instance.co_sign_data["cosign_date"] = timezone.localtime().isoformat()
+    instance.co_sign_data["cosign_date"] = timezone.now().isoformat()
     instance.save()

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -4,7 +4,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.test import override_settings, tag
 from django.test.client import RequestFactory
-from django.utils import timezone
 
 from freezegun import freeze_time
 from rest_framework.request import Request
@@ -306,7 +305,7 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
         )
 
 
-@freeze_time("2021-11-26T17:00:00+01:00")
+@freeze_time("2021-11-26T17:00:00+00:00")
 class SetCosignDataTests(APITestCase):
     def test_set_cosigner_data(self):
         submission = SubmissionFactory.create(completed=True)
@@ -330,6 +329,6 @@ class SetCosignDataTests(APITestCase):
                 "plugin": "digid",
                 "attribute": "bsn",
                 "value": "123456782",
-                "cosign_date": timezone.localtime().isoformat(),
+                "cosign_date": "2021-11-26T17:00:00+00:00",
             },
         )

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -4,7 +4,9 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.test import override_settings, tag
 from django.test.client import RequestFactory
+from django.utils import timezone
 
+from freezegun import freeze_time
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, APITestCase
 
@@ -304,6 +306,7 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
         )
 
 
+@freeze_time("2021-11-26T17:00:00+01:00")
 class SetCosignDataTests(APITestCase):
     def test_set_cosigner_data(self):
         submission = SubmissionFactory.create(completed=True)
@@ -327,5 +330,6 @@ class SetCosignDataTests(APITestCase):
                 "plugin": "digid",
                 "attribute": "bsn",
                 "value": "123456782",
+                "cosign_date": timezone.localtime().isoformat(),
             },
         )

--- a/src/openforms/authentication/typing.py
+++ b/src/openforms/authentication/typing.py
@@ -1,0 +1,13 @@
+from typing import TypedDict
+
+from .constants import AuthAttribute
+
+
+class BaseAuth(TypedDict):
+    """The base structure of authentication data."""
+
+    plugin: str
+    """The unique identifier of the plugin that inititiated the authentication data."""
+
+    attribute: AuthAttribute
+    value: str

--- a/src/openforms/authentication/utils.py
+++ b/src/openforms/authentication/utils.py
@@ -1,5 +1,3 @@
-from typing import Literal, TypedDict
-
 from furl import furl
 from rest_framework.request import Request
 from rest_framework.reverse import reverse
@@ -10,17 +8,7 @@ from openforms.submissions.models import Submission
 from .constants import FORM_AUTH_SESSION_KEY, AuthAttribute
 from .models import AuthInfo, RegistratorInfo
 from .registry import register as auth_register
-
-
-class BaseAuth(TypedDict):
-    plugin: str
-    attribute: Literal[
-        AuthAttribute.bsn,
-        AuthAttribute.kvk,
-        AuthAttribute.pseudo,
-        AuthAttribute.employee_id,
-    ]
-    value: str
+from .typing import BaseAuth
 
 
 class FormAuth(BaseAuth):

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -280,21 +280,23 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
         }
 
     @staticmethod
-    def get_cosign_context_data(submission: Submission) -> dict[str, Any]:
+    def get_cosign_context_data(
+        submission: Submission,
+    ) -> dict[str, str | datetime] | None:
         if not submission.cosign_complete:
-            return {
-                "bsn": "",
-                "kvk": "",
-                "pseudo": "",
-                "date": "",
-            }
+            return None
         else:
+            # date can be missing on existing submissions, so fallback to an empty string
+            date = (
+                datetime.fromisoformat(submission.co_sign_data["cosign_date"])
+                if "cosign_date" in submission.co_sign_data
+                else ""
+            )
             return {
                 "bsn": get_cosign_value(submission, AuthAttribute.bsn),
                 "kvk": get_cosign_value(submission, AuthAttribute.kvk),
                 "pseudo": get_cosign_value(submission, AuthAttribute.pseudo),
-                # date can be missing on existing submissions, so fallback to an empty string
-                "date": submission.co_sign_data.get("cosign_date", ""),
+                "date": date,
             }
 
     @override

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -11,6 +11,7 @@ import glom
 from glom import PathAccessError
 from typing_extensions import override
 
+from openforms.authentication.service import AuthAttribute
 from openforms.contrib.objects_api.helpers import prepare_data_for_registration
 from openforms.contrib.objects_api.rendering import render_to_json
 from openforms.contrib.zgw.service import (
@@ -36,7 +37,7 @@ from openforms.variables.utils import get_variables_for_context
 from ...constants import REGISTRATION_ATTRIBUTE, RegistrationAttribute
 from .client import DocumentenClient, get_documents_client
 from .models import ObjectsAPIRegistrationData, ObjectsAPISubmissionAttachment
-from .registration_variables import register as variables_registry
+from .registration_variables import get_cosign_value, register as variables_registry
 from .typing import (
     ConfigVersion,
     ObjecttypeVariableMapping,
@@ -278,6 +279,24 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
             "public_order_ids": submission.payments.get_completed_public_order_ids(),
         }
 
+    @staticmethod
+    def get_cosign_context_data(submission: Submission) -> dict[str, Any]:
+        if not submission.cosign_complete:
+            return {
+                "bsn": "",
+                "kvk": "",
+                "pseudo": "",
+                "date": "",
+            }
+        else:
+            return {
+                "bsn": get_cosign_value(submission, AuthAttribute.bsn),
+                "kvk": get_cosign_value(submission, AuthAttribute.kvk),
+                "pseudo": get_cosign_value(submission, AuthAttribute.pseudo),
+                # date can be missing on existing submissions, so fallback to an empty string
+                "date": submission.co_sign_data.get("cosign_date", ""),
+            }
+
     @override
     def get_object_data(
         self,
@@ -298,6 +317,7 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
             "_submission": submission,
             "productaanvraag_type": options["productaanvraag_type"],
             "payment": self.get_payment_context_data(submission),
+            "cosign_data": self.get_cosign_context_data(submission),
             "variables": get_variables_for_context(submission),
             # Github issue #661, nested for namespacing note: other templates and context expose all submission
             # variables in the top level namespace, but that is due for refactor

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -1299,7 +1299,7 @@ class V1HandlerTests(TestCase):
             "content_json": textwrap.dedent(
                 """
                 {
-                    "cosign_date": "{{ cosign_data.date }}",
+                    "cosign_date": "{{ cosign_data.date.isoformat }}",
                     "cosign_bsn": "{{ cosign_data.bsn }}",
                     "cosign_kvk": "{{ cosign_data.kvk }}",
                     "cosign_pseudo": "{{ cosign_data.pseudo }}"

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -3,12 +3,14 @@ from datetime import date
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 import requests_mock
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test import generate_oas_component
 from zgw_consumers.test.factories import ServiceFactory
 
+from openforms.authentication.service import AuthAttribute
 from openforms.payments.constants import PaymentStatus
 from openforms.payments.tests.factories import SubmissionPaymentFactory
 from openforms.submissions.tests.factories import (
@@ -17,8 +19,10 @@ from openforms.submissions.tests.factories import (
 )
 
 from ....constants import RegistrationAttribute
-from ..models import ObjectsAPIConfig
+from ..models import ObjectsAPIConfig, ObjectsAPIRegistrationData
 from ..plugin import PLUGIN_IDENTIFIER, ObjectsAPIRegistration
+from ..submission_registration import ObjectsAPIV1Handler
+from ..typing import RegistrationOptionsV1
 
 
 def get_create_json(req, ctx):
@@ -1253,3 +1257,147 @@ class ObjectsAPIBackendV1Tests(TestCase):
                 "public_order_ids": [],
             },
         )
+
+
+class V1HandlerTests(TestCase):
+    """
+    Test V1 registration backend without actual HTTP calls.
+
+    Test the behaviour of the V1 registration handler for producing record data to send
+    to the Objects API.
+    """
+
+    def test_cosign_info_available(self):
+        now = timezone.now().isoformat()
+
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "cosign",
+                    "type": "cosign",
+                    "validate": {"required": False},
+                },
+            ],
+            completed=True,
+            submitted_data={
+                "cosign": "example@localhost",
+            },
+            cosign_complete=True,
+            co_sign_data={
+                "value": "123456789",
+                "attribute": AuthAttribute.bsn,
+                "cosign_date": now,
+            },
+        )
+
+        ObjectsAPIRegistrationData.objects.create(submission=submission)
+        v2_options: RegistrationOptionsV1 = {
+            "version": 1,
+            "objecttype": "-dummy-",
+            "objecttype_version": 1,
+            "productaanvraag_type": "-dummy-",
+            "content_json": textwrap.dedent(
+                """
+                {
+                    "cosign_date": "{{ cosign_data.date }}",
+                    "cosign_bsn": "{{ cosign_data.bsn }}",
+                    "cosign_kvk": "{{ cosign_data.kvk }}",
+                    "cosign_pseudo": "{{ cosign_data.pseudo }}"
+                }
+                """
+            ),
+        }
+        handler = ObjectsAPIV1Handler()
+
+        object_data = handler.get_object_data(submission=submission, options=v2_options)
+
+        record_data = object_data["record"]["data"]
+
+        self.assertEqual(record_data["cosign_date"], now)
+        self.assertEqual(record_data["cosign_bsn"], "123456789")
+        self.assertEqual(record_data["cosign_kvk"], "")
+        self.assertEqual(record_data["cosign_pseudo"], "")
+
+    def test_cosign_info_not_available(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "cosign",
+                    "type": "cosign",
+                    "validate": {"required": False},
+                },
+            ],
+            completed=True,
+            submitted_data={
+                "cosign": "example@localhost",
+            },
+            cosign_complete=False,
+        )
+
+        ObjectsAPIRegistrationData.objects.create(submission=submission)
+        v2_options: RegistrationOptionsV1 = {
+            "version": 1,
+            "objecttype": "-dummy-",
+            "objecttype_version": 1,
+            "productaanvraag_type": "-dummy-",
+            "content_json": textwrap.dedent(
+                """
+                {
+                    {% if cosign_data %}
+                    "cosign_date": "{{ cosign_data.date }}",
+                    "cosign_bsn": "{{ cosign_data.bsn }}",
+                    "cosign_kvk": "{{ cosign_data.kvk }}",
+                    "cosign_pseudo": "{{ cosign_data.pseudo }}"
+                    {% endif %}
+                }
+                """
+            ),
+        }
+        handler = ObjectsAPIV1Handler()
+
+        object_data = handler.get_object_data(submission=submission, options=v2_options)
+
+        self.assertEqual(object_data["record"]["data"], {})
+
+    def test_cosign_info_no_cosign_date(self):
+        """The cosign date might not be available on existing submissions."""
+
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "cosign",
+                    "type": "cosign",
+                    "validate": {"required": False},
+                },
+            ],
+            completed=True,
+            submitted_data={
+                "cosign": "example@localhost",
+            },
+            cosign_complete=True,
+            co_sign_data={
+                "value": "123456789",
+                "attribute": AuthAttribute.bsn,
+            },
+        )
+
+        ObjectsAPIRegistrationData.objects.create(submission=submission)
+        v2_options: RegistrationOptionsV1 = {
+            "version": 1,
+            "objecttype": "-dummy-",
+            "objecttype_version": 1,
+            "productaanvraag_type": "-dummy-",
+            "content_json": textwrap.dedent(
+                """
+                {
+                    "cosign_date": "{{ cosign_data.date }}"
+                }
+                """
+            ),
+        }
+        handler = ObjectsAPIV1Handler()
+
+        object_data = handler.get_object_data(submission=submission, options=v2_options)
+
+        record_data = object_data["record"]["data"]
+        self.assertEqual(record_data["cosign_date"], "")

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -496,7 +496,11 @@ class V2HandlerTests(TestCase):
             submitted_data={
                 "cosign": "example@localhost",
             },
-            cosign_complete=False,
+            cosign_complete=True,
+            co_sign_data={
+                "value": "123456789",
+                "attribute": AuthAttribute.bsn,
+            },
         )
 
         ObjectsAPIRegistrationData.objects.create(submission=submission)

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -529,7 +529,7 @@ class CosignValidationSerializer(serializers.Serializer):
     )
 
     def save(self, **kwargs):
-        submission = self.context["submission"]
+        submission: Submission = self.context["submission"]
         submission.cosign_complete = True
         submission.cosign_privacy_policy_accepted = True
         submission.cosign_statement_of_truth_accepted = True


### PR DESCRIPTION
Closes #4302

**Changes**

Still needs legacy Objects API registration support

Adds the necessary registration variables.

As I had to explore a bit the cosign flow (both legacy and new), noticed that the `co_sign_data` field seems to have a validator incompatible with the new cosign flow:

https://github.com/open-formulieren/open-forms/blob/e780ea782eb2264dc63cf33dd19c67d57a7a15c2/src/openforms/submissions/models/submission.py#L124-L130

`CosignDataSerializer` is defined as:

https://github.com/open-formulieren/open-forms/blob/e780ea782eb2264dc63cf33dd19c67d57a7a15c2/src/openforms/submissions/serializers.py#L12-L22

But the new flow sets this data from the auth plugin data directly:

https://github.com/open-formulieren/open-forms/blob/e780ea782eb2264dc63cf33dd19c67d57a7a15c2/src/openforms/authentication/signals.py#L140-L147

and the data from the auth plugin doesn't have `co_sign_auth_attribute`, `representation`, etc.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
