### PR TITLE
Add manual/documentation for DMN-evaluation actions

### DIFF
--- a/docs/manual/forms/examples/camunda7.rst
+++ b/docs/manual/forms/examples/camunda7.rst
@@ -7,12 +7,13 @@ Formulier met Camunda en DMN evaluatie
 In dit voorbeeld maken we een fictief formulier bestaande uit 1 stap, waarbij een logica regel gebruik maakt van Camunda
 om een beslistabel te evalueren.
 
-Beslissingsdefinitie maken
+Beslisdefinitie maken
 ==========================
 
-Volg de `Camunda tutorial`_ om een beslissingsdefinitie aan te maken in de Camunda Modeller. De beslissingsdefinitie moet
-ID **mag-formulier-indienen** en naam **Mag formulier indienen?** hebben.
-De beslistabel moet de volgende input kolommen hebben:
+Volg de `Camunda tutorial`_ om een beslisdefinitie aan te maken in de
+`Camunda Modeller <https://camunda.com/download/modeler/>`_. De beslisdefinitie moet ID
+**mag-formulier-indienen** en naam **Mag formulier indienen?** hebben. De beslistabel
+moet de volgende input kolommen hebben:
 
 #. **Leeftijd**:
 
@@ -41,7 +42,8 @@ Voeg deze regels toe:
 
 .. image:: _assets/decision_table.png
 
-Rol dan de beslissingsdefinitie uit op Camunda.
+Rol dan de beslisdefinitie uit op Camunda - in de Camunda Modeler doe je dit via het
+raketicoon linksonder.
 
 .. _Camunda tutorial: https://docs.camunda.org/get-started/dmn/model/
 
@@ -50,15 +52,15 @@ Formulier maken
 
 #. Maak een formulier aan met de volgende componenten in een formulier stap:
 
-   * Nummer component met label **Leeftijd** en eigenschapsnaam **leeftijd**
-   * Nummer component met label **Inkomen** en eigenschapsnaam **inkomen**
+   * Getal-component met label **Leeftijd** en eigenschapsnaam **leeftijd**
+   * Getal-component met label **Inkomen** en eigenschapsnaam **inkomen**
 
 #. Maak een gebruikersvariabele aan met label **Mag formulier indienen?** en eigenschapsnaam **magFormulierIndienen**.
 #. Maak een geavanceerde logica regelen aan waar de trigger ``true`` is (deze regel wordt altijd geëvalueerd).
 #. Voeg een actie aan de regel toe, van type **Evalueer DMN** en klik op de **Instellen** knop.
 
    #. Selecter de plugin **Camunda 7**.
-   #. Selecteer de **Mag formulier indienen?** beslissingsdefinitie.
+   #. Selecteer de **Mag formulier indienen?** beslisdefinitie.
    #. In de **Input Mapping** tabel, voeg twee variabelen toe:
 
       - **Leeftijd**: **leeftijd**

--- a/docs/manual/forms/index.rst
+++ b/docs/manual/forms/index.rst
@@ -10,6 +10,7 @@ De kern van Open Formulieren is uiteraard het beheren van formulieren.
    basics
    form_fields
    logic
+   logic_dmn
    translations
    registrator
    examples/index

--- a/docs/manual/forms/logic.rst
+++ b/docs/manual/forms/logic.rst
@@ -161,6 +161,8 @@ gegevens die de gebruiker invult. Er zijn verschillende acties mogelijk:
 
   * *<stap>* - De formulierstap die als n.v.t. wordt aangemerkt.
 
+* **DMN evalueren** - Met deze actie kunnen beslistabellen uitgevoerd worden. Zie
+  :ref:`manual_logic_dmn` voor meer details.
 
 Geavanceerde logica
 ===================

--- a/docs/manual/forms/logic_dmn.rst
+++ b/docs/manual/forms/logic_dmn.rst
@@ -1,0 +1,55 @@
+.. _manual_logic_dmn:
+
+====================
+Beslistabellen (DMN)
+====================
+
+Open Formulieren heeft een module om beslistabellen/beslissingen te evalueren. Deze
+dient :ref:`geconfigureerd <configuration_dmn_index>` te zijn voor je hier gebruik van
+kan maken.
+
+.. seealso:: Zie ook het voorbeeldformulier :ref:`examples_camunda`.
+
+Wat zijn beslistabellen?
+========================
+
+In beslistabellen kan je regels vastleggen - op basis van een aantal inputs en deze
+regels volgt hier een (berekend) resultaat uit. Deze tabellen worden door een
+*DMN-engine* uitgevoerd om het resultaat te bepalen. Beslistabellen zijn doorgaans
+een overzichtelijke, gecentraliseerde manier om regels (zoals wetgeving) te toetsen,
+en zijn vaak een goed alternatief voor complexe JsonLogic-expressies.
+
+Configuratie
+============
+
+DMN-acties moeten geconfigureerd worden.
+
+**Algemene instellingen**
+
+* Pluginkeuze
+* Beslisdefinitie/tabel om te evalueren
+* Eventuele versie van de beslissing - indien niet opgegeven, dan wordt de meest recente
+  versie gebruikt.
+
+**In- en uitvoerparameters**
+
+Bij de invoerparameters worden de waardes van formuliervariabelen ingestuurd als input
+voor de geselecteerde beslistabel. Formuliervariabelen en beslistabelvariabelen kunnen
+hierbij verschillende namen hebben.
+
+Op deze manier stuur je de gebruikersinvoer tijdens het invullen van het formulier naar
+de beslistabel. Je kan ook statische variabelen of zelf-gedefinieerde variabelen koppelen.
+
+.. note::
+
+   Let op dat je het juiste datatype selecteert - als de tabel een getal verwacht,
+   dan mag je geen tekstuele waarden/variabelen koppelen.
+
+   Als je een letterlijke booleanwaarde (``true``/``false``) nodig hebt, let er dan op
+   dat je als formulierveld een selectievakje gebruikt - radio en keuzemenu-opties
+   worden namelijk als tekstuele waarde geïnterpreteerd.
+
+Uitvoerparameters schrijven het resultaat van de beslistabel terug naar
+formuliervariabelen. Je kan hiermee veldwaarden en zelf-gedefinieerde variabelen
+(over)schrijven. Vervolgens kan je deze variabelen ook weer gebruiken in andere
+logicaregels.

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -4081,6 +4081,12 @@
       "value": "Are you sure you want to delete this variable?"
     }
   ],
+  "hhoWxC": [
+    {
+      "type": 0,
+      "value": "If left blank, then the most recent version is used."
+    }
+  ],
   "huHjRm": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -4086,6 +4086,12 @@
       "value": "Bent u zeker dat u deze variabele wilt verwijderen?"
     }
   ],
+  "hhoWxC": [
+    {
+      "type": 0,
+      "value": "If left blank, then the most recent version is used."
+    }
+  ],
   "huHjRm": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.js
@@ -140,6 +140,12 @@ const DecisionDefinitionVersionField = () => {
           description="Decision definition version label"
         />
       }
+      helpText={
+        <FormattedMessage
+          description="DMN action: definition version field help text"
+          defaultMessage="If left blank, then the most recent version is used."
+        />
+      }
     >
       <Select
         allowBlank

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1879,6 +1879,11 @@
     "description": "User defined variable deletion confirm message",
     "originalDefault": "Are you sure you want to delete this variable?"
   },
+  "hhoWxC": {
+    "defaultMessage": "If left blank, then the most recent version is used.",
+    "description": "DMN action: definition version field help text",
+    "originalDefault": "If left blank, then the most recent version is used."
+  },
   "huHjRm": {
     "defaultMessage": "Configure",
     "description": "Manage complex process vars configure column title",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1893,6 +1893,11 @@
     "description": "User defined variable deletion confirm message",
     "originalDefault": "Are you sure you want to delete this variable?"
   },
+  "hhoWxC": {
+    "defaultMessage": "If left blank, then the most recent version is used.",
+    "description": "DMN action: definition version field help text",
+    "originalDefault": "If left blank, then the most recent version is used."
+  },
   "huHjRm": {
     "defaultMessage": "Configureren",
     "description": "Manage complex process vars configure column title",


### PR DESCRIPTION
Closes #4294

**Changes**

* Added overview of DMN action configuration
* Added warning about boolean values and requirement for checkbox components

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
