### PR TITLE
:wrench: [#4575] added SENDFILE_BACKEND configuration option

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -365,6 +365,8 @@ Other settings
 
 * ``SUBPATH``: A string with a prefix for all URL paths, for example ``/openforms``. Typically used at the infrastructure level to route to a particular application on the same (sub)domain. Defaults to empty string meaning that Open Forms is hosted at the root (``/``).
 
+* ``SENDFILE_BACKEND``: which backend to use for authorization-secured upload downloads. Defaults to sendfile.backends.nginx. See `django-sendfile2 <https://pypi.org/project/django-sendfile2/>`_` for available backends.
+
 .. _`Django DATABASE settings`: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-DATABASE-ENGINE
 
 Specifying the environment variables

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -365,7 +365,14 @@ Other settings
 
 * ``SUBPATH``: A string with a prefix for all URL paths, for example ``/openforms``. Typically used at the infrastructure level to route to a particular application on the same (sub)domain. Defaults to empty string meaning that Open Forms is hosted at the root (``/``).
 
-* ``SENDFILE_BACKEND``: which backend to use for authorization-secured upload downloads. Defaults to sendfile.backends.nginx. See `django-sendfile2 <https://pypi.org/project/django-sendfile2/>`_` for available backends.
+* ``SENDFILE_BACKEND``: which backend to use to serve the content of non-public files. The value depends on the
+  reverse proxy solution used with Open Forms. For available backends, see the `django-sendfile documentation`_.
+  Defaults to ``sendfile.backends.nginx``.
+  
+  .. note:: Open Forms only considers nginx to be in scope. You can deviate from using nginx, but we cannot offer any
+    support on other backends.
+  
+.. _django-sendfile documentation: https://django-sendfile2.readthedocs.io/en/stable/backends.html
 
 .. _`Django DATABASE settings`: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-DATABASE-ENGINE
 

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -343,7 +343,7 @@ PRIVATE_MEDIA_URL = "/private-media/"
 
 FILE_UPLOAD_PERMISSIONS = 0o644
 
-SENDFILE_BACKEND = "django_sendfile.backends.nginx"
+SENDFILE_BACKEND = config("SENDFILE_BACKEND", default="django_sendfile.backends.nginx")
 SENDFILE_ROOT = PRIVATE_MEDIA_ROOT
 SENDFILE_URL = PRIVATE_MEDIA_URL
 

--- a/src/openforms/conf/ci.py
+++ b/src/openforms/conf/ci.py
@@ -16,6 +16,9 @@ import weasyprint  # noqa: F401
 
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
+
+os.environ.setdefault("SENDFILE_BACKEND", "django_sendfile.backends.development")
+
 # Do not log requests in CI/tests:
 #
 # * overhead making tests slower
@@ -47,9 +50,6 @@ ENVIRONMENT = "CI"
 # Django-axes
 #
 AXES_BEHIND_REVERSE_PROXY = False
-
-# Django privates
-SENDFILE_BACKEND = "django_sendfile.backends.development"
 
 # THOU SHALT NOT USE NAIVE DATETIMES
 warnings.filterwarnings(

--- a/src/openforms/conf/ci.py
+++ b/src/openforms/conf/ci.py
@@ -16,7 +16,6 @@ import weasyprint  # noqa: F401
 
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
-
 os.environ.setdefault("SENDFILE_BACKEND", "django_sendfile.backends.development")
 
 # Do not log requests in CI/tests:

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -28,6 +28,8 @@ os.environ.setdefault("LOG_REQUESTS", "no")
 os.environ.setdefault("LOG_STDOUT", "1")
 os.environ.setdefault("VCR_RECORD_MODE", "once")
 
+os.environ.setdefault("SENDFILE_BACKEND", "django_sendfile.backends.development")
+
 from .base import *  # noqa isort:skip
 
 # Feel free to switch dev to sqlite3 for simple projects,
@@ -96,9 +98,6 @@ INSTALLED_APPS += ["django_extensions"]
 REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += [
     "djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer"
 ]
-
-# Django privates
-SENDFILE_BACKEND = "django_sendfile.backends.development"
 
 # Django rosetta
 ROSETTA_SHOW_AT_ADMIN_PANEL = True


### PR DESCRIPTION
Closes #4575 

**Changes**

Added SENDFILE_BACKEND option to conf/base.py and set ci and dev defaults using the environment variable. Included update to documentation. 

Note of caution: I haven't been able to test the changes.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages_js.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
