### PR TITLE
Disallow using temporary file uploads not owned

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -30,6 +30,7 @@ from csp_post_processor import post_process_html
 from openforms.config.constants import UploadFileType
 from openforms.config.models import GlobalConfiguration
 from openforms.submissions.attachments import temporary_upload_from_url
+from openforms.submissions.constants import UPLOADS_SESSION_KEY
 from openforms.typing import DataMapping
 from openforms.utils.urls import build_absolute_uri
 from openforms.validations.service import PluginValidator
@@ -331,6 +332,11 @@ class FileSerializer(serializers.Serializer):
 
         temporary_upload = temporary_upload_from_url(attrs["url"])
         if temporary_upload is None:
+            raise serializers.ValidationError({"url": _("Invalid URL.")})
+
+        if str(temporary_upload.uuid) not in self.context["request"].session.get(
+            UPLOADS_SESSION_KEY, []
+        ):
             raise serializers.ValidationError({"url": _("Invalid URL.")})
 
         if attrs["size"] != temporary_upload.file_size:

--- a/src/openforms/formio/tests/validation/helpers.py
+++ b/src/openforms/formio/tests/validation/helpers.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Any
 from unittest.mock import patch
 
 from rest_framework.exceptions import ErrorDetail
@@ -13,12 +14,13 @@ from ...typing import Component
 
 
 def validate_formio_data(
-    component: Component, data: JSONValue
+    component: Component, data: JSONValue, extra_context: dict[str, Any] = {}
 ) -> tuple[bool, ReturnDict]:
     """
     Dynamically build the serializer, validate it and return the status.
     """
-    context = {"submission": SubmissionFactory.build()}
+
+    context = {"submission": SubmissionFactory.build(), **extra_context}
     serializer = build_serializer(components=[component], data=data, context=context)
     is_valid = serializer.is_valid(raise_exception=False)
     return is_valid, serializer.errors

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -293,7 +293,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         step_data_serializer = build_serializer(
             configuration["components"],
             data=data,
-            context={"submission": submission},
+            context={"submission": submission, "request": self.context["request"]},
         )
         step_data_serializer.is_valid(raise_exception=True)
 

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -71,7 +71,10 @@ class CompletionValidationSerializer(serializers.Serializer):
                 step_data_serializer = build_serializer(
                     configuration["components"],
                     data=data,
-                    context={"submission": submission},
+                    context={
+                        "submission": submission,
+                        "request": self.context["request"],
+                    },
                 )
                 if not step_data_serializer.is_valid():
                     errors = step_data_serializer.errors


### PR DESCRIPTION
Closes https://github.com/open-formulieren/security-issues/issues/30

**Changes**

We use the request from the context to validate that the user owns the temporary file uploads.

I'm not too happy with the test implementation but I don't think we can do any better.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
