### PR TITLE
Add support for Token Exchange extension to BRK client/validator

### DIFF
--- a/src/openforms/contrib/brk/tests/files/vcr_cassettes/BRKValidatorTestCase/BRKValidatorTestCase.test_pre_request_hooks_called.yaml
+++ b/src/openforms/contrib/brk/tests/files/vcr_cassettes/BRKValidatorTestCase/BRKValidatorTestCase.test_pre_request_hooks_called.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/hal+json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/hal+json
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v2/kadastraalonroerendezaken?postcode=7361EW&huisnummer=21
+  response:
+    body:
+      string: '{"_links":{"self":{"href":"/kadastraalonroerendezaken?postcode=7361EW&huisnummer=21"}},"_embedded":{"kadastraalOnroerendeZaken":[{"identificatie":"76870482570000","domein":"NL.IMKAD.KadastraalObject","begrenzingPerceel":{"type":"Polygon","coordinates":[[[194618.354,464161.294],[194619.326,464151.276],[194631.322,464153.988],[194635.099,464154.75],[194633.498,464163.819],[194631.173,464176.992],[194627.691,464176.428],[194624.201,464175.924],[194620.702,464175.479],[194617.197,464175.093],[194616.973,464175.072],[194618.174,464162.759],[194618.354,464161.294]]]},"plaatscoordinaten":{"type":"Point","coordinates":[194625.551,464156.205]},"type":"perceel","kadastraleAanduiding":"Beekbergen
+        K 4825","kadastraleGrootte":{"soortGrootte":{"code":"1","waarde":"Vastgesteld"},"waarde":350},"adressen":[{"straat":"Atalanta","huisnummer":21,"postcode":"7361EW","woonplaats":"Beekbergen","nummeraanduidingIdentificatie":"0200200000003730","adresregel1":"Atalanta
+        21","adresregel2":"7361EW Beekbergen","koppelingswijze":{"code":"ADM_GEO","waarde":"administratief
+        en geometrisch"}}],"zakelijkGerechtigdeIdentificaties":["20170719","20170717","20170718"],"hypotheekIdentificaties":["25381030"],"_links":{"self":{"href":"/kadastraalonroerendezaken/76870482570000"},"zakelijkGerechtigden":[{"href":"/kadastraalonroerendezaken/76870482570000/zakelijkgerechtigden/{zakelijkGerechtigdeIdentificaties}","templated":true}],"hypotheken":[{"href":"/kadastraalonroerendezaken/76870482570000/hypotheken/{hypotheekIdentificaties}","templated":true}],"adressen":[{"href":"https://api.bag.kadaster.nl/lvbag/individuelebevragingen/v2/adressen/{adressen.nummeraanduidingIdentificatie}","templated":true}]}}]}}'
+    headers:
+      Api-Version:
+      - 2.0.0
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - epsg:28992
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '736'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 12 Jun 2024 10:34:13 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Unspecified
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/hal+json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/hal+json
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v2/kadastraalonroerendezaken/76870482570000/zakelijkgerechtigden
+  response:
+    body:
+      string: '{"_links":{"self":{"href":"/kadastraalonroerendezaken/76870482570000/zakelijkgerechtigden"}},"_embedded":{"zakelijkGerechtigden":[{"identificatie":"20170719","type":"eigenaar","aanvangsdatum":"2018-10-11","tenaamstelling":{"aandeel":{"noemer":1,"teller":1},"isGebaseerdOpStukdeelIdentificaties":["1006938879"],"isVermeldInStukdeelIdentificaties":["1006971479"],"stukIdentificaties":["20160425002157","20161130002071"]},"persoon":{"identificatie":"71291440","omschrijving":"Bankbedrijf","type":"kadaster_niet_natuurlijk_persoon"},"_links":{"self":{"href":"/kadastraalonroerendezaken/76870482570000/zakelijkgerechtigden/20170719"},"persoon":{"href":"/kadasternietnatuurlijkpersonen/71291440"},"stukken":[{"href":"/stukken/{tenaamstelling.stukIdentificaties}","templated":true}],"stukdelen":[{"href":"/stukdelen/{tenaamstelling.isGebaseerdOpStukdeelIdentificaties}","templated":true},{"href":"/stukdelen/{tenaamstelling.isVermeldInStukdeelIdentificaties}","templated":true}]}},{"identificatie":"20170717","type":"erfpachter","aanvangsdatum":"2018-10-11","erfpachtCanon":{"soortErfpachtCanon":{"code":"2","waarde":"Afgekocht
+        tot en met"},"jaarlijksBedrag":{"som":100.0,"valuta":{"code":"EUR","waarde":"Euro"}},"betrefMeerOnroerendeZaken":true,"einddatumAfkoop":"2028-09-30","indicatieOudeOnroerendeZaakBetrokken":true,"isGebaseerdOpStukdeelIdentificatie":"1006942716","isVermeldInStukdeelIdentificaties":["32790052","32790053"],"stukIdentificaties":["20160523001278","20200617001837"]},"tenaamstelling":{"aandeel":{"noemer":2,"teller":1},"burgerlijkeStaatTenTijdeVanVerkrijging":{"code":"2","waarde":"Ongehuwd
+        en geen geregistreerd partnerschap"},"isGebaseerdOpStukdeelIdentificaties":["1006942716"],"stukIdentificaties":["20160523001278"]},"persoon":{"identificatie":"71303564","omschrijving":"Christiaan
+        de Goede","type":"kadaster_natuurlijk_persoon"},"_links":{"self":{"href":"/kadastraalonroerendezaken/76870482570000/zakelijkgerechtigden/20170717"},"persoon":{"href":"/kadasternatuurlijkpersonen/71303564"},"stukken":[{"href":"/stukken/{tenaamstelling.stukIdentificaties}","templated":true},{"href":"/stukken/{erfpachtCanon.stukIdentificaties}","templated":true}],"stukdelen":[{"href":"/stukdelen/{tenaamstelling.isGebaseerdOpStukdeelIdentificaties}","templated":true},{"href":"/stukdelen/{erfpachtCanon.isGebaseerdOpStukdeelIdentificatie}","templated":true},{"href":"/stukdelen/{erfpachtCanon.isVermeldInStukdeelIdentificaties}","templated":true}]}},{"identificatie":"20170718","type":"erfpachter","aanvangsdatum":"2018-10-11","erfpachtCanon":{"soortErfpachtCanon":{"code":"2","waarde":"Afgekocht
+        tot en met"},"jaarlijksBedrag":{"som":100.0,"valuta":{"code":"EUR","waarde":"Euro"}},"betrefMeerOnroerendeZaken":true,"einddatumAfkoop":"2028-09-30","indicatieOudeOnroerendeZaakBetrokken":true,"isGebaseerdOpStukdeelIdentificatie":"1006942716","isVermeldInStukdeelIdentificaties":["32790052","32790053"],"stukIdentificaties":["20160523001278","20200617001837"]},"tenaamstelling":{"aandeel":{"noemer":2,"teller":1},"burgerlijkeStaatTenTijdeVanVerkrijging":{"code":"2","waarde":"Ongehuwd
+        en geen geregistreerd partnerschap"},"isGebaseerdOpStukdeelIdentificaties":["1006942716"],"stukIdentificaties":["20160523001278"]},"persoon":{"identificatie":"999991905","omschrijving":"Linda
+        Haglund","type":"ingeschreven_natuurlijk_persoon"},"_links":{"self":{"href":"/kadastraalonroerendezaken/76870482570000/zakelijkgerechtigden/20170718"},"stukken":[{"href":"/stukken/{tenaamstelling.stukIdentificaties}","templated":true},{"href":"/stukken/{erfpachtCanon.stukIdentificaties}","templated":true}],"stukdelen":[{"href":"/stukdelen/{tenaamstelling.isGebaseerdOpStukdeelIdentificaties}","templated":true},{"href":"/stukdelen/{erfpachtCanon.isGebaseerdOpStukdeelIdentificatie}","templated":true},{"href":"/stukdelen/{erfpachtCanon.isVermeldInStukdeelIdentificaties}","templated":true}]}}]}}'
+    headers:
+      Api-Version:
+      - 2.0.0
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/hal+json
+      Date:
+      - Wed, 12 Jun 2024 10:34:13 GMT
+      Keep-Alive:
+      - timeout=60
+      Server:
+      - Unspecified
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/contrib/brk/tests/test_validators.py
+++ b/src/openforms/contrib/brk/tests/test_validators.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -9,6 +9,8 @@ from privates.test import temp_private_root
 
 from openforms.authentication.constants import AuthAttribute
 from openforms.contrib.brk.models import BRKConfig
+from openforms.pre_requests.base import PreRequestHookBase
+from openforms.pre_requests.registry import Registry
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.utils.tests.vcr import OFVCRMixin
 
@@ -134,6 +136,33 @@ class BRKValidatorTestCase(BRKTestMixin, OFVCRMixin, TestCase):
             ),
         ):
             validator({"postcode": "1234AA", "houseNumber": "1"}, submission_bsn)
+
+    def test_pre_request_hooks_called(self):
+        pre_req_register = Registry()
+        mock = MagicMock()
+
+        @pre_req_register("test")
+        class PreRequestHook(PreRequestHookBase):
+            def __call__(self, *args, **kwargs):
+                mock(*args, **kwargs)
+
+        validator = BRKZakelijkGerechtigdeValidator("brk_validator")
+        submission_bsn = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__authentication_backends=["demo"],
+            form__formstep__form_definition__login_required=False,
+            auth_info__attribute_hashed=False,
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__value="71291440",
+            auth_info__plugin="demo",
+        )
+
+        with patch("openforms.pre_requests.clients.registry", new=pre_req_register):
+            validator({"postcode": "7361EW", "houseNumber": "21"}, submission_bsn)
+
+        self.assertEqual(mock.call_count, 2)  # 2 API calls expected
+        context = mock.call_args.kwargs["context"]
+        self.assertIsNotNone(context)  # type: ignore
 
 
 class BRKValidatorNotConfiguredTestCase(TestCase):

--- a/src/openforms/contrib/brk/validators.py
+++ b/src/openforms/contrib/brk/validators.py
@@ -67,7 +67,7 @@ class BRKZakelijkGerechtigdeValidator(BasePlugin[AddressValue]):
         assert not submission.auth_info.attribute_hashed
 
         try:
-            client = get_client()
+            client = get_client(submission=submission)
         except NoServiceConfigured as e:
             logger.error(
                 "No BRK service configured when trying to validate address data",


### PR DESCRIPTION
Closes #4377

**Changes**

* Added test to check for pre-request context in the BRK client (this is the mechanism used by the token exchange extension)
* Ensure we set up the pre-request context when building a BRK client

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
