### PR TITLE
Register authentication context data in Objects API (v1 registration)

### DIFF
--- a/src/openforms/authentication/tests/factories.py
+++ b/src/openforms/authentication/tests/factories.py
@@ -1,6 +1,11 @@
 import factory
+from digid_eherkenning.choices import AssuranceLevels
 
-from ..constants import AuthAttribute
+from ..constants import (
+    ActingSubjectIdentifierType,
+    AuthAttribute,
+    LegalSubjectIdentifierType,
+)
 from ..contrib.digid.constants import DIGID_DEFAULT_LOA
 from ..models import AuthInfo, RegistratorInfo
 
@@ -23,6 +28,28 @@ class AuthInfoFactory(factory.django.DjangoModelFactory):
             _hashed_id_attrs=factory.PostGenerationMethodCall(
                 "hash_identifying_attributes"
             ),
+        )
+        is_eh_bewindvoering = factory.Trait(
+            attribute=AuthAttribute.bsn,
+            value="999991607",
+            attribute_hashed=False,
+            loa=AssuranceLevels.substantial,
+            legal_subject_identifier_type=LegalSubjectIdentifierType.kvk,
+            legal_subject_identifier_value="90002768",
+            acting_subject_identifier_type=ActingSubjectIdentifierType.opaque,
+            acting_subject_identifier_value=(
+                "4B75A0EA107B3D36C82FD675B5B78CC2F181B22E33D85F2D4A5DA63452EE3018"
+                "@2D8FF1EF10279BC2643F376D89835151"
+            ),
+            mandate_context={
+                "role": "bewindvoerder",
+                "services": [
+                    {
+                        "id": "urn:etoegang:DV:00000001002308836000:services:9113",
+                        "uuid": "34085d78-21aa-4481-a219-b28d7f3282fc",
+                    }
+                ],
+            },
         )
 
 

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -336,6 +336,11 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
                 "pdf_url": registration_data.pdf_url,
                 "csv_url": registration_data.csv_url,
             },
+            "auth_context": (
+                submission.auth_info.to_auth_context_data()
+                if submission.is_authenticated
+                else None
+            ),
         }
 
         object_mapping = {

--- a/src/openforms/registrations/contrib/objects_api/templatetags/registrations/contrib/objects_api/json_tags.py
+++ b/src/openforms/registrations/contrib/objects_api/templatetags/registrations/contrib/objects_api/json_tags.py
@@ -6,6 +6,7 @@ from django.utils.safestring import SafeString
 
 from openforms.formio.rendering.structured import render_json
 from openforms.registrations.contrib.objects_api.utils import html_escape_json
+from openforms.typing import JSONEncodable
 
 register = template.Library()
 
@@ -16,7 +17,7 @@ def uploaded_attachment_urls(context: template.Context) -> SafeString:
     Output a sequence of attachment URLs as a JSON-serialized list.
     """
     attachments = context.get("submission", {}).get("uploaded_attachment_urls", [])
-    return SafeString(json.dumps(attachments))
+    return as_json(attachments)
 
 
 @register.simple_tag(takes_context=True)
@@ -47,4 +48,15 @@ def as_geo_json(value: list[float] | str) -> SafeString:
         else {}
     )
 
-    return SafeString(json.dumps(data))
+    return as_json(data)
+
+
+@register.simple_tag
+def as_json(value: JSONEncodable):
+    """
+    Dump the value as a JSON string.
+
+    DO NOT USE THIS OUTSIDE OF OBJECTS API REGISTRATION TEMPLATES. It is unsafe. The
+    objects API templates validate that the result can be loaded as JSON.
+    """
+    return SafeString(json.dumps(value))


### PR DESCRIPTION
Partly closes #4246

---

Requires #4421 to be merged first!

---

**Changes**

* Added template variable and generic `as_json` tag
* Documented shape of template var and meaning of the data

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
