### PR TITLE
Bump django-digid-eherkenning and django-simple-certmanager

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -152,7 +152,7 @@ django-csp==3.8
     # via -r requirements/base.in
 django-csp-reports==1.8.1
     # via -r requirements/base.in
-django-digid-eherkenning==0.16.0
+django-digid-eherkenning==0.17.1
     # via -r requirements/base.in
 django-filter==24.2
     # via -r requirements/base.in
@@ -194,7 +194,7 @@ django-sendfile2==0.7.1
     # via django-privates
 django-sessionprofile==2.0.0
     # via django-digid-eherkenning
-django-simple-certmanager==2.0.0
+django-simple-certmanager==2.3.0
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -251,7 +251,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.16.0
+django-digid-eherkenning==0.17.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -334,7 +334,7 @@ django-sessionprofile==2.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-django-simple-certmanager==2.0.0
+django-simple-certmanager==2.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -274,7 +274,7 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
-django-digid-eherkenning==0.16.0
+django-digid-eherkenning==0.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -365,7 +365,7 @@ django-sessionprofile==2.0.0
     #   django-digid-eherkenning
 django-silk==5.1.0
     # via -r requirements/dev.in
-django-simple-certmanager==2.0.0
+django-simple-certmanager==2.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -239,7 +239,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.16.0
+django-digid-eherkenning==0.17.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -320,7 +320,7 @@ django-sessionprofile==2.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-digid-eherkenning
-django-simple-certmanager==2.0.0
+django-simple-certmanager==2.3.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -267,7 +267,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.16.0
+django-digid-eherkenning==0.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -352,7 +352,7 @@ django-sessionprofile==2.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-django-simple-certmanager==2.0.0
+django-simple-certmanager==2.3.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/test_eidas_auth.py
@@ -1,16 +1,18 @@
 import os
 import sys
 from base64 import b64decode
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.core.files import File
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 
 import requests_mock
-from digid_eherkenning.models import EherkenningConfiguration
-from freezegun import freeze_time
+from digid_eherkenning.choices import ConfigTypes
+from digid_eherkenning.models import ConfigCertificate, EherkenningConfiguration
 from furl import furl
 from lxml import etree
 from privates.test import temp_private_root
@@ -45,7 +47,6 @@ class EIDASConfigMixin:
         METADATA = TEST_FILES / "eherkenning-metadata.xml"
 
         config = EherkenningConfiguration.get_solo()
-        config.certificate = cert
         config.base_url = "https://test-sp.nl"
         config.entity_id = "urn:etoegang:DV:00000001111111111000:entities:9000"
         config.idp_service_entity_id = (
@@ -70,6 +71,12 @@ class EIDASConfigMixin:
         with METADATA.open("rb") as md_file:
             config.idp_metadata_file = File(md_file, METADATA.name)
             config.save()
+
+        config_cert = ConfigCertificate.objects.create(
+            config_type=ConfigTypes.eherkenning, certificate=cert
+        )
+        # Will fail if/when the certificate expires
+        assert config_cert.is_ready_for_authn_requests
 
     @classmethod
     def tearDownClass(cls):
@@ -132,7 +139,6 @@ class AuthenticationStep2Tests(EIDASConfigMixin, TestCase):
             response, str(expected_redirect_url), fetch_redirect_response=False
         )
 
-    @freeze_time("2020-04-09T08:31:46Z")
     @patch(
         "onelogin.saml2.authn_request.OneLogin_Saml2_Utils.generate_unique_id",
         return_value="ONELOGIN_123456",
@@ -150,6 +156,7 @@ class AuthenticationStep2Tests(EIDASConfigMixin, TestCase):
         form_path = reverse("core:form-detail", kwargs={"slug": form.slug})
         form_url = f"https://testserver{form_path}"
         login_url = furl(login_url).set({"next": form_url})
+        now = timezone.now()
 
         response = self.client.get(login_url.url, follow=True)
 
@@ -168,19 +175,32 @@ class AuthenticationStep2Tests(EIDASConfigMixin, TestCase):
         )
         tree = etree.fromstring(saml_request)
 
-        self.assertEqual(
-            tree.attrib,
-            {
-                "ID": "ONELOGIN_123456",
-                "Version": "2.0",
-                "ForceAuthn": "true",
-                "IssueInstant": "2020-04-09T08:31:46Z",
-                "Destination": "https://test-iwelcome.nl/broker/sso/1.13",
-                "ProtocolBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-                "AssertionConsumerServiceURL": "https://test-sp.nl/eherkenning/acs/",
-                "AttributeConsumingServiceIndex": "9999",
-            },
-        )
+        expected_attributes = {
+            "ID": "ONELOGIN_123456",
+            "Version": "2.0",
+            "ForceAuthn": "true",
+            "Destination": "https://test-iwelcome.nl/broker/sso/1.13",
+            "ProtocolBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
+            "AssertionConsumerServiceURL": "https://test-sp.nl/eherkenning/acs/",
+            "AttributeConsumingServiceIndex": "9999",
+        }
+
+        for key, expected_value in expected_attributes.items():
+            with self.subTest(attribute=key):
+                value = tree.attrib[key]
+
+                self.assertEqual(value, expected_value)
+
+        with self.subTest(attribute="IssueInstant"):
+            try:
+                issue_instant = datetime.fromisoformat(tree.attrib["IssueInstant"])
+            except Exception as exc:
+                raise self.failureException("Not a valid timestamp") from exc
+            self.assertTrue(
+                now.replace(microsecond=0)
+                <= issue_instant
+                < (now + timedelta(seconds=3))
+            )
 
 
 @override_settings(CORS_ALLOW_ALL_ORIGINS=True)
@@ -306,7 +326,6 @@ class AuthenticationStep5Tests(EIDASConfigMixin, TestCase):
 @temp_private_root()
 @requests_mock.Mocker()
 class CoSignLoginAuthenticationTests(SubmissionsMixin, EIDASConfigMixin, TestCase):
-    @freeze_time("2020-04-09T08:31:46Z")
     @patch(
         "onelogin.saml2.authn_request.OneLogin_Saml2_Utils.generate_unique_id",
         return_value="ONELOGIN_123456",

--- a/src/openforms/authentication/contrib/tests/saml_utils.py
+++ b/src/openforms/authentication/contrib/tests/saml_utils.py
@@ -24,7 +24,8 @@ def get_artifact_response(filepath: str, context: dict | None = None) -> bytes:
 
 def get_encrypted_attribute(attr: str, identifier: str):
     config = EherkenningConfiguration.get_solo()
-    with config.certificate.public_certificate.open("r") as cert_file:
+    certificate, _ = config.select_certificates()
+    with certificate.public_certificate.open("r") as cert_file:
         cert = cert_file.read()
     return OneLogin_Saml2_Utils.generate_name_id(
         identifier,

--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -172,6 +172,10 @@
             ],
             [
                 "digid_eherkenning",
+                "configcertificate"
+            ],
+            [
+                "digid_eherkenning",
                 "digidconfiguration"
             ],
             [


### PR DESCRIPTION
Closes #4442
Closes #4514

**Changes**

* Upgraded django-digid-eherkenning to version with multi-certificate support
* Upgraded django-simple-certmanager with support for encrypted private keys

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
