### PR TITLE
Improve UX by using react-select (Objects API registration options)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.51.0",
-        "@open-formulieren/formio-builder": "^0.26.0",
+        "@open-formulieren/formio-builder": "^0.27.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@rjsf/core": "^4.2.1",
@@ -4680,9 +4680,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.26.0.tgz",
-      "integrity": "sha512-p02MHJra6ut6UpmpfwPaW9GaTFC3ghfp2u8yhUlRN0QMwlfXhqdHkH2xMIHrtadbd98bqAWpXufsYk0ILesu8Q==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.27.0.tgz",
+      "integrity": "sha512-Saa2qsXCr7bR+qkAgWDP8dnw4yf8ZuAT11f5i4FKi9RxFcDwlOZvldztyBF0YDUAlIOv8K74THqKcGxmZjqZ0Q==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",
@@ -26599,9 +26599,9 @@
       "integrity": "sha512-SpAYCkqIOe2DMGxPg2vweRJOnUjDwD+h7nQEKZz2+1kgW2XwcFIDwerBRBqgaYtDvzxrYmSaTIB0SnoZYg4YDw=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.26.0.tgz",
-      "integrity": "sha512-p02MHJra6ut6UpmpfwPaW9GaTFC3ghfp2u8yhUlRN0QMwlfXhqdHkH2xMIHrtadbd98bqAWpXufsYk0ILesu8Q==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.27.0.tgz",
+      "integrity": "sha512-Saa2qsXCr7bR+qkAgWDP8dnw4yf8ZuAT11f5i4FKi9RxFcDwlOZvldztyBF0YDUAlIOv8K74THqKcGxmZjqZ0Q==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "postcss": "^8.0.8",
         "postcss-loader": "^4.0.1",
         "prettier": "^3.3.0",
+        "react-select-event": "^5.5.1",
         "sass": "^1.32.12",
         "sass-loader": "^12.3.0",
         "semver": "^7.3.7",
@@ -19852,6 +19853,15 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-select-event": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-select-event/-/react-select-event-5.5.1.tgz",
+      "integrity": "sha512-goAx28y0+iYrbqZA2FeRTreHHs/ZtSuKxtA+J5jpKT5RHPCbVZJ4MqACfPnWyFXsEec+3dP5bCrNTxIX8oYe9A==",
+      "dev": true,
+      "dependencies": {
+        "@testing-library/dom": ">=7"
+      }
+    },
     "node_modules/react-signature-canvas": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.0.6.tgz",
@@ -37753,6 +37763,15 @@
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0",
         "use-isomorphic-layout-effect": "^1.1.2"
+      }
+    },
+    "react-select-event": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-select-event/-/react-select-event-5.5.1.tgz",
+      "integrity": "sha512-goAx28y0+iYrbqZA2FeRTreHHs/ZtSuKxtA+J5jpKT5RHPCbVZJ4MqACfPnWyFXsEec+3dP5bCrNTxIX8oYe9A==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": ">=7"
       }
     },
     "react-signature-canvas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-formio": "^4.3.0",
         "react-intl": "^6.4.2",
         "react-modal": "^3.16.1",
+        "react-select": "^5.8.0",
         "react-tabs": "^6.0.2",
         "react-use": "^17.2.4",
         "state-pool": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "postcss": "^8.0.8",
     "postcss-loader": "^4.0.1",
     "prettier": "^3.3.0",
+    "react-select-event": "^5.5.1",
     "sass": "^1.32.12",
     "sass-loader": "^12.3.0",
     "semver": "^7.3.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.51.0",
-    "@open-formulieren/formio-builder": "^0.26.0",
+    "@open-formulieren/formio-builder": "^0.27.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@rjsf/core": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-formio": "^4.3.0",
     "react-intl": "^6.4.2",
     "react-modal": "^3.16.1",
+    "react-select": "^5.8.0",
     "react-tabs": "^6.0.2",
     "react-use": "^17.2.4",
     "state-pool": "^0.7.1",

--- a/src/openforms/forms/tests/e2e_tests/test_form_configuration.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_configuration.py
@@ -4,7 +4,12 @@ from asgiref.sync import sync_to_async
 from furl import furl
 from playwright.async_api import expect
 
-from openforms.tests.e2e.base import E2ETestCase, browser_page, create_superuser
+from openforms.tests.e2e.base import (
+    E2ETestCase,
+    browser_page,
+    create_superuser,
+    rs_select_option,
+)
 
 from ..factories import FormFactory
 from .helpers import close_modal
@@ -40,12 +45,7 @@ class FormDesignerComponentDefinitionTests(E2ETestCase):
             await page.get_by_role("link", name="File").click()
 
             dropdown = page.get_by_role("combobox", name="File types")
-            await dropdown.focus()
-            await page.keyboard.press("ArrowDown")
-            option = page.get_by_text(".pdf", exact=True)
-            await option.scroll_into_view_if_needed()
-            await option.click()
-            await dropdown.blur()
+            await rs_select_option(dropdown, option_label=".pdf")
 
             # Save component
             await close_modal(page, "Save")

--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -8,7 +8,12 @@ from furl import furl
 from playwright.async_api import Page, expect
 
 from openforms.products.tests.factories import ProductFactory
-from openforms.tests.e2e.base import E2ETestCase, browser_page, create_superuser
+from openforms.tests.e2e.base import (
+    E2ETestCase,
+    browser_page,
+    create_superuser,
+    rs_select_option,
+)
 from openforms.utils.tests.cache import clear_caches
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
@@ -772,11 +777,7 @@ class FormDesignerRegressionTests(E2ETestCase):
 
                 # select the validation mode in the dropdown
                 dropdown = page.get_by_role("combobox", name="Mode preset")
-                await dropdown.focus()
-                await page.keyboard.press("ArrowDown")
-                option = page.get_by_text("Relative to variable", exact=True)
-                await option.scroll_into_view_if_needed()
-                await option.click()
+                await rs_select_option(dropdown, option_label="Relative to variable")
 
                 # Fill in years, months, days and submit
                 years = page.get_by_label("Years")

--- a/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
+++ b/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
@@ -11,7 +11,12 @@ from openforms.registrations.contrib.objects_api.tests.factories import (
 from openforms.registrations.contrib.zgw_apis.tests.factories import (
     ZGWApiGroupConfigFactory,
 )
-from openforms.tests.e2e.base import E2ETestCase, browser_page, create_superuser
+from openforms.tests.e2e.base import (
+    E2ETestCase,
+    browser_page,
+    create_superuser,
+    rs_select_option,
+)
 from openforms.tests.utils import log_flaky
 
 from ..factories import FormFactory
@@ -260,8 +265,9 @@ class FormDesignerRegistrationBackendConfigTests(E2ETestCase):
                 await page.get_by_role("button", name="Configure options").click()
 
                 config_modal = page.get_by_role("dialog")
-                await config_modal.get_by_label("API group").select_option(
-                    label="Group 1"
+                await rs_select_option(
+                    config_modal.get_by_role("combobox", name="API group"),
+                    option_label="Group 1",
                 )
                 await config_modal.get_by_role("button", name="Save").click()
 
@@ -280,8 +286,9 @@ class FormDesignerRegistrationBackendConfigTests(E2ETestCase):
                 await page.get_by_role("button", name="Configure options").click()
 
                 config_modal = page.get_by_role("dialog")
-                await config_modal.get_by_label("API group").select_option(
-                    label="Group 2"
+                await rs_select_option(
+                    config_modal.get_by_role("combobox", name="API group"),
+                    option_label="Group 2",
                 )
                 await config_modal.get_by_role("button", name="Save").click()
 

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -5044,7 +5044,7 @@
   "q3kxsb": [
     {
       "type": 0,
-      "value": "Dit sjabloon wordt geëvalueerd met de inzendingsgegevens wanneer de betaling ontvangen is. De resulterende JSON wordt naar de Objecten API gestuurd om de (betaalattributen van) het eerder aangemaakte object bij te werken."
+      "value": "Dit sjabloon wordt geëvalueerd met de inzendingsgegevens wanneer de betaling ontvangen is. De resulterende JSON wordt naar de Objecten API gestuurd om (de betaalattributen van) het eerder aangemaakte object bij te werken."
     }
   ],
   "qUYLVg": [

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -301,17 +301,15 @@ export const ObjectsAPI = {
     await userEvent.click(canvas.getByRole('button', {name: 'Opties instellen'}));
 
     // check that the sole api group is automatically selected
-    const apiGroupSelect = await screen.findByLabelText('API-groep');
-    expect(apiGroupSelect).toHaveValue('1');
+    const modalForm = await screen.findByTestId('modal-form');
+    expect(modalForm).toBeVisible();
+    expect(modalForm).toHaveFormValues({objectsApiGroup: '1'});
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Objecttype')).toHaveValue(
-        'd89f3a0e-096b-45ea-afe1-ce211d63d1f2'
-      );
-    });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Versie')).toHaveValue('1');
+      expect(modalForm).toHaveFormValues({
+        objecttype: 'd89f3a0e-096b-45ea-afe1-ce211d63d1f2',
+        objecttypeVersion: '1',
+      });
     });
   },
 };
@@ -349,17 +347,15 @@ export const ObjectsAPILegacy = {
     await userEvent.click(canvas.getByRole('button', {name: 'Opties instellen'}));
 
     // check that the sole api group is automatically selected
-    const apiGroupSelect = await screen.findByLabelText('API-groep');
-    expect(apiGroupSelect).toHaveValue('1');
+    const modalForm = await screen.findByTestId('modal-form');
+    expect(modalForm).toBeVisible();
+    expect(modalForm).toHaveFormValues({objectsApiGroup: '1'});
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Objecttype')).toHaveValue(
-        'd89f3a0e-096b-45ea-afe1-ce211d63d1f2'
-      );
-    });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Versie')).toHaveValue('1');
+      expect(modalForm).toHaveFormValues({
+        objecttype: 'd89f3a0e-096b-45ea-afe1-ce211d63d1f2',
+        objecttypeVersion: '1',
+      });
     });
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -85,7 +85,6 @@ const ProductAanvraag = () => {
   const [fieldProps] = useField('productaanvraagType');
   return (
     <FormRow>
-      {/*TODO: errors*/}
       <Field
         name="productaanvraagType"
         label={
@@ -111,7 +110,6 @@ const JSONTemplateField = ({name, label, helpText}) => {
   const [fieldProps] = useField(name);
   return (
     <FormRow>
-      {/*TODO: errors*/}
       <Field name={name} label={label} helpText={helpText}>
         <TextArea
           id={`id_${name}`}

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -9,9 +9,7 @@ import {TextArea, TextInput} from 'components/admin/forms/Inputs';
 import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {
-  InformatieobjecttypeAttachment,
-  InformatieobjecttypeSubmissionCsv,
-  InformatieobjecttypeSubmissionReport,
+  DocumentTypesFieldet,
   ObjectTypeSelect,
   ObjectTypeVersionSelect,
   ObjectsAPIGroup,
@@ -53,24 +51,7 @@ const LegacyConfigFields = ({apiGroupChoices}) => (
       <PaymentStatusUpdateJSON />
     </Fieldset>
 
-    <Fieldset
-      title={
-        <FormattedMessage
-          description="Objects registration: document types"
-          defaultMessage="Document types"
-        />
-      }
-      collapsible
-      fieldNames={[
-        'informatieobjecttypeSubmissionReport',
-        'informatieobjecttypeSubmissionCsv',
-        'informatieobjecttypeAttachment',
-      ]}
-    >
-      <InformatieobjecttypeSubmissionReport />
-      <InformatieobjecttypeSubmissionCsv />
-      <InformatieobjecttypeAttachment />
-    </Fieldset>
+    <DocumentTypesFieldet />
 
     <Fieldset
       title={

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -1,5 +1,6 @@
 import {expect, fn, userEvent, waitFor, within} from '@storybook/test';
 import {Form, Formik} from 'formik';
+import selectEvent from 'react-select-event';
 
 import {ValidationErrorsDecorator} from 'components/admin/form_design/story-decorators';
 
@@ -66,7 +67,7 @@ export const SwitchToV2Empty = {
     await userEvent.click(v2Tab);
 
     const groupSelect = canvas.getByLabelText('API-groep');
-    await userEvent.selectOptions(groupSelect, 'Objects API group 1');
+    await selectEvent.select(groupSelect, 'Objects API group 1');
 
     const testForm = await canvas.findByTestId('test-form');
     await waitFor(() => {
@@ -181,7 +182,7 @@ export const APIFetchError = {
     await userEvent.click(v2Tab);
 
     const groupSelect = canvas.getByLabelText('API-groep');
-    await userEvent.selectOptions(groupSelect, 'Objects API group 1');
+    await selectEvent.select(groupSelect, 'Objects API group 1');
 
     const errorMessage = await canvas.findByText(
       'Er ging iets fout bij het ophalen van de objecttypes.'
@@ -193,6 +194,9 @@ export const APIFetchError = {
 
 export const V1ValidationErrors = {
   args: {
+    formData: {
+      version: 1,
+    },
     validationErrors: [
       [`${NAME}.objectsApiGroup`, 'Computer says no'],
       [`${NAME}.objecttype`, 'Computer says no'],
@@ -210,6 +214,9 @@ export const V1ValidationErrors = {
 
 export const V2ValidationErrors = {
   args: {
+    formData: {
+      version: 2,
+    },
     validationErrors: [
       [`${NAME}.objectsApiGroup`, 'Some API-group error'],
       [`${NAME}.objecttype`, 'Computer says no'],

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -10,7 +10,7 @@ const NAME = 'form.registrationBackends.0.options';
 
 const render = ({apiGroups, formData}) => (
   <Formik initialValues={formData} onSubmit={fn()}>
-    <Form>
+    <Form data-testid="test-form">
       <ObjectsApiOptionsFormFields index={0} name={NAME} apiGroupChoices={apiGroups} />
     </Form>
   </Formik>
@@ -68,20 +68,23 @@ export const SwitchToV2Empty = {
     const groupSelect = canvas.getByLabelText('API-groep');
     await userEvent.selectOptions(groupSelect, 'Objects API group 1');
 
-    await canvas.findByRole('option', {name: 'Tree (open)'}, {timeout: 5000});
-    expect(canvas.getByLabelText('Objecttype')).toHaveValue('2c77babf-a967-4057-9969-0200320d23f1');
-
-    await canvas.findByRole('option', {name: '2 (draft)'});
-    expect(canvas.getByLabelText('Versie')).toHaveValue('2');
+    const testForm = await canvas.findByTestId('test-form');
+    await waitFor(() => {
+      expect(testForm).toHaveFormValues({
+        objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+        objecttypeVersion: '2',
+      });
+    });
+    expect(canvas.getByText('Tree (open)')).toBeVisible();
+    expect(canvas.getByText('2 (draft)')).toBeVisible();
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
-
     await waitFor(() => {
-      expect(canvas.getByLabelText('Objecttype')).toHaveValue(
-        '2c77babf-a967-4057-9969-0200320d23f1'
-      );
-      expect(canvas.getByLabelText('Versie')).toHaveValue('2');
+      expect(testForm).toHaveFormValues({
+        objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+        objecttypeVersion: '2',
+      });
     });
   },
 };
@@ -101,23 +104,26 @@ export const SwitchToV2Existing = {
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
     await userEvent.click(v2Tab);
 
-    const groupSelect = canvas.getByLabelText('API-groep');
-    expect(groupSelect).toHaveValue('1');
+    const testForm = await canvas.findByTestId('test-form');
 
-    await canvas.findByRole('option', {name: 'Person (open)'}, {timeout: 5000});
-    expect(canvas.getByLabelText('Objecttype')).toHaveValue('2c77babf-a967-4057-9969-0200320d23f2');
-
-    await canvas.findByRole('option', {name: '1 (published)'});
-    expect(canvas.getByLabelText('Versie')).toHaveValue('1');
+    await waitFor(() => {
+      expect(testForm).toHaveFormValues({
+        objectsApiGroup: '1',
+        objecttype: '2c77babf-a967-4057-9969-0200320d23f2',
+        objecttypeVersion: '1',
+      });
+    });
+    expect(canvas.getByText('Person (open)')).toBeVisible();
+    expect(canvas.getByText('1 (published)')).toBeVisible();
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
-
     await waitFor(() => {
-      expect(canvas.getByLabelText('Objecttype')).toHaveValue(
-        '2c77babf-a967-4057-9969-0200320d23f2'
-      );
-      expect(canvas.getByLabelText('Versie')).toHaveValue('1');
+      expect(testForm).toHaveFormValues({
+        objectsApiGroup: '1',
+        objecttype: '2c77babf-a967-4057-9969-0200320d23f2',
+        objecttypeVersion: '1',
+      });
     });
   },
 };
@@ -137,22 +143,23 @@ export const SwitchToV2NonExisting = {
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
     await userEvent.click(v2Tab);
 
-    await canvas.findByRole('option', {name: 'Tree (open)'}, {timeout: 5000});
-    expect(canvas.getByLabelText('Objecttype')).toHaveValue('2c77babf-a967-4057-9969-0200320d23f1');
-
-    await canvas.findByRole('option', {name: '2 (draft)'});
+    const testForm = await canvas.findByTestId('test-form');
     await waitFor(() => {
-      expect(canvas.getByLabelText('Versie')).toHaveValue('2');
+      expect(testForm).toHaveFormValues({
+        objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+        objecttypeVersion: '2',
+      });
     });
+    expect(canvas.getByText('Tree (open)')).toBeVisible();
+    expect(canvas.getByText('2 (draft)')).toBeVisible();
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
-
     await waitFor(() => {
-      expect(canvas.getByLabelText('Objecttype')).toHaveValue(
-        '2c77babf-a967-4057-9969-0200320d23f1'
-      );
-      expect(canvas.getByLabelText('Versie')).toHaveValue('2');
+      expect(testForm).toHaveFormValues({
+        objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+        objecttypeVersion: '2',
+      });
     });
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -6,9 +6,7 @@ import Fieldset from 'components/admin/forms/Fieldset';
 import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {
-  InformatieobjecttypeAttachment,
-  InformatieobjecttypeSubmissionCsv,
-  InformatieobjecttypeSubmissionReport,
+  DocumentTypesFieldet,
   ObjectTypeSelect,
   ObjectTypeVersionSelect,
   ObjectsAPIGroup,
@@ -82,24 +80,7 @@ const V2ConfigFields = ({apiGroupChoices}) => {
         </ErrorBoundary>
       </Fieldset>
 
-      <Fieldset
-        title={
-          <FormattedMessage
-            description="Objects registration: document types"
-            defaultMessage="Document types"
-          />
-        }
-        collapsible
-        fieldNames={[
-          'informatieobjecttypeSubmissionReport',
-          'informatieobjecttypeSubmissionCsv',
-          'informatieobjecttypeAttachment',
-        ]}
-      >
-        <InformatieobjecttypeSubmissionReport />
-        <InformatieobjecttypeSubmissionCsv />
-        <InformatieobjecttypeAttachment />
-      </Fieldset>
+      <DocumentTypesFieldet />
 
       <Fieldset
         title={

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentType.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentType.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
 import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
 import {TextInput} from 'components/admin/forms/Inputs';
 
@@ -27,7 +28,7 @@ DocumentType.propTypes = {
   helpText: PropTypes.node,
 };
 
-export const InformatieobjecttypeSubmissionReport = () => (
+const InformatieobjecttypeSubmissionReport = () => (
   <DocumentType
     name="informatieobjecttypeSubmissionReport"
     label={
@@ -45,7 +46,7 @@ export const InformatieobjecttypeSubmissionReport = () => (
   />
 );
 
-export const InformatieobjecttypeSubmissionCsv = () => (
+const InformatieobjecttypeSubmissionCsv = () => (
   <DocumentType
     name="informatieobjecttypeSubmissionCsv"
     label={
@@ -63,7 +64,7 @@ export const InformatieobjecttypeSubmissionCsv = () => (
   />
 );
 
-export const InformatieobjecttypeAttachment = () => (
+const InformatieobjecttypeAttachment = () => (
   <DocumentType
     name="informatieobjecttypeAttachment"
     label={
@@ -81,4 +82,23 @@ export const InformatieobjecttypeAttachment = () => (
   />
 );
 
-export default DocumentType;
+export const DocumentTypesFieldet = () => (
+  <Fieldset
+    title={
+      <FormattedMessage
+        description="Objects registration: document types"
+        defaultMessage="Document types"
+      />
+    }
+    collapsible
+    fieldNames={[
+      'informatieobjecttypeSubmissionReport',
+      'informatieobjecttypeSubmissionCsv',
+      'informatieobjecttypeAttachment',
+    ]}
+  >
+    <InformatieobjecttypeSubmissionReport />
+    <InformatieobjecttypeSubmissionCsv />
+    <InformatieobjecttypeAttachment />
+  </Fieldset>
+);

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/ObjectTypeSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/ObjectTypeSelect.js
@@ -1,14 +1,13 @@
-import {getReactSelectStyles} from '@open-formulieren/formio-builder/esm/components/formio/select';
 import {useField, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
-import ReactSelect from 'react-select';
 import {usePrevious, useUpdateEffect} from 'react-use';
 import useAsync from 'react-use/esm/useAsync';
 
 import {REGISTRATION_OBJECTTYPES_ENDPOINT} from 'components/admin/form_design/constants';
 import Field from 'components/admin/forms/Field';
 import FormRow from 'components/admin/forms/FormRow';
+import ReactSelect from 'components/admin/forms/ReactSelect';
 import {get} from 'utils/fetch';
 
 import {useSynchronizeSelect} from './hooks';
@@ -19,34 +18,6 @@ const getAvailableObjectTypes = async apiGroupID => {
     throw new Error('Loading available object types failed');
   }
   return response.data;
-};
-
-const initialStyles = getReactSelectStyles();
-const styles = {
-  ...initialStyles,
-  control: (...args) => ({
-    ...initialStyles.control(...args),
-    minHeight: '1.875rem',
-    height: '1.875rem',
-  }),
-  valueContainer: (...args) => ({
-    ...initialStyles.valueContainer(...args),
-    height: 'calc(1.875rem - 2px)',
-    padding: '0 6px',
-  }),
-  input: (...args) => ({
-    ...initialStyles.input(...args),
-    margin: '0px',
-  }),
-  indicatorsContainer: baseStyles => ({
-    ...baseStyles,
-    height: 'calc(1.875rem - 2px)',
-    padding: '0 2px',
-  }),
-  dropdownIndicator: (...args) => ({
-    ...initialStyles.dropdownIndicator(...args),
-    padding: '5px 2px',
-  }),
 };
 
 const ObjectTypeSelect = ({onChangeCheck}) => {
@@ -107,18 +78,12 @@ const ObjectTypeSelect = ({onChangeCheck}) => {
         }
         noManageChildProps
       >
-        {/*https://stackoverflow.com/questions/54218351/changing-height-of-react-select-component*/}
         <ReactSelect
-          inputId="id_objecttype"
-          className="admin-react-select"
-          styles={styles}
-          menuPlacement="auto"
+          name="objecttype"
           options={options}
           isLoading={loading}
           isDisabled={!objectsApiGroup}
           required
-          {...fieldProps}
-          value={options.find(opt => opt.value === value)}
           onChange={selectedOption => {
             const okToProceed = onChangeCheck === undefined || onChangeCheck();
             if (okToProceed) setValue(selectedOption.value);

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/ObjectTypeVersionSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/ObjectTypeVersionSelect.js
@@ -4,7 +4,7 @@ import useAsync from 'react-use/esm/useAsync';
 
 import Field from 'components/admin/forms/Field';
 import FormRow from 'components/admin/forms/FormRow';
-import Select, {LOADING_OPTION} from 'components/admin/forms/Select';
+import ReactSelect from 'components/admin/forms/ReactSelect';
 import {get} from 'utils/fetch';
 
 import {useSynchronizeSelect} from './hooks';
@@ -29,7 +29,6 @@ const getAvailableVersions = async (uuid, apiGroupID) => {
 };
 
 const ObjectTypeVersionSelect = () => {
-  const [fieldProps, , {setValue}] = useField('objecttypeVersion');
   const {
     values: {objectsApiGroup = null, objecttype = ''},
   } = useFormikContext();
@@ -45,11 +44,12 @@ const ObjectTypeVersionSelect = () => {
   if (error) throw error;
 
   const choices = loading
-    ? LOADING_OPTION
+    ? []
     : versions.map(version => [version.version, `${version.version} (${version.status})`]);
 
   useSynchronizeSelect('objecttypeVersion', loading, choices);
 
+  const options = choices.map(([value, label]) => ({value, label}));
   return (
     <FormRow>
       <Field
@@ -61,19 +61,14 @@ const ObjectTypeVersionSelect = () => {
             defaultMessage="Version"
           />
         }
+        noManageChildProps
       >
-        <Select
+        <ReactSelect
+          name="objecttypeVersion"
           required
-          disabled={!objecttype}
-          choices={choices}
-          id="id_objecttypeVersion"
-          {...fieldProps}
-          onChange={event => {
-            // overridden to handle the proper data type, since every <option value>
-            // turns into a string in HTML
-            const newVersion = parseInt(event.currentTarget.value, 10);
-            setValue(newVersion);
-          }}
+          options={options}
+          isLoading={loading}
+          isDisabled={!objecttype}
         />
       </Field>
     </FormRow>

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/ObjectsAPIGroup.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/ObjectsAPIGroup.js
@@ -5,7 +5,7 @@ import {useUpdateEffect} from 'react-use';
 
 import Field from 'components/admin/forms/Field';
 import FormRow from 'components/admin/forms/FormRow';
-import Select from 'components/admin/forms/Select';
+import ReactSelect from 'components/admin/forms/ReactSelect';
 
 const ObjectsAPIGroup = ({apiGroupChoices, onChangeCheck}) => {
   const [{onChange: onChangeFormik, ...fieldProps}, , {setValue}] = useField('objectsApiGroup');
@@ -23,17 +23,7 @@ const ObjectsAPIGroup = ({apiGroupChoices, onChangeCheck}) => {
     setValues(newValues);
   }, [setValues, value]); // deliberately excluding values!
 
-  const onChange = event => {
-    const okToProceed = onChangeCheck === undefined || onChangeCheck();
-    if (okToProceed) {
-      // overridden to handle the proper data type, since very <option value>
-      // turns into a string in HTML
-      const newValue = event.currentTarget.value;
-      const newId = newValue ? parseInt(newValue, 10) : null;
-      setValue(newId);
-    }
-  };
-
+  const options = apiGroupChoices.map(([value, label]) => ({value, label}));
   return (
     <FormRow>
       <Field
@@ -51,13 +41,16 @@ const ObjectsAPIGroup = ({apiGroupChoices, onChangeCheck}) => {
             defaultMessage="The API group specifies which objects and objecttypes services to use."
           />
         }
+        noManageChildProps
       >
-        <Select
-          allowBlank
-          choices={apiGroupChoices}
-          id="id_objectsApiGroup"
-          {...fieldProps}
-          onChange={onChange}
+        <ReactSelect
+          name="objectsApiGroup"
+          options={options}
+          required
+          onChange={selectedOption => {
+            const okToProceed = onChangeCheck === undefined || onChangeCheck();
+            if (okToProceed) setValue(selectedOption.value);
+          }}
         />
       </Field>
     </FormRow>

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/index.js
@@ -1,12 +1,7 @@
 export {default as ObjectsAPIGroup} from './ObjectsAPIGroup';
 export {default as ObjectTypeSelect} from './ObjectTypeSelect';
 export {default as ObjectTypeVersionSelect} from './ObjectTypeVersionSelect';
-export {
-  default as DocumentType,
-  InformatieobjecttypeSubmissionReport,
-  InformatieobjecttypeSubmissionCsv,
-  InformatieobjecttypeAttachment,
-} from './DocumentType';
+export {DocumentTypesFieldet} from './DocumentType';
 export {default as UpdateExistingObject} from './UpdateExistingObject';
 export {default as UploadSubmissionCsv} from './UploadSubmissionCSV';
 export {default as OrganisationRSIN} from './OrganisationRSIN';

--- a/src/openforms/js/components/admin/forms/Field.js
+++ b/src/openforms/js/components/admin/forms/Field.js
@@ -36,6 +36,7 @@ const Field = ({
   fieldBox = false,
   errorClassPrefix = '',
   errorClassModifier = '',
+  noManageChildProps = false,
 }) => {
   const intl = useIntl();
   const originalName = name;
@@ -44,11 +45,15 @@ const Field = ({
 
   const htmlFor = `id_${name}`;
 
-  const childProps = {id: htmlFor, name: originalName};
-  if (disabled) {
-    childProps.disabled = true;
+  const manageChildProps = !noManageChildProps;
+  let modifiedChildren = children;
+  if (manageChildProps) {
+    const childProps = {id: htmlFor, name: originalName};
+    if (disabled) {
+      childProps.disabled = true;
+    }
+    modifiedChildren = React.cloneElement(children, childProps);
   }
-  const modifiedChildren = React.cloneElement(children, childProps);
   const [hasErrors, formattedErrors] = normalizeErrors(errors, intl);
   const className = classNames({
     fieldBox: fieldBox,

--- a/src/openforms/js/components/admin/forms/ReactSelect.js
+++ b/src/openforms/js/components/admin/forms/ReactSelect.js
@@ -1,0 +1,65 @@
+import {getReactSelectStyles} from '@open-formulieren/formio-builder/esm/components/formio/select';
+import {useField} from 'formik';
+import PropTypes from 'prop-types';
+import ReactSelect from 'react-select';
+
+const initialStyles = getReactSelectStyles();
+const styles = {
+  ...initialStyles,
+  control: (...args) => ({
+    ...initialStyles.control(...args),
+    minHeight: '1.875rem',
+    height: '1.875rem',
+  }),
+  valueContainer: (...args) => ({
+    ...initialStyles.valueContainer(...args),
+    height: 'calc(1.875rem - 2px)',
+    padding: '0 6px',
+  }),
+  input: (...args) => ({
+    ...initialStyles.input(...args),
+    margin: '0px',
+  }),
+  indicatorsContainer: baseStyles => ({
+    ...baseStyles,
+    height: 'calc(1.875rem - 2px)',
+    padding: '0 2px',
+  }),
+  dropdownIndicator: (...args) => ({
+    ...initialStyles.dropdownIndicator(...args),
+    padding: '5px 2px',
+  }),
+};
+
+/**
+ * A select dropdown backed by react-select for Formik forms.
+ *
+ * Any additional props are forwarded to the underlyng ReactSelect component.
+ */
+const Select = ({name, options, ...props}) => {
+  const [fieldProps, , fieldHelpers] = useField(name);
+  const {value} = fieldProps;
+  const {setValue} = fieldHelpers;
+  return (
+    <ReactSelect
+      inputId={`id_${name}`}
+      className="admin-react-select"
+      styles={styles}
+      menuPlacement="auto"
+      options={options}
+      {...fieldProps}
+      value={options.find(opt => opt.value === value)}
+      onChange={selectedOption => {
+        setValue(selectedOption.value);
+      }}
+      {...props}
+    />
+  );
+};
+
+Select.propTypes = {
+  name: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default Select;

--- a/src/openforms/js/components/admin/modals/FormModal.js
+++ b/src/openforms/js/components/admin/modals/FormModal.js
@@ -22,6 +22,7 @@ const FormModal = ({
     <form
       className="aligned react-modal__form"
       onSubmit={event => onFormSubmit && onFormSubmit(event)}
+      data-testid="modal-form"
     >
       {children}
     </form>

--- a/src/openforms/scss/_vendor.scss
+++ b/src/openforms/scss/_vendor.scss
@@ -7,6 +7,7 @@
 @import './vendor/tinymce';
 @import './vendor/django-two-factor-auth';
 @import './vendor/design-token-editor';
+@import './vendor/react-select';
 
 #openforms-container {
   @include margin(

--- a/src/openforms/scss/vendor/_react-select.scss
+++ b/src/openforms/scss/vendor/_react-select.scss
@@ -11,5 +11,9 @@
     max-inline-size: calc(170px + var(--of-admin-select-max-inline-size));
   }
 
+  @at-root .form-row:has(&) {
+    overflow: visible;
+  }
+
   inline-size: clamp(200px, 100%, var(--of-admin-select-max-inline-size));
 }

--- a/src/openforms/scss/vendor/_react-select.scss
+++ b/src/openforms/scss/vendor/_react-select.scss
@@ -1,0 +1,15 @@
+.admin-react-select {
+  @at-root .react-modal__form .form-row & {
+    &,
+    & * {
+      box-sizing: border-box;
+    }
+  }
+
+  @at-root .flex-container:has(&) {
+    flex-grow: 1;
+    max-inline-size: calc(170px + var(--of-admin-select-max-inline-size));
+  }
+
+  inline-size: clamp(200px, 100%, var(--of-admin-select-max-inline-size));
+}


### PR DESCRIPTION
Related to #4577 

**Changes**

* Refactored existing selects to use react-select under the hood. This provides a search field which is useful for large lists to filter down in the options.
* Updated to new formio-builder version so we can re-use the dark-mode support styles
* Added base react-select component with some additional django-admin style overrides
* Refactored some duplicated code into single component so that we can easily deprecate it next

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
