### PR TITLE
Fix more ZGW registration backend issues

### DIFF
--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -125,7 +125,10 @@ class ZGWRegistration(BasePlugin):
         # "betrokkeneIdentificatie.emailadres": RegistrationAttribute.initiator_emailadres,
         # Vestiging
         "betrokkeneIdentificatie.vestigingsNummer": RegistrationAttribute.initiator_vestigingsnummer,
-        "betrokkeneIdentificatie.handelsnaam": RegistrationAttribute.initiator_handelsnaam,
+        "betrokkeneIdentificatie.handelsnaam": FieldConf(
+            attribute=RegistrationAttribute.initiator_handelsnaam,
+            transform=lambda v: [v],
+        ),
         # Niet Natuurlijk Persoon
         "betrokkeneIdentificatie.statutaireNaam": RegistrationAttribute.initiator_handelsnaam,
         "betrokkeneIdentificatie.innNnpId": FieldConf(

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -212,8 +212,15 @@ class ZGWRegistration(BasePlugin):
             rol_data["betrokkeneType"] = "natuurlijk_persoon"
 
         if verblijfsadres := betrokkene_identificatie.get("verblijfsadres"):
-            # GH-4191: Required, can currently be empty.
-            verblijfsadres["aoaIdentificatie"] = ""
+            # GH-4191: Required and min length of 1 char, but we don't have a way to get
+            # this value without trying to look up the other details in the BAG API,
+            # which would make BAG integration mandatory... this doesn't seem
+            # intentional. An issue was opened with VNG:
+            # https://github.com/VNG-Realisatie/gemma-zaken/issues/2451
+            #
+            # So, we put a dummy value in here that can be ignored by the received
+            # party...
+            verblijfsadres["aoaIdentificatie"] = "OFWORKAROUND"
 
         with (
             get_documents_client(zgw) as documents_client,

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -354,7 +354,7 @@ class ZGWBackendTests(TestCase):
                     "geslachtsnaam": "Bar",
                     "verblijfsadres": {
                         "aoaPostcode": "1000 AA",
-                        "aoaIdentificatie": "",
+                        "aoaIdentificatie": "OFWORKAROUND",
                     },
                     "voorletters": "J.W.",
                     "geslachtsaanduiding": "m",
@@ -568,13 +568,13 @@ class ZGWBackendTests(TestCase):
             self.assertEqual(
                 create_rol_body["betrokkeneIdentificatie"],
                 {
-                    "handelsnaam": "ACME",
+                    "handelsnaam": ["ACME"],
                     "vestigingsNummer": "87654321",
                     "innNnpId": "12345678",
                     "statutaireNaam": "ACME",
                     "verblijfsadres": {
                         "aoaPostcode": "1000 AA",
-                        "aoaIdentificatie": "",
+                        "aoaIdentificatie": "OFWORKAROUND",
                     },
                 },
             )
@@ -851,12 +851,12 @@ class ZGWBackendTests(TestCase):
             self.assertEqual(
                 create_rol_body["betrokkeneIdentificatie"],
                 {
-                    "handelsnaam": "ACME",
+                    "handelsnaam": ["ACME"],
                     "innNnpId": "12345678",
                     "statutaireNaam": "ACME",
                     "verblijfsadres": {
                         "aoaPostcode": "1000 AA",
-                        "aoaIdentificatie": "",
+                        "aoaIdentificatie": "OFWORKAROUND",
                     },
                 },
             )


### PR DESCRIPTION
Closes #4191 

**Changes**

* aoaIdentifictie may not be empty
* handelsnaam must be an array

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
