### PR TITLE
[#4534] Use iterators in the `Catalogi` client

### DIFF
--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Iterator
 
 from zgw_consumers.nlx import NLXClient
 
@@ -21,17 +21,16 @@ def omschrijving_matcher(omschrijving: str):
 
 
 class CatalogiClient(NLXClient):
-    def get_all_catalogi(self) -> list[dict]:
+    def get_all_catalogi(self) -> Iterator[dict]:
         """
         List all available catalogi, consuming pagination if relevant.
         """
         response = self.get("catalogussen")
         response.raise_for_status()
         data = response.json()
-        all_data = pagination_helper(self, data)
-        return list(all_data)
+        yield from pagination_helper(self, data)
 
-    def get_all_informatieobjecttypen(self, *, catalogus: str = "") -> list[dict]:
+    def get_all_informatieobjecttypen(self, *, catalogus: str = "") -> Iterator[dict]:
         """List all informatieobjecttypen.
 
         :arg catalogus: the catalogus URL the informatieobjecttypen should belong to.
@@ -42,8 +41,7 @@ class CatalogiClient(NLXClient):
         response = self.get("informatieobjecttypen", params=params)
         response.raise_for_status()
         data = response.json()
-        all_data = pagination_helper(self, data)
-        return list(all_data)
+        yield from pagination_helper(self, data)
 
     def list_statustypen(self, zaaktype: str) -> list[dict]:
         query = {"zaaktype": zaaktype}

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -288,7 +288,9 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
 
         objects_api_group: ObjectsAPIGroupConfig = attrs["objects_api_group"]
         with get_catalogi_client(objects_api_group) as catalogi_client:
-            informatieobjecttypen = catalogi_client.get_all_informatieobjecttypen()
+            informatieobjecttypen_urls = [
+                iot["url"] for iot in catalogi_client.get_all_informatieobjecttypen()
+            ]
 
         for field in (
             "informatieobjecttype_submission_report",
@@ -296,10 +298,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             "informatieobjecttype_attachment",
         ):
             url = attrs.get(field)
-            if url is not None and not any(
-                informatieobjecttype["url"] == url
-                for informatieobjecttype in informatieobjecttypen
-            ):
+            if url is not None and url not in informatieobjecttypen_urls:
                 raise serializers.ValidationError(
                     {
                         field: _(

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -144,7 +144,7 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
 
         # Run all validations against catalogi API in the same connection pool.
         with get_catalogi_client(group_config) as client:
-            catalogi = client.get_all_catalogi()
+            catalogi = list(client.get_all_catalogi())
 
             # validate that the zaaktype is in the provided catalogi
             zaaktype_url = attrs["zaaktype"]


### PR DESCRIPTION
Closes #4534

`list_eigenschappen` was left as a list as it is used in:

https://github.com/open-formulieren/open-forms/blob/2e1ca4dabe7e1e018e7bc9d2409557c646ac1eb9/src/openforms/registrations/contrib/zgw_apis/plugin.py#L413-L417

And would complicate this `partial` call even more

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
