### PR TITLE
Fix incorrect payment amount being sent to Objects API

### DIFF
--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -308,7 +308,7 @@ def confirmation_email_skip(submission: Submission):
 # - - -
 
 
-def payment_flow_start(payment: SubmissionPayment, plugin):
+def payment_flow_start(payment: SubmissionPayment, plugin, from_email: bool = False):
     _create_log(
         payment.submission,
         "payment_flow_start",
@@ -316,6 +316,7 @@ def payment_flow_start(payment: SubmissionPayment, plugin):
         extra_data={
             "payment_order_id": payment.public_order_id,
             "payment_id": payment.id,
+            "from_email": from_email,
         },
     )
 

--- a/src/openforms/logging/templates/logging/events/payment_flow_start.txt
+++ b/src/openforms/logging/templates/logging/events/payment_flow_start.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% blocktrans trimmed with plugin=log.fmt_plugin order_id=log.extra_data.payment_order_id lead=log.fmt_lead %}
    {{ lead }}: Payment plugin {{ plugin }} order '{{ order_id }}' started browser flow.
-{% endblocktrans %}
+{% endblocktrans %}{% if log.exra_data.from_email %} {% trans "Flow entered via email link." %}{% endif %}

--- a/src/openforms/payments/models.py
+++ b/src/openforms/payments/models.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from django.db import models, transaction
-from django.db.models import Sum
 from django.utils.translation import gettext_lazy as _
 
 from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
@@ -66,9 +65,6 @@ class SubmissionPaymentManager(models.Manager["SubmissionPayment"]):
 
 
 class SubmissionPaymentQuerySet(models.QuerySet["SubmissionPayment"]):
-    def sum_amount(self) -> Decimal:
-        return self.aggregate(sum_amount=Sum("amount"))["sum_amount"] or Decimal("0")
-
     def get_completed_public_order_ids(self) -> list[str]:
         return list(
             self.filter(

--- a/src/openforms/payments/models.py
+++ b/src/openforms/payments/models.py
@@ -65,6 +65,10 @@ class SubmissionPaymentManager(models.Manager["SubmissionPayment"]):
 
 
 class SubmissionPaymentQuerySet(models.QuerySet["SubmissionPayment"]):
+    def mark_registered(self):
+        qs = self.filter(status=PaymentStatus.completed)
+        return qs.update(status=PaymentStatus.registered)
+
     def get_completed_public_order_ids(self) -> list[str]:
         return list(
             self.filter(

--- a/src/openforms/payments/services.py
+++ b/src/openforms/payments/services.py
@@ -37,7 +37,7 @@ def update_submission_payment_registration(submission: Submission):
 
         try:
             plugin.update_payment_status(submission, options_serializer.validated_data)
-            payments.update(status=PaymentStatus.registered)
+            payments.mark_registered()
         except Exception as e:
             logevent.registration_payment_update_failure(
                 submission, error=e, plugin=plugin

--- a/src/openforms/payments/tests/test_models.py
+++ b/src/openforms/payments/tests/test_models.py
@@ -90,14 +90,6 @@ class SubmissionPaymentTests(TransactionTestCase):
         )
         self.assertEqual(payment.public_order_id, "xyz2020/OF-123456/4")
 
-    def test_queryset_sum_amount(self):
-        self.assertEqual(0, SubmissionPayment.objects.none().sum_amount())
-
-        SubmissionPaymentFactory.create(amount=Decimal("1"))
-        SubmissionPaymentFactory.create(amount=Decimal("2"))
-        SubmissionPaymentFactory.create(amount=Decimal("3"))
-        self.assertEqual(6, SubmissionPayment.objects.sum_amount())
-
     def test_status_is_final(self):
         for s in [PaymentStatus.started, PaymentStatus.processing]:
             with self.subTest(s):

--- a/src/openforms/payments/views.py
+++ b/src/openforms/payments/views.py
@@ -384,6 +384,7 @@ class PaymentLinkView(DetailView):
             )
 
             info = plugin.start_payment(self.request, payment)
+            logevent.payment_flow_start(payment, plugin, from_email=True)
 
             context["url"] = info.url
             context["method"] = info.type.upper()

--- a/src/openforms/registrations/contrib/objects_api/registration_variables.py
+++ b/src/openforms/registrations/contrib/objects_api/registration_variables.py
@@ -62,12 +62,14 @@ class PaymentCompleted(BaseStaticVariable):
 @register("payment_amount")
 class PaymentAmount(BaseStaticVariable):
     name = _("Payment amount")
-    data_type = FormVariableDataTypes.string
+    data_type = FormVariableDataTypes.float
 
     def get_initial_value(self, submission: Submission | None = None):
         if submission is None:
             return None
-        return float(submission.payments.sum_amount())
+        if submission.price is None:
+            return None
+        return float(submission.price)
 
 
 @register("payment_public_order_ids")

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Generic, Iterator, TypeVar, cast
 
 from django.db.models import F
@@ -273,9 +274,11 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
 
     @staticmethod
     def get_payment_context_data(submission: Submission) -> dict[str, Any]:
+        price = submission.price
+        amount = Decimal(price).quantize(Decimal("0.01")) if price is not None else 0
         return {
             "completed": submission.payment_user_has_paid,
-            "amount": str(submission.payments.sum_amount()),
+            "amount": str(amount),
             "public_order_ids": submission.payments.get_completed_public_order_ids(),
         }
 

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -1215,11 +1215,12 @@ class ObjectsAPIBackendV1Tests(TestCase):
             registration_result={
                 "url": "https://objecten.nl/api/v1/objects/111-222-333"
             },
+            form__payment_backend="demo",
+            form__product__price=10,
         )
-        SubmissionPaymentFactory.create(
+        SubmissionPaymentFactory.for_submission(
             submission=submission,
             status=PaymentStatus.started,
-            amount=10,
             public_order_id="",
         )
 

--- a/src/openforms/registrations/contrib/objects_api/tests/test_update_payment_status_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_update_payment_status_v1.py
@@ -32,6 +32,8 @@ class ObjectsAPIPaymentStatusUpdateV1Tests(TestCase):
             registration_result={
                 "url": "https://objecten.nl/api/v1/objects/111-222-333"
             },
+            form__payment_backend="demo",
+            form__product__price=10.01,
         )
         SubmissionPaymentFactory.create(
             submission=submission,
@@ -101,6 +103,8 @@ class ObjectsAPIPaymentStatusUpdateV1Tests(TestCase):
             registration_result={
                 "url": "https://objecten.nl/api/v1/objects/111-222-333"
             },
+            form__payment_backend="demo",
+            form__product__price=10,
         )
         SubmissionPaymentFactory.create(
             submission=submission,

--- a/src/openforms/registrations/contrib/objects_api/tests/test_utils.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_utils.py
@@ -73,25 +73,35 @@ class EscapeHTMLTests(TestCase):
                 self.assertIs(result, sample)
 
     def test_render_to_json_large_numbers(self):
-        payment = SubmissionPaymentFactory.create(
-            amount=1_000,
+        submission = SubmissionFactory.create(
+            completed=True,
+            form__payment_backend="demo",
+            form__product__price=1_000,
         )
+        assert submission.price == 1_000
 
-        context_data = ObjectsAPIV1Handler.get_payment_context_data(payment.submission)
+        context_data = ObjectsAPIV1Handler.get_payment_context_data(submission)
 
         self.assertEqual("1000.00", context_data["amount"])
 
     def test_render_to_json_many_decimal_places(self):
-        payment = SubmissionPaymentFactory.create(
-            amount=3.1415926535,
+        submission = SubmissionFactory.create(
+            completed=True,
+            form__payment_backend="demo",
+            form__product__price=3.1415926535,
         )
+        assert submission.price == 3.1415926535
 
-        context_data = ObjectsAPIV1Handler.get_payment_context_data(payment.submission)
+        context_data = ObjectsAPIV1Handler.get_payment_context_data(submission)
 
         self.assertEqual("3.14", context_data["amount"])
 
     def test_multiple_public_order_ids(self):
-        submission = SubmissionFactory.create(with_public_registration_reference=True)
+        submission = SubmissionFactory.create(
+            with_public_registration_reference=True,
+            form__payment_backend="demo",
+            form__product__price=20,
+        )
         payment1, payment2 = SubmissionPaymentFactory.create_batch(
             2, submission=submission, status=PaymentStatus.completed, amount=10
         )

--- a/src/openforms/registrations/tasks.py
+++ b/src/openforms/registrations/tasks.py
@@ -12,7 +12,6 @@ from rest_framework.exceptions import ValidationError
 from openforms.celery import app
 from openforms.config.models import GlobalConfiguration
 from openforms.logging import logevent
-from openforms.payments.constants import PaymentStatus
 from openforms.submissions.constants import PostSubmissionEvents, RegistrationStatuses
 from openforms.submissions.models import Submission
 from openforms.submissions.public_references import set_submission_reference
@@ -320,7 +319,7 @@ def register_submission(submission_id: int, event: PostSubmissionEvents | str) -
         config.wait_for_payment_to_register
         and event == PostSubmissionEvents.on_payment_complete
     ):
-        submission.payments.update(status=PaymentStatus.registered)
+        submission.payments.mark_registered()
 
     submission.save_registration_status(RegistrationStatuses.success, result or {})
     logevent.registration_success(submission, plugin)

--- a/src/openforms/registrations/tests/test_registration_hook.py
+++ b/src/openforms/registrations/tests/test_registration_hook.py
@@ -5,7 +5,7 @@ Test the registration hook on submissions.
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -17,6 +17,7 @@ from zgw_consumers.models import Service
 from openforms.config.models import GlobalConfiguration
 from openforms.forms.models import FormRegistrationBackend
 from openforms.logging.models import TimelineLogProxy
+from openforms.payments.constants import PaymentStatus
 from openforms.submissions.constants import PostSubmissionEvents, RegistrationStatuses
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.utils.tests.logging import ensure_logger_level
@@ -353,6 +354,32 @@ class RegistrationHookTests(TestCase):
         submission.refresh_from_db()
 
         self.assertEqual(submission.registration_status, RegistrationStatuses.success)
+
+    @tag("gh-4425")
+    def test_registration_hook_with_failed_and_completed_payments(self):
+        submission = SubmissionFactory.create(
+            completed=True,
+            with_public_registration_reference=True,
+            with_failed_payment=True,
+            with_completed_payment=True,
+            form__registration_backend="email",
+            form__registration_backend_options={"to_emails": ["registration@test.nl"]},
+        )
+        assert submission.payments.count() == 2
+        with patch(
+            "openforms.registrations.tasks.GlobalConfiguration.get_solo",
+            return_value=GlobalConfiguration(wait_for_payment_to_register=True),
+        ):
+            register_submission(
+                submission.id, str(PostSubmissionEvents.on_payment_complete)
+            )
+
+        registered_payments = submission.payments.filter(
+            status=PaymentStatus.registered
+        )
+        self.assertEqual(registered_payments.count(), 1)
+        failed_payments = submission.payments.filter(status=PaymentStatus.failed)
+        self.assertEqual(failed_payments.count(), 1)
 
 
 class NumRegistrationsTest(TestCase):

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -126,7 +126,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         )
         with_completed_payment = factory.Trait(
             form__payment_backend="demo",
-            product=factory.RelatedFactory(
+            payment=factory.RelatedFactory(
                 "openforms.payments.tests.factories.SubmissionPaymentFactory",
                 factory_related_name="submission",
                 status=PaymentStatus.completed,
@@ -134,10 +134,18 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         )
         with_registered_payment = factory.Trait(
             form__payment_backend="demo",
-            product=factory.RelatedFactory(
+            payment=factory.RelatedFactory(
                 "openforms.payments.tests.factories.SubmissionPaymentFactory",
                 factory_related_name="submission",
                 status=PaymentStatus.registered,
+            ),
+        )
+        with_failed_payment = factory.Trait(
+            form__payment_backend="demo",
+            payment=factory.RelatedFactory(
+                "openforms.payments.tests.factories.SubmissionPaymentFactory",
+                factory_related_name="submission",
+                status=PaymentStatus.failed,
             ),
         )
         with_public_registration_reference = factory.Trait(

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -126,7 +126,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         )
         with_completed_payment = factory.Trait(
             form__payment_backend="demo",
-            payment=factory.RelatedFactory(
+            completed_payment=factory.RelatedFactory(
                 "openforms.payments.tests.factories.SubmissionPaymentFactory",
                 factory_related_name="submission",
                 status=PaymentStatus.completed,
@@ -134,7 +134,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         )
         with_registered_payment = factory.Trait(
             form__payment_backend="demo",
-            payment=factory.RelatedFactory(
+            registered_payment=factory.RelatedFactory(
                 "openforms.payments.tests.factories.SubmissionPaymentFactory",
                 factory_related_name="submission",
                 status=PaymentStatus.registered,
@@ -142,7 +142,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         )
         with_failed_payment = factory.Trait(
             form__payment_backend="demo",
-            payment=factory.RelatedFactory(
+            failed_payment=factory.RelatedFactory(
                 "openforms.payments.tests.factories.SubmissionPaymentFactory",
                 factory_related_name="submission",
                 status=PaymentStatus.failed,


### PR DESCRIPTION
Closes #4425 

**Changes**

* `payment.amount` is now derived from `submission.price` instead of `SubmissionPayment` record aggregation. The documentation describes this field as being the cost of a submission, not the sum of all payment attempts.
* The submission variable for payment amount is updated accordingly.
* Removed (confusing and dangerous) queryset method to aggregate the total amount in submission payments.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
