### PR TITLE
:bug: [#4450] Fix submission PDF rows overlapping

### DIFF
--- a/src/openforms/scss/pdfs/_submission-step-row.scss
+++ b/src/openforms/scss/pdfs/_submission-step-row.scss
@@ -1,6 +1,9 @@
 @import '~microscope-sass/lib/typography';
 
 .submission-step-row {
+  // TODO this fixes overlap on next page but also adds empty pages in case of long values
+  break-inside: avoid-page;
+
   & + & {
     margin-top: 1mm;
   }
@@ -59,5 +62,12 @@
     > * {
       max-width: 100%;
     }
+  }
+
+  // Avoid rows from overlapping in case the field label is more than 1 line (#4450)
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
   }
 }


### PR DESCRIPTION
previously, rows could overlap if the field labels were longer more than one line

Closes #4450 

**Changes**

* Fix submission PDF rows overlapping

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
