### PR TITLE
:white_check_mark: [#598] Add unit tests for appointments failure flow

### DIFF
--- a/src/openforms/appointments/contrib/jcc/tests/mock/getGovAppointmentDetailsEmptyResponse.xml
+++ b/src/openforms/appointments/contrib/jcc/tests/mock/getGovAppointmentDetailsEmptyResponse.xml
@@ -1,0 +1,9 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <getGovAppointmentDetailsResponse xmlns="http://www.genericCBS.org/GenericCBS/">
+         <appointment xmlns="">
+
+         </appointment>
+      </getGovAppointmentDetailsResponse>
+   </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
Closes #598

**Changes**

* Add unit tests for appointments failure flow

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
