### PR TITLE
Prevent crash due to array-value for textfield|textarea defaultValue when multiple is true

### DIFF
--- a/src/openforms/js/components/formio_builder/translation.js
+++ b/src/openforms/js/components/formio_builder/translation.js
@@ -30,8 +30,6 @@ const ALWAYS_TRANSLATABLE_PROPERTIES = ['label', 'description', 'placeholder', '
  *   test the property path against.
  */
 const ADDITIONAL_PROPERTIES_BY_COMPONENT_TYPE = {
-  textfield: ['defaultValue'],
-  textarea: ['defaultValue'],
   content: ['html'],
   fieldset: ['legend'],
   editgrid: ['groupLabel'],


### PR DESCRIPTION
Closes #4362

Textfield and textarea have the multiple: true option, which turns the defaultValue into an array of strings rather than a single string, and that doesn't play well with the translations machinery or missing translation detection.

Open Forms 2.7.0 removes support for translations for this property, and older versions get a hotfix to prevent the crash from happening during detection, where we just don't look at `defaultValue` to extract missing translations.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
