### PR TITLE
Keep username/password form/2fa form visible

### DIFF
--- a/src/openforms/js/components/admin/login.js
+++ b/src/openforms/js/components/admin/login.js
@@ -5,11 +5,22 @@ const addAdminLoginExpand = () => {
   const loginForm = document.querySelector('#login-form');
 
   if (defaultLoginToggle && loginForm) {
-    defaultLoginToggle.addEventListener('click', e => {
-      e.preventDefault();
+    const showLoginForm = () => {
       loginForm.classList.toggle('login-form--enabled');
       defaultLoginToggle.classList.toggle('admin-login-option--disabled');
+    };
+
+    // bind click event
+    defaultLoginToggle.addEventListener('click', e => {
+      e.preventDefault();
+      showLoginForm();
     });
+
+    // if the form is bound, there is feedback, so toggle it to visible
+    const {bound, wizardstep} = defaultLoginToggle.dataset;
+    if (bound === 'true' || wizardstep !== 'auth') {
+      showLoginForm();
+    }
   }
 };
 

--- a/src/openforms/templates/maykin_2fa/login.html
+++ b/src/openforms/templates/maykin_2fa/login.html
@@ -4,9 +4,15 @@
 {% block extra_login_options %}
     {% get_solo 'mozilla_django_oidc_db.OpenIDConnectConfig' as oidc_config %}
     {% if oidc_config.enabled %}
-        <div class="admin-login-option admin-login-option--password">
+
+        <div
+            class="admin-login-option admin-login-option--password"
+            data-bound="{{ form.is_bound|yesno:'true,false' }}"
+            data-wizardstep="{{ wizard.steps.current }}"
+        >
             <a href="#">{% trans "Login with application account" %}</a>
         </div>
+
         <div class="admin-login-divider"><span>{% trans "or" %}</span></div>
         <div class="admin-login-option admin-login-option--oidc">
             <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>


### PR DESCRIPTION
The JS approach to toggle this does not play well with the markup in the library templates, so we need to resort to programmatically clicking the show link. IMO this feature request was rushed and it leads to this kind of fragile code to deal with that fallout from that :/

Closes #4429 

**Changes**

* Added meta-information about login-phase to DOM
* Added JS triggers to toggle visibility depending on meta-information/state of login flow

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
