### PR TITLE
[#1906] Fix duplicate form definitions after importing a form

### DIFF
--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Forms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-21 10:26+0200\n"
+"POT-Creation-Date: 2024-05-21 13:43+0200\n"
 "PO-Revision-Date: 2024-05-17 15:22+0200\n"
 "Last-Translator: Sergei Maertens <sergei+local@maykinmedia.nl>\n"
 "Language-Team: Dutch <support@maykinmedia.nl>\n"
@@ -4874,11 +4874,11 @@ msgstr "Form.io configuratie"
 msgid "The form definition as Form.io JSON schema"
 msgstr "De formulier definitie als Form.io JSON schema"
 
-#: openforms/forms/api/serializers/form_definition.py:168
+#: openforms/forms/api/serializers/form_definition.py:172
 msgid "Used in forms"
 msgstr "Gebruikt in formulieren"
 
-#: openforms/forms/api/serializers/form_definition.py:170
+#: openforms/forms/api/serializers/form_definition.py:174
 msgid ""
 "The collection of forms making use of this definition. This includes both "
 "active and inactive forms."
@@ -8257,8 +8257,8 @@ msgid ""
 "The co-sign component requires the '{field_label}' ({config_verbose_name}) "
 "to be configured."
 msgstr ""
-"Het mede-ondertekencomponent vereist de configuratie van '{field_label}' "
-"({config_verbose_name})."
+"Het mede-ondertekencomponent vereist de configuratie van "
+"'{field_label}' ({config_verbose_name})."
 
 #: openforms/products/api/viewsets.py:15
 msgid "Retrieve details of a single product"

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -130,10 +130,14 @@ class FormDefinitionSerializer(
         #    for the dynamic formio configuration in the context of a submission.
         # 2. The serializers/API endpoints of :module:`openforms.forms.api` for
         #    'standalone' use/introspection.
-        rewrite_formio_components_for_request(
-            instance.configuration_wrapper,
-            request=self.context["request"],
-        )
+        is_export = self.context.get("is_export", False)
+
+        if not is_export:
+            rewrite_formio_components_for_request(
+                instance.configuration_wrapper,
+                request=self.context["request"],
+            )
+
         representation["configuration"] = instance.configuration_wrapper.configuration
 
         return representation

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -96,7 +96,7 @@ def form_to_json(form_id: int) -> dict:
     form_definitions = FormDefinitionSerializer(
         instance=form_definitions,
         many=True,
-        context={"request": request},
+        context={"request": request, "is_export": True},
     ).data
     form_steps = FormStepSerializer(
         instance=form_steps, many=True, context={"request": request}


### PR DESCRIPTION
Closes #1906

**Changes**

- Added regression tests for import and export with a file component as an input
- Removed the dynamic rewrite_formio_components from the export flow as we don't care about the request at this point

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
