### PR TITLE
[#4267] Add management command to migrate existing configurations

### DIFF
--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -1,4 +1,5 @@
-from typing import Callable, Iterator
+from typing import Any, Callable, Iterator
+from uuid import UUID
 
 from zgw_consumers.nlx import NLXClient
 
@@ -42,6 +43,11 @@ class CatalogiClient(NLXClient):
         response.raise_for_status()
         data = response.json()
         yield from pagination_helper(self, data)
+
+    def get_informatieobjecttype(self, uuid: str | UUID) -> dict[str, Any]:
+        response = self.get(f"informatieobjecttypen/{uuid}")
+        response.raise_for_status()
+        return response.json()
 
     def list_statustypen(self, zaaktype: str) -> list[dict]:
         query = {"zaaktype": zaaktype}

--- a/src/openforms/registrations/contrib/objects_api/management/commands/migrate_objects_api_config.py
+++ b/src/openforms/registrations/contrib/objects_api/management/commands/migrate_objects_api_config.py
@@ -1,0 +1,119 @@
+from typing import Any
+
+from django.core.management import BaseCommand
+
+import requests
+
+from openforms.forms.models import FormRegistrationBackend
+from openforms.registrations.contrib.objects_api.models import ObjectsAPIGroupConfig
+
+from ...client import get_catalogi_client
+from ...plugin import PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER
+
+IOT_FIELDS = (
+    "informatieobjecttype_submission_report",
+    "informatieobjecttype_submission_csv",
+    "informatieobjecttype_attachment",
+)
+
+
+class SkipBackend(Exception):
+    """The backend options were already migrated."""
+
+
+class InvalidBackend(Exception):
+    """The backend options are invalid and can't be migrated."""
+
+    def __init__(self, message: str, /) -> None:
+        self.message = message
+
+
+def migrate_registration_backend(options: dict[str, Any]) -> None:
+    # idempotent check:
+    if "catalogus_domein" in options:
+        raise SkipBackend
+
+    try:
+        config = ObjectsAPIGroupConfig.objects.get(pk=options["objects_api_group"])
+    except ObjectsAPIGroupConfig.DoesNotExist:
+        raise InvalidBackend("The configured objects API group does not exist")
+
+    iot_omschrijving: dict[str, str] = {}
+
+    with get_catalogi_client(config) as catalogi_client:
+        catalogus_domein: str | None = None
+        catalogus_rsin: str | None = None
+
+        for field in IOT_FIELDS:
+            if url := options.get(field):
+                try:
+                    uuid = url.rsplit("/", 1)[1]
+                except IndexError:
+                    raise InvalidBackend(f"{field}: {url} is invalid")
+
+                try:
+                    iot = catalogi_client.get_informatieobjecttype(uuid)
+                except requests.HTTPError as e:
+                    if (status := e.response.status_code) == 404:
+                        raise InvalidBackend(f"{field}: {url} does not exist")
+                    else:
+                        raise RuntimeError(
+                            f"Encountered {status} error when fetching informatieobjecttype {uuid}"
+                        )
+
+                catalogus_resp = catalogi_client.get(iot["catalogus"])
+                if not catalogus_resp.ok:
+                    raise RuntimeError(
+                        f"Encountered {catalogus_resp.status_code} error when fetching catalog {iot['catalogus']}"
+                    )
+                catalogus = catalogus_resp.json()
+
+                if catalogus_domein is None and catalogus_rsin is None:
+                    catalogus_domein = catalogus["domein"]
+                    catalogus_rsin = catalogus["rsin"]
+                else:
+                    if (
+                        catalogus["domein"] != catalogus_domein
+                        or catalogus["rsin"] != catalogus_rsin
+                    ):
+                        raise InvalidBackend(
+                            "Informatieobjecttypes don't share the same catalog"
+                        )
+
+                iot_omschrijving[field] = iot["omschrijving"]
+
+    if catalogus_domein is not None and catalogus_rsin is not None:
+        options["catalogus_domein"] = catalogus_domein
+        options["catalogus_rsin"] = catalogus_rsin
+
+        for field in IOT_FIELDS:
+            if field in iot_omschrijving:
+                options[field] = iot_omschrijving[field]
+
+
+class Command(BaseCommand):
+    help = (
+        "Migrate existing Objects API form registration backends "
+        "to switch from an informatieobjectype URL to a omschrijving and catalogus."
+    )
+
+    def handle(self, **options):
+        for registration_backend in FormRegistrationBackend.objects.filter(
+            backend=OBJECTS_API_PLUGIN_IDENTIFIER
+        ):
+            backend_name = registration_backend.name
+
+            try:
+                migrate_registration_backend(registration_backend.options)
+            except SkipBackend:
+                self.stdout.write(f"{backend_name!r} was already migrated")
+            except InvalidBackend as e:
+                self.stderr.write(
+                    f"{backend_name!r} configuration is invalid: {e.message!r}"
+                )
+            except RuntimeError as e:
+                self.stderr.write(
+                    f"Encountered runtime error when trying to migrate {backend_name!r}: {e.args[0]!r}"
+                )
+            else:
+                registration_backend.save()

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/MigrateObjectsAPIV2ConfigTests/MigrateObjectsAPIV2ConfigTests.test_iots_different_catalogs.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/MigrateObjectsAPIV2ConfigTests/MigrateObjectsAPIV2ConfigTests.test_iots_different_catalogs.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"CSV
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '804'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"c8e3c727b5a6eb192feeb5fdc3c12c67"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","domein":"OTHER","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f"],"naam":"Test
+        catalog 2","versie":"","begindatumVersie":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '466'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"7236b46ee9fd8c1eb24dd69c2e5cd51c"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"beginObject":"2024-03-19","eindeObject":"2024-07-10"}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '899'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"cf350f1b55d7eb0ccd17cceb88c1c6c8"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '846'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"3b954569daa5871216ebb13dbf11eb9e"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/MigrateObjectsAPIV2ConfigTests/MigrateObjectsAPIV2ConfigTests.test_unknown_iot.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/MigrateObjectsAPIV2ConfigTests/MigrateObjectsAPIV2ConfigTests.test_unknown_iot.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen/996946c4-92e8-4bf2-a18f-3ef41dbb423f
+  response:
+    body:
+      string: '{"type":"http://localhost:8003/ref/fouten/NotFound/","code":"not_found","title":"Niet
+        gevonden.","status":404,"detail":"Niet gevonden.","instance":"urn:uuid:9878f790-825a-4eaa-9ff4-fd66d0442a00"}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '195'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/MigrateObjectsAPIV2ConfigTests/MigrateObjectsAPIV2ConfigTests.test_valid_config.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/MigrateObjectsAPIV2ConfigTests/MigrateObjectsAPIV2ConfigTests.test_valid_config.yaml
@@ -1,0 +1,266 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '798'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"bfa6b74c27efa9845576bf1d54281820"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '846'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"3b954569daa5871216ebb13dbf11eb9e"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"CSV
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"89d53439caa01c2f00ab822679e80c7b"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '846'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"3b954569daa5871216ebb13dbf11eb9e"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"beginObject":"2024-03-19","eindeObject":"2024-07-10"}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '899'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"cf350f1b55d7eb0ccd17cceb88c1c6c8"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTM4MDMzMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.hwTglJOQWFg8kKGO_-lZUg5FBp17bCkbqh8nCbpVgV0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '846'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"3b954569daa5871216ebb13dbf11eb9e"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/test_management_commands.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_management_commands.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from openforms.forms.models import FormRegistrationBackend
+from openforms.forms.tests.factories import FormRegistrationBackendFactory
+from openforms.utils.tests.vcr import OFVCRMixin
+
+from ..management.commands.migrate_objects_api_config import (
+    InvalidBackend,
+    SkipBackend,
+    migrate_registration_backend,
+)
+from ..plugin import PLUGIN_IDENTIFIER
+from .factories import ObjectsAPIGroupConfigFactory
+
+FILES_DIR = Path(__file__).parent / "files"
+
+
+class MigrateObjectsAPIV2ConfigTests(OFVCRMixin, TestCase):
+
+    VCR_TEST_FILES = FILES_DIR
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+
+        cls.objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            for_test_docker_compose=True
+        )
+
+    def test_already_migrated(self):
+        with self.assertRaises(SkipBackend):
+            migrate_registration_backend(
+                {
+                    "objects_api_group": self.objects_api_group.pk,
+                    "catalogus_domein": "TEST DOMEIN",
+                    "catalogus_rsin": "000000000",
+                }
+            )
+
+    def test_invalid_objects_api_group(self):
+        with self.assertRaises(InvalidBackend):
+            migrate_registration_backend(
+                {
+                    "objects_api_group": -1,
+                }
+            )
+
+    def test_no_iot_fields(self):
+        options = {
+            "objects_api_group": self.objects_api_group.pk,
+        }
+        migrate_registration_backend(options)
+
+        self.assertEqual(
+            options,
+            {
+                "objects_api_group": self.objects_api_group.pk,
+            },
+        )
+
+    def test_invalid_iot(self):
+        options = {
+            # This should be an URL:
+            "objects_api_group": self.objects_api_group.pk,
+            "informatieobjecttype_attachment": "--wrong--",
+        }
+        with self.assertRaises(InvalidBackend):
+            migrate_registration_backend(options)
+
+    def test_unknown_iot(self):
+        options = {
+            "objects_api_group": self.objects_api_group.pk,
+            # 996946c4-92e8-4bf2-a18f-3ef41dbb423f does not exist on the Docker Compose instance:
+            "informatieobjecttype_attachment": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/996946c4-92e8-4bf2-a18f-3ef41dbb423f",
+        }
+        with self.assertRaises(InvalidBackend):
+            migrate_registration_backend(options)
+
+    def test_iots_different_catalogs(self):
+        options = {
+            "objects_api_group": self.objects_api_group.pk,
+            # Belongs to Catalogus PK 1:
+            "informatieobjecttype_attachment": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
+            # Belongs to Catalogus PK 2:
+            "informatieobjecttype_submission_csv": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f",
+        }
+        with self.assertRaises(InvalidBackend):
+            migrate_registration_backend(options)
+
+    def test_valid_config(self):
+        backend: FormRegistrationBackend = FormRegistrationBackendFactory.create(
+            backend=PLUGIN_IDENTIFIER,
+            options={
+                "objects_api_group": self.objects_api_group.pk,
+                # Same catalog for all:
+                "informatieobjecttype_attachment": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
+                "informatieobjecttype_submission_csv": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3",
+                "informatieobjecttype_submission_report": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b",
+            },
+        )
+
+        call_command("migrate_objects_api_config")
+
+        backend.refresh_from_db()
+
+        self.assertEqual(
+            backend.options,
+            {
+                "objects_api_group": self.objects_api_group.pk,
+                "informatieobjecttype_attachment": "Attachment Informatieobjecttype",
+                "informatieobjecttype_submission_csv": "CSV Informatieobjecttype",
+                "informatieobjecttype_submission_report": "PDF Informatieobjecttype",
+                "catalogus_domein": "TEST",
+                "catalogus_rsin": "000000000",
+            },
+        )


### PR DESCRIPTION
Partly closes #4267

Relates to https://github.com/open-formulieren/open-forms/pull/4541 (although I think this can be merged independently)

**Changes**

Add a management command to migrate V1 and V2 configurations. 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
