### PR TITLE
[#4400] Fix email digest concerning invalid JSON logic expressions

### DIFF
--- a/src/openforms/emails/templates/emails/admin_digest.html
+++ b/src/openforms/emails/templates/emails/admin_digest.html
@@ -136,11 +136,19 @@
         <ul>
         {% for logic_rule in invalid_logic_rules %}
             <li>
+                {% if logic_rule.exception %}
+                    <p>
+                        {% blocktranslate with index=logic_rule.rule_index form_name=logic_rule.form_name trimmed %}
+                            We couldn't process logic rule {{ index }} for '{{ form_name }}' because it appears to be invalid. <br>
+                        {% endblocktranslate %}
+                    </p>
+                {% else %}
                 <p>
                     {% blocktranslate with var=logic_rule.variable form_name=logic_rule.form_name trimmed %}
                         Logic rule for variable '{{ var }}' is invalid in form '{{ form_name }}'.<br>
                     {% endblocktranslate %}
                 </p>
+                {% endif %}
                 <p><a href="{{ logic_rule.admin_link }}">{% trans "View form" %}</a></p>
             </li>
         {% endfor %}

--- a/src/openforms/emails/tests/test_tasks_integration.py
+++ b/src/openforms/emails/tests/test_tasks_integration.py
@@ -182,6 +182,10 @@ class EmailDigestTaskIntegrationTests(TestCase):
                 form=form,
                 json_logic_trigger={"==": [{"var": "foo"}, "apple"]},
             )
+            FormLogicFactory(
+                form=form,
+                json_logic_trigger={"custom_operator": [5, 3]},
+            )
 
             with (
                 open(TEST_FILES / "test2.certificate", "r") as client_certificate_f,
@@ -273,6 +277,10 @@ class EmailDigestTaskIntegrationTests(TestCase):
             self.assertIn(admin_form_url, sent_email.body)
 
         with self.subTest("invalid logic rules"):
+            self.assertIn(
+                f"We couldn't process logic rule 2 for '{form.admin_name}' because it appears to be invalid.",
+                sent_email.body,
+            )
             self.assertIn(
                 f"Logic rule for variable 'foo' is invalid in form '{form.admin_name}'.",
                 sent_email.body,


### PR DESCRIPTION
Closes #4400

**Changes**

- Added regression tests
- Handle exceptions in broken JSON logic rules

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
