### PR TITLE
[#4519] Decrease horizontal space of form variable dropdowns

### DIFF
--- a/src/openforms/js/components/admin/forms/VariableSelection.js
+++ b/src/openforms/js/components/admin/forms/VariableSelection.js
@@ -39,6 +39,7 @@ const VariableSelection = ({
   return (
     <Select
       id={id}
+      className="form-variable-dropdown"
       name={name}
       choices={choices}
       allowBlank

--- a/src/openforms/scss/_vars.scss
+++ b/src/openforms/scss/_vars.scss
@@ -28,6 +28,7 @@ $django-hijack-yellow: #ffe761;
   /* Dimensions */
   --of-admin-input-field-size: 40em; // original: 20em;
   --of-admin-checkbox-gap: 5px;
+  --of-admin-select-max-inline-size: 300px;
 
   /* Tooltip */
   --of-admin-tooltip-background-color: #fffeaa;

--- a/src/openforms/scss/components/admin/_dsl-editor.scss
+++ b/src/openforms/scss/components/admin/_dsl-editor.scss
@@ -10,7 +10,7 @@
     // account for possibly long labels
     select,
     input {
-      max-width: 30em;
+      max-inline-size: var(--of-admin-select-max-inline-size);
     }
 
     label {

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -43,3 +43,6 @@
 
 // Errors
 @import './error-message';
+
+// Form variables select-dropdown
+@import './select';

--- a/src/openforms/scss/components/admin/_select.scss
+++ b/src/openforms/scss/components/admin/_select.scss
@@ -1,0 +1,3 @@
+.form-variable-dropdown {
+  max-inline-size: var(--of-admin-select-max-inline-size);
+}


### PR DESCRIPTION
Closes #4519

**Changes**

- Added class name to the `VariableSelection` in order to define `max-inline-size` for the form variable dropdowns

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
