### PR TITLE
:clown_face: [#4380] Mock docker service for StUF-ZDS

### DIFF
--- a/docker/docker-compose.stuf-zds.yml
+++ b/docker/docker-compose.stuf-zds.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  flask_app:
+    build: ./stuf-zds
+    ports:
+      - "80:80"
+    volumes:
+      - ./stuf-zds/:/app/
+      - ../src/stuf/stuf_zds/templates/stuf_zds/soap/response-mock/:/app/templates/

--- a/docker/stuf-zds/Dockerfile
+++ b/docker/stuf-zds/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.12-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install the dependencies
+RUN pip install Flask Jinja2
+
+# Make port 80 available to the world outside this container
+EXPOSE 80
+
+# Run app.py when the container launches
+CMD ["python", "app.py"]

--- a/docker/stuf-zds/app.py
+++ b/docker/stuf-zds/app.py
@@ -1,0 +1,40 @@
+import logging
+from secrets import token_hex
+
+from flask import Flask, Response, request
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+env = Environment(loader=FileSystemLoader("templates"), autoescape=select_autoescape())
+
+app = Flask(__name__)
+
+# Set up logging to stdout
+logging.basicConfig(level=logging.INFO)
+
+
+@app.route("/stuf-zds", methods=["POST", "GET"])
+def handle_request():
+    # Log the request body
+    app.logger.info("Request body: %s", request.data.decode("utf-8"))
+
+    if "genereerZaakIdentificatie" in request.data.decode("utf-8"):
+        template = env.get_template("genereerZaakIdentificatie.xml")
+        return Response(
+            template.render(zaak_identificatie=token_hex(8)), content_type="text/xml"
+        )
+    elif "zakLk01" in request.data.decode("utf-8"):
+        template = env.get_template("creeerZaak.xml")
+        return Response(template.render(), content_type="text/xml")
+    elif "genereerDocumentIdentificatie" in request.data.decode("utf-8"):
+        template = env.get_template("genereerDocumentIdentificatie.xml")
+        return Response(
+            template.render(document_identificatie=token_hex(8)),
+            content_type="text/xml",
+        )
+    elif "edcLk01" in request.data.decode("utf-8"):
+        template = env.get_template("voegZaakdocumentToe.xml")
+        return Response(template.render(), content_type="text/xml")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=80, debug=True)

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -49,4 +49,12 @@ export const BACKEND_OPTIONS_FORMS = {
     form: ZGWOptionsForm,
     onStepEdit: onZGWStepEdit,
   },
+  'stuf-zds-create-zaak:ext-utrecht': {
+    uiSchema: {
+      paymentStatusUpdateXml: {
+        'ui:widget': 'textarea',
+        'ui:rows': '10',
+      },
+    },
+  },
 };


### PR DESCRIPTION
Closes #4380

Related PR in extension repo: https://github.com/open-formulieren/open-forms-ext-stuf-zds-payments/pull/1

**Changes**

* Add mock docker service for StUF-ZDS
* Add custom UI schema for StUF-ZDS payments registration options XML template

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
