### PR TITLE
Add document type select/dropdowns

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3905,6 +3905,7 @@ paths:
         schema:
           type: string
           format: uri
+          default: ''
           minLength: 1
         description: Filter informatieobjecttypen against this catalogus URL.
       - in: query
@@ -4105,6 +4106,7 @@ paths:
         schema:
           type: string
           format: uri
+          default: ''
           minLength: 1
         description: Filter informatieobjecttypen against this catalogus URL.
       - in: query
@@ -6842,10 +6844,16 @@ components:
         label:
           type: string
           description: The display label of the catalogue
+        url:
+          type: string
+          format: uri
+          description: The API resource URL of the catalogue. You can use this for
+            subsequent filtering operations.
       required:
       - domain
       - label
       - rsin
+      - url
     Category:
       type: object
       properties:
@@ -8396,22 +8404,21 @@ components:
     InformatieObjectType:
       type: object
       properties:
-        catalogusDomein:
-          type: string
-        catalogusRsin:
-          type: string
-        catalogusLabel:
-          type: string
-          description: The display label of the catalogus
         url:
           type: string
           format: uri
         omschrijving:
           type: string
+          title: description
+          description: The description uniquely identifies a document type within
+            a catalogue. Multiple versions of the same document type may exist, these
+            have non-overlapping valid from/valid until dates.
+        catalogusLabel:
+          type: string
+          title: catalogue label
+          description: A representation of the catalogue containing the document type.
       required:
-      - catalogusDomein
       - catalogusLabel
-      - catalogusRsin
       - omschrijving
       - url
     Language:

--- a/src/openforms/contrib/zgw/api/filters.py
+++ b/src/openforms/contrib/zgw/api/filters.py
@@ -1,9 +1,23 @@
+from django.utils.translation import gettext_lazy as _
+
 from rest_framework import serializers
 
 from ..clients import CatalogiClient
 
 
 class ProvidesCatalogiClientQueryParamsSerializer(serializers.Serializer):
+
+    def get_ztc_client(self) -> CatalogiClient:
+        raise NotImplementedError()
+
+
+class DocumentTypesFilter(serializers.Serializer):
+    catalogus_url = serializers.URLField(
+        label=_("catalogus URL"),
+        help_text=_("Filter informatieobjecttypen against this catalogus URL."),
+        required=False,
+        default="",
+    )
 
     def get_ztc_client(self) -> CatalogiClient:
         raise NotImplementedError()

--- a/src/openforms/contrib/zgw/api/serializers.py
+++ b/src/openforms/contrib/zgw/api/serializers.py
@@ -9,13 +9,27 @@ class CatalogueSerializer(serializers.Serializer):
     label = serializers.CharField(  # type: ignore
         label=_("label"), help_text=_("The display label of the catalogue")
     )
-
-
-class InformatieObjectTypeSerializer(serializers.Serializer):
-    catalogus_domein = serializers.CharField(label=_("catalogus domein"))
-    catalogus_rsin = serializers.CharField(label=_("catalogus rsin"))
-    catalogus_label = serializers.CharField(
-        label=_("catalogus label"), help_text=_("The display label of the catalogus")
+    url = serializers.URLField(
+        label=_("url"),
+        help_text=_(
+            "The API resource URL of the catalogue. You can use this for subsequent "
+            "filtering operations.",
+        ),
     )
+
+
+# TODO: OF 3.0 -> use English instead of Dutch.
+class InformatieObjectTypeSerializer(serializers.Serializer):
     url = serializers.URLField(label=_("url"))
-    omschrijving = serializers.CharField(label=_("omschrijving"))
+    omschrijving = serializers.CharField(
+        label=_("description"),
+        help_text=_(
+            "The description uniquely identifies a document type within a catalogue. "
+            "Multiple versions of the same document type may exist, these have "
+            "non-overlapping valid from/valid until dates."
+        ),
+    )
+    catalogus_label = serializers.CharField(
+        label=_("catalogue label"),
+        help_text=_("A representation of the catalogue containing the document type."),
+    )

--- a/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
+++ b/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 from django.urls import Resolver404, resolve, reverse
 
@@ -18,12 +18,17 @@ from openforms.tests.e2e.base import (
     rs_select_option,
 )
 from openforms.tests.utils import log_flaky
+from openforms.utils.tests.vcr import OFVCRMixin
 
 from ..factories import FormFactory
 from .helpers import close_modal, open_component_options_modal, phase
 
+VCR_CASSETTES = (Path(__file__).parent).resolve()
 
-class FormDesignerRegistrationBackendConfigTests(E2ETestCase):
+
+class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
+    VCR_TEST_FILES = VCR_CASSETTES
+
     async def test_configuring_zgw_api_group(self):
         """
         Test that the admin editor dynamically changes the request to InformatieObjectTypenListView based on the registration backend configuration.
@@ -149,57 +154,32 @@ class FormDesignerRegistrationBackendConfigTests(E2ETestCase):
             str(zgw_api_2.pk),
         )
 
-    @patch(
-        "openforms.registrations.contrib.objects_api.client.ObjecttypesClient.list_objecttype_versions"
-    )
-    @patch(
-        "openforms.registrations.contrib.objects_api.client.ObjecttypesClient.list_objecttypes"
-    )
-    async def test_configuration_objects_api_group(
-        self,
-        m_list_objecttypes: MagicMock,
-        m_list_objecttype_versions: MagicMock,
-    ):
+    async def test_configuration_objects_api_group(self):
         """
-        Test that the admin editor dynamically changes the request to
-        InformatieObjectTypenListView based on the registration backend configuration.
+        Assert that the document types are retrieved based on the selected API group.
 
-        The flow in this test is:
-        - Configure the Registration backend to use set 1 of the configured Object apis
-        - Go to the file upload component and check that the query parameter in the
-          request to the informatieobjecttype endpoint is the PK of the right group
-        - Go back to the registration tab and change which Objects API group should be used
-        - Go to the file component and check that the query parameter in the request changes
+        This test uses VCR, when re-recording cassettes, ensure that the docker-compose
+        services are up and running. From the root of the repo:
+
+        .. code-block:: bash
+
+            cd docker
+            docker compose \
+                -f docker-compose.open-zaak.yml \
+                -f docker-compose.objects-apis.yml \
+                up
         """
-        ot_root = "https://objecttypes-1.nl/api/v2/"
-        # subset of fields, API spec is at
-        # https://github.com/maykinmedia/objecttypes-api/
-        m_list_objecttypes.return_value = [
-            {
-                "url": f"{ot_root}objecttypes/0879828e-823b-493e-9879-e310b1bfda77",
-                "uuid": "0879828e-823b-493e-9879-e310b1bfda77",
-                "name": "Some object type",
-                "namePlural": "Some object types",
-                "dataClassification": "open",
-            }
-        ]
-        m_list_objecttype_versions.return_value = [{"version": 1, "status": "draft"}]
 
         @sync_to_async
         def setUpTestData():
+            # both groups talk to the same services for simplicity
             objects_api_1 = ObjectsAPIGroupConfigFactory.create(
                 name="Group 1",
-                objects_service__api_root="https://objects-1.nl/api/v1/",
-                objecttypes_service__api_root=ot_root,
-                drc_service__api_root="https://documenten-1.nl/api/v1/",
-                catalogi_service__api_root="https://catalogus-1.nl/api/v1/",
+                for_test_docker_compose=True,
             )
             objects_api_2 = ObjectsAPIGroupConfigFactory.create(
                 name="Group 2",
-                objects_service__api_root="https://objects-2.nl/api/v1/",
-                objecttypes_service__api_root="https://objecttypes-2.nl/api/v1/",
-                drc_service__api_root="https://documenten-2.nl/api/v1/",
-                catalogi_service__api_root="https://catalogus-2.nl/api/v1/",
+                for_test_docker_compose=True,
             )
             form = FormFactory.create(
                 name="Configure registration test",

--- a/src/openforms/forms/tests/e2e_tests/vcr_cassettes/FormDesignerRegistrationBackendConfigTests/FormDesignerRegistrationBackendConfigTests.test_configuration_objects_api_group.yaml
+++ b/src/openforms/forms/tests/e2e_tests/vcr_cassettes/FormDesignerRegistrationBackendConfigTests/FormDesignerRegistrationBackendConfigTests.test_configuration_objects_api_group.yaml
@@ -1,0 +1,374 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIwODQ0NiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.njS_gm4E0-e0dKtr9oTpClq4V2fh45kXfeSAMe-o7FQ
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","domein":"OTHER","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81"],"naam":"Test
+        catalog 2","versie":"","begindatumVersie":null},{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1563'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","status":"draft","jsonSchema":{"type":"object"},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","publishedAt":null}]}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '385'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 09 Aug 2024 13:00:47 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIwODQ0OCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.1pcrmrwh8sZY2uSHULJrg0Pc6Hp-ZxhGuVyM1ftKxYY
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","domein":"OTHER","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81"],"naam":"Test
+        catalog 2","versie":"","begindatumVersie":null},{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1563'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIwODQ0OCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.1pcrmrwh8sZY2uSHULJrg0Pc6Hp-ZxhGuVyM1ftKxYY
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen
+  response:
+    body:
+      string: '{"count":7,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"Attachment
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"PDF
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"CSV
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-11","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"beginObject":"2024-03-19","eindeObject":"2024-07-10"},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"CSV
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '5754'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIwODQ1MCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.5DTo7XgvclZA0i1QZqnFdC2EkXRkbua881z6PqihMLI
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","domein":"OTHER","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81"],"naam":"Test
+        catalog 2","versie":"","begindatumVersie":null},{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1563'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","status":"draft","jsonSchema":{"type":"object"},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","publishedAt":null}]}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '385'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 09 Aug 2024 13:00:50 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIwODQ1MiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.jHdnuLZZiT2c3XCBbVbyfnCb2nuZcjKvpzzpxanmqdw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","domein":"OTHER","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81"],"naam":"Test
+        catalog 2","versie":"","begindatumVersie":null},{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1563'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIwODQ1MiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.jHdnuLZZiT2c3XCBbVbyfnCb2nuZcjKvpzzpxanmqdw
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen
+  response:
+    body:
+      string: '{"count":7,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"Attachment
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"PDF
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","omschrijving":"CSV
+        Informatieobjecttype other catalog","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-07-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-11","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"beginObject":"2024-03-19","eindeObject":"2024-07-10"},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"CSV
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '5754'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -3,6 +3,7 @@ import selectEvent from 'react-select-event';
 
 import {
   mockCataloguesGet,
+  mockDocumentTypesGet,
   mockObjecttypeVersionsGet,
   mockObjecttypesGet,
 } from 'components/admin/form_design/registrations/objectsapi/mocks';
@@ -189,6 +190,7 @@ export default {
             {version: 2, status: 'draft'},
           ]),
           mockCataloguesGet(),
+          mockDocumentTypesGet(),
         ],
       },
     },

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
@@ -20,6 +20,7 @@ const ObjectsApiOptionsForm = ({index, name, label, schema, formData, onChange})
   const {objectsApiGroup} = schema.properties;
   const apiGroupChoices = getChoicesFromSchema(objectsApiGroup.enum, objectsApiGroup.enumNames);
   const numErrors = filterErrors(name, validationErrors).length;
+
   return (
     <Field name={name} label={label}>
       <>

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -5,7 +5,13 @@ import selectEvent from 'react-select-event';
 import {ValidationErrorsDecorator} from 'components/admin/form_design/story-decorators';
 
 import ObjectsApiOptionsFormFields from './ObjectsApiOptionsFormFields';
-import {mockObjecttypeVersionsGet, mockObjecttypesError, mockObjecttypesGet} from './mocks';
+import {
+  mockCataloguesGet,
+  mockDocumentTypesGet,
+  mockObjecttypeVersionsGet,
+  mockObjecttypesError,
+  mockObjecttypesGet,
+} from './mocks';
 
 const NAME = 'form.registrationBackends.0.options';
 
@@ -51,6 +57,8 @@ export default {
           {version: 1, status: 'published'},
           {version: 2, status: 'draft'},
         ]),
+        mockCataloguesGet(),
+        mockDocumentTypesGet(),
       ],
     },
   },

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -200,10 +200,6 @@ export const APIFetchError = {
     });
 
     await step('Retrieving catalogues and document types', async () => {
-      const fieldsetTitle = canvas.getByRole('heading', {name: 'Documenttypen (Tonen)'});
-      expect(fieldsetTitle).toBeVisible();
-      await userEvent.click(within(fieldsetTitle).getByRole('link', {name: '(Tonen)'}));
-
       const errorMessage = await canvas.findByText(
         'Er ging iets fout bij het ophalen van de beschikbare catalogi en/of documenttypen.'
       );
@@ -246,5 +242,70 @@ export const V2ValidationErrors = {
       [`${NAME}.informatieobjecttypeAttachment`, 'Computer says no'],
       [`${NAME}.organisatieRsin`, 'Computer says no'],
     ],
+  },
+};
+
+export const SelectDocumentType = {
+  args: {
+    formData: {
+      version: 2,
+      objectsApiGroup: 1,
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const fieldsetTitle = canvas.getByRole('heading', {name: 'Documenttypen (Tonen)'});
+    expect(fieldsetTitle).toBeVisible();
+    await userEvent.click(within(fieldsetTitle).getByRole('link', {name: '(Tonen)'}));
+
+    const catalogueSelect = canvas.getByLabelText('Catalogus');
+    await selectEvent.select(catalogueSelect, 'Catalogus 1');
+    const pdfSelect = canvas.getByLabelText('Informatieobjecttype inzendings-PDF');
+    await selectEvent.select(pdfSelect, 'Test PDF');
+
+    const testForm = await canvas.findByTestId('test-form');
+    await waitFor(() => {
+      expect(testForm).toHaveFormValues({
+        iotSubmissionReport: 'Test PDF',
+        iotSubmissionCsv: '',
+        iotAttachment: '',
+      });
+    });
+
+    await selectEvent.select(catalogueSelect, 'Catalogus 2');
+    await waitFor(() => {
+      expect(testForm).toHaveFormValues({
+        iotSubmissionReport: '',
+        iotSubmissionCsv: '',
+        iotAttachment: '',
+      });
+    });
+  },
+};
+
+export const DisplayPersistedConfiguration = {
+  args: {
+    formData: {
+      version: 2,
+      objectsApiGroup: 1,
+      catalogue: {
+        rsin: '000000000',
+        domain: 'TEST',
+      },
+      iotSubmissionReport: 'Test PDF',
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const fieldsetTitle = canvas.getByRole('heading', {name: 'Documenttypen (Tonen)'});
+    expect(fieldsetTitle).toBeVisible();
+    await userEvent.click(within(fieldsetTitle).getByRole('link', {name: '(Tonen)'}));
+
+    expect(await canvas.findByText('Catalogus 1')).toBeVisible();
+    expect(await canvas.findByText('Test PDF')).toBeVisible();
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
@@ -1,28 +1,203 @@
+import {useField, useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import {useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
+import {useAsync, usePrevious} from 'react-use';
 
+import Field from 'components/admin/forms/Field';
 import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import ReactSelect from 'components/admin/forms/ReactSelect';
+import {get} from 'utils/fetch';
 
-import CatalogueSelect from './CatalogueSelect';
+import CatalogueSelect, {extractValue as getCatalogueOption} from './CatalogueSelect';
 
-export const DocumentTypesFieldet = () => (
-  <Fieldset
-    title={
-      <FormattedMessage
-        description="Objects registration: document types"
-        defaultMessage="Document types"
-      />
-    }
-    collapsible
-    fieldNames={['catalogue']}
-  >
-    <div className="description">
-      <FormattedMessage
-        description="New document types informative message"
-        defaultMessage={`The legacy document types configuration will be ignored
+// Data fetching
+
+const CATALOGUES_ENDPOINT = '/api/v2/registration/plugins/objects-api/catalogues';
+const IOT_ENDPOINT = '/api/v2/registration/plugins/objects-api/informatieobjecttypen';
+
+const getCatalogues = async apiGroupID => {
+  const response = await get(CATALOGUES_ENDPOINT, {objects_api_group: apiGroupID});
+  if (!response.ok) {
+    throw new Error('Loading available catalogues failed');
+  }
+  const catalogues = response.data;
+
+  const _optionsByRSIN = {};
+  for (const catalogue of catalogues) {
+    const {rsin} = catalogue;
+    if (!_optionsByRSIN[rsin]) _optionsByRSIN[rsin] = [];
+    _optionsByRSIN[rsin].push(catalogue);
+  }
+
+  const groups = Object.entries(_optionsByRSIN)
+    .map(([rsin, options]) => ({
+      label: rsin,
+      options: options.sort((a, b) => a.label.localeCompare(b.label)),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return groups;
+};
+
+const getDocumentTypes = async (apiGroupID, catalogueUrl) => {
+  const response = await get(IOT_ENDPOINT, {
+    objects_api_group: apiGroupID,
+    catalogus_url: catalogueUrl,
+  });
+  if (!response.ok) {
+    throw new Error('Loading available document types failed');
+  }
+  const documentTypes = response.data.sort((a, b) => a.omschrijving.localeCompare(b.omschrijving));
+  return documentTypes.map(({omschrijving}) => ({
+    value: omschrijving,
+    label: omschrijving,
+  }));
+};
+
+// Components
+
+const DocumentType = ({name, label, loading, options, isDisabled, helpText}) => {
+  const [, , fieldHelpers] = useField(name);
+  const {setValue} = fieldHelpers;
+  return (
+    <FormRow>
+      <Field name={name} label={label} helpText={helpText} noManageChildProps>
+        <ReactSelect
+          name={name}
+          options={options}
+          isLoading={loading}
+          isDisabled={isDisabled}
+          onChange={selectedOption => {
+            // unset form key entirely if the selection is cleared
+            setValue(selectedOption ? selectedOption.value : undefined);
+          }}
+          isClearable
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+DocumentType.propTypes = {
+  name: PropTypes.oneOf(['iotSubmissionReport', 'iotSubmissionCsv', 'iotAttachment']).isRequired,
+  label: PropTypes.node.isRequired,
+  loading: PropTypes.bool.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  helpText: PropTypes.node,
+};
+
+export const DocumentTypesFieldet = () => {
+  const {values, setValues} = useFormikContext();
+  const {objectsApiGroup = null, catalogue = undefined} = values;
+
+  // fetch available catalogues and re-use the result
+  const {
+    loading: loadingCatalogues,
+    value: catalogueOptionGroups = [],
+    error: cataloguesError,
+  } = useAsync(async () => {
+    if (!objectsApiGroup) return [];
+    return await getCatalogues(objectsApiGroup);
+  }, [objectsApiGroup]);
+  if (cataloguesError) throw cataloguesError;
+
+  const catalogueValue = getCatalogueOption(catalogueOptionGroups, catalogue || {});
+  const catalogueUrl = catalogueValue?.url;
+  const previousCatalogueUrl = usePrevious(catalogueUrl);
+
+  // if the catalogue changes, reset the selected document types
+  useEffect(() => {
+    // only run the update if the catalogue is changed from one value to another
+    // OR the catalogue was cleared.
+    const hadCatalogueBefore = previousCatalogueUrl !== undefined;
+    const hasCatalogueNow = catalogueUrl !== undefined;
+    const isCleared = hadCatalogueBefore && !hasCatalogueNow;
+    const hasChanged = hadCatalogueBefore && catalogueUrl !== previousCatalogueUrl;
+    if (!isCleared && !hasChanged) return;
+
+    setValues(prevValues => ({
+      ...prevValues,
+      iotSubmissionReport: undefined,
+      iotSubmissionCsv: undefined,
+      iotAttachment: undefined,
+    }));
+  }, [previousCatalogueUrl, catalogueUrl]);
+
+  const {
+    loading,
+    value: documentTypeOptions = [],
+    error,
+  } = useAsync(async () => {
+    if (!objectsApiGroup) return [];
+    if (!catalogueUrl) return [];
+    return await getDocumentTypes(objectsApiGroup, catalogueUrl);
+  }, [objectsApiGroup, catalogueUrl]);
+  if (error) throw error;
+
+  const documentTypeProps = {
+    isDisabled: !objectsApiGroup || !catalogueUrl,
+    loading: loading,
+    options: documentTypeOptions,
+  };
+
+  return (
+    <Fieldset
+      title={
+        <FormattedMessage
+          description="Objects registration: document types"
+          defaultMessage="Document types"
+        />
+      }
+      collapsible
+      fieldNames={['catalogue', 'iotSubmissionReport', 'iotSubmissionCsv', 'iotAttachment']}
+    >
+      <div className="description">
+        <FormattedMessage
+          description="New document types informative message"
+          defaultMessage={`The legacy document types configuration will be ignored
         as soon as a catalogue is selected, even if you don't select any document
         type in the dropdowns.`}
+        />
+      </div>
+      <CatalogueSelect loading={loadingCatalogues} optionGroups={catalogueOptionGroups} />
+      <DocumentType
+        name="iotSubmissionReport"
+        label={
+          <FormattedMessage
+            description='Objects API registration options "Submission report PDF informatieobjecttype" label'
+            defaultMessage="Submission report PDF informatieobjecttype"
+          />
+        }
+        {...documentTypeProps}
       />
-    </div>
-    <CatalogueSelect />
-  </Fieldset>
-);
+      <DocumentType
+        name="iotSubmissionCsv"
+        label={
+          <FormattedMessage
+            description='Objects API registration options "Submission report CSV informatieobjecttype" label'
+            defaultMessage="Submission report CSV informatieobjecttype"
+          />
+        }
+        {...documentTypeProps}
+      />
+      <DocumentType
+        name="iotAttachment"
+        label={
+          <FormattedMessage
+            description='Objects API registration options "Attachment informatieobjecttype" label'
+            defaultMessage="Attachment informatieobjecttype"
+          />
+        }
+        {...documentTypeProps}
+      />
+    </Fieldset>
+  );
+};

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -36,19 +36,23 @@ export const mockTargetPathsPost = paths =>
 
 const CATALOGUES = [
   {
+    url: 'https://example.com/catalogi/api/v1/catalogussen/1',
     rsin: '000000000',
     domain: 'TEST',
     label: 'Catalogus 1',
   },
   {
+    url: 'https://example.com/catalogi/api/v1/catalogussen/2',
     rsin: '000000000',
     domain: 'OTHER',
     label: 'Catalogus 2',
   },
   {
+    url: 'https://example.com/catalogi/api/v1/catalogussen/3',
     rsin: '111111111',
     domain: 'TEST',
     label: 'TEST (111111111)',
+    catalogusLabel: '',
   },
 ];
 
@@ -57,5 +61,59 @@ export const mockCataloguesGet = () =>
     `${API_BASE_URL}/api/v2/registration/plugins/objects-api/catalogues`,
     (req, res, ctx) => {
       return res(ctx.json(CATALOGUES));
+    }
+  );
+
+const DOCUMENT_TYPES = {
+  'https://example.com/catalogi/api/v1/catalogussen/1': [
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/1',
+      omschrijving: 'Test PDF',
+      catalogusLabel: 'Catalogus 1',
+    },
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/2',
+      omschrijving: 'Test attachment',
+      catalogusLabel: 'Catalogus 1',
+    },
+  ],
+  'https://example.com/catalogi/api/v1/catalogussen/2': [
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/1',
+      omschrijving: 'Other PDF',
+      catalogusLabel: 'Catalogus 2',
+    },
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/4',
+      omschrijving: 'Other attachment',
+      catalogusLabel: 'Catalogus 2',
+    },
+  ],
+  'https://example.com/catalogi/api/v1/catalogussen/3': [
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/10',
+      omschrijving: 'Document type 1',
+      catalogusLabel: 'TEST (111111111)',
+    },
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/11',
+      omschrijving: 'Document type 2',
+      catalogusLabel: 'TEST (111111111)',
+    },
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/12',
+      omschrijving: 'Document type 3',
+      catalogusLabel: 'TEST (111111111)',
+    },
+  ],
+};
+
+export const mockDocumentTypesGet = () =>
+  rest.get(
+    `${API_BASE_URL}/api/v2/registration/plugins/objects-api/informatieobjecttypen`,
+    (req, res, ctx) => {
+      const catalogusUrl = req.url.searchParams.get('catalogus_url');
+      const match = DOCUMENT_TYPES[catalogusUrl] ?? [];
+      return res(ctx.json(match));
     }
   );

--- a/src/openforms/js/components/admin/forms/ReactSelect.js
+++ b/src/openforms/js/components/admin/forms/ReactSelect.js
@@ -48,7 +48,7 @@ const Select = ({name, options, ...props}) => {
       menuPlacement="auto"
       options={options}
       {...fieldProps}
-      value={options.find(opt => opt.value === value)}
+      value={options.find(opt => opt.value === value) || null}
       onChange={selectedOption => {
         setValue(selectedOption.value);
       }}

--- a/src/openforms/registrations/contrib/objects_api/api/filters.py
+++ b/src/openforms/registrations/contrib/objects_api/api/filters.py
@@ -5,6 +5,7 @@ from zgw_consumers.client import build_client
 
 from openforms.api.fields import PrimaryKeyRelatedAsChoicesField
 from openforms.contrib.zgw.api.filters import (
+    DocumentTypesFilter,
     ProvidesCatalogiClientQueryParamsSerializer,
 )
 from openforms.contrib.zgw.clients.catalogi import CatalogiClient
@@ -12,7 +13,7 @@ from openforms.contrib.zgw.clients.catalogi import CatalogiClient
 from ..models import ObjectsAPIGroupConfig
 
 
-class APIGroupQueryParamsSerializer(ProvidesCatalogiClientQueryParamsSerializer):
+class ObjectsAPIGroupMixin(serializers.Serializer):
     objects_api_group = PrimaryKeyRelatedAsChoicesField(
         queryset=ObjectsAPIGroupConfig.objects.exclude(catalogi_service=None),
         help_text=_(
@@ -31,9 +32,13 @@ class APIGroupQueryParamsSerializer(ProvidesCatalogiClientQueryParamsSerializer)
         )
 
 
-class ListInformatieObjectTypenQueryParamsSerializer(APIGroupQueryParamsSerializer):
-    catalogus_url = serializers.URLField(
-        label=_("catalogus URL"),
-        help_text=_("Filter informatieobjecttypen against this catalogus URL."),
-        required=False,
-    )
+class APIGroupQueryParamsSerializer(
+    ObjectsAPIGroupMixin, ProvidesCatalogiClientQueryParamsSerializer
+):
+    pass
+
+
+class ListInformatieObjectTypenQueryParamsSerializer(
+    ObjectsAPIGroupMixin, DocumentTypesFilter
+):
+    pass

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_retrieve_filter_by_catalogus.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_retrieve_filter_by_catalogus.yaml
@@ -7,31 +7,31 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzE5MTUzMywiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3Lixayz90f1SMsqMQWttxzHrUgvPyrNCIxDqMKsxSCs
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzQ3MTI4MiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.C7_c3W3_ZihBnSligl_y7dlaEuSa21AZAAHWyXOXL4M
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8003/catalogi/api/v1/catalogussen
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d
   response:
     body:
-      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/630271f6-568a-485e-b1c4-4ed2d6ab3a58","domein":"OTHER","rsin":"000000000","contactpersoonBeheerNaam":"Test
-        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81"],"naam":"Test
-        catalog 2","versie":"","begindatumVersie":null},{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
         name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
-        catalog","versie":"","begindatumVersie":null}]}'
+        catalog","versie":"","begindatumVersie":null}'
     headers:
       API-version:
       - 1.3.1
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, HEAD, OPTIONS
       Content-Length:
-      - '1563'
+      - '846'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
+      ETag:
+      - '"3b954569daa5871216ebb13dbf11eb9e"'
       Referrer-Policy:
       - same-origin
       Vary:
@@ -51,7 +51,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzE5MTUzMywiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3Lixayz90f1SMsqMQWttxzHrUgvPyrNCIxDqMKsxSCs
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzQ3MTI4MiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.C7_c3W3_ZihBnSligl_y7dlaEuSa21AZAAHWyXOXL4M
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/registrations/contrib/objects_api/tests/test_api_endpoints.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_api_endpoints.py
@@ -314,12 +314,20 @@ class GetInformatieObjecttypesViewTests(OFVCRMixin, APITestCase):
         self.assertGreaterEqual(num_document_types, 6)
         # assert that multiple versions are de-duplicated
         num_unique = len(
-            {
-                (item["omschrijving"], item["catalogusDomein"], item["catalogusRsin"])
-                for item in data
-            }
+            {(item["omschrijving"], item["catalogusLabel"]) for item in data}
         )
         self.assertEqual(num_unique, num_document_types)
+
+        # check the data types of returned information
+        record = data[0]
+        expected = {
+            "catalogusLabel": str,
+            "omschrijving": str,
+            "url": str,
+        }
+        for key, type in expected.items():
+            with self.subTest(key=key):
+                self.assertIsInstance(record[key], type)
 
     def test_retrieve_filter_by_catalogus(self):
         user = StaffUserFactory.create()
@@ -339,7 +347,15 @@ class GetInformatieObjecttypesViewTests(OFVCRMixin, APITestCase):
 
         self.assertGreaterEqual(len(data), 3)
         # we expect only one catalogue to be returned
-        catalogi_domains_seen = {item["catalogusDomein"] for item in data}
-        self.assertEqual(len(catalogi_domains_seen), 1)
-        catalogi_rsin_seen = {item["catalogusRsin"] for item in data}
-        self.assertEqual(len(catalogi_rsin_seen), 1)
+        catalogi_labels_seen = {item["catalogusLabel"] for item in data}
+        self.assertEqual(len(catalogi_labels_seen), 1)
+        # check the data types of returned information
+        record = data[0]
+        expected = {
+            "catalogusLabel": str,
+            "omschrijving": str,
+            "url": str,
+        }
+        for key, type in expected.items():
+            with self.subTest(key=key):
+                self.assertIsInstance(record[key], type)

--- a/src/openforms/registrations/contrib/zgw_apis/api/filters.py
+++ b/src/openforms/registrations/contrib/zgw_apis/api/filters.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from openforms.api.fields import PrimaryKeyRelatedAsChoicesField
 from openforms.contrib.zgw.api.filters import (
+    DocumentTypesFilter,
     ProvidesCatalogiClientQueryParamsSerializer,
 )
 from openforms.contrib.zgw.clients.catalogi import CatalogiClient
@@ -12,7 +13,7 @@ from ..client import get_catalogi_client
 from ..models import ZGWApiGroupConfig
 
 
-class APIGroupQueryParamsSerializer(ProvidesCatalogiClientQueryParamsSerializer):
+class ZGWAPIGroupMixin(serializers.Serializer):
     zgw_api_group = PrimaryKeyRelatedAsChoicesField(
         queryset=ZGWApiGroupConfig.objects.exclude(drc_service=None),
         help_text=_(
@@ -27,9 +28,13 @@ class APIGroupQueryParamsSerializer(ProvidesCatalogiClientQueryParamsSerializer)
         return get_catalogi_client(zgw_api_group)
 
 
-class ListInformatieObjectTypenQueryParamsSerializer(APIGroupQueryParamsSerializer):
-    catalogus_url = serializers.URLField(
-        label=_("catalogus URL"),
-        help_text=_("Filter informatieobjecttypen against this catalogus URL."),
-        required=False,
-    )
+class APIGroupQueryParamsSerializer(
+    ZGWAPIGroupMixin, ProvidesCatalogiClientQueryParamsSerializer
+):
+    pass
+
+
+class ListInformatieObjectTypenQueryParamsSerializer(
+    ZGWAPIGroupMixin, DocumentTypesFilter
+):
+    pass

--- a/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_retrieve_filter_by_catalogus.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_retrieve_filter_by_catalogus.yaml
@@ -7,29 +7,31 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTEzOTUwOCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Au7bo9JjrKcg20xjsATUl6EUfuyp05clpffE3z2JnoA
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzAzNjc0NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.dIfgnx-t_KUd-4mEykTM1mUUBiTZN6Rc_EChFyq6EbI
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8003/catalogi/api/v1/catalogussen
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
         name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
-        catalog","versie":"","begindatumVersie":null}]}'
+        catalog","versie":"","begindatumVersie":null}'
     headers:
       API-version:
       - 1.3.1
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, HEAD, OPTIONS
       Content-Length:
-      - '898'
+      - '846'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
+      ETag:
+      - '"3b954569daa5871216ebb13dbf11eb9e"'
       Referrer-Policy:
       - same-origin
       Vary:
@@ -49,7 +51,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMTEzOTUwOCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.Au7bo9JjrKcg20xjsATUl6EUfuyp05clpffE3z2JnoA
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzAzNjc0NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.dIfgnx-t_KUd-4mEykTM1mUUBiTZN6Rc_EChFyq6EbI
       Connection:
       - keep-alive
       User-Agent:


### PR DESCRIPTION
Partially closes #4577

~~Depends on #4574~~ merged
~~Depends on #4586~~ merged

**Changes**

* Added queries to document types endpoint to populate dropdown options
* Added dropdowns to select the desired document type
* Added interaction tests
* Added reset of document types when a different catalogue is selected (or it's being unset)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
