### PR TITLE
Fix another flaky test when intercepting/spying on API calls

### DIFF
--- a/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
+++ b/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
@@ -81,7 +81,12 @@ class FormDesignerRegistrationBackendConfigTests(E2ETestCase):
 
         def collect_requests(request):
             url = furl(request.url)
-            match = resolve(url.path)
+            try:
+                match = resolve(str(url.path))
+            except Resolver404:
+                print(f"Failed to resolve URL: {request.url}")
+                log_flaky()
+                return
 
             if match.view_name == "api:iotypen-list":
                 requests_to_endpoint.append(request)


### PR DESCRIPTION
Webkit seems to make requests to some 'srcdoc' somewhere that we have no idea about... Surpressing it should be fine, but logging it to make the problem more visible in CI seems appropriate.