### PR TITLE
✨ [#4337] Use form name in ZGW registration Zaak.omschrijving

### DIFF
--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -3,6 +3,7 @@ from functools import partial, wraps
 from typing import Any, TypedDict
 
 from django.urls import reverse
+from django.utils.text import Truncator
 from django.utils.translation import gettext, gettext_lazy as _
 
 import requests
@@ -171,6 +172,7 @@ class ZGWRegistration(BasePlugin):
             _create_zaak = partial(
                 zaken_client.create_zaak,
                 zaaktype=options["zaaktype"],
+                omschrijving=Truncator(submission.form.name).chars(80),
                 bronorganisatie=options["organisatie_rsin"],
                 vertrouwelijkheidaanduiding=options.get(
                     "zaak_vertrouwelijkheidaanduiding", ""


### PR DESCRIPTION
Closes #4337 

**Changes**

* Use form name in ZGW registration Zaak.omschrijving

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
