### PR TITLE
[#4323] Disable sending hidden fields to objects API (v2.7)

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -619,6 +619,7 @@ MAX_UNTRUSTED_JSON_PARSE_SIZE = config(
 )  # 1mb in bytes
 # Perform HTML escaping on user's data-input
 ESCAPE_REGISTRATION_OUTPUT = config("ESCAPE_REGISTRATION_OUTPUT", default=False)
+DISABLE_SENDING_HIDDEN_FIELDS = config("DISABLE_SENDING_HIDDEN_FIELDS", default=False)
 
 
 ##############################

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Callable, Iterator
 
+from django.conf import settings
 from django.urls import reverse
 from django.utils.html import format_html_join
 from django.utils.safestring import SafeString, mark_safe
@@ -35,7 +36,10 @@ class ContainerMixin:
         # class.
         # In registration mode, we need to treat layout/container nodes as visible so
         # that their children are emitted too.
-        if self.mode in {RenderModes.export, RenderModes.registration}:
+        visible_modes = {RenderModes.export, RenderModes.registration}
+        if settings.DISABLE_SENDING_HIDDEN_FIELDS:
+            visible_modes.remove(RenderModes.registration)
+        if self.mode in visible_modes:
             return True
 
         # We only pass the step data, since frontend logic only has access to the current step data.

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -2,6 +2,8 @@ import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal
 
+from django.conf import settings
+
 from glom import Path, assign, glom
 
 from openforms.submissions.models import SubmissionStep
@@ -117,7 +119,10 @@ class ComponentNode(Node):
 
         # everything is emitted in export mode to get consistent columns
         # the same happens with the registration in order to include hidden fields as well
-        if self.mode in {RenderModes.export, RenderModes.registration}:
+        visible_modes = {RenderModes.export, RenderModes.registration}
+        if settings.DISABLE_SENDING_HIDDEN_FIELDS:
+            visible_modes.remove(RenderModes.registration)
+        if self.mode in visible_modes:
             return True
 
         # explicitly hidden components never show up. Note that this property can be set


### PR DESCRIPTION
Closes #4323

**Changes**

-  Added flag for disabling sending hidden fields to Objects API 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
