### PR TITLE
:zap: [#4255] Speed up PDF generation by replacing flexbox with float

### DIFF
--- a/src/openforms/scss/pdfs/_submission-step-row.scss
+++ b/src/openforms/scss/pdfs/_submission-step-row.scss
@@ -1,10 +1,6 @@
 @import '~microscope-sass/lib/typography';
 
 .submission-step-row {
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-
   & + & {
     margin-top: 1mm;
   }
@@ -42,12 +38,17 @@
     @include body();
     width: 40%;
     padding-right: 2em;
+    // float is used here, because flexbox/grid/tables are really slow with
+    // weasyprint, especially if large textareas are used
+    // see: https://github.com/open-formulieren/open-forms/issues/4255
+    float: left;
   }
 
   &__value {
     @include body();
     width: 60%;
     word-break: break-all;
+    margin-left: 40%;
 
     // wysiwyg content
     p {


### PR DESCRIPTION
Turns out that flexbox was the problem here (also mentioned at the end of this comment https://github.com/Kozea/WeasyPrint/issues/578#issuecomment-1058889147). I didn't want to use floats, but all the alternatives I tried were just as slow :disappointed:.

For comparison, this is what a PDF currently looks like if I enter 3500 characters in the textarea (takes about a minute to render locally, if I double the characters it exceeds the maximum): 
[original.pdf](https://github.com/open-formulieren/open-forms/files/15433138/original.pdf). I'm not sure if it's intentional that the first page does not contain any of the steps yet, but I could change that as well if needed

This is what it looks like after these CSS changes (takes about 2-3 seconds to render): [fixes.pdf](https://github.com/open-formulieren/open-forms/files/15433164/fixes.pdf).

Closes #4255

**Changes**
* Speed up PDF generation by replacing flexbox with float

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
