### PR TITLE
:recycle: Reduce test flakiness

### DIFF
--- a/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/jcc/tests/test_plugin.py
@@ -6,11 +6,11 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 import requests_mock
-from hypothesis import given, strategies as st
 from requests.exceptions import RequestException
 from zeep.exceptions import Error as ZeepError
 
 from openforms.formio.service import build_serializer
+from openforms.utils.tests.http import fuzzy_server_error_status_code
 from openforms.utils.tests.logging import disable_logging
 from openforms.utils.xml import fromstring
 from soap.tests.factories import SoapServiceFactory
@@ -557,8 +557,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.plugin = JccAppointment("jcc")
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_available_products_server_error(self, m, status_code):
+    def test_get_available_products_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.post(requests_mock.ANY, status_code=status_code)
 
         products = self.plugin.get_available_products()
@@ -573,8 +573,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             self.plugin.get_available_products()
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_locations_server_error(self, m, status_code):
+    def test_get_locations_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.post(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
 
@@ -596,8 +596,7 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             self.plugin.get_locations(products=[product])
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_locations_location_details_server_error(self, m, status_code):
+    def test_get_locations_location_details_server_error(self, m):
         m.post(
             "http://example.com/soap11",
             text=mock_response("getGovLocationsResponse.xml"),
@@ -605,7 +604,7 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         )
 
         def location_details_callback(request, context):
-            context.status_code = status_code
+            context.status_code = fuzzy_server_error_status_code()
             return "<broken />"
 
         m.post(
@@ -619,8 +618,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.assertEqual(locations, [])
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_dates_server_error(self, m, status_code):
+    def test_get_dates_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.post(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
         location = Location(identifier="1", name="Bahamas")
@@ -639,8 +638,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             self.plugin.get_dates(products=[product], location=location)
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_times_server_error(self, m, status_code):
+    def test_get_times_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.post(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
         location = Location(identifier="1", name="Bahamas")

--- a/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_plugin.py
@@ -5,11 +5,14 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 import requests_mock
-from hypothesis import given, strategies as st
 from requests.exceptions import RequestException
 
 from openforms.formio.service import build_serializer
 from openforms.utils.date import TIMEZONE_AMS
+from openforms.utils.tests.http import (
+    fuzzy_client_error_status_code,
+    fuzzy_server_error_status_code,
+)
 from openforms.utils.tests.logging import disable_logging
 
 from ....base import AppointmentDetails, Customer, Location, Product
@@ -398,8 +401,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.plugin = QmaticAppointment("qmatic")
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_available_products_server_error(self, m, status_code):
+    def test_get_available_products_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
 
         products = self.plugin.get_available_products()
@@ -407,8 +410,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.assertEqual(products, [])
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=400, max_value=499))
-    def test_get_available_products_client_error(self, m, status_code):
+    def test_get_available_products_client_error(self, m):
+        status_code = fuzzy_client_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
 
         products = self.plugin.get_available_products()
@@ -423,8 +426,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             self.plugin.get_available_products()
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_locations_server_error(self, m, status_code):
+    def test_get_locations_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
 
         locations = self.plugin.get_locations()
@@ -432,8 +435,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.assertEqual(locations, [])
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=400, max_value=499))
-    def test_get_locations_client_error(self, m, status_code):
+    def test_get_locations_client_error(self, m):
+        status_code = fuzzy_client_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
 
         locations = self.plugin.get_locations()
@@ -448,8 +451,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             self.plugin.get_locations()
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_dates_server_error(self, m, status_code):
+    def test_get_dates_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
         location = Location(identifier="1", name="Bahamas")
@@ -459,8 +462,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.assertEqual(dates, [])
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=400, max_value=499))
-    def test_get_dates_client_error(self, m, status_code):
+    def test_get_dates_client_error(self, m):
+        status_code = fuzzy_client_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
         location = Location(identifier="1", name="Bahamas")
@@ -479,8 +482,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
             self.plugin.get_dates(products=[product], location=location)
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=500, max_value=511))
-    def test_get_times_server_error(self, m, status_code):
+    def test_get_times_server_error(self, m):
+        status_code = fuzzy_server_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
         location = Location(identifier="1", name="Bahamas")
@@ -492,8 +495,8 @@ class SadFlowPluginTests(MockConfigMixin, SimpleTestCase):
         self.assertEqual(times, [])
 
     @requests_mock.Mocker()
-    @given(st.integers(min_value=400, max_value=499))
-    def test_get_times_client_error(self, m, status_code):
+    def test_get_times_client_error(self, m):
+        status_code = fuzzy_client_error_status_code()
         m.get(requests_mock.ANY, status_code=status_code)
         product = Product(identifier="k@pu77", name="Kaputt")
         location = Location(identifier="1", name="Bahamas")

--- a/src/openforms/utils/tests/http.py
+++ b/src/openforms/utils/tests/http.py
@@ -1,0 +1,24 @@
+"""
+Use factory boy for fuzzing HTTP status codes.
+
+Hypothesis results in random/flaky timeouts in CI (and sometimes even locally) which
+is hard to debug. Using factory boy's fuzzy module allows us to test with randomness,
+and if needed, we can extract the random seed from factory boy to reproduce potential
+flakiness.
+"""
+
+from functools import partial
+
+import factory.fuzzy
+
+# Ranges taken from https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+_CLIENT_ERROR_STATUS_CODE = factory.fuzzy.FuzzyInteger(400, 451)
+_SERVER_ERROR_STATUS_CODE = factory.fuzzy.FuzzyInteger(500, 511)
+
+
+def _fuzzy_status_code_factory(fi: factory.fuzzy.FuzzyInteger):
+    return partial(fi.evaluate, None, None, extra={})
+
+
+fuzzy_client_error_status_code = _fuzzy_status_code_factory(_CLIENT_ERROR_STATUS_CODE)
+fuzzy_server_error_status_code = _fuzzy_status_code_factory(_SERVER_ERROR_STATUS_CODE)


### PR DESCRIPTION
Replaced 4xx and 5xx status code fuzzy with hypothesis with factory boy fuzzing, which also has options to make it reproducible if needed. This should reveal potential issues over time the same way that hypothesis does, except it will only run one case in each CI run of course where hypothesis could potentially cover the entire range in a single test run by generating 100 (or less) samples.