### PR TITLE
Bump to latest formio builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.20.0",
+        "@open-formulieren/formio-builder": "^0.21.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -4654,9 +4654,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.20.0.tgz",
-      "integrity": "sha512-vVZXS7NEMWq/g5Fl8ICB4xeZIBZkee7XKtqjBtGg2oIX7MvUTTm2rLJg+uQypGEWi2Ljj0NUK8SJzyTOhr+XTQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.21.1.tgz",
+      "integrity": "sha512-X7z1q1jr1rBP+X4WkFNzQz4FnYG8qoJ6oWBAfKzQITNp58bKY9WQSRRmoxBqepTRAZUl8BpocLw/dnmVElny0Q==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",
@@ -27755,9 +27755,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.20.0.tgz",
-      "integrity": "sha512-vVZXS7NEMWq/g5Fl8ICB4xeZIBZkee7XKtqjBtGg2oIX7MvUTTm2rLJg+uQypGEWi2Ljj0NUK8SJzyTOhr+XTQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.21.1.tgz",
+      "integrity": "sha512-X7z1q1jr1rBP+X4WkFNzQz4FnYG8qoJ6oWBAfKzQITNp58bKY9WQSRRmoxBqepTRAZUl8BpocLw/dnmVElny0Q==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.20.0",
+    "@open-formulieren/formio-builder": "^0.21.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -333,6 +333,12 @@
       "value": "Validation"
     }
   ],
+  "2sbkGI": [
+    {
+      "type": 0,
+      "value": "When enabled, the street name and city are derived from the entered postcode and house number."
+    }
+  ],
   "2uIYst": [
     {
       "type": 0,
@@ -1413,6 +1419,12 @@
     {
       "type": 0,
       "value": "Boolean"
+    }
+  ],
+  "DEetjI": [
+    {
+      "type": 0,
+      "value": "Street name"
     }
   ],
   "DGpAyT": [
@@ -4719,6 +4731,12 @@
       "value": "link"
     }
   ],
+  "osSl3z": [
+    {
+      "type": 0,
+      "value": "City"
+    }
+  ],
   "ow5AAO": [
     {
       "type": 0,
@@ -5109,6 +5127,12 @@
     {
       "type": 0,
       "value": "Whether to show this value in the confirmation email"
+    }
+  ],
+  "toTZ0C": [
+    {
+      "type": 0,
+      "value": "Derive address"
     }
   ],
   "twWsC2": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -333,6 +333,12 @@
       "value": "Validatie"
     }
   ],
+  "2sbkGI": [
+    {
+      "type": 0,
+      "value": "Indien aangevinkt, dan worden de straatnaam en stad afgeleid op basis van de ingevoerde postcode en huisnummer."
+    }
+  ],
   "2uIYst": [
     {
       "type": 0,
@@ -1417,6 +1423,12 @@
     {
       "type": 0,
       "value": "Waar/Niet waar (boolean)"
+    }
+  ],
+  "DEetjI": [
+    {
+      "type": 0,
+      "value": "Straatnaam"
     }
   ],
   "DGpAyT": [
@@ -4725,6 +4737,12 @@
       "value": "link"
     }
   ],
+  "osSl3z": [
+    {
+      "type": 0,
+      "value": "Stad"
+    }
+  ],
   "ow5AAO": [
     {
       "type": 0,
@@ -5115,6 +5133,12 @@
     {
       "type": 0,
       "value": "Geef aan of deze waarde in de bevestigingsmail moet opgenomen worden."
+    }
+  ],
+  "toTZ0C": [
+    {
+      "type": 0,
+      "value": "Adres afleiden"
     }
   ],
   "twWsC2": [


### PR DESCRIPTION
Closes #4362

**Changes**

This version removes the support for `defaultValue` translations.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
