### PR TITLE
Add/enable environment information display in the admin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,11 @@ services:
       - USE_LEGACY_OIDC_ENDPOINTS=no
       - USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS=no
       - USE_LEGACY_ORG_OIDC_ENDPOINTS=no
+      # Environment labeling
+      - SHOW_ENVIRONMENT=yes
+      - ENVIRONMENT_LABEL=docker-compose
+      - ENVIRONMENT_BACKGROUND_COLOR=#1d63ed
+      - ENVIRONMENT_FOREGROUND_COLOR=white
     volumes: &web_volumes
       - media:/app/media
       - private_media:/app/private_media

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -245,6 +245,21 @@ Other settings
 * ``ENVIRONMENT``: Short string to indicate the environment (test, production,
   etc.) Defaults to ``""``.
 
+* ``SHOW_ENVIRONMENT``: Display environment information in the header in the admin.
+  Defaults to ``True``. Environment information is only displayed to logged in users.
+
+* ``ENVIRONMENT_LABEL``: Environment information to display, defaults to the value of
+  ``ENVIRONMENT``. Only displayed when ``SHOW_ENVIRONMENT`` is set to ``True``. You can
+  set this to strings like ``OpenGem PROD`` or simply ``PROD``, depending on your needs.
+
+* ``ENVIRONMENT_BACKGROUND_COLOR``: CSS color value for the environment information
+  background color. Defaults to ``orange``, example values can be specified in HEX
+  format too, e.g.: ``#FF0000`` for red.
+
+* ``ENVIRONMENT_FOREGROUND_COLOR``: CSS color value for the environment information
+  text color. Defaults to ``black``. Follows the same rules as
+  ``ENVIRONMENT_BACKGROUND_COLOR``.
+
 * ``GIT_SHA``: The Git commit hash belonging to the code running the instance.
   Defaults to the automatically determined commit hash, if the application is
   run from a checked out Git repository.

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -546,7 +546,12 @@ FIXTURE_DIRS = (os.path.join(DJANGO_PROJECT_DIR, "fixtures"),)
 #
 PROJECT_NAME = "Open Formulieren"
 ENVIRONMENT = config("ENVIRONMENT", "")
-SHOW_ALERT = True
+
+# Displaying environment information
+ENVIRONMENT_LABEL = config("ENVIRONMENT_LABEL", ENVIRONMENT)
+ENVIRONMENT_BACKGROUND_COLOR = config("ENVIRONMENT_BACKGROUND_COLOR", "orange")
+ENVIRONMENT_FOREGROUND_COLOR = config("ENVIRONMENT_FOREGROUND_COLOR", "black")
+SHOW_ENVIRONMENT = config("SHOW_ENVIRONMENT", default=True)
 
 if "GIT_SHA" in os.environ:
     GIT_SHA = config("GIT_SHA", "")

--- a/src/openforms/conf/production.py
+++ b/src/openforms/conf/production.py
@@ -47,11 +47,6 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_CONTENT_TYPE_NOSNIFF = True  # Sets X-Content-Type-Options: nosniff
 SECURE_BROWSER_XSS_FILTER = True  # Sets X-XSS-Protection: 1; mode=block
 
-#
-# Custom settings overrides
-#
-SHOW_ALERT = False
-
 ##############################
 #                            #
 # 3RD PARTY LIBRARY SETTINGS #

--- a/src/openforms/scss/admin/_admin_theme.scss
+++ b/src/openforms/scss/admin/_admin_theme.scss
@@ -236,26 +236,16 @@ div.breadcrumbs {
 }
 
 /**
- * Environment banner
+ * Environment information
  */
-.env {
+.env-info {
   display: block;
-  line-height: 35px;
-  text-align: center;
-  font-weight: bold;
-  text-transform: uppercase;
-  color: $color_secondary;
-  background-color: $color_dark;
-  position: fixed;
-  top: 0;
-  height: 35px;
-  width: 300px;
-  left: 50%;
-  margin-left: -150px;
-  z-index: 1000001;
-  box-shadow:
-    0 4px 8px 0 rgba(0, 0, 0, 0.2),
-    0 6px 20px 0 rgba(0, 0, 0, 0.2);
+  align-self: center;
+  padding-inline: 8px;
+  padding-block: 5px;
+  background-color: var(--of-env-info-background-color, var(--secondary));
+  color: var(--of-env-info-color, var(--primary-fg));
+  border-radius: 3px;
 }
 
 /**

--- a/src/openforms/templates/admin/base_site.html
+++ b/src/openforms/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-{% load i18n static multidomain %}
+{% load i18n static multidomain utils %}
 
 {% block title %}{{ title }} | {{ settings.PROJECT_NAME }}{% endblock %}
 
@@ -20,7 +20,10 @@
 {% endblock extrahead %}
 
 {% block branding %}
-    <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ settings.PROJECT_NAME }} {% trans 'Administration' %}</a></h1>
+    <h1 id="site-name">
+        <a href="{% url 'admin:index' %}">{{ settings.PROJECT_NAME }} {% trans "Administration" %}</a>
+    </h1>
+    {% environment_info %}
     {% if user.is_anonymous %}
       {% include "admin/color_theme_toggle.html" %}
     {% endif %}
@@ -59,13 +62,6 @@
 {# end block usertools #}
 
 {% block nav-global %}{% endblock %}
-
-{% block messages %}
-    {% if settings.ENVIRONMENT_SHOWN_IN_ADMIN %}
-        <div class="env env-{{ settings.ENVIRONMENT }}">{{ settings.ENVIRONMENT }}</div>
-    {% endif %}
-    {{ block.super }}
-{% endblock %}
 
 {% block footer %}
     <div id="footer">

--- a/src/openforms/utils/context_processors.py
+++ b/src/openforms/utils/context_processors.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.conf import settings as django_settings
 from django.template.defaultfilters import filesizeformat
 from django.utils import formats
@@ -5,16 +7,13 @@ from django.utils import formats
 
 def settings(request):
     public_settings = (
-        "GOOGLE_ANALYTICS_ID",
-        "ENVIRONMENT",
-        "SHOW_ALERT",
         "PROJECT_NAME",
         "RELEASE",
         "GIT_SHA",
         "PRIVACY_POLICY_URL",
     )
 
-    context = {
+    context: dict[str, Any] = {
         "settings": dict(
             [(k, getattr(django_settings, k, None)) for k in public_settings]
         ),

--- a/src/openforms/utils/templatetags/utils.py
+++ b/src/openforms/utils/templatetags/utils.py
@@ -5,6 +5,8 @@ Any template tag added to this file will automatically be added to the 'sandboxe
 """
 
 from django import template
+from django.conf import settings
+from django.utils.html import format_html
 
 register = template.Library()
 
@@ -15,3 +17,22 @@ def get_value(value: dict, value_key: str) -> str:
         return ""
 
     return str(value.get(value_key, ""))
+
+
+@register.simple_tag(takes_context=True)
+def environment_info(context) -> str:
+    if not settings.SHOW_ENVIRONMENT:
+        return ""
+    if (user := context.get("user")) is None or not user.is_authenticated:
+        return ""
+
+    return format_html(
+        """
+        <div class="env-info" style="--of-env-info-background-color: {bg_color}; --of-env-info-color: {color}">
+            {label}
+        </div>
+        """,
+        label=settings.ENVIRONMENT_LABEL,
+        bg_color=settings.ENVIRONMENT_BACKGROUND_COLOR,
+        color=settings.ENVIRONMENT_FOREGROUND_COLOR,
+    )

--- a/src/openforms/utils/tests/test_templatetags.py
+++ b/src/openforms/utils/tests/test_templatetags.py
@@ -1,9 +1,11 @@
-from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+from django.test import SimpleTestCase, override_settings
 
+from openforms.accounts.tests.factories import UserFactory
 from openforms.template import render_from_string
 
 
-class TemplateTagsTests(TestCase):
+class TemplateTagsTests(SimpleTestCase):
     def test_get_value(self):
         result = render_from_string(
             "{% get_value a_dictionary 'a key with spaces' %} {% get_value a_dictionary 'missingKey' %} {% get_value a_dictionary 'someKey' %}",
@@ -27,3 +29,35 @@ class TemplateTagsTests(TestCase):
         )
 
         self.assertEqual("", result)
+
+
+@override_settings(SHOW_ENVIRONMENT=True)
+class EnvironmentInfoTests(SimpleTestCase):
+
+    def _render(self, context=None):
+        tpl = r"{% environment_info %}"
+        return render_from_string(tpl, context=context or {}).strip()
+
+    @override_settings(SHOW_ENVIRONMENT=False)
+    def test_disabled_via_settings(self):
+        with self.subTest("without user"):
+            result = self._render()
+
+            self.assertEqual(result, "")
+
+        with self.subTest("with user"):
+            result = self._render({"user": UserFactory.build()})
+
+            self.assertEqual(result, "")
+
+    def test_anonymous_user(self):
+        result = self._render({"user": AnonymousUser()})
+
+        self.assertEqual(result, "")
+
+    @override_settings(ENVIRONMENT_LABEL="my super duper env")
+    def test_authenticated_user(self):
+        result = self._render({"user": UserFactory.build()})
+
+        self.assertNotEqual(result, "")
+        self.assertInHTML("my super duper env", result)


### PR DESCRIPTION
Closes #4456
Closes #4153

**Changes**

By default, environment information is now displayed in the admin:

![image](https://github.com/user-attachments/assets/ddee2d28-ead3-453e-8e2c-8efd58407757)

The content of the label, background color and text color can be set via environment variables so you can differentiate between environments more easily:

![image](https://github.com/user-attachments/assets/e5d1b650-b57b-434c-98ba-3348b3a21019)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
