### PR TITLE
:recycle: [#4380] Modify stuf-zds plugin to support extra data

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -51,9 +51,12 @@ export const BACKEND_OPTIONS_FORMS = {
   },
   'stuf-zds-create-zaak:ext-utrecht': {
     uiSchema: {
-      paymentStatusUpdateXml: {
-        'ui:widget': 'textarea',
-        'ui:rows': '10',
+      paymentStatusUpdateMapping: {
+        'ui:orderable': false,
+        items: {
+          'ui:orderable': false,
+          'ui:removable': false,
+        },
       },
     },
   },

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -2,6 +2,7 @@ import logging
 import re
 from dataclasses import dataclass
 from functools import partial
+from typing import Any
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -213,6 +214,11 @@ class StufZDSRegistration(BasePlugin):
 
         return PreRegistrationResult(reference=zaak_id)
 
+    def get_extra_data(
+        self, submission: Submission, options: ZaakOptions
+    ) -> dict[str, Any]:
+        return get_unmapped_data(submission, self.zaak_mapping, REGISTRATION_ATTRIBUTE)
+
     def register_submission(
         self, submission: Submission, options: ZaakOptions
     ) -> dict | None:
@@ -241,9 +247,7 @@ class StufZDSRegistration(BasePlugin):
                     REGISTRATION_ATTRIBUTE,
                 )["key"]
 
-            extra_data = get_unmapped_data(
-                submission, self.zaak_mapping, REGISTRATION_ATTRIBUTE
-            )
+            extra_data = self.get_extra_data(submission, options)
             # The extraElement tag of StUF-ZDS expects primitive types
             extra_data = flatten_data(extra_data)
 


### PR DESCRIPTION
added a method `get_extra_data` on the StUFZDSRegistration plugin to make it easier for extensions to override this behaviour (see stuf-zds-payments extension)

required for https://github.com/open-formulieren/open-forms-ext-stuf-zds-payments/pull/1

Closes #4380 partially

**Changes**

* Modify stuf-zds plugin to support extra data

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
