### PR TITLE
Bump DRF & tinymce dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21546,9 +21546,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinymce": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
-      "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.4.tgz",
+      "integrity": "sha512-okoJyxuPv1gzASxQDNgQbnUXOdAIyoOSXcXcZZu7tiW0PSKEdf3SdASxPBupRj+64/E3elHwVRnzSdo82Emqbg=="
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
@@ -38812,9 +38812,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinymce": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
-      "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.4.tgz",
+      "integrity": "sha512-okoJyxuPv1gzASxQDNgQbnUXOdAIyoOSXcXcZZu7tiW0PSKEdf3SdASxPBupRj+64/E3elHwVRnzSdo82Emqbg=="
     },
     "tinyspy": {
       "version": "2.2.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -121,6 +121,7 @@ django==4.2.11
     #   django-simple-certmanager
     #   django-solo
     #   django-timeline-logger
+    #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
     #   djangorestframework
@@ -216,7 +217,7 @@ django-solo==2.1.0
     #   zgw-consumers
 django-timeline-logger==4.0.0
     # via -r requirements/base.in
-django-tinymce==3.6.1
+django-tinymce==4.1.0
     # via -r requirements/base.in
 django-treebeard==4.7
     # via -r requirements/base.in
@@ -224,7 +225,7 @@ django-two-factor-auth[phonenumberslite,webauthn]==1.16.0
     # via maykin-2fa
 django-yubin==2.0.4
     # via -r requirements/base.in
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -r requirements/base.in
     #   drf-jsonschema-serializer
@@ -407,7 +408,6 @@ python-magic==0.4.27
 pytz==2022.2.1
     # via
     #   django-yubin
-    #   djangorestframework
     #   flower
     #   zeep
 pytz-deprecation-shim==0.1.0.post0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -201,6 +201,7 @@ django==4.2.11
     #   django-simple-certmanager
     #   django-solo
     #   django-timeline-logger
+    #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
     #   djangorestframework
@@ -367,7 +368,7 @@ django-timeline-logger==4.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-tinymce==3.6.1
+django-tinymce==4.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -387,7 +388,7 @@ django-yubin==2.0.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -804,7 +805,6 @@ pytz==2022.2.1
     #   -r requirements/base.txt
     #   babel
     #   django-yubin
-    #   djangorestframework
     #   flower
     #   zeep
 pytz-deprecation-shim==0.1.0.post0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -225,6 +225,7 @@ django==4.2.11
     #   django-simple-certmanager
     #   django-solo
     #   django-timeline-logger
+    #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
     #   djangorestframework
@@ -401,7 +402,7 @@ django-timeline-logger==4.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-tinymce==3.6.1
+django-tinymce==4.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -423,7 +424,7 @@ django-yubin==2.0.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -918,7 +919,6 @@ pytz==2022.2.1
     #   -r requirements/ci.txt
     #   babel
     #   django-yubin
-    #   djangorestframework
     #   flower
     #   zeep
 pytz-deprecation-shim==0.1.0.post0

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -166,6 +166,7 @@ django==4.2.11
     #   django-simple-certmanager
     #   django-solo
     #   django-timeline-logger
+    #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
     #   djangorestframework
@@ -323,7 +324,7 @@ django-timeline-logger==4.0.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-django-tinymce==3.6.1
+django-tinymce==4.1.0
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -340,7 +341,7 @@ django-yubin==2.0.4
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
-djangorestframework==3.14.0
+djangorestframework==3.15.2
     # via
     #   -c requirements/base.in
     #   -r requirements/base.txt
@@ -650,7 +651,6 @@ pytz==2022.2.1
     # via
     #   -r requirements/base.txt
     #   django-yubin
-    #   djangorestframework
     #   flower
     #   zeep
 pytz-deprecation-shim==0.1.0.post0

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8823,6 +8823,9 @@ components:
       - version
     PaginatedFormDefinitionList:
       type: object
+      required:
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -8850,6 +8853,9 @@ components:
             $ref: '#/components/schemas/PublicForm'
     PaginatedServiceFetchConfigurationList:
       type: object
+      required:
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -8870,6 +8876,9 @@ components:
             $ref: '#/components/schemas/ServiceFetchConfiguration'
     PaginatedSubmissionList:
       type: object
+      required:
+      - count
+      - results
       properties:
         count:
           type: integer

--- a/src/openforms/api/tests/test_validators.py
+++ b/src/openforms/api/tests/test_validators.py
@@ -104,11 +104,6 @@ def validate_not_staff(user: User):
         raise ValidationError({"is_staff": err})
 
 
-def validate_non_field_attrs_not_set(user: User):
-    if hasattr(user, "extra_field"):
-        raise ValidationError("Non-model field attr set", code="bad_attr")
-
-
 class UserSerializer(serializers.ModelSerializer):
     extra_field = serializers.CharField(required=False)
 
@@ -119,6 +114,7 @@ class UserSerializer(serializers.ModelSerializer):
             "username": {
                 "validators": []
             },  # disable unique validator which does queries
+            "email": {"validators": []},  # disable unique validator which does queries
         }
         validators = [
             ModelValidator[User](validate_not_staff),

--- a/src/openforms/api/urls.py
+++ b/src/openforms/api/urls.py
@@ -45,7 +45,7 @@ forms_router.register(r"versions", FormVersionViewSet, basename="form-versions")
 
 # form decoration
 # Expose this endpoint on 2 different URLs
-router.register(r"categories", CategoryViewSet, basename="categories")
+router.register(r"categories", CategoryViewSet, basename="legacy-categories")
 router.register(r"public/categories", CategoryViewSet, basename="categories")
 
 # submissions API

--- a/src/openforms/api/validators.py
+++ b/src/openforms/api/validators.py
@@ -58,7 +58,7 @@ class ModelValidator(Generic[MT]):
     ...         })
     ...
 
-    Then `ModelValidator(validate_service_has_oas)` will be validator you can use on a
+    Then `ModelValidator(validate_service_has_oas)` will be a validator you can use on a
     Serializer.
 
     You can annotate `ModelValidator` with a type:


### PR DESCRIPTION
django-tinymce upgrade aligns the tinymce versions used in React and the admin, so that's nice. The breaking changes don't appear to affect us (but CI can say otherwise of course).

The DRF upgrade is a YOLO - we'll see what breaks in this PR :grimacing: 