### PR TITLE
Implement backend validation for formio datetime component

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -477,7 +477,7 @@ glom==20.11.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-greenlet==2.0.2
+greenlet==3.0.3
     # via playwright
 html5lib==1.1
     # via
@@ -688,7 +688,7 @@ platformdirs==2.2.0
     #   -r requirements/base.txt
     #   black
     #   zeep
-playwright==1.38.0
+playwright==1.44.0
     # via -r requirements/test-tools.in
 pluggy==0.13.1
     # via pytest
@@ -733,7 +733,7 @@ pydyf==0.8.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
-pyee==9.0.4
+pyee==11.1.0
     # via playwright
 pyflakes==3.0.1
     # via flake8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -530,7 +530,7 @@ glom==20.11.0
     #   mozilla-django-oidc-db
 gprof2dot==2021.2.21
     # via django-silk
-greenlet==2.0.2
+greenlet==3.0.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -779,7 +779,7 @@ platformdirs==2.2.0
     #   -r requirements/ci.txt
     #   black
     #   zeep
-playwright==1.38.0
+playwright==1.44.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -835,7 +835,7 @@ pydyf==0.8.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-pyee==9.0.4
+pyee==11.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Forms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-21 13:43+0200\n"
+"POT-Creation-Date: 2024-05-22 10:57+0200\n"
 "PO-Revision-Date: 2024-05-17 15:22+0200\n"
 "Last-Translator: Sergei Maertens <sergei+local@maykinmedia.nl>\n"
 "Language-Team: Dutch <support@maykinmedia.nl>\n"
@@ -4464,14 +4464,14 @@ msgstr ""
 msgid "Formio integration"
 msgstr "Form.io-integratie"
 
-#: openforms/formio/components/custom.py:179
-#: openforms/formio/components/custom.py:371
+#: openforms/formio/components/custom.py:245
+#: openforms/formio/components/custom.py:437
 #: openforms/formio/components/vanilla.py:111
 #: openforms/formio/components/vanilla.py:272
 msgid "This value does not match the required pattern."
 msgstr "De waarde komt niet overeen met het verwachte patroon."
 
-#: openforms/formio/components/custom.py:234
+#: openforms/formio/components/custom.py:300
 msgid "Selecting family members is currently not available."
 msgstr "Het selecteren van gezinsleden is momenteel niet beschikbaar."
 
@@ -8303,8 +8303,8 @@ msgid ""
 "The co-sign component requires the '{field_label}' ({config_verbose_name}) "
 "to be configured."
 msgstr ""
-"Het mede-ondertekencomponent vereist de configuratie van "
-"'{field_label}' ({config_verbose_name})."
+"Het mede-ondertekencomponent vereist de configuratie van '{field_label}' "
+"({config_verbose_name})."
 
 #: openforms/products/api/viewsets.py:15
 msgid "Retrieve details of a single product"

--- a/src/openforms/formio/tests/validation/test_datetime.py
+++ b/src/openforms/formio/tests/validation/test_datetime.py
@@ -1,0 +1,150 @@
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from openforms.submissions.models import Submission
+from openforms.typing import JSONValue
+
+from ...datastructures import FormioConfigurationWrapper
+from ...dynamic_config import rewrite_formio_components
+from ...typing import DatetimeComponent
+from .helpers import extract_error, validate_formio_data
+
+
+class DatetimeFieldValidationTests(SimpleTestCase):
+
+    def test_datetimefield_required_validation(self):
+        component: DatetimeComponent = {
+            "type": "datetime",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": True},
+        }
+
+        invalid_values = [
+            ({}, "required"),
+            ({"foo": None}, "null"),
+            ({"foo": ""}, "required"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+    def test_min_max_datetime(self):
+        # variant with explicit fixed values
+        component: DatetimeComponent = {
+            "type": "datetime",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": False},
+            "openForms": {
+                "minDate": {"mode": "fixedValue"},
+                "maxDate": {"mode": "fixedValue"},
+            },
+            "datePicker": {
+                "minDate": "2024-03-10T12:00",
+                "maxDate": "2025-03-10T22:30",
+            },
+        }
+
+        invalid_values = [
+            ({"foo": "2023-01-01T12:00:00+00:00"}, "min_value"),
+            ({"foo": "2025-05-17T12:00:00+02:00"}, "max_value"),
+            ({"foo": "2024-05-17"}, "invalid"),
+            ({"foo": "blah"}, "invalid"),
+        ]
+
+        for data, error_code in invalid_values:
+            with self.subTest(data=data):
+                is_valid, errors = validate_formio_data(component, data)
+
+                self.assertFalse(is_valid)
+                self.assertIn(component["key"], errors)
+                error = extract_error(errors, component["key"])
+                self.assertEqual(error.code, error_code)
+
+        valid_values = [
+            "2024-05-06T13:49:00+02:00",
+            "2024-03-10T12:00:00+01:00",  # exactly on the minimum value, without DST
+            "2025-03-10T22:30:00+01:00",  # exactly on the maximum value, without DST
+        ]
+        for value in valid_values:
+            with self.subTest("valid value", value=value):
+                is_valid, _ = validate_formio_data(component, {"foo": value})
+
+                self.assertTrue(is_valid)
+
+    def test_dynamic_configuration(self):
+        component: DatetimeComponent = {
+            "type": "datetime",
+            "key": "foo",
+            "label": "Foo",
+            "validate": {"required": False},
+            "openForms": {
+                "minDate": {
+                    "mode": "future",
+                },
+            },
+        }
+        submission = Submission()  # this test is not supposed to hit the DB
+        config_wraper = FormioConfigurationWrapper(
+            configuration={"components": [component]}
+        )
+        now = timezone.now()
+        config_wraper = rewrite_formio_components(
+            config_wraper,
+            submission=submission,
+            data={"now": now},
+        )
+
+        updated_component = config_wraper["foo"]
+        # check that rewrite_formio_components behaved as expected
+        assert "datePicker" in updated_component
+        assert "minDate" in updated_component["datePicker"]
+
+        with self.subTest("valid value"):
+            is_valid, _ = validate_formio_data(component, {"foo": now.isoformat()})
+
+            self.assertTrue(is_valid)
+
+        with self.subTest("invalid value"):
+            is_valid, _ = validate_formio_data(
+                component, {"foo": "2020-01-01T12:00:00+01:00"}
+            )
+
+            self.assertFalse(is_valid)
+
+    def test_empty_default_value(self):
+        component: DatetimeComponent = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Optional datetime",
+            "validate": {"required": False},
+        }
+
+        is_valid, _ = validate_formio_data(component, {"datetime": ""})
+
+        self.assertTrue(is_valid)
+
+    def test_multiple(self):
+        component: DatetimeComponent = {
+            "type": "datetime",
+            "key": "datetimes",
+            "label": "Multiple datetimes",
+            "multiple": True,
+        }
+        data: JSONValue = {"datetimes": ["2024-01-01T00:00:00+00:00", "notdatetime"]}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = errors["datetimes"][1][0]
+        self.assertEqual(error.code, "invalid")
+
+        with self.subTest("valid item"):
+            self.assertNotIn(0, errors["datetimes"])


### PR DESCRIPTION
Partly closes #72

**Changes**

Added serializer field for min/max datetime validation of formio datetime components.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
