### PR TITLE
[#4505] Add missing addressNL fields to the confirmation pdf

### DIFF
--- a/src/openforms/formio/formatters/custom.py
+++ b/src/openforms/formio/formatters/custom.py
@@ -1,11 +1,14 @@
 # TODO implement: iban, bsn, postcode, licenseplate, npFamilyMembers, cosign
+from typing import TypedDict
+
 from django.template.defaultfilters import date as fmt_date, time as fmt_time
 from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
-from openforms.contrib.brk.constants import AddressValue
+from typing_extensions import NotRequired
 
-from ..typing import Component
+from ..typing import AddressNLComponent, Component
 from .base import FormatterBase
 
 
@@ -26,17 +29,52 @@ class MapFormatter(FormatterBase):
         return ", ".join((str(x) for x in value))
 
 
+class AddressValue(TypedDict):
+    """
+    Redefined, as the BRK structure is converted to snake_case.
+
+    The Formio data is not transformed, and it stays camelCased. So while it's the same
+    data, the shape is different.
+    """
+
+    postcode: str
+    houseNumber: str
+    houseLetter: NotRequired[str]
+    houseNumberAddition: NotRequired[str]
+    city: NotRequired[str]
+    streetName: NotRequired[str]
+    secretStreetCity: NotRequired[str]
+
+
 class AddressNLFormatter(FormatterBase):
 
     empty_values = ({},)
 
-    def format(self, component: Component, value: AddressValue) -> str:
+    def format(self, component: AddressNLComponent, value: AddressValue) -> str:
         value = value.copy()
         value.setdefault("houseLetter", "")
         value.setdefault("houseNumberAddition", "")
-        return format_html(
-            "{postcode} {houseNumber}{houseLetter} {houseNumberAddition}", **value
-        ).strip()
+        value.setdefault("city", "")
+        value.setdefault("streetName", "")
+
+        short_template = "{postcode} {houseNumber}{houseLetter} {houseNumberAddition}"
+        full_template = (
+            "{streetName} {houseNumber}{houseLetter} {houseNumberAddition}"
+            "{sep}{postcode} {city}"
+        )
+
+        # setdefault doesn't narrow it for the type checker :(
+        assert "city" in value
+        assert "streetName" in value
+        template = (
+            full_template if (value["city"] or value["streetName"]) else short_template
+        )
+
+        if self.as_html:
+            sep = mark_safe("<br>")
+            return format_html(template, sep=sep, **value)
+
+        return template.format(sep="\n", **value).strip()
 
 
 class CosignFormatter(FormatterBase):

--- a/src/openforms/formio/formatters/tests/test_default_formatters.py
+++ b/src/openforms/formio/formatters/tests/test_default_formatters.py
@@ -138,3 +138,33 @@ class DefaultFormatterTestCase(TestCase):
             formatted_html,
             "1234AA 1",
         )
+
+    def test_addressnl_html(self):
+        component = {
+            "type": "addressNL",
+            "key": "addressNL",
+        }
+
+        value = {
+            "postcode": "1234AA",
+            "houseNumber": "1",
+            "streetName": "test",
+            "houseLetter": "A",
+            "houseNumberAddition": "DD",
+            "city": "Amsterdam",
+        }
+
+        with self.subTest("as_html False"):
+            formatted_value = format_value(component, value, as_html=False)
+
+            self.assertEqual(
+                formatted_value,
+                "test 1A DD\n1234AA Amsterdam",
+            )
+        with self.subTest("as_html True"):
+            formatted_html = format_value(component, value, as_html=True)
+
+            self.assertHTMLEqual(
+                formatted_html,
+                "test 1A DD<br>1234AA Amsterdam",
+            )

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -1062,6 +1062,7 @@ class SingleAddressNLTests(ValidationsTestCase):
                     "houseLetter": "A",
                     "houseNumberAddition": "",
                 },
+                "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB).",
             ),
             (
                 "houseNumber",
@@ -1071,6 +1072,7 @@ class SingleAddressNLTests(ValidationsTestCase):
                     "houseLetter": "A",
                     "houseNumberAddition": "",
                 },
+                "Huisnummer moet een nummer zijn met maximaal 5 cijfers (bijv. 456).",
             ),
             (
                 "houseLetter",
@@ -1080,6 +1082,7 @@ class SingleAddressNLTests(ValidationsTestCase):
                     "houseLetter": "89",
                     "houseNumberAddition": "",
                 },
+                "Huisletter moet een enkele letter zijn.",
             ),
             (
                 "houseNumberAddition",
@@ -1089,14 +1092,15 @@ class SingleAddressNLTests(ValidationsTestCase):
                     "houseLetter": "A",
                     "houseNumberAddition": "9999A",
                 },
+                "Huisnummertoevoeging moet bestaan uit maximaal vier letters en cijfers.",
             ),
         ]
 
-        for field_name, invalid_data in test_cases:
+        for field_name, invalid_data, expected_error in test_cases:
             with self.subTest(field_name):
                 self.assertAddressNLValidationIsAligned(
                     component,
                     ui_inputs=invalid_data,
                     api_value=invalid_data,
-                    expected_ui_error="Ongeldig.",
+                    expected_ui_error=expected_error,
                 )


### PR DESCRIPTION
Partly fixes #4505

**Changes**

- Added missing `city` and `streetName` fields to the confirmation pdf

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
