### PR TITLE
:bug: [#4560] Use row based layout for submission report

### DIFF
--- a/src/openforms/scss/pdfs/_submission-step-row.scss
+++ b/src/openforms/scss/pdfs/_submission-step-row.scss
@@ -1,8 +1,7 @@
 @import '~microscope-sass/lib/typography';
 
 .submission-step-row {
-  // TODO this fixes overlap on next page but also adds empty pages in case of long values
-  break-inside: avoid-page;
+  break-inside: avoid-page; // needed to avoid spreading labels and their values across two pages
 
   & + & {
     margin-top: 1mm;
@@ -37,22 +36,25 @@
     padding-top: $grid-margin-2;
   }
 
+  &__fieldset-label {
+    @include body();
+    font-size: 1.25em;
+    font-weight: bold;
+  }
+
   &__label {
     @include body();
-    width: 40%;
-    padding-right: 2em;
-    // float is used here, because flexbox/grid/tables are really slow with
-    // weasyprint, especially if large textareas are used
-    // see: https://github.com/open-formulieren/open-forms/issues/4255
-    float: left;
+    font-weight: bold;
   }
 
   &__value {
     @include body();
-    width: 60%;
     word-break: break-all;
-    margin-left: 40%;
-    min-height: 1.5em; // required to ensure styling still works if value has no text
+    margin-bottom: 0.5em;
+
+    &--empty {
+      font-style: italic;
+    }
 
     // wysiwyg content
     p {
@@ -62,12 +64,5 @@
     > * {
       max-width: 100%;
     }
-  }
-
-  // Avoid rows from overlapping in case the field label is more than 1 line (#4450)
-  &::after {
-    content: '';
-    display: table;
-    clear: both;
   }
 }

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -55,13 +55,18 @@
                                     {% if component_node.spans_full_width %}
                                         {{ component_node.display_value }}
                                     {% else %}
-                                        <div class="submission-step-row__label">
-                                            {{ component_node.label }}
-                                        </div>
+                                        {% if component_node.component.type == "fieldset" %}
+                                            <span class="submission-step-row__fieldset-label">{{ component_node.label }}</span>
+                                        {% else %}
+                                            <div class="submission-step-row__label">
+                                                {{ component_node.label }}
+                                            </div>
 
-                                        <div class="submission-step-row__value">
-                                            {{ component_node.display_value }}
-                                        </div>
+                                            <div class="submission-step-row__value{% if not component_node.display_value %} submission-step-row__value--empty{% endif %}">
+                                                {% trans "(not filled in)" as empty_value %}
+                                                {{ component_node.display_value|default:empty_value }}
+                                            </div>
+                                        {% endif %}
                                     {% endif %}
                                 </div>
                             {% endif %}


### PR DESCRIPTION
previously this was a column based layout, initially it used flexbox, but this was later replaced with float due to performance issues with weasyprint

The problem with float is that there are a lot of edge cases when it comes to displaying everything properly (page breaks cause text to overlap, empty values must be accounted for, etc.) and ultimately there doesn't seem to be a proper solution to make long labels display properly if they exceed the page length.

Other layout styles like grid, tables or using `display: block` had the same performance issues as flexbox, so we decided to switch to a row based layout (displaying values under labels to avoid the performance and styling issues

Closes #4560 

**Changes**
* Use row based layout for submission report

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
