### PR TITLE
Initiate download of submission report PDF

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4302,43 +4302,6 @@ paths:
         schema:
           type: string
         required: true
-  /api/v2/submissions/{report_id}/{token}/download:
-    get:
-      operationId: submissions_download_retrieve
-      description: Download het document met de ingezonden gegevens, in PDF vorm.
-        Dit document kan alleen worden opgevraagd indien het juiste token is meegegeven,
-        die hoort bij de formulier sessie. Het token vervalt automatisch na 1 dag(en).
-      summary: Download the PDF report
-      parameters:
-      - in: path
-        name: report_id
-        schema:
-          type: integer
-        required: true
-      - in: path
-        name: token
-        schema:
-          type: string
-        required: true
-      tags:
-      - submissions
-      responses:
-        '200':
-          content:
-            application/pdf:
-              schema:
-                type: string
-                format: binary
-          description: ''
-          headers:
-            X-Session-Expires-In:
-              $ref: '#/components/headers/X-Session-Expires-In'
-            X-CSRFToken:
-              $ref: '#/components/headers/X-CSRFToken'
-            X-Is-Form-Designer:
-              $ref: '#/components/headers/X-Is-Form-Designer'
-            Content-Language:
-              $ref: '#/components/headers/Content-Language'
   /api/v2/submissions/{submission_uuid}/steps/{step_uuid}:
     get:
       operationId: submissions_steps_retrieve

--- a/src/openforms/submissions/api/permissions.py
+++ b/src/openforms/submissions/api/permissions.py
@@ -9,10 +9,7 @@ from openforms.api.permissions import TimestampedTokenPermission
 from ..constants import SUBMISSIONS_SESSION_KEY
 from ..form_logic import check_submission_logic
 from ..models import SubmissionStep, TemporaryFileUpload
-from ..tokens import (
-    submission_report_token_generator,
-    submission_status_token_generator,
-)
+from ..tokens import submission_status_token_generator
 from .validation import is_step_unexpectedly_incomplete
 
 
@@ -91,10 +88,6 @@ class OwnsTemporaryUploadPermission(AnyActiveSubmissionPermission):
     ) -> bool:
         submission_uuid = str(obj.submission.uuid)
         return owns_submission(request, submission_uuid)
-
-
-class DownloadSubmissionReportPermission(TimestampedTokenPermission):
-    token_generator = submission_report_token_generator
 
 
 class SubmissionStatusPermission(TimestampedTokenPermission):

--- a/src/openforms/submissions/api/renderers.py
+++ b/src/openforms/submissions/api/renderers.py
@@ -1,19 +1,6 @@
 from rest_framework import renderers
 
 
-class PDFRenderer(renderers.BaseRenderer):
-    # this is a bit of a lie, since we're using it for a send-file response that returns
-    # generated PDFs. So it's actually nginx doing the actual response.
-    # Example in DRF docs: https://www.django-rest-framework.org/api-guide/renderers/#setting-the-character-set
-    media_type = "application/pdf"
-    format = "pdf"
-    charset = None
-    render_style = "binary"
-
-    def render(self, data, media_type=None, renderer_context=None):
-        return data
-
-
 class FileRenderer(renderers.BaseRenderer):
     media_type = "application/octet-stream"
     format = "octet"

--- a/src/openforms/submissions/api/urls.py
+++ b/src/openforms/submissions/api/urls.py
@@ -1,15 +1,10 @@
 from django.urls import path
 
-from .views import DownloadSubmissionReportView, TemporaryFileView
+from .views import TemporaryFileView
 
 app_name = "submissions"
 
 urlpatterns = [
-    path(
-        "<int:report_id>/<str:token>/download",
-        DownloadSubmissionReportView.as_view(),
-        name="download-submission",
-    ),
     path(
         "files/<uuid:uuid>",
         TemporaryFileView.as_view(),

--- a/src/openforms/submissions/tests/test_submission_co_sign.py
+++ b/src/openforms/submissions/tests/test_submission_co_sign.py
@@ -185,7 +185,7 @@ class SubmissionCosignEndpointTests(SubmissionsMixin, APITestCase):
 
         match = resolve(furl(data["reportDownloadUrl"]).path)
 
-        self.assertEqual(match.view_name, "api:submissions:download-submission")
+        self.assertEqual(match.view_name, "submissions:download-submission")
 
         submission.refresh_from_db()
 

--- a/src/openforms/submissions/tests/test_submission_report.py
+++ b/src/openforms/submissions/tests/test_submission_report.py
@@ -25,7 +25,7 @@ class DownloadSubmissionReportTests(APITestCase):
         report = SubmissionReportFactory.create(submission__completed=True)
         token = submission_report_token_generator.make_token(report)
         download_report_url = reverse(
-            "api:submissions:download-submission",
+            "submissions:download-submission",
             kwargs={"report_id": report.id, "token": token},
         )
 
@@ -34,11 +34,29 @@ class DownloadSubmissionReportTests(APITestCase):
 
             self.assertEqual(status.HTTP_200_OK, response.status_code)
 
+    def test_download_response(self):
+        report = SubmissionReportFactory.create(
+            submission__completed=True, content__filename="report.pdf"
+        )
+        token = submission_report_token_generator.make_token(report)
+        download_report_url = reverse(
+            "submissions:download-submission",
+            kwargs={"report_id": report.id, "token": token},
+        )
+
+        response = self.client.get(download_report_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertEqual(
+            response["Content-Disposition"], 'attachment; filename="report.pdf"'
+        )
+
     def test_expired_token(self):
         report = SubmissionReportFactory.create(submission__completed=True)
         token = submission_report_token_generator.make_token(report)
         download_report_url = reverse(
-            "api:submissions:download-submission",
+            "submissions:download-submission",
             kwargs={"report_id": report.id, "token": token},
         )
 
@@ -51,7 +69,7 @@ class DownloadSubmissionReportTests(APITestCase):
         report = SubmissionReportFactory.create(submission__completed=True)
         token = submission_report_token_generator.make_token(report)
         download_report_url = reverse(
-            "api:submissions:download-submission",
+            "submissions:download-submission",
             kwargs={"report_id": report.id, "token": token},
         )
 
@@ -68,7 +86,7 @@ class DownloadSubmissionReportTests(APITestCase):
     def test_wrongly_formatted_token(self):
         report = SubmissionReportFactory.create(submission__completed=True)
         download_report_url = reverse(
-            "api:submissions:download-submission",
+            "submissions:download-submission",
             kwargs={"report_id": report.id, "token": "dummy"},
         )
 
@@ -79,7 +97,7 @@ class DownloadSubmissionReportTests(APITestCase):
     def test_invalid_token_timestamp(self):
         report = SubmissionReportFactory.create(submission__completed=True)
         download_report_url = reverse(
-            "api:submissions:download-submission",
+            "submissions:download-submission",
             kwargs={"report_id": report.id, "token": "$$$-blegh"},
         )
 

--- a/src/openforms/submissions/urls.py
+++ b/src/openforms/submissions/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    DownloadSubmissionReportView,
     ResumeSubmissionView,
     SearchSubmissionForCosignFormView,
     SubmissionAttachmentDownloadView,
@@ -9,6 +10,11 @@ from .views import (
 app_name = "submissions"
 
 urlpatterns = [
+    path(
+        "pdf/<int:report_id>/<str:token>/download",
+        DownloadSubmissionReportView.as_view(),
+        name="download-submission",
+    ),
     path(
         "<uuid:submission_uuid>/<str:token>/resume",
         ResumeSubmissionView.as_view(),

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -305,7 +305,7 @@ def check_form_status(
 def get_report_download_url(request: Request, report: SubmissionReport) -> str:
     token = submission_report_token_generator.make_token(report)
     download_url = reverse(
-        "api:submissions:download-submission",
+        "submissions:download-submission",
         kwargs={"report_id": report.id, "token": token},
     )
     return request.build_absolute_uri(download_url)


### PR DESCRIPTION
Closes #4488

**Changes**

* Refactored to use the PrivateMediaView generic CBV
* URL moved to non-API url
* Deleted the API-related code that is now obsolete

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
