### PR TITLE
[#4432] Add an error boundary to the registration summary

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2125,6 +2125,12 @@
       "value": "Optional theme to use for styling."
     }
   ],
+  "L9L8X7": [
+    {
+      "type": 0,
+      "value": "Something went wrong while rendering the registration options"
+    }
+  ],
   "LD3weJ": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2146,6 +2146,12 @@
       "value": "Stijl waarin het formulier wordt weergegeven (niet verplicht)."
     }
   ],
+  "L9L8X7": [
+    {
+      "type": 0,
+      "value": "Something went wrong while rendering the registration options"
+    }
+  ],
   "LD3weJ": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
@@ -9,6 +9,7 @@ import {BACKEND_OPTIONS_FORMS} from 'components/admin/form_design/registrations'
 import {SubmitAction} from 'components/admin/forms/ActionButton';
 import SubmitRow from 'components/admin/forms/SubmitRow';
 import {FormModal} from 'components/admin/modals';
+import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 /**
  *
@@ -67,31 +68,38 @@ const RegistrationSummary = ({
         isOpen={modalOpen}
         closeModal={() => setModalOpen(false)}
       >
-        <Formik
-          initialValues={backend.options}
-          onSubmit={(values, actions) => {
-            const updatedBackend = {...backend, options: values};
-            onChange({
-              target: {name: `form.registrationBackends.${backendIndex}`, value: updatedBackend},
-            });
-            actions.setSubmitting(false);
-            setModalOpen(false);
-          }}
+        <ErrorBoundary
+          errorMessage={intl.formatMessage({
+            description: 'Registration summary error message',
+            defaultMessage: 'Something went wrong while rendering the registration options',
+          })}
         >
-          {({handleSubmit}) => (
-            <>
-              {variableConfigurationEditor}
-              <SubmitRow>
-                <SubmitAction
-                  onClick={event => {
-                    event.preventDefault();
-                    handleSubmit(event);
-                  }}
-                />
-              </SubmitRow>
-            </>
-          )}
-        </Formik>
+          <Formik
+            initialValues={backend.options}
+            onSubmit={(values, actions) => {
+              const updatedBackend = {...backend, options: values};
+              onChange({
+                target: {name: `form.registrationBackends.${backendIndex}`, value: updatedBackend},
+              });
+              actions.setSubmitting(false);
+              setModalOpen(false);
+            }}
+          >
+            {({handleSubmit}) => (
+              <>
+                {variableConfigurationEditor}
+                <SubmitRow>
+                  <SubmitAction
+                    onClick={event => {
+                      event.preventDefault();
+                      handleSubmit(event);
+                    }}
+                  />
+                </SubmitRow>
+              </>
+            )}
+          </Formik>
+        </ErrorBoundary>
       </FormModal>
     </>
   );

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -964,6 +964,11 @@
     "description": "Form theme field help text",
     "originalDefault": "Optional theme to use for styling."
   },
+  "L9L8X7": {
+    "defaultMessage": "Something went wrong while rendering the registration options",
+    "description": "Registration summary error message",
+    "originalDefault": "Something went wrong while rendering the registration options"
+  },
   "LD3weJ": {
     "defaultMessage": "Advanced configuration",
     "description": "Advanced configuration tab title",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -970,6 +970,11 @@
     "description": "Form theme field help text",
     "originalDefault": "Optional theme to use for styling."
   },
+  "L9L8X7": {
+    "defaultMessage": "Something went wrong while rendering the registration options",
+    "description": "Registration summary error message",
+    "originalDefault": "Something went wrong while rendering the registration options"
+  },
   "LD3weJ": {
     "defaultMessage": "Geavanceerde instellingen",
     "description": "Advanced configuration tab title",


### PR DESCRIPTION
Closes #4432

**Changes**

Not sure if this is the best place to put it

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
