### PR TITLE
[#4363] Missing translated description from the values of the components

### DIFF
--- a/src/openforms/formio/components/translations.py
+++ b/src/openforms/formio/components/translations.py
@@ -10,9 +10,17 @@ def translate_options(
         if not (translations := option.get("openForms", {}).get("translations")):
             continue
 
-        translated_label = translations.get(language_code, {}).get("label", "")
-        if enabled and translated_label:
-            option["label"] = translated_label
+        if enabled:
+            translated_label = translations.get(language_code, {}).get("label", "")
+            translated_description = translations.get(language_code, {}).get(
+                "description", ""
+            )
+
+            if translated_label:
+                option["label"] = translated_label
+
+            if translated_description:
+                option["description"] = translated_description
 
         # always clean up
         del option["openForms"]["translations"]  # type: ignore

--- a/src/openforms/formio/components/translations.py
+++ b/src/openforms/formio/components/translations.py
@@ -7,20 +7,18 @@ def translate_options(
     enabled: bool,
 ) -> None:
     for option in options:
-        if not (translations := option.get("openForms", {}).get("translations")):
+        if "openForms" not in option:
             continue
 
-        if enabled:
-            translated_label = translations.get(language_code, {}).get("label", "")
-            translated_description = translations.get(language_code, {}).get(
-                "description", ""
-            )
+        if not (translations := option["openForms"].get("translations")):
+            continue
 
-            if translated_label:
+        if enabled and (_translations := translations.get(language_code)):
+            if translated_label := _translations.get("label"):
                 option["label"] = translated_label
 
-            if translated_description:
+            if translated_description := _translations.get("description"):
                 option["description"] = translated_description
 
         # always clean up
-        del option["openForms"]["translations"]  # type: ignore
+        del option["openForms"]["translations"]

--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -553,7 +553,10 @@ class SelectBoxesTranslationTests(SimpleTestCase):
                     "label": "First option",
                     "openForms": {
                         "translations": {
-                            lang_code: {"label": translation},
+                            lang_code: {
+                                "label": translation,
+                                "description": translation,
+                            },
                         }
                     },
                 }
@@ -565,8 +568,11 @@ class SelectBoxesTranslationTests(SimpleTestCase):
         assert "values" in component
         opt1 = component["values"][0]
         assert "label" in opt1
+        assert "description" in opt1
         assert "openForms" in opt1
+
         self.assertEqual(opt1["label"], translation)
+        self.assertEqual(opt1["description"], translation)
         self.assertNotIn("translations", opt1["openForms"])
 
 
@@ -726,7 +732,10 @@ class RadioTranslationTests(SimpleTestCase):
                     "label": "First option",
                     "openForms": {
                         "translations": {
-                            lang_code: {"label": translation},
+                            lang_code: {
+                                "label": translation,
+                                "description": translation,
+                            },
                         }
                     },
                 }
@@ -738,8 +747,10 @@ class RadioTranslationTests(SimpleTestCase):
         assert "values" in component
         opt1 = component["values"][0]
         assert "label" in opt1
+        assert "description" in opt1
         assert "openForms" in opt1
         self.assertEqual(opt1["label"], translation)
+        self.assertEqual(opt1["description"], translation)
         self.assertNotIn("translations", opt1["openForms"])
 
 

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -52,6 +52,7 @@ class OptionDict(TypedDict):
 
     value: str
     label: str
+    description: NotRequired[str]
     openForms: NotRequired[OpenFormsOptionExtension]
 
 


### PR DESCRIPTION
Closes #4363

**Changes**

- Added description translations of the values for components which support this (selectboxes, radio)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
