### PR TITLE
Remove storing upload IDs in the session

### DIFF
--- a/src/openforms/formio/api/views.py
+++ b/src/openforms/formio/api/views.py
@@ -16,7 +16,6 @@ from openforms.submissions.api.permissions import AnyActiveSubmissionPermission
 from openforms.submissions.api.renderers import PlainTextErrorRenderer
 from openforms.submissions.attachments import clean_mime_type
 from openforms.submissions.models import TemporaryFileUpload
-from openforms.submissions.utils import add_upload_to_session
 
 from .serializers import TemporaryFileUploadSerializer
 
@@ -73,8 +72,6 @@ class TemporaryFileUploadView(GenericAPIView):
             content_type=clean_mime_type(file.content_type),
             file_size=file.size,
         )
-        add_upload_to_session(upload, self.request.session)
-
         return Response(
             self.serializer_class(instance=upload, context={"request": request}).data
         )

--- a/src/openforms/submissions/api/mixins.py
+++ b/src/openforms/submissions/api/mixins.py
@@ -11,11 +11,7 @@ from ..models import Submission
 from ..signals import submission_complete
 from ..tasks import on_post_submission_event
 from ..tokens import submission_status_token_generator
-from ..utils import (
-    persist_user_defined_variables,
-    remove_submission_from_session,
-    remove_submission_uploads_from_session,
-)
+from ..utils import persist_user_defined_variables, remove_submission_from_session
 
 
 class SubmissionCompletionMixin:
@@ -46,7 +42,6 @@ class SubmissionCompletionMixin:
         logevent.form_submit_success(submission)
 
         remove_submission_from_session(submission, self.request.session)
-        remove_submission_uploads_from_session(submission, self.request.session)
 
         # after committing the database transaction where the submissions completion is
         # stored, start processing the completion.

--- a/src/openforms/submissions/api/views.py
+++ b/src/openforms/submissions/api/views.py
@@ -11,7 +11,6 @@ from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.serializers import ExceptionSerializer
 
 from ..models import SubmissionReport, TemporaryFileUpload
-from ..utils import remove_upload_from_session
 from .permissions import (
     DownloadSubmissionReportPermission,
     OwnsTemporaryUploadPermission,
@@ -107,6 +106,4 @@ class TemporaryFileView(DestroyAPIView):
         # delete files from disc as well if they had been already
         # saved when trying to access the next form step
         instance.attachments.all().delete()
-
-        remove_upload_from_session(instance, self.request.session)
         instance.delete()

--- a/src/openforms/submissions/constants.py
+++ b/src/openforms/submissions/constants.py
@@ -2,7 +2,6 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 SUBMISSIONS_SESSION_KEY = "form-submissions"
-UPLOADS_SESSION_KEY = "form-uploads"
 
 IMAGE_COMPONENTS = ["signature"]
 

--- a/src/openforms/submissions/tests/mixins.py
+++ b/src/openforms/submissions/tests/mixins.py
@@ -3,8 +3,8 @@ from rest_framework.reverse import reverse
 from openforms.middleware import CSRF_TOKEN_HEADER_NAME
 from openforms.utils.tests.cache import clear_caches
 
-from ..constants import SUBMISSIONS_SESSION_KEY, UPLOADS_SESSION_KEY
-from ..models import Submission, TemporaryFileUpload
+from ..constants import SUBMISSIONS_SESSION_KEY
+from ..models import Submission
 
 
 class SubmissionsMixin:
@@ -19,17 +19,9 @@ class SubmissionsMixin:
         session[SUBMISSIONS_SESSION_KEY] = ids
         session.save()
 
-    def _add_upload_to_session(self, upload: TemporaryFileUpload):
-        session = self.client.session
-        ids = session.get(UPLOADS_SESSION_KEY, [])
-        ids += [str(upload.uuid)]
-        session[UPLOADS_SESSION_KEY] = ids
-        session.save()
-
     def _clear_session(self):
         session = self.client.session
         session[SUBMISSIONS_SESSION_KEY] = []
-        session[UPLOADS_SESSION_KEY] = []
         session.save()
 
     def _get_session_submission_uuids(self):

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -28,15 +28,10 @@ from openforms.logging import logevent
 from openforms.utils.urls import build_absolute_uri
 from openforms.variables.constants import FormVariableSources
 
-from .constants import SUBMISSIONS_SESSION_KEY, UPLOADS_SESSION_KEY
+from .constants import SUBMISSIONS_SESSION_KEY
 from .exceptions import FormDeactivated, FormMaintenance
 from .form_logic import check_submission_logic
-from .models import (
-    Submission,
-    SubmissionReport,
-    SubmissionValueVariable,
-    TemporaryFileUpload,
-)
+from .models import Submission, SubmissionReport, SubmissionValueVariable
 from .tokens import submission_report_token_generator
 
 logger = logging.getLogger(__name__)
@@ -160,29 +155,6 @@ def remove_submission_from_session(
     Remove the submission UUID from the session if it's present.
     """
     remove_from_session_list(session, SUBMISSIONS_SESSION_KEY, str(submission.uuid))
-
-
-def add_upload_to_session(upload: TemporaryFileUpload, session: SessionBase) -> None:
-    """
-    Store the upload UUID in the request session for authorization checks.
-    """
-    append_to_session_list(session, UPLOADS_SESSION_KEY, str(upload.uuid))
-
-
-def remove_upload_from_session(
-    upload: TemporaryFileUpload, session: SessionBase
-) -> None:
-    """
-    Remove the submission UUID from the session if it's present.
-    """
-    remove_from_session_list(session, UPLOADS_SESSION_KEY, str(upload.uuid))
-
-
-def remove_submission_uploads_from_session(
-    submission: Submission, session: SessionBase
-) -> None:
-    for attachment in submission.get_attachments().filter(temporary_file__isnull=False):
-        remove_upload_from_session(attachment.temporary_file, session)
 
 
 def send_confirmation_email(submission: Submission) -> None:


### PR DESCRIPTION
Closes #4492

**Changes**

This is no longer necessary now that we relate the temporary upload to a submission (session) - we can use the submission authorization checks for upload ownership checks.

This removes a source of race conditions, as we have one less array of UUIDs to keep track of in the session, and especially file uploads were susceptible to this when multiple uploads are performed in parallel.

Additionally, it turns out there was more dead code in the permissions (`filter_queryset`) that was never called, and coverage reports also show it never was, so I deleted it too.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
