### PR TITLE
Fix too-optimistic assert in auth context data calculation

### DIFF
--- a/src/openforms/api/tests/test_error_format.py
+++ b/src/openforms/api/tests/test_error_format.py
@@ -1,7 +1,11 @@
+from unittest.mock import patch
+
+from django.test import tag
 from django.utils.translation import gettext as _
 
 from rest_framework.test import APIRequestFactory, APITestCase
 
+from ..views import exception_handler
 from . import error_views as views
 
 
@@ -170,3 +174,15 @@ class ExceptionHandlerTests(APITestCase):
                 "detail": _("Everything broke"),
             },
         )
+
+    @tag("gh-4505")
+    @patch.dict("os.environ", {"DEBUG": "no"})
+    def test_assertion_error_crash(self):
+        exc = AssertionError()
+
+        try:
+            result = exception_handler(exc, context={})
+        except Exception:
+            raise self.failureException("Exception handler may not crash")
+
+        self.assertIsNotNone(result)

--- a/src/openforms/api/views/views.py
+++ b/src/openforms/api/views/views.py
@@ -38,7 +38,8 @@ def exception_handler(exc, context):
         if os.getenv("DEBUG", "").lower() in ["yes", "1", "true"]:
             return None
 
-        logger.exception(exc.args[0], exc_info=1)
+        exc_message = args[0] if (args := exc.args) else type(exc).__name__
+        logger.exception(exc_message, exc_info=True)
 
         # unkown type, so we use the generic Internal Server Error
         exc = drf_exceptions.APIException("Internal Server Error")

--- a/src/openforms/authentication/models.py
+++ b/src/openforms/authentication/models.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Collection
 
 from django.contrib.auth.hashers import make_password as get_salted_hash
@@ -20,6 +21,8 @@ from .types import (
     EHerkenningContext,
     EHerkenningMachtigenContext,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BaseAuthInfo(models.Model):
@@ -262,7 +265,12 @@ class AuthInfo(BaseAuthInfo):
         | EHerkenningContext
         | EHerkenningMachtigenContext
     ):
-        assert not self.attribute_hashed
+        if self.attribute_hashed:
+            logger.debug(
+                "Authentication attributes are (already) hashed, using these values "
+                "can lead to unexpected results.",
+                extra={"auth_info": self.pk},
+            )
 
         match (self.attribute, self.legal_subject_identifier_type):
             # DigiD without machtigen/mandate


### PR DESCRIPTION
Partly closes #4505

**Changes**

* Fixed a bug in the DRF exception handler - `Exception.args` can be empty
* Removed hard `assert` in `AuthInfo.to_auth_context_data`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
