### PR TITLE
Disable link prompt

### DIFF
--- a/src/openforms/conf/tinymce_config.json
+++ b/src/openforms/conf/tinymce_config.json
@@ -9,6 +9,6 @@
     "content_style": "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
     "default_link_target": "_blank",
     "link_default_protocol": "https",
-    "link_assume_external_targets": true,
+    "link_assume_external_targets": false,
     "convert_urls": false
 }

--- a/src/openforms/scss/admin/themes/_dark.scss
+++ b/src/openforms/scss/admin/themes/_dark.scss
@@ -158,6 +158,13 @@
       }
     }
   }
+
+  .mce-content-body {
+    // Fix dark mode selections
+    [data-mce-selected='inline-boundary'] {
+      background-color: #0a2647;
+    }
+  }
 }
 
 @mixin ckeditor-variables {


### PR DESCRIPTION
Closes #4350

**Changes**

* Disabled link prompt. From #1080 I couldn't find a specific requirement to enable this prompt.
* Noticed a dark-mode style issue and fixed it.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
