### PR TITLE
Add detection for defaultValue translations

### DIFF
--- a/bin/report_component_problems.py
+++ b/bin/report_component_problems.py
@@ -57,6 +57,16 @@ def check_component(component: Component) -> str | None:
             if default_value not in expected_values:
                 return f"Default value '{default_value}' is not valid."
 
+        case {
+            "type": "textfield" | "textarea",
+            "openForms": {"translations": dict() as translations},
+        }:
+            for translation_dict in translations.values():
+                if not isinstance(translation_dict, dict):
+                    return "invalid translations structure"
+                if bool(translation_dict.get("defaultValue")):
+                    return "defaultValue has a translation"
+
 
 def report_problems(component_types: Sequence[str]) -> bool:
     from openforms.forms.models import FormDefinition


### PR DESCRIPTION
Related to #4362

**Changes**

Extended the component problem detection to report on textfield/textarea components that have a translation for `defaultValue`, since it's being removed.

I'm not touching the JS code in this PR to remove the cause of the crash, since the missing translation extraction feature is being removed entirely in a different PR by @vaszig 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
