### PR TITLE
[#4409] Update payment status text in registration pdf report

### DIFF
--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -81,7 +81,7 @@
             <section class="payment-info">
                 <div class="submission-step-row">
                     <div class="submission-step-row__label">
-                        {% trans "Total payment required" %}
+                        {% trans "Total amount" %}
                     </div>
                     <div class="submission-step-row__value">
                         &euro; {{ report.submission.price }}


### PR DESCRIPTION
Closes #4409

**Changes**

- Updated payment status text in registration pdf report from "Total amount to be paid" to "Total amount" in order to cover situations where the pdf is generated before the payment status update. 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
