### PR TITLE
[#4430] Handle empty response from bag client

### DIFF
--- a/src/openforms/contrib/kadaster/api/views.py
+++ b/src/openforms/contrib/kadaster/api/views.py
@@ -86,10 +86,6 @@ class AddressAutocompleteView(APIView):
             timeout=ADDRESS_AUTOCOMPLETE_CACHE_TIMEOUT,
         )
 
-        if not address_data:
-            # If address is not found just return an empty response
-            return Response({})
-
         return Response(GetStreetNameAndCityViewResultSerializer(address_data).data)
 
 


### PR DESCRIPTION
Closes #4430

**Changes**

- Handle empty response from bag client in combination with the backend validation of `secretStreetCity `field

When we had no data from the API call, secretStreetCity was not created and was an empty str, so it couldn't validate with the one that was created in the backend validation. Now, we create one even when no data is returned and this makes backend validation possible.


**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
