### PR TITLE
[#4423] Update form builder to v0.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.22.0",
+        "@open-formulieren/formio-builder": "^0.23.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@rjsf/core": "^4.2.1",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -4678,9 +4678,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.22.0.tgz",
-      "integrity": "sha512-wavc+/GgXKFWLYR7yDoU/k+nBnh6MID3hJM76j0Cg4tbRK4SeF6J+vw9OReYiVCsIN76jmIthbhhmu5VmWONUg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.23.0.tgz",
+      "integrity": "sha512-TCQPMpBdcbU2w/Wsu+ZpHZUf42jpZSW1QZeXqC1A7dEuCtLy1Qd29pDV4RmhoVXGx0f6acUIs5u7eeuDuymSww==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",
@@ -26356,9 +26356,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.22.0.tgz",
-      "integrity": "sha512-wavc+/GgXKFWLYR7yDoU/k+nBnh6MID3hJM76j0Cg4tbRK4SeF6J+vw9OReYiVCsIN76jmIthbhhmu5VmWONUg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.23.0.tgz",
+      "integrity": "sha512-TCQPMpBdcbU2w/Wsu+ZpHZUf42jpZSW1QZeXqC1A7dEuCtLy1Qd29pDV4RmhoVXGx0f6acUIs5u7eeuDuymSww==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.22.0",
+    "@open-formulieren/formio-builder": "^0.23.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@rjsf/core": "^4.2.1",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -1129,6 +1129,7 @@ class FormDesignerRegressionTests(E2ETestCase):
             await page.get_by_role("tab", name="Steps and fields").click()
             await open_component_options_modal(page, "Field 2")
             await page.get_by_role("tab", name="Location").click()
+            await page.get_by_role("button", name="Configuration (deprecated)").click()
 
             dropdown = page.get_by_role("combobox", name="Postcode component")
             await dropdown.focus()
@@ -1193,6 +1194,7 @@ class FormDesignerRegressionTests(E2ETestCase):
             await page.get_by_role("tab", name="Steps and fields").click()
             await open_component_options_modal(page, "Field 1")
             await page.get_by_role("tab", name="Location").click()
+            await page.get_by_role("button", name="Configuration (deprecated)").click()
 
             dropdown = page.get_by_role("combobox", name="Postcode component")
             await dropdown.focus()

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2777,6 +2777,12 @@
       "value": "The placeholder text that will appear when this field is empty."
     }
   ],
+  "Tw9+0D": [
+    {
+      "type": 0,
+      "value": "Layout"
+    }
+  ],
   "U/t6b+": [
     {
       "type": 0,
@@ -2861,6 +2867,12 @@
     {
       "type": 0,
       "value": "File"
+    }
+  ],
+  "V2/ceD": [
+    {
+      "type": 0,
+      "value": "Configuration (deprecated)"
     }
   ],
   "V21YkS": [
@@ -3873,6 +3885,12 @@
     {
       "type": 0,
       "value": "Amount of days incomplete submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+    }
+  ],
+  "fGTdJz": [
+    {
+      "type": 0,
+      "value": "Deriving the location via text fields is deprecated. Use the AddressNL component instead."
     }
   ],
   "fLCWjk": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2777,6 +2777,12 @@
       "value": "De placeholder-tekst die verschijnt als dit veld leeg is."
     }
   ],
+  "Tw9+0D": [
+    {
+      "type": 0,
+      "value": "Weergave"
+    }
+  ],
   "U/t6b+": [
     {
       "type": 0,
@@ -2861,6 +2867,12 @@
     {
       "type": 0,
       "value": "Bestand"
+    }
+  ],
+  "V2/ceD": [
+    {
+      "type": 0,
+      "value": "Instellingen (verouderd)"
     }
   ],
   "V21YkS": [
@@ -3878,6 +3890,12 @@
     {
       "type": 0,
       "value": "Aantal dagen dat een sessie bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken."
+    }
+  ],
+  "fGTdJz": [
+    {
+      "type": 0,
+      "value": "Het afleiden van adres via tekstveld-componenten is verouderd. Gebruik in de plaats de 'AddressNL'-component (in de 'Speciale velden' groep)."
     }
   ],
   "fLCWjk": [


### PR DESCRIPTION
Closes #4423

**Changes**

- Update formbuilder to v0.23.0 (contains the new layout dropdown for single/double column in the addressNl component)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
