### PR TITLE
Fix warnings produced since the 3.12 upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -253,7 +253,7 @@ furl==2.1.2
     #   -r requirements/base.in
     #   ape-pie
     #   django-digid-eherkenning
-glom==20.11.0
+glom==23.5.0
     # via
     #   -r requirements/base.in
     #   mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -457,7 +457,7 @@ furl==2.1.2
     #   -r requirements/base.txt
     #   ape-pie
     #   django-digid-eherkenning
-glom==20.11.0
+glom==23.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -499,7 +499,7 @@ gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
     # via -r requirements/dev.in
-glom==20.11.0
+glom==23.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -423,7 +423,7 @@ furl==2.1.2
     #   ape-pie
     #   django-digid-eherkenning
     #   open-forms-ext-token-exchange
-glom==20.11.0
+glom==23.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -492,7 +492,7 @@ furl==2.1.2
     #   -r requirements/ci.txt
     #   ape-pie
     #   django-digid-eherkenning
-glom==20.11.0
+glom==23.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/config/migrations/0001_initial_to_v250.py
+++ b/src/openforms/config/migrations/0001_initial_to_v250.py
@@ -58,7 +58,7 @@ default_cke_values = [
 
 
 def hsl_to_rgbhex(hsl_css_color):
-    exp = "^hsl\((\d+), (\d+)%, (\d+)%\)$"
+    exp = r"^hsl\((\d+), (\d+)%, (\d+)%\)$"
     m = re.match(exp, hsl_css_color)
     if m:
         h = int(m.group(1))


### PR DESCRIPTION
There are more - notably `celery_once` and `stringcase` have some warnings, but both libraries have not had releases in a long time and appear unmaintained :(