### PR TITLE
Nudge people to the organisation login if OIDC enabled.

### DIFF
--- a/src/openforms/js/components/admin/index.js
+++ b/src/openforms/js/components/admin/index.js
@@ -10,6 +10,7 @@ import './form-category';
 import {TinyMceContext} from './form_design/Context';
 import {FormCreationForm} from './form_design/form-creation-form';
 import FormVersionsTable from './form_versions/FormVersionsTable';
+import './login';
 import './plugin_configuration';
 
 const mountForm = wrapperProps => {

--- a/src/openforms/js/components/admin/login.js
+++ b/src/openforms/js/components/admin/login.js
@@ -1,9 +1,16 @@
-const defaultLogin = document.querySelector('.admin-login-password');
-const loginForm = document.querySelector('#login-form');
+import {onLoaded} from 'utils/dom';
 
-if (defaultLogin && loginForm) {
-  defaultLogin.addEventListener('click', e => {
-    loginForm.style.display = 'block';
-    defaultLogin.style.display = 'none';
-  });
-}
+const addAdminLoginExpand = () => {
+  const defaultLoginToggle = document.querySelector('.admin-login-option--password');
+  const loginForm = document.querySelector('#login-form');
+
+  if (defaultLoginToggle && loginForm) {
+    defaultLoginToggle.addEventListener('click', e => {
+      e.preventDefault();
+      loginForm.classList.toggle('login-form--enabled');
+      defaultLoginToggle.classList.toggle('admin-login-option--disabled');
+    });
+  }
+};
+
+onLoaded(addAdminLoginExpand);

--- a/src/openforms/js/components/admin/login.js
+++ b/src/openforms/js/components/admin/login.js
@@ -1,0 +1,9 @@
+const defaultLogin = document.querySelector('.admin-login-password');
+const loginForm = document.querySelector('#login-form');
+
+if (defaultLogin && loginForm) {
+  defaultLogin.addEventListener('click', e => {
+    loginForm.style.display = 'block';
+    defaultLogin.style.display = 'none';
+  });
+}

--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -97,6 +97,7 @@ $djai-padding--tablet: 30px;
   clear: both;
   padding-top: 1em;
 }
+
 .admin-login-divider {
   text-align: center;
   clear: both;
@@ -106,13 +107,21 @@ $djai-padding--tablet: 30px;
   text-align: center;
   border-bottom: 1px solid #ccc;
   line-height: 0.1em;
-  margin: 10px 0 20px;
+  margin: 10px 0 10px;
 
   span {
     background: #fff;
     padding: 0 10px;
   }
-} 
+}
+
+/**
+ * mozilla-django-oidc-db
+ * hide the regular admin login form by default if OIDC is enabled
+ */
+#login-form:has(~ .admin-login-oidc) {
+  display: none;
+}
 
 /* Styling for react-jsonschema-form */
 .rjsf {

--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -97,6 +97,22 @@ $djai-padding--tablet: 30px;
   clear: both;
   padding-top: 1em;
 }
+.admin-login-divider {
+  text-align: center;
+  clear: both;
+  padding-top: 1em;
+
+  width: 100%;
+  text-align: center;
+  border-bottom: 1px solid #ccc;
+  line-height: 0.1em;
+  margin: 10px 0 20px;
+
+  span {
+    background: #fff;
+    padding: 0 10px;
+  }
+} 
 
 /* Styling for react-jsonschema-form */
 .rjsf {

--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -3,6 +3,7 @@
 
  Generic overrides should go in _admin_theme.scss
  */
+@use 'microscope-sass/lib/bem';
 @import '~microscope-sass/lib/responsive';
 @import '~microscope-sass/lib/util';
 
@@ -96,22 +97,27 @@ $djai-padding--tablet: 30px;
   text-align: center;
   clear: both;
   padding-top: 1em;
+
+  @include bem.modifier('disabled') {
+    display: none;
+  }
 }
 
 .admin-login-divider {
-  text-align: center;
-  clear: both;
-  padding-top: 1em;
-
-  width: 100%;
-  text-align: center;
-  border-bottom: 1px solid #ccc;
-  line-height: 0.1em;
-  margin: 10px 0 10px;
-
-  span {
-    background: #fff;
-    padding: 0 10px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding-block-start: 1em;
+  &:after,
+  &:before {
+    content: '';
+    display: block;
+    border-bottom: 1px solid var(--border-color);
+    flex-grow: 1;
+  }
+  > span {
+    flex-shrink: 0;
+    padding-inline: 10px;
   }
 }
 
@@ -119,8 +125,14 @@ $djai-padding--tablet: 30px;
  * mozilla-django-oidc-db
  * hide the regular admin login form by default if OIDC is enabled
  */
-#login-form:has(~ .admin-login-oidc) {
-  display: none;
+#login-form {
+  &:has(~ .admin-login-option--oidc) {
+    display: none;
+  }
+
+  &.login-form--enabled {
+    display: block;
+  }
 }
 
 /* Styling for react-jsonschema-form */

--- a/src/openforms/templates/maykin_2fa/login.html
+++ b/src/openforms/templates/maykin_2fa/login.html
@@ -4,11 +4,11 @@
 {% block extra_login_options %}
     {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
     {% if oidc_config.enabled %}
-        <div class="admin-login-option admin-login-password">
+        <div class="admin-login-option admin-login-option--password">
             <a href="#">{% trans "Login with application account" %}</a>
         </div>
         <div class="admin-login-divider"><span>{% trans "or" %}</span></div>
-        <div class="admin-login-option admin-login-oidc">
+        <div class="admin-login-option admin-login-option--oidc">
             <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
         </div>
     {% endif %}

--- a/src/openforms/templates/maykin_2fa/login.html
+++ b/src/openforms/templates/maykin_2fa/login.html
@@ -4,10 +4,17 @@
 {% block extra_login_options %}
     {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
     {% if oidc_config.enabled %}
-        <div class="admin-login-option">{% trans "or" %}</div>
-        <div class="admin-login-option">
+        <div class="admin-login-option admin-login-password">
+            <a href="#" onclick="javascript: document.getElementById('login-form').style.display='block'; this.style.display='none';">{% trans "Login with application account" %}</a>
+        </div>
+        <div class="admin-login-divider"><span>{% trans "or" %}</span></div>
+        <div class="admin-login-option admin-login-oidc">
             <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
         </div>
+        <style>
+            #login-form { display: none; }
+        </style>
+    
     {% endif %}
 {% endblock %}
 

--- a/src/openforms/templates/maykin_2fa/login.html
+++ b/src/openforms/templates/maykin_2fa/login.html
@@ -1,20 +1,16 @@
 {% extends "maykin_2fa/login.html" %}
-{% load solo_tags i18n %}
+{% load solo_tags i18n static %}
 
 {% block extra_login_options %}
     {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
     {% if oidc_config.enabled %}
         <div class="admin-login-option admin-login-password">
-            <a href="#" onclick="javascript: document.getElementById('login-form').style.display='block'; this.style.display='none';">{% trans "Login with application account" %}</a>
+            <a href="#">{% trans "Login with application account" %}</a>
         </div>
         <div class="admin-login-divider"><span>{% trans "or" %}</span></div>
         <div class="admin-login-option admin-login-oidc">
             <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
         </div>
-        <style>
-            #login-form { display: none; }
-        </style>
-    
     {% endif %}
 {% endblock %}
 
@@ -27,4 +23,5 @@
 {# Do not show any version information #}
 {% block footer %}
     <div id="footer"></div>
+    <script src="{% static 'bundles/core-js.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Closes #4347

**Changes**

Hides the form when OIDC is disabled. Note that this is not the best code, but it shows the intent of what I want. It has 2 aspects: 1) nicer and better visible -or-, 2) less nudge towards form login

![msedge_yrdXJ7k9O5](https://github.com/open-formulieren/open-forms/assets/96970/b094d1fd-4446-4061-a681-23966a9747ff)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
