### PR TITLE
:arrow_up: Bump lxml and xmlsec libraries to their latest versions

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,10 +12,6 @@ jsonschema
 jsonschema_specifications
 jq
 html5lib
-# see https://github.com/onelogin/python3-saml/issues/292 and
-# https://bugs.launchpad.net/lxml/+bug/1960668 -> we can avoid this by compiling lxml
-# against the system libxml2
---no-binary lxml
 lxml
 O365  # microsoft graph
 Pillow  # handle images

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,6 @@
 #
 #    ./bin/compile_dependencies.sh
 #
---no-binary lxml
-
 amqp==5.2.0
     # via kombu
 ape-pie==0.1.0
@@ -162,9 +160,7 @@ django-csp==3.8
 django-csp-reports==1.8.1
     # via -r requirements/base.in
 django-digid-eherkenning[oidc]==0.14.0
-    # via
-    #   -r requirements/base.in
-    #   django-digid-eherkenning
+    # via -r requirements/base.in
 django-filter==23.2
     # via -r requirements/base.in
 django-flags==5.0.13
@@ -311,7 +307,7 @@ kombu==5.3.7
     # via celery
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   -r requirements/base.in
     #   django-camunda
@@ -553,7 +549,7 @@ xlrd==2.0.1
     # via tablib
 xlwt==1.3.0
     # via tablib
-xmlsec==1.3.10
+xmlsec==1.3.14
     # via maykin-python3-saml
 xmltodict==0.12.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,8 +4,6 @@
 #
 #    ./bin/compile_dependencies.sh
 #
---no-binary lxml
-
 alabaster==0.7.16
     # via sphinx
 amqp==5.2.0
@@ -567,7 +565,7 @@ lazy-object-proxy==1.9.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   openapi-spec-validator
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1110,7 +1108,7 @@ xlwt==1.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   tablib
-xmlsec==1.3.10
+xmlsec==1.3.14
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,6 @@
 #
 #    ./bin/compile_dependencies.sh
 #
---no-binary lxml
-
 alabaster==0.7.16
     # via
     #   -c requirements/ci.txt
@@ -636,7 +634,7 @@ lazy-object-proxy==1.9.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   openapi-spec-validator
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1292,7 +1290,7 @@ xlwt==1.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   tablib
-xmlsec==1.3.10
+xmlsec==1.3.14
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -4,8 +4,6 @@
 #
 #    ./bin/compile_dependencies.sh
 #
---no-binary lxml
-
 amqp==5.2.0
     # via
     #   -r requirements/base.txt
@@ -473,7 +471,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/base.txt
     #   openapi-spec-validator
-lxml==4.9.1
+lxml==5.2.2
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -863,7 +861,7 @@ xlwt==1.3.0
     # via
     #   -r requirements/base.txt
     #   tablib
-xmlsec==1.3.10
+xmlsec==1.3.14
     # via
     #   -r requirements/base.txt
     #   maykin-python3-saml


### PR DESCRIPTION
These versions can be installed from binary wheels again, so the --no-binary lxml flag can be dropped, speeding up installation in CI and docker image builds :tada:
