### PR TITLE
:bug: [#4012] Fix content component link popup in form builder

### DIFF
--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -184,6 +184,7 @@ class WebformBuilder extends WebformBuilderFormio {
         // Clean up.
         this.removeEventListener(this.dialog, 'close', dialogClose);
         this.dialog = null;
+        root.unmount();
       };
       this.addEventListener(this.dialog, 'close', dialogClose);
 


### PR DESCRIPTION
Closes #4012 

**Changes**

* remove the ckeditor node after closing the formbuilder editcomponent modal

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
