### PR TITLE
[#4395] Add flag for updating an object to the ObjectsAPI registration

### DIFF
--- a/src/openforms/contrib/objects_api/clients/objects.py
+++ b/src/openforms/contrib/objects_api/clients/objects.py
@@ -15,3 +15,17 @@ class ObjectsClient(NLXClient):
         response.raise_for_status()
 
         return response.json()
+
+    def update_object(
+        self, objecttype_url: str, record_data: dict, initial_data_reference: str
+    ) -> dict:
+        endpoint = f"objects/{initial_data_reference}"
+        json = {
+            "type": objecttype_url,
+            "record": record_data,
+        }
+
+        response = self.patch(endpoint, json=json, headers=CRS_HEADERS)
+        response.raise_for_status()
+
+        return response.json()

--- a/src/openforms/contrib/objects_api/clients/objects.py
+++ b/src/openforms/contrib/objects_api/clients/objects.py
@@ -16,12 +16,17 @@ class ObjectsClient(NLXClient):
 
         return response.json()
 
-    def update_object(
-        self, objecttype_url: str, record_data: dict, initial_data_reference: str
-    ) -> dict:
-        endpoint = f"objects/{initial_data_reference}"
+    def get_object(self, object_uuid: str) -> dict:
+        endpoint = f"objects/{object_uuid}"
+
+        response = self.get(endpoint, headers=CRS_HEADERS)
+        response.raise_for_status()
+
+        return response.json()
+
+    def update_object(self, record_data: dict, object_uuid: str) -> dict:
+        endpoint = f"objects/{object_uuid}"
         json = {
-            "type": objecttype_url,
             "record": record_data,
         }
 

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2291,6 +2291,12 @@
       "value": "A short instruction shown below the signature pad."
     }
   ],
+  "Nv0J2Y": [
+    {
+      "type": 0,
+      "value": "Update existing object"
+    }
+  ],
   "NwTdLM": [
     {
       "type": 0,
@@ -3173,6 +3179,12 @@
     {
       "type": 0,
       "value": "Basic"
+    }
+  ],
+  "XiPZpg": [
+    {
+      "type": 0,
+      "value": "Indicates whether the (existing) object should be updated and not created"
     }
   ],
   "Xj1uvL": [

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -3181,12 +3181,6 @@
       "value": "Basic"
     }
   ],
-  "XiPZpg": [
-    {
-      "type": 0,
-      "value": "Indicates whether the (existing) object should be updated and not created"
-    }
-  ],
   "Xj1uvL": [
     {
       "type": 0,
@@ -5627,6 +5621,12 @@
     {
       "type": 0,
       "value": "Use logic rules to determine the price"
+    }
+  ],
+  "zrsWsH": [
+    {
+      "type": 0,
+      "value": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead"
     }
   ]
 }

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2312,6 +2312,12 @@
       "value": "Een korte instructie onder het handtekenvlak."
     }
   ],
+  "Nv0J2Y": [
+    {
+      "type": 0,
+      "value": "Update existing object"
+    }
+  ],
   "NwTdLM": [
     {
       "type": 0,
@@ -3190,6 +3196,12 @@
     {
       "type": 0,
       "value": "Basis"
+    }
+  ],
+  "XiPZpg": [
+    {
+      "type": 0,
+      "value": "Indicates whether the (existing) object should be updated and not created"
     }
   ],
   "Xj1uvL": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -3198,12 +3198,6 @@
       "value": "Basis"
     }
   ],
-  "XiPZpg": [
-    {
-      "type": 0,
-      "value": "Indicates whether the (existing) object should be updated and not created"
-    }
-  ],
   "Xj1uvL": [
     {
       "type": 0,
@@ -5649,6 +5643,12 @@
     {
       "type": 0,
       "value": "Gebruik prijsregels om de prijs te bepalen"
+    }
+  ],
+  "zrsWsH": [
+    {
+      "type": 0,
+      "value": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead"
     }
   ]
 }

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -18,6 +18,7 @@ const LegacyConfigFields = ({index, name, schema, formData, onFieldChange}) => {
     objecttype = '',
     objecttypeVersion = '',
     productaanvraagType = '',
+    updateExistingObject = false,
     informatieobjecttypeSubmissionReport = '',
     uploadSubmissionCsv = false,
     informatieobjecttypeSubmissionCsv = '',
@@ -112,6 +113,31 @@ const LegacyConfigFields = ({index, name, schema, formData, onFieldChange}) => {
           name="objecttypeVersion"
           value={objecttypeVersion}
           onChange={onFieldChange}
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
+        id="root_updateExistingObject"
+        label={intl.formatMessage({
+          defaultMessage: 'Update existing object',
+          description: 'Objects API registration options "Update existing object" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'Indicates whether the (existing) object should be updated and not created',
+          description: 'Objects API registration options "Upload submission CSV" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'updateExistingObject')}
+        errors={buildErrorsComponent('updateExistingObject')}
+        displayLabel
+      >
+        <Checkbox
+          id="root_updateExistingObject"
+          name="updateExistingObject"
+          value={updateExistingObject}
+          checked={updateExistingObject}
+          onChange={e =>
+            onFieldChange({target: {name: 'updateExistingObject', value: !updateExistingObject}})
+          }
         />
       </CustomFieldTemplate>
       <CustomFieldTemplate
@@ -319,6 +345,7 @@ LegacyConfigFields.propTypes = {
     version: PropTypes.number,
     objecttype: PropTypes.string,
     objecttypeVersion: PropTypes.string,
+    updateExistingObject: PropTypes.bool,
     productaanvraagType: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
     uploadSubmissionCsv: PropTypes.bool,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -123,8 +123,8 @@ const LegacyConfigFields = ({index, name, schema, formData, onFieldChange}) => {
         })}
         rawDescription={intl.formatMessage({
           defaultMessage:
-            'Indicates whether the (existing) object should be updated and not created',
-          description: 'Objects API registration options "Upload submission CSV" description',
+            'Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead',
+          description: 'Objects API registration options "Update existing object" description',
         })}
         rawErrors={getFieldErrors(name, index, validationErrors, 'updateExistingObject')}
         errors={buildErrorsComponent('updateExistingObject')}
@@ -133,7 +133,6 @@ const LegacyConfigFields = ({index, name, schema, formData, onFieldChange}) => {
         <Checkbox
           id="root_updateExistingObject"
           name="updateExistingObject"
-          value={updateExistingObject}
           checked={updateExistingObject}
           onChange={e =>
             onFieldChange({target: {name: 'updateExistingObject', value: !updateExistingObject}})

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
@@ -28,6 +28,7 @@ ObjectsApiOptionsForm.propTypes = {
     version: PropTypes.number,
     objecttype: PropTypes.string,
     objecttypeVersion: PropTypes.string,
+    updateExistingObject: PropTypes.bool,
     productaanvraagType: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
     uploadSubmissionCsv: PropTypes.bool,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -133,6 +133,7 @@ ObjectsApiOptionsFormFields.propTypes = {
     version: PropTypes.number,
     objecttype: PropTypes.string,
     objecttypeVersion: PropTypes.string,
+    updateExistingObject: PropTypes.bool,
     productaanvraagType: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
     uploadSubmissionCsv: PropTypes.bool,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -23,6 +23,7 @@ const V2ConfigFields = ({index, name, schema, formData, onFieldChange, onChange}
     objecttype = '',
     objecttypeVersion = '',
     informatieobjecttypeSubmissionReport = '',
+    updateExistingObject = false,
     uploadSubmissionCsv = false,
     informatieobjecttypeSubmissionCsv = '',
     informatieobjecttypeAttachment = '',
@@ -167,6 +168,31 @@ const V2ConfigFields = ({index, name, schema, formData, onFieldChange, onChange}
         />
       </CustomFieldTemplate>
       <CustomFieldTemplate
+        id="root_updateExistingObject"
+        label={intl.formatMessage({
+          defaultMessage: 'Update existing object',
+          description: 'Objects API registration options "Update existing object" label',
+        })}
+        rawDescription={intl.formatMessage({
+          defaultMessage:
+            'Indicates whether the (existing) object should be updated and not created',
+          description: 'Objects API registration options "Upload submission CSV" description',
+        })}
+        rawErrors={getFieldErrors(name, index, validationErrors, 'updateExistingObject')}
+        errors={buildErrorsComponent('updateExistingObject')}
+        displayLabel
+      >
+        <Checkbox
+          id="root_updateExistingObject"
+          name="updateExistingObject"
+          value={updateExistingObject}
+          checked={updateExistingObject}
+          onChange={e =>
+            onFieldChange({target: {name: 'updateExistingObject', value: !updateExistingObject}})
+          }
+        />
+      </CustomFieldTemplate>
+      <CustomFieldTemplate
         id="root_informatieobjecttypeSubmissionReport"
         label={intl.formatMessage({
           defaultMessage: 'Submission report PDF informatieobjecttype',
@@ -306,6 +332,7 @@ V2ConfigFields.propTypes = {
     objecttype: PropTypes.string,
     objecttypeVersion: PropTypes.string,
     informatieobjecttypeSubmissionReport: PropTypes.string,
+    updateExistingObject: PropTypes.bool,
     uploadSubmissionCsv: PropTypes.bool,
     informatieobjecttypeSubmissionCsv: PropTypes.string,
     informatieobjecttypeAttachment: PropTypes.string,

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -175,8 +175,8 @@ const V2ConfigFields = ({index, name, schema, formData, onFieldChange, onChange}
         })}
         rawDescription={intl.formatMessage({
           defaultMessage:
-            'Indicates whether the (existing) object should be updated and not created',
-          description: 'Objects API registration options "Upload submission CSV" description',
+            'Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead',
+          description: 'Objects API registration options "Update existing object" description',
         })}
         rawErrors={getFieldErrors(name, index, validationErrors, 'updateExistingObject')}
         errors={buildErrorsComponent('updateExistingObject')}
@@ -185,7 +185,6 @@ const V2ConfigFields = ({index, name, schema, formData, onFieldChange, onChange}
         <Checkbox
           id="root_updateExistingObject"
           name="updateExistingObject"
-          value={updateExistingObject}
           checked={updateExistingObject}
           onChange={e =>
             onFieldChange({target: {name: 'updateExistingObject', value: !updateExistingObject}})

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1064,6 +1064,11 @@
     "description": "Warning that all simple variables are mapped",
     "originalDefault": "All simple variables are mapped to a case property."
   },
+  "Nv0J2Y": {
+    "defaultMessage": "Update existing object",
+    "description": "Objects API registration options \"Update existing object\" label",
+    "originalDefault": "Update existing object"
+  },
   "NwTdLM": {
     "defaultMessage": "Component where locations for an appointment will be shown",
     "description": "Locations Component field help text",
@@ -1468,6 +1473,11 @@
     "defaultMessage": "Basic",
     "description": "Service fetch configuration modal basic fieldset title",
     "originalDefault": "Basic"
+  },
+  "XiPZpg": {
+    "defaultMessage": "Indicates whether the (existing) object should be updated and not created",
+    "description": "Objects API registration options \"Upload submission CSV\" description",
+    "originalDefault": "Indicates whether the (existing) object should be updated and not created"
   },
   "XqTjf+": {
     "defaultMessage": "JSON template for the content of the request sent to the Objects API.",

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1474,11 +1474,6 @@
     "description": "Service fetch configuration modal basic fieldset title",
     "originalDefault": "Basic"
   },
-  "XiPZpg": {
-    "defaultMessage": "Indicates whether the (existing) object should be updated and not created",
-    "description": "Objects API registration options \"Upload submission CSV\" description",
-    "originalDefault": "Indicates whether the (existing) object should be updated and not created"
-  },
   "XqTjf+": {
     "defaultMessage": "JSON template for the content of the request sent to the Objects API.",
     "description": "Objects API - JSON content field",
@@ -2578,5 +2573,10 @@
     "defaultMessage": "Use logic rules to determine the price",
     "description": "dynamic pricing mode label",
     "originalDefault": "Use logic rules to determine the price"
+  },
+  "zrsWsH": {
+    "defaultMessage": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead",
+    "description": "Objects API registration options \"Update existing object\" description",
+    "originalDefault": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead"
   }
 }

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1070,6 +1070,11 @@
     "description": "Warning that all simple variables are mapped",
     "originalDefault": "All simple variables are mapped to a case property."
   },
+  "Nv0J2Y": {
+    "defaultMessage": "Update existing object",
+    "description": "Objects API registration options \"Update existing object\" label",
+    "originalDefault": "Update existing object"
+  },
   "NwTdLM": {
     "defaultMessage": "Veld waar beschikbare locaties voor een afspraak komen te staan",
     "description": "Locations Component field help text",
@@ -1480,6 +1485,11 @@
     "defaultMessage": "Basis",
     "description": "Service fetch configuration modal basic fieldset title",
     "originalDefault": "Basic"
+  },
+  "XiPZpg": {
+    "defaultMessage": "Indicates whether the (existing) object should be updated and not created",
+    "description": "Objects API registration options \"Upload submission CSV\" description",
+    "originalDefault": "Indicates whether the (existing) object should be updated and not created"
   },
   "XqTjf+": {
     "defaultMessage": "JSON-sjabloon voor de inhoud van het verzoek wat naar de Objecten API gestuurd wordt.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1486,11 +1486,6 @@
     "description": "Service fetch configuration modal basic fieldset title",
     "originalDefault": "Basic"
   },
-  "XiPZpg": {
-    "defaultMessage": "Indicates whether the (existing) object should be updated and not created",
-    "description": "Objects API registration options \"Upload submission CSV\" description",
-    "originalDefault": "Indicates whether the (existing) object should be updated and not created"
-  },
   "XqTjf+": {
     "defaultMessage": "JSON-sjabloon voor de inhoud van het verzoek wat naar de Objecten API gestuurd wordt.",
     "description": "Objects API - JSON content field",
@@ -2596,5 +2591,10 @@
     "defaultMessage": "Gebruik prijsregels om de prijs te bepalen",
     "description": "dynamic pricing mode label",
     "originalDefault": "Use logic rules to determine the price"
+  },
+  "zrsWsH": {
+    "defaultMessage": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead",
+    "description": "Objects API registration options \"Update existing object\" description",
+    "originalDefault": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead"
   }
 }

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -86,6 +86,13 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         label=_("objecttype version"),
         help_text=_("Version of the objecttype in the Objecttypes API"),
     )
+    update_existing_object = serializers.BooleanField(
+        label=_("Update existing object"),
+        help_text=_(
+            "Indicates whether the (existing) object should be updated and not created."
+        ),
+        default=False,
+    )
     informatieobjecttype_submission_report = serializers.URLField(
         label=_("submission report PDF informatieobjecttype"),
         help_text=_(

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -84,12 +84,12 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
     )
     objecttype_version = serializers.IntegerField(
         label=_("objecttype version"),
-        help_text=_("Version of the objecttype in the Objecttypes API"),
+        help_text=_("Version of the objecttype in the Objecttypes API."),
     )
     update_existing_object = serializers.BooleanField(
         label=_("Update existing object"),
         help_text=_(
-            "Indicates whether the (existing) object should be updated and not created."
+            "Indicates whether the existing object should be updated (if it exists), instead of creating a new one."
         ),
         default=False,
     )
@@ -97,7 +97,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         label=_("submission report PDF informatieobjecttype"),
         help_text=_(
             "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API "
-            "to be used for the submission report PDF"
+            "to be used for the submission report PDF."
         ),
         required=False,
     )
@@ -105,7 +105,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         label=_("Upload submission CSV"),
         help_text=_(
             "Indicates whether or not the submission CSV should be uploaded as "
-            "a Document in Documenten API and attached to the ProductAanvraag"
+            "a Document in Documenten API and attached to the ProductAanvraag."
         ),
         default=False,
     )
@@ -113,7 +113,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         label=_("submission report CSV informatieobjecttype"),
         help_text=_(
             "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API "
-            "to be used for the submission report CSV"
+            "to be used for the submission report CSV."
         ),
         required=False,
     )
@@ -121,21 +121,21 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         label=_("attachment informatieobjecttype"),
         help_text=_(
             "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API "
-            "to be used for the submission attachments"
+            "to be used for the submission attachments."
         ),
         required=False,
     )
     organisatie_rsin = serializers.CharField(
         label=_("organisation RSIN"),
         validators=[validate_rsin],
-        help_text=_("RSIN of organization, which creates the INFORMATIEOBJECT"),
+        help_text=_("RSIN of organization, which creates the INFORMATIEOBJECT."),
         required=False,
     )
 
     # V1 only fields:
     productaanvraag_type = serializers.CharField(
         label=_("productaanvraag type"),
-        help_text=_("The type of ProductAanvraag"),
+        help_text=_("The type of ProductAanvraag."),
         required=False,
     )
     content_json = serializers.CharField(

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -92,15 +92,31 @@ class ObjectsAPIRegistration(BasePlugin):
             objecttype_url = objecttype["url"]
 
         with get_objects_client(options["objects_api_group"]) as objects_client:
-            response = execute_unless_result_exists(
-                partial(
-                    objects_client.create_object,
-                    objecttype_url=objecttype_url,
-                    record_data=record_data,
-                ),
-                submission,
-                "intermediate.objects_api_object",
-            )
+            # update or create the object
+            if not (
+                options.get("update_existing_object")
+                and submission.initial_data_reference
+            ):
+                response = execute_unless_result_exists(
+                    partial(
+                        objects_client.create_object,
+                        objecttype_url=objecttype_url,
+                        record_data=record_data,
+                    ),
+                    submission,
+                    "intermediate.objects_api_object_create",
+                )
+            else:
+                response = execute_unless_result_exists(
+                    partial(
+                        objects_client.update_object,
+                        initial_data_reference=submission.initial_data_reference,
+                        objecttype_url=objecttype_url,
+                        record_data=record_data,
+                    ),
+                    submission,
+                    "intermediate.objects_api_object_update",
+                )
 
         return response
 

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -93,30 +93,27 @@ class ObjectsAPIRegistration(BasePlugin):
 
         with get_objects_client(options["objects_api_group"]) as objects_client:
             # update or create the object
-            if not (
-                options.get("update_existing_object")
-                and submission.initial_data_reference
-            ):
-                response = execute_unless_result_exists(
-                    partial(
-                        objects_client.create_object,
-                        objecttype_url=objecttype_url,
-                        record_data=record_data,
-                    ),
-                    submission,
-                    "intermediate.objects_api_object_create",
+            is_update = (
+                options["update_existing_object"] and submission.initial_data_reference
+            )
+            update_or_create = (
+                partial(
+                    objects_client.update_object,
+                    object_uuid=submission.initial_data_reference,
+                    record_data=record_data,
                 )
-            else:
-                response = execute_unless_result_exists(
-                    partial(
-                        objects_client.update_object,
-                        initial_data_reference=submission.initial_data_reference,
-                        objecttype_url=objecttype_url,
-                        record_data=record_data,
-                    ),
-                    submission,
-                    "intermediate.objects_api_object_update",
+                if is_update
+                else partial(
+                    objects_client.create_object,
+                    objecttype_url=objecttype_url,
+                    record_data=record_data,
                 )
+            )
+            response = execute_unless_result_exists(
+                update_or_create,
+                submission,
+                "intermediate.objects_api_object",
+            )
 
         return response
 

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendVCRTests/ObjectsAPIBackendVCRTests.test_submission_with_objects_api_backend_create_and_update_object.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendVCRTests/ObjectsAPIBackendVCRTests.test_submission_with_objects_api_backend_create_and_update_object.yaml
@@ -1,54 +1,8 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.32.2
-    method: GET
-    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
-  response:
-    body:
-      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
-    headers:
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '790'
-      Content-Type:
-      - application/json
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Mon, 22 Jul 2024 07:18:51 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.27.0
-      Vary:
-      - origin
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
     body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
-      "record": {"typeVersion": 3, "data": {"data": {"fd-create": {"voornaam": "Foo"}},
-      "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id": "cede1440-ade3-4827-8d87-7634f35cd274",
-      "language_code": "nl", "payment": {"completed": false, "amount": 0, "public_order_ids":
-      []}}, "startAt": "2024-07-22"}}'
+      "record": {"typeVersion": 3, "data": {"name": {"voornaam": "My last name"}},
+      "startAt": "2024-07-26"}}'
     headers:
       Accept:
       - '*/*'
@@ -61,7 +15,7 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '411'
+      - '198'
       Content-Type:
       - application/json
       User-Agent:
@@ -70,7 +24,8 @@ interactions:
     uri: http://localhost:8002/api/v2/objects
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d","uuid":"b6d8124f-c8c4-4900-ae78-cfa91040ef3d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-create":{"voornaam":"Foo"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"cede1440-ade3-4827-8d87-7634f35cd274","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/49641f62-6f46-400d-88d9-25582e928e1d","uuid":"49641f62-6f46-400d-88d9-25582e928e1d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"name":{"voornaam":"My
+        last name"}},"geometry":null,"startAt":"2024-07-26","endAt":null,"registrationAt":"2024-07-26","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
@@ -79,19 +34,21 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '620'
+      - '427'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:51 GMT
+      - Fri, 26 Jul 2024 06:04:22 GMT
       Location:
-      - http://localhost:8002/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d
+      - http://localhost:8002/api/v2/objects/49641f62-6f46-400d-88d9-25582e928e1d
       Referrer-Policy:
       - same-origin
       Server:
       - nginx/1.27.0
+      Vary:
+      - origin
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -129,7 +86,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:51 GMT
+      - Fri, 26 Jul 2024 06:04:22 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -145,10 +102,10 @@ interactions:
       message: OK
 - request:
     body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
-      "record": {"typeVersion": 3, "data": {"data": {"fd-update1": {"voornaam": "Updated
-      value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
-      "87387ceb-0021-4f1a-ae20-da34e9c717d8", "language_code": "nl", "payment": {"completed":
-      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-22"}}'
+      "record": {"typeVersion": 3, "data": {"data": {"fd-test": {"voornaam": "My last
+      name"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
+      "0606cb22-7553-481f-9a27-efbf324b67c5", "language_code": "nl", "payment": {"completed":
+      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-26"}}'
     headers:
       Accept:
       - '*/*'
@@ -161,17 +118,120 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '422'
+      - '418'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/3a2e4dc8-99d1-4874-884f-a61a037b5858","uuid":"3a2e4dc8-99d1-4874-884f-a61a037b5858","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-test":{"voornaam":"My
+        last name"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"0606cb22-7553-481f-9a27-efbf324b67c5","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-26","endAt":null,"registrationAt":"2024-07-26","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '627'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 26 Jul 2024 06:04:23 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/3a2e4dc8-99d1-4874-884f-a61a037b5858
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 26 Jul 2024 06:04:23 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"record": {"typeVersion": 3, "data": {"data": {"fd-test": {"voornaam":
+      "Updated value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [],
+      "submission_id": "50062a33-1651-4c6b-a733-ed9d6bbc643b", "language_code": "nl",
+      "payment": {"completed": false, "amount": 0, "public_order_ids": []}}, "startAt":
+      "2024-07-26"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '324'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.2
     method: PATCH
-    uri: http://localhost:8002/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d
+    uri: http://localhost:8002/api/v2/objects/49641f62-6f46-400d-88d9-25582e928e1d
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d","uuid":"b6d8124f-c8c4-4900-ae78-cfa91040ef3d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":2,"typeVersion":3,"data":{"bsn":"","data":{"fd-create":{"voornaam":"Foo"},"fd-update1":{"voornaam":"Updated
-        value"}},"type":"","payment":{"amount":0,"completed":false,"public_order_ids":[]},"pdf_url":"","attachments":[],"language_code":"nl","submission_id":"87387ceb-0021-4f1a-ae20-da34e9c717d8"},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/49641f62-6f46-400d-88d9-25582e928e1d","uuid":"49641f62-6f46-400d-88d9-25582e928e1d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":2,"typeVersion":3,"data":{"name":{"voornaam":"My
+        last name"},"data":{"fd-test":{"voornaam":"Updated value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"50062a33-1651-4c6b-a733-ed9d6bbc643b","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-26","endAt":null,"registrationAt":"2024-07-26","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
@@ -180,17 +240,68 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '662'
+      - '663'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:52 GMT
+      - Fri, 26 Jul 2024 06:04:23 GMT
       Referrer-Policy:
       - same-origin
       Server:
       - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8002/api/v2/objects/49641f62-6f46-400d-88d9-25582e928e1d
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/49641f62-6f46-400d-88d9-25582e928e1d","uuid":"49641f62-6f46-400d-88d9-25582e928e1d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":2,"typeVersion":3,"data":{"bsn":"","data":{"fd-test":{"voornaam":"Updated
+        value"}},"name":{"voornaam":"My last name"},"type":"","payment":{"amount":0,"completed":false,"public_order_ids":[]},"pdf_url":"","attachments":[],"language_code":"nl","submission_id":"50062a33-1651-4c6b-a733-ed9d6bbc643b"},"geometry":null,"startAt":"2024-07-26","endAt":null,"registrationAt":"2024-07-26","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '663'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 26 Jul 2024 06:04:23 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -228,7 +339,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:52 GMT
+      - Fri, 26 Jul 2024 06:04:23 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -244,10 +355,10 @@ interactions:
       message: OK
 - request:
     body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
-      "record": {"typeVersion": 3, "data": {"data": {"fd-update2": {"voornaam": "Updated
+      "record": {"typeVersion": 3, "data": {"data": {"fd-test": {"voornaam": "Updated
       value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
-      "ab64cb46-bba5-4b0d-97e4-2e671be34406", "language_code": "nl", "payment": {"completed":
-      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-22"}}'
+      "786e1558-40ee-4c65-bd2f-3ce110f00b24", "language_code": "nl", "payment": {"completed":
+      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-26"}}'
     headers:
       Accept:
       - '*/*'
@@ -260,7 +371,7 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '422'
+      - '419'
       Content-Type:
       - application/json
       User-Agent:
@@ -269,8 +380,8 @@ interactions:
     uri: http://localhost:8002/api/v2/objects
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/47e05390-48cd-4af7-8c16-8d925881938c","uuid":"47e05390-48cd-4af7-8c16-8d925881938c","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-update2":{"voornaam":"Updated
-        value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"ab64cb46-bba5-4b0d-97e4-2e671be34406","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/7209312c-cf7f-4619-ad55-67ea62164451","uuid":"7209312c-cf7f-4619-ad55-67ea62164451","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-test":{"voornaam":"Updated
+        value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"786e1558-40ee-4c65-bd2f-3ce110f00b24","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-26","endAt":null,"registrationAt":"2024-07-26","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
@@ -279,19 +390,21 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '631'
+      - '628'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:52 GMT
+      - Fri, 26 Jul 2024 06:04:23 GMT
       Location:
-      - http://localhost:8002/api/v2/objects/47e05390-48cd-4af7-8c16-8d925881938c
+      - http://localhost:8002/api/v2/objects/7209312c-cf7f-4619-ad55-67ea62164451
       Referrer-Policy:
       - same-origin
       Server:
       - nginx/1.27.0
+      Vary:
+      - origin
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -329,7 +442,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:52 GMT
+      - Fri, 26 Jul 2024 06:04:23 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -345,10 +458,10 @@ interactions:
       message: OK
 - request:
     body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
-      "record": {"typeVersion": 3, "data": {"data": {"fd-update3": {"voornaam": "Updated
+      "record": {"typeVersion": 3, "data": {"data": {"fd-test": {"voornaam": "Updated
       value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
-      "f28fef72-732e-4b1a-bbdb-a75f0787bd4d", "language_code": "nl", "payment": {"completed":
-      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-22"}}'
+      "2957e996-f4b9-4728-a143-a7ddfc8b2a25", "language_code": "nl", "payment": {"completed":
+      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-26"}}'
     headers:
       Accept:
       - '*/*'
@@ -361,7 +474,7 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '422'
+      - '419'
       Content-Type:
       - application/json
       User-Agent:
@@ -370,8 +483,8 @@ interactions:
     uri: http://localhost:8002/api/v2/objects
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/1c9b704e-7a89-4c96-82be-599559a5878c","uuid":"1c9b704e-7a89-4c96-82be-599559a5878c","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-update3":{"voornaam":"Updated
-        value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"f28fef72-732e-4b1a-bbdb-a75f0787bd4d","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/72e64b2f-73ae-4821-8fa6-0d8bbe60c5d3","uuid":"72e64b2f-73ae-4821-8fa6-0d8bbe60c5d3","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-test":{"voornaam":"Updated
+        value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"2957e996-f4b9-4728-a143-a7ddfc8b2a25","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-26","endAt":null,"registrationAt":"2024-07-26","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
@@ -380,19 +493,21 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '631'
+      - '628'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 22 Jul 2024 07:18:52 GMT
+      - Fri, 26 Jul 2024 06:04:23 GMT
       Location:
-      - http://localhost:8002/api/v2/objects/1c9b704e-7a89-4c96-82be-599559a5878c
+      - http://localhost:8002/api/v2/objects/72e64b2f-73ae-4821-8fa6-0d8bbe60c5d3
       Referrer-Policy:
       - same-origin
       Server:
       - nginx/1.27.0
+      Vary:
+      - origin
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendVCRTests/ObjectsAPIBackendVCRTests.test_submission_with_objects_api_backend_create_and_update_object.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendVCRTests/ObjectsAPIBackendVCRTests.test_submission_with_objects_api_backend_create_and_update_object.yaml
@@ -1,0 +1,403 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:51 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+      "record": {"typeVersion": 3, "data": {"data": {"fd-create": {"voornaam": "Foo"}},
+      "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id": "cede1440-ade3-4827-8d87-7634f35cd274",
+      "language_code": "nl", "payment": {"completed": false, "amount": 0, "public_order_ids":
+      []}}, "startAt": "2024-07-22"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '411'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d","uuid":"b6d8124f-c8c4-4900-ae78-cfa91040ef3d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-create":{"voornaam":"Foo"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"cede1440-ade3-4827-8d87-7634f35cd274","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '620'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:51 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:51 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+      "record": {"typeVersion": 3, "data": {"data": {"fd-update1": {"voornaam": "Updated
+      value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
+      "87387ceb-0021-4f1a-ae20-da34e9c717d8", "language_code": "nl", "payment": {"completed":
+      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-22"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '422'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: PATCH
+    uri: http://localhost:8002/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/b6d8124f-c8c4-4900-ae78-cfa91040ef3d","uuid":"b6d8124f-c8c4-4900-ae78-cfa91040ef3d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":2,"typeVersion":3,"data":{"bsn":"","data":{"fd-create":{"voornaam":"Foo"},"fd-update1":{"voornaam":"Updated
+        value"}},"type":"","payment":{"amount":0,"completed":false,"public_order_ids":[]},"pdf_url":"","attachments":[],"language_code":"nl","submission_id":"87387ceb-0021-4f1a-ae20-da34e9c717d8"},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '662'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:52 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:52 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+      "record": {"typeVersion": 3, "data": {"data": {"fd-update2": {"voornaam": "Updated
+      value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
+      "ab64cb46-bba5-4b0d-97e4-2e671be34406", "language_code": "nl", "payment": {"completed":
+      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-22"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '422'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/47e05390-48cd-4af7-8c16-8d925881938c","uuid":"47e05390-48cd-4af7-8c16-8d925881938c","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-update2":{"voornaam":"Updated
+        value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"ab64cb46-bba5-4b0d-97e4-2e671be34406","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '631'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:52 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/47e05390-48cd-4af7-8c16-8d925881938c
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '790'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:52 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+      "record": {"typeVersion": 3, "data": {"data": {"fd-update3": {"voornaam": "Updated
+      value"}}, "type": "", "bsn": "", "pdf_url": "", "attachments": [], "submission_id":
+      "f28fef72-732e-4b1a-bbdb-a75f0787bd4d", "language_code": "nl", "payment": {"completed":
+      false, "amount": 0, "public_order_ids": []}}, "startAt": "2024-07-22"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '422'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/1c9b704e-7a89-4c96-82be-599559a5878c","uuid":"1c9b704e-7a89-4c96-82be-599559a5878c","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"data":{"fd-update3":{"voornaam":"Updated
+        value"}},"type":"","bsn":"","pdf_url":"","attachments":[],"submission_id":"f28fef72-732e-4b1a-bbdb-a75f0787bd4d","language_code":"nl","payment":{"completed":false,"amount":0,"public_order_ids":[]}},"geometry":null,"startAt":"2024-07-22","endAt":null,"registrationAt":"2024-07-22","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '631'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 22 Jul 2024 07:18:52 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/1c9b704e-7a89-4c96-82be-599559a5878c
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -145,6 +145,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
             "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
             "objecttype_version": 1,
             "productaanvraag_type": "testproduct",
+            "update_existing_object": False,
             # `omschrijving` "PDF Informatieobjecttype other catalog":
             "informatieobjecttype_submission_report": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25",
             "upload_submission_csv": True,
@@ -236,6 +237,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
             "productaanvraag_type": "testproduct",
             "informatieobjecttype_submission_report": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25",
             "upload_submission_csv": True,
+            "update_existing_object": False,
             "organisatie_rsin": "123456782",
             "zaak_vertrouwelijkheidaanduiding": "geheim",
             "doc_vertrouwelijkheidaanduiding": "geheim",
@@ -292,6 +294,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objecttype_version": 1,
                 "objects_api_group": self.objects_api_group,
                 "upload_submission_csv": False,
+                "update_existing_object": False,
             },
         )
 
@@ -323,6 +326,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objecttype_version": 1,
                 "objects_api_group": self.objects_api_group,
                 "upload_submission_csv": True,
+                "update_existing_object": False,
                 "informatieobjecttype_submission_csv": "",
             },
         )
@@ -367,6 +371,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
             "objecttype_version": 1,
             "objects_api_group": self.objects_api_group,
             "upload_submission_csv": False,
+            "update_existing_object": False,
             "content_json": textwrap.dedent(
                 """
                 {
@@ -430,6 +435,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objects_api_group": self.objects_api_group,
                 "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
                 "objecttype_version": 1,
+                "update_existing_object": False,
             },
         )
 
@@ -503,6 +509,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objects_api_group": self.objects_api_group,
                 "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
                 "objecttype_version": 1,
+                "update_existing_object": False,
             },
         )
 
@@ -612,6 +619,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objects_api_group": self.objects_api_group,
                 "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
                 "objecttype_version": 1,
+                "update_existing_object": False,
             },
         )
 
@@ -707,6 +715,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objects_api_group": self.objects_api_group,
                 "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
                 "objecttype_version": 1,
+                "update_existing_object": False,
             },
         )
 
@@ -789,6 +798,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objects_api_group": self.objects_api_group,
                 "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
                 "objecttype_version": 1,
+                "update_existing_object": False,
             },
         )
 
@@ -847,6 +857,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objecttype_version": 1,
                 "content_json": content_template,
                 "upload_submission_csv": False,
+                "update_existing_object": False,
             },
         )
 
@@ -890,6 +901,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objects_api_group": self.objects_api_group,
                 "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
                 "objecttype_version": 1,
+                "update_existing_object": False,
             },
         )
 
@@ -925,6 +937,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objecttype_version": 1,
                 "informatieobjecttype_submission_report": "",
                 "upload_submission_csv": False,
+                "update_existing_object": False,
                 "content_json": r"""{"auth": {% as_json variables.auth_context %}}""",
             },
         )
@@ -984,6 +997,7 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 "objecttype_version": 1,
                 "informatieobjecttype_submission_report": "",
                 "upload_submission_csv": False,
+                "update_existing_object": False,
                 "content_json": r"""{"auth": {% as_json variables.auth_context %}}""",
             },
         )
@@ -1037,6 +1051,7 @@ class V1HandlerTests(TestCase):
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
             "productaanvraag_type": "-dummy-",
+            "update_existing_object": False,
             "content_json": textwrap.dedent(
                 """
                 {
@@ -1082,6 +1097,7 @@ class V1HandlerTests(TestCase):
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
             "productaanvraag_type": "-dummy-",
+            "update_existing_object": False,
             "content_json": textwrap.dedent(
                 """
                 {
@@ -1130,6 +1146,7 @@ class V1HandlerTests(TestCase):
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
             "productaanvraag_type": "-dummy-",
+            "update_existing_object": False,
             "content_json": textwrap.dedent(
                 """
                 {
@@ -1161,6 +1178,7 @@ class V1HandlerTests(TestCase):
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
             "productaanvraag_type": "-dummy-",
+            "update_existing_object": False,
             "content_json": """{"amount": {{ payment.amount }}}""",
         }
         handler = ObjectsAPIV1Handler()

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -79,6 +79,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
             "objecttype": UUID("8e46e0a5-b1b4-449b-b9e9-fa3cea655f48"),
             "objecttype_version": 3,
             "upload_submission_csv": True,
+            "update_existing_object": False,
             "informatieobjecttype_submission_report": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b",
             "informatieobjecttype_submission_csv": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3",
             "informatieobjecttype_attachment": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
@@ -201,6 +202,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
             "objecttype": UUID("527b8408-7421-4808-a744-43ccb7bdaaa2"),
             "objecttype_version": 1,
             "upload_submission_csv": False,
+            "update_existing_object": False,
             "informatieobjecttype_attachment": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
             "organisatie_rsin": "000000000",
             "variables_mapping": [
@@ -282,6 +284,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "location",
@@ -325,6 +328,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "fieldset.textfield",
@@ -364,6 +368,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "textfield",
@@ -391,6 +396,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "public_reference",
@@ -433,6 +439,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "cosign_data",
@@ -491,6 +498,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "cosign_date",
@@ -542,6 +550,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "cosign_date",
@@ -577,6 +586,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "auth_context",
@@ -684,6 +694,7 @@ class V2HandlerTests(TestCase):
             "version": 2,
             "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
             "objecttype_version": 1,
+            "update_existing_object": False,
             "variables_mapping": [
                 {
                     "variable_key": "auth_context",

--- a/src/openforms/registrations/contrib/objects_api/tests/test_template.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_template.py
@@ -78,6 +78,7 @@ class JSONTemplatingTests(TestCase):
                     "objecttype_version": 300,
                     "informatieobjecttype_submission_report": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
                     "informatieobjecttype_attachment": "https://catalogi.nl/api/v1/informatieobjecttypen/2",
+                    "update_existing_object": False,
                 },
             )
 
@@ -196,6 +197,7 @@ class JSONTemplatingTests(TestCase):
                     "objecttype_version": 300,
                     "productaanvraag_type": "tralala-type",
                     "upload_submission_csv": True,
+                    "update_existing_object": False,
                     "informatieobjecttype_submission_csv": "http://oz.nl/informatieobjecttype/1",
                     "informatieobjecttype_submission_report": "http://oz.nl/informatieobjecttype/2",
                     "informatieobjecttype_attachment": "http://oz.nl/informatieobjecttype/3",
@@ -414,6 +416,7 @@ class JSONTemplatingRegressionTests(SubmissionsMixin, TestCase):
                     # skip document uploads
                     "informatieobjecttype_submission_report": "",
                     "upload_submission_csv": False,
+                    "update_existing_object": False,
                     "informatieobjecttype_attachment": "",
                 },
             )
@@ -525,6 +528,7 @@ class JSONTemplatingRegressionTests(SubmissionsMixin, TestCase):
                     # skip document uploads
                     "informatieobjecttype_submission_report": "",
                     "upload_submission_csv": False,
+                    "update_existing_object": False,
                     "informatieobjecttype_attachment": "",
                     "content_json": "{% json_summary %}",
                 },

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -15,6 +15,7 @@ class _BaseRegistrationOptions(TypedDict, total=False):
     objects_api_group: Required[ObjectsAPIGroupConfig]
     objecttype: Required[UUID]
     objecttype_version: Required[int]
+    update_existing_object: bool
     informatieobjecttype_submission_report: str
     upload_submission_csv: bool
     informatieobjecttype_submission_csv: str

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -15,7 +15,7 @@ class _BaseRegistrationOptions(TypedDict, total=False):
     objects_api_group: Required[ObjectsAPIGroupConfig]
     objecttype: Required[UUID]
     objecttype_version: Required[int]
-    update_existing_object: bool
+    update_existing_object: Required[bool]
     informatieobjecttype_submission_report: str
     upload_submission_csv: bool
     informatieobjecttype_submission_csv: str


### PR DESCRIPTION
Closes #4395

- Added `update_existing_object` flag to the ObjectsAPI (both versions). This will be used in combination with `submission.initial_data_reference` in order to update an existing object and not recreate it.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
