### PR TITLE
:children_crossing: Link to all relevant configuration in overview

### DIFF
--- a/src/openforms/config/templates/admin/config/overview.html
+++ b/src/openforms/config/templates/admin/config/overview.html
@@ -44,6 +44,7 @@
                                         {% else %}
                                         {{ label }}
                                         {% endif %}
+                                        {% if not forloop.last %}|{% endif %}
                                     {% endfor %}
                                 </td>
                             </tr>

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, override
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from openforms.config.data import Action
 from openforms.registrations.utils import execute_unless_result_exists
 from openforms.variables.service import get_static_variables
 
@@ -120,10 +121,16 @@ class ObjectsAPIRegistration(BasePlugin):
         check_config()
 
     @override
-    def get_config_actions(self):
+    def get_config_actions(self) -> list[Action]:
         return [
             (
-                _("Configuration"),
+                _("Manage API groups"),
+                reverse(
+                    "admin:registrations_objects_api_objectsapigroupconfig_changelist"
+                ),
+            ),
+            (
+                _("Defaults configuration"),
                 reverse(
                     "admin:registrations_objects_api_objectsapiconfig_change",
                     args=(ObjectsAPIConfig.singleton_instance_id,),

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -471,10 +471,8 @@ class ZGWRegistration(BasePlugin):
     def get_config_actions(self) -> list[Action]:
         return [
             (
-                gettext("Configuration"),
-                reverse(
-                    "admin:zgw_apis_zgwapigroupconfig_changelist",
-                ),
+                _("Manage API groups"),
+                reverse("admin:zgw_apis_zgwapigroupconfig_changelist"),
             ),
         ]
 


### PR DESCRIPTION
**Changes**

Added links to configuration overview so that users don't have to find the menu items in "Overige" in admin index.

* Added missing link to objects API groups
* Added missign link to zgw API groups
* Fixed displaying multiple actions (separator was missing)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
