### PR TITLE
[#4533] Fix onFieldChange in upload submission csv checkbox (ObjectsAPI)

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -19,7 +19,7 @@ const LegacyConfigFields = ({index, name, schema, formData, onFieldChange}) => {
     objecttypeVersion = '',
     productaanvraagType = '',
     informatieobjecttypeSubmissionReport = '',
-    uploadSubmissionCsv = '',
+    uploadSubmissionCsv = false,
     informatieobjecttypeSubmissionCsv = '',
     informatieobjecttypeAttachment = '',
     organisatieRsin = '',
@@ -182,8 +182,10 @@ const LegacyConfigFields = ({index, name, schema, formData, onFieldChange}) => {
         <Checkbox
           id="root_uploadSubmissionCsv"
           name="uploadSubmissionCsv"
-          value={uploadSubmissionCsv}
-          onChange={onFieldChange}
+          checked={uploadSubmissionCsv}
+          onChange={e =>
+            onFieldChange({target: {name: 'uploadSubmissionCsv', value: !uploadSubmissionCsv}})
+          }
         />
       </CustomFieldTemplate>
       <CustomFieldTemplate
@@ -319,7 +321,7 @@ LegacyConfigFields.propTypes = {
     objecttypeVersion: PropTypes.string,
     productaanvraagType: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
-    uploadSubmissionCsv: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.bool,
     informatieobjecttypeSubmissionCsv: PropTypes.string,
     informatieobjecttypeAttachment: PropTypes.string,
     organisatieRsin: PropTypes.string,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
@@ -30,7 +30,7 @@ ObjectsApiOptionsForm.propTypes = {
     objecttypeVersion: PropTypes.string,
     productaanvraagType: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
-    uploadSubmissionCsv: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.bool,
     informatieobjecttypeSubmissionCsv: PropTypes.string,
     informatieobjecttypeAttachment: PropTypes.string,
     organisatieRsin: PropTypes.string,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -135,7 +135,7 @@ ObjectsApiOptionsFormFields.propTypes = {
     objecttypeVersion: PropTypes.string,
     productaanvraagType: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
-    uploadSubmissionCsv: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.bool,
     informatieobjecttypeSubmissionCsv: PropTypes.string,
     informatieobjecttypeAttachment: PropTypes.string,
     organisatieRsin: PropTypes.string,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -23,7 +23,7 @@ const V2ConfigFields = ({index, name, schema, formData, onFieldChange, onChange}
     objecttype = '',
     objecttypeVersion = '',
     informatieobjecttypeSubmissionReport = '',
-    uploadSubmissionCsv = '',
+    uploadSubmissionCsv = false,
     informatieobjecttypeSubmissionCsv = '',
     informatieobjecttypeAttachment = '',
     organisatieRsin = '',
@@ -213,8 +213,10 @@ const V2ConfigFields = ({index, name, schema, formData, onFieldChange, onChange}
         <Checkbox
           id="root_uploadSubmissionCsv"
           name="uploadSubmissionCsv"
-          value={uploadSubmissionCsv}
-          onChange={onFieldChange}
+          checked={uploadSubmissionCsv}
+          onChange={e =>
+            onFieldChange({target: {name: 'uploadSubmissionCsv', value: !uploadSubmissionCsv}})
+          }
         />
       </CustomFieldTemplate>
       <CustomFieldTemplate
@@ -304,7 +306,7 @@ V2ConfigFields.propTypes = {
     objecttype: PropTypes.string,
     objecttypeVersion: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
-    uploadSubmissionCsv: PropTypes.string,
+    uploadSubmissionCsv: PropTypes.bool,
     informatieobjecttypeSubmissionCsv: PropTypes.string,
     informatieobjecttypeAttachment: PropTypes.string,
     organisatieRsin: PropTypes.string,


### PR DESCRIPTION
Closes #4533

- Updated `onChange` event in the checkbox in Objects API. There was a problem for both legacy and the new version, since the value of the checkbox would always be `"false"` 

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
