### PR TITLE
[#4416] Add ontvangstdatum attribute for attachments in ZGW and ObjectsAPI backends

### DIFF
--- a/src/openforms/contrib/zgw/clients/documenten.py
+++ b/src/openforms/contrib/zgw/clients/documenten.py
@@ -28,6 +28,7 @@ class DocumentenClient(NLXClient):
         content: ContentFile | BinaryIO,
         status: DocumentStatus,
         filename: str,
+        received_date: str | None = None,
         description: str = "",
         vertrouwelijkheidaanduiding: str = "",
     ):
@@ -46,6 +47,7 @@ class DocumentenClient(NLXClient):
             "inhoud": base64_body,
             "status": status,
             "bestandsnaam": filename,
+            "ontvangstdatum": received_date,
             "beschrijving": description,
             "indicatieGebruiksrecht": False,
             "bestandsomvang": (

--- a/src/openforms/contrib/zgw/service.py
+++ b/src/openforms/contrib/zgw/service.py
@@ -84,6 +84,7 @@ def create_attachment_document(
             status="definitief",
             filename=submission_attachment.get_display_name(),
             description="Bijgevoegd document",
+            received_date=options["ontvangstdatum"],
             vertrouwelijkheidaanduiding=options.get(
                 "doc_vertrouwelijkheidaanduiding", ""
             ),

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -31,6 +31,7 @@ from openforms.submissions.models import (
     SubmissionReport,
 )
 from openforms.typing import JSONObject
+from openforms.utils.date import datetime_in_amsterdam
 from openforms.variables.constants import FormVariableSources
 from openforms.variables.service import get_static_variables
 from openforms.variables.utils import get_variables_for_context
@@ -147,6 +148,14 @@ def register_submission_attachment(
             "doc_vertrouwelijkheidaanduiding": "doc_vertrouwelijkheidaanduiding",
         },
     )
+
+    # this helps the type checker in narrowing the type
+    # and expressing that it should not happen that submission.completed_on is not set
+    assert submission.completed_on is not None
+    attachment_options["ontvangstdatum"] = (
+        datetime_in_amsterdam(submission.completed_on).date().isoformat()
+    )
+
     component_overwrites = {
         "doc_vertrouwelijkheidaanduiding": attachment.doc_vertrouwelijkheidaanduiding,
         "titel": attachment.titel,

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -863,6 +863,7 @@ class ObjectsAPIBackendV1Tests(TestCase):
                 "https://catalogi.nl/api/v1/informatieobjecttypen/3",
             )
             self.assertNotIn("vertrouwelijkheidaanduiding", attachment1_create_data)
+            self.assertIsNotNone(attachment1_create_data["ontvangstdatum"])
 
         with self.subTest("Document create (attachment 2)"):
             attachment2_create_data = attachment2_create.json()
@@ -878,6 +879,7 @@ class ObjectsAPIBackendV1Tests(TestCase):
                 "https://catalogi.nl/api/v1/informatieobjecttypen/3",
             )
             self.assertNotIn("vertrouwelijkheidaanduiding", attachment2_create_data)
+            self.assertIsNotNone(attachment2_create_data["ontvangstdatum"])
 
     def test_submission_with_objects_api_backend_attachments_specific_iotypen(self, m):
         submission = SubmissionFactory.from_components(
@@ -898,6 +900,7 @@ class ObjectsAPIBackendV1Tests(TestCase):
                 },
             ],
             language_code="en",
+            completed=True,
         )
         submission_step = submission.steps[0]
         SubmissionFileAttachmentFactory.create(
@@ -1050,6 +1053,7 @@ class ObjectsAPIBackendV1Tests(TestCase):
                 ],
             },
             language_code="en",
+            completed=True,
         )
         submission_step = submission.steps[0]
         SubmissionFileAttachmentFactory.create(
@@ -1177,6 +1181,7 @@ class ObjectsAPIBackendV1Tests(TestCase):
                 ],
             },
             language_code="en",
+            completed=True,
         )
         submission_step = submission.steps[0]
         SubmissionFileAttachmentFactory.create(

--- a/src/openforms/registrations/contrib/objects_api/tests/test_template.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_template.py
@@ -35,6 +35,7 @@ class JSONTemplatingTests(TestCase):
             submitted_data={"voorNaam": "Jane", "achterNaam": "Doe"},
             form_definition_kwargs={"slug": "test-step-tralala"},
             auth_info__value="123456789",
+            completed=True,
         )
         SubmissionFileAttachmentFactory.create(submission_step=submission.steps[0])
         config = ObjectsAPIConfig(
@@ -152,6 +153,7 @@ class JSONTemplatingTests(TestCase):
             form_definition_kwargs={"slug": "test-step-tralala"},
             auth_info__attribute="bsn",
             auth_info__value="123456789",
+            completed=True,
         )
         SubmissionFileAttachmentFactory.create(submission_step=submission.steps[0])
         m.post("https://objecten.nl/api/v1/objects", status_code=201, json={})

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -22,6 +22,7 @@ from openforms.registrations.contrib.objects_api.client import get_objects_clien
 from openforms.registrations.contrib.objects_api.models import ObjectsAPIGroupConfig
 from openforms.submissions.mapping import SKIP, FieldConf, apply_data_mapping
 from openforms.submissions.models import Submission, SubmissionReport
+from openforms.utils.date import datetime_in_amsterdam
 from openforms.variables.utils import get_variables_for_context
 
 from ...base import BasePlugin, PreRegistrationResult
@@ -319,6 +320,14 @@ class ZGWRegistration(BasePlugin):
                     "organisatie_rsin": bronorganisatie,
                     "titel": titel,
                 }
+
+                # this helps the type checker in narrowing the type
+                # and expressing that it should not happen that submission.completed_on is not set
+                assert submission.completed_on is not None
+                doc_options["ontvangstdatum"] = (
+                    datetime_in_amsterdam(submission.completed_on).date().isoformat()
+                )
+
                 if vertrouwelijkheidaanduiding:
                     doc_options["doc_vertrouwelijkheidaanduiding"] = (
                         vertrouwelijkheidaanduiding

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_zgw_api_config.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_zgw_api_config.py
@@ -294,6 +294,7 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
             submitted_data={
                 "field1": "Foo",
             },
+            completed=True,
         )
         # Configure to use the second ZGW API
         SubmissionFileAttachmentFactory.create(
@@ -328,6 +329,7 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
         submission = SubmissionFactory.from_components(
             [{"key": "field1", "type": "file"}],
             submitted_data={"field1": "Foo"},
+            completed=True,
         )
         SubmissionFileAttachmentFactory.create(
             submission_step=submission.steps[0],
@@ -416,6 +418,7 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
             submitted_data={
                 "field1": "Foo",
             },
+            completed=True,
         )
         SubmissionFileAttachmentFactory.create(
             submission_step=submission.steps[0],


### PR DESCRIPTION
Closes #4416 (first bullet)

- Added `ontvangstdatum` to the data sent to ObjectsAPI and ZGW
- Tested with both registration backends and the date is sent as expected

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
