### PR TITLE
Add feature flag for draft document types (and prepare for ZGW similar mechanics)

### DIFF
--- a/docker/open-zaak/fixtures/open_zaak_fixtures.json
+++ b/docker/open-zaak/fixtures/open_zaak_fixtures.json
@@ -50,6 +50,22 @@
     }
 },
 {
+    "model": "catalogi.catalogus",
+    "pk": 3,
+    "fields": {
+        "_etag": "70058e53ac6aa06b1ef64966509660a2",
+        "naam": "Drafts",
+        "uuid": "aa0e0a50-33f6-4473-99a1-b92bab94e749",
+        "domein": "DRAFT",
+        "rsin": "000000000",
+        "contactpersoon_beheer_naam": "OF",
+        "contactpersoon_beheer_telefoonnummer": "",
+        "contactpersoon_beheer_emailadres": "",
+        "versie": "",
+        "begindatum_versie": null
+    }
+},
+{
     "model": "catalogi.eigenschapspecificatie",
     "pk": 1,
     "fields": {
@@ -221,6 +237,27 @@
         "omschrijving_generiek_hierarchie": "",
         "omschrijving_generiek_opmerking": "",
         "catalogus": 2
+    }
+},
+{
+    "model": "catalogi.informatieobjecttype",
+    "pk": 8,
+    "fields": {
+        "_etag": "3835df1ae4bf5b9a3db52df04cbceee1",
+        "datum_begin_geldigheid": "2024-08-09",
+        "datum_einde_geldigheid": null,
+        "concept": true,
+        "uuid": "3628d25f-f491-4375-a752-39d16bf2dd59",
+        "omschrijving": "Unpublished",
+        "informatieobjectcategorie": "Tests",
+        "trefwoord": "[]",
+        "vertrouwelijkheidaanduiding": "openbaar",
+        "omschrijving_generiek_informatieobjecttype": "",
+        "omschrijving_generiek_definitie": "",
+        "omschrijving_generiek_herkomst": "",
+        "omschrijving_generiek_hierarchie": "",
+        "omschrijving_generiek_opmerking": "",
+        "catalogus": 3
     }
 },
 {

--- a/docker/open-zaak/fixtures/open_zaak_fixtures.json
+++ b/docker/open-zaak/fixtures/open_zaak_fixtures.json
@@ -410,5 +410,12 @@
         "catalogus": 1,
         "deelzaaktypen": []
     }
+},
+{
+    "model": "config.featureflags",
+    "pk": 1,
+    "fields": {
+        "allow_unpublished_typen": true
+    }
 }
 ]

--- a/docs/configuration/registration/objects.rst
+++ b/docs/configuration/registration/objects.rst
@@ -200,22 +200,80 @@ some guidelines for schema authors:
   external entity (resolving this will likely be added in the future in a way that does
   not create security issues).
 
+.. _configuration_registration_objects_feature_flags:
+
+Feature flags
+=============
+
+Feature flags can be enabled or disabled in the admin interface, via **Admin** >
+**Configuration** > **Flag states**.
+
+``ZGW_APIS_INCLUDE_DRAFTS``
+---------------------------
+
+When drafts are included in the ZGW APIs integration, you will be able to select
+document types that have not been published yet for the attachments, submission report
+PDF and CSV. This can be useful when you're testing out things and iterating quickly.
+
+.. note:: Support for creating documents from unpublished document types depends on your
+   particular ZGW API's provider/implementation. The VNG standard requires document
+   types to be published before you can create documents of that type.
+
+Can be enabled at :ref:`deploy time <installation_environment_config_feature_flags>` or
+through the admin interface. Find or create the record with:
+
+* **Flag**: ``ZGW_APIS_INCLUDE_DRAFTS``
+* **Condition name**: ``boolean``
+* **Expected value**: ``true`` to enable it, ``false`` to disable.
+* **Required**: leave unchecked
+
 Technical
 =========
 
-Open Forms requires Objects API v2.2 or newer.
+Open Forms requires Objects API v2.2 or newer and the Objecttypes API v2.0 or newer.
 
-================  ==========================================
+================  ===============================================
 Objects API       Test status
-================  ==========================================
+================  ===============================================
 2.2.x             Manually verified
-2.3.x             Manually verified, integration tests in CI
-================  ==========================================
+2.3.x             Manually verified
+2.4.x             Manually verified, automated end-to-end testing
+================  ===============================================
 
 .. versionchanged:: 2.6.0
 
     Objects API versions older than 2.2.0 are no longer officially supported. You need
     at least version 2.2.0.
+
+================  ===============================================
+Objecttypes API   Test status
+================  ===============================================
+2.0.x             Unknown
+2.1.x             Manually verified
+2.2.x             Manually verified, automated end-to-end testing
+================  ===============================================
+
+For Documents API integration (to upload attachments), Open Forms requires the
+Catalogi API and Documenten API.
+
+================  ===============================================
+Catalogi API      Test status
+================  ===============================================
+1.0.x             Manually verified, some tests in CI
+1.1.x             Manually verified, some tests in CI
+1.2.x             Manually verified, some tests in CI
+1.3.x             Manually verified, automated end-to-end testing
+================  ===============================================
+
+================  ===============================================
+Documenten API    Test status
+================  ===============================================
+1.0.x             Manually verified, some tests in CI
+1.1.x             Manually verified, some tests in CI
+1.2.x             Manually verified, some tests in CI
+1.3.x             Manually verified, some tests in CI
+1.4.x             Manually verified, automated end-to-end testing
+================  ===============================================
 
 
 .. _`Objects API`: https://objects-and-objecttypes-api.readthedocs.io/

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -294,16 +294,6 @@ Other settings
   reasons. New installations should opt-out. If ``False``, the OIDC callback URL is
   ``/auth/oidc/callback/``, if ``True``, it is ``/org-oidc/callback/``.
 
-* ``DIGID_EHERKENNING_OIDC_STRICT``: Enable strict claim processing/validation when
-  using :ref:`configuration_authentication_oidc_digid`,
-  :ref:`configuration_authentication_oidc_eherkenning` or
-  :ref:`configuration_authentication_oidc_machtigen`. Defaults to ``False``. You can
-  also add a feature flag in the admin interface to enable this behaviour.
-
-  .. versionadded:: 2.7.0
-     A formal and more complete authentication context data model is used - existing
-     installations likely do not provide all this information yet.
-
 * ``SESSION_EXPIRE_AT_BROWSER_CLOSE``: Controls if sessions expire at browser close.
   This applies to both the session of end-users filling out forms and staff using the
   administrative interface. Enabling this forces users to log in every time they open
@@ -390,9 +380,17 @@ Feature flags are usually documented in the relevant module that they apply to. 
 you can find a list of feature flags that can be set through their matching environment
 variables, linking to the description of their behaviour in their respective module.
 
-* :ref:`DIGID_EHERKENNING_OIDC_STRICT <>`
 * :ref:`ZGW_APIS_INCLUDE_DRAFTS <configuration_registration_objects_feature_flags>` -
   set to ``True`` to allow unpublished types to be used in the ZGW APIs.
+
+* ``DIGID_EHERKENNING_OIDC_STRICT``: Enable strict claim processing/validation when
+  using :ref:`configuration_authentication_oidc_digid`,
+  :ref:`configuration_authentication_oidc_eherkenning` or
+  :ref:`configuration_authentication_oidc_machtigen`. Defaults to ``False``.
+
+  .. versionadded:: 2.7.0
+     A formal and more complete authentication context data model is used - existing
+     installations likely do not provide all this information yet.
 
 
 Specifying the environment variables

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -376,6 +376,25 @@ Other settings
 
 .. _`Django DATABASE settings`: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-DATABASE-ENGINE
 
+.. _installation_environment_config_feature_flags:
+
+Feature flags
+=============
+
+Open Forms sometimes supports a layered approach for feature flags, where some
+behaviours can be enabled at deploy-time through environment variables already. If
+this option is not available, you can still enable/disable the feature flag in the
+admin interface, via **Admin** > **Configuration** > **Flag states**.
+
+Feature flags are usually documented in the relevant module that they apply to. Below
+you can find a list of feature flags that can be set through their matching environment
+variables, linking to the description of their behaviour in their respective module.
+
+* :ref:`DIGID_EHERKENNING_OIDC_STRICT <>`
+* :ref:`ZGW_APIS_INCLUDE_DRAFTS <configuration_registration_objects_feature_flags>` -
+  set to ``True`` to allow unpublished types to be used in the ZGW APIs.
+
+
 Specifying the environment variables
 =====================================
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8417,8 +8417,13 @@ components:
           type: string
           title: catalogue label
           description: A representation of the catalogue containing the document type.
+        isPublished:
+          type: boolean
+          description: Unpublished document types may be returned when the feature
+            flag 'ZGW_APIS_INCLUDE_DRAFTS' is enabled.
       required:
       - catalogusLabel
+      - isPublished
       - omschrijving
       - url
     Language:

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1199,6 +1199,13 @@ FLAGS = {
             "value": config("DIGID_EHERKENNING_OIDC_STRICT", default=False),
         }
     ],
+    # ZGW API's
+    "ZGW_APIS_INCLUDE_DRAFTS": [
+        {
+            "condition": "boolean",
+            "value": config("ZGW_APIS_INCLUDE_DRAFTS", default=False),
+        },
+    ],
 }
 
 #

--- a/src/openforms/contrib/zgw/api/serializers.py
+++ b/src/openforms/contrib/zgw/api/serializers.py
@@ -33,3 +33,10 @@ class InformatieObjectTypeSerializer(serializers.Serializer):
         label=_("catalogue label"),
         help_text=_("A representation of the catalogue containing the document type."),
     )
+    is_published = serializers.BooleanField(
+        label=_("Is published"),
+        help_text=_(
+            "Unpublished document types may be returned when the feature flag "
+            "'ZGW_APIS_INCLUDE_DRAFTS' is enabled."
+        ),
+    )

--- a/src/openforms/contrib/zgw/api/views.py
+++ b/src/openforms/contrib/zgw/api/views.py
@@ -56,6 +56,9 @@ class DocumentType:
     catalogue: Catalogue
     omschrijving: str
     url: str = field(compare=False)  # different versions have different URLs
+    is_published: bool = field(
+        compare=False
+    )  # different versions may have different publication states
 
     def catalogus_label(self) -> str:
         return self.catalogue.label
@@ -109,6 +112,7 @@ class BaseInformatieObjectTypenListView(ListMixin[DocumentType], APIView):
                     url=iotype["url"],
                     omschrijving=iotype["omschrijving"],
                     catalogue=catalogues[iotype["catalogus"]],
+                    is_published=not iotype.get("concept", False),
                 )
                 if document_type in document_types:
                     continue

--- a/src/openforms/contrib/zgw/tests/test_catalogi_client.py
+++ b/src/openforms/contrib/zgw/tests/test_catalogi_client.py
@@ -11,7 +11,7 @@ These tests make use of requests-mock rather than VCR for two reasons:
 
 from datetime import date
 
-from django.test import SimpleTestCase
+from django.test import TestCase
 
 import requests_mock
 from furl import furl
@@ -20,7 +20,7 @@ from ..clients import CatalogiClient
 from ..exceptions import StandardViolation
 
 
-class CatalogiClientTests(SimpleTestCase):
+class CatalogiClientTests(TestCase):
 
     @requests_mock.Mocker()
     def test_automatic_version_information_extraction(self, m: requests_mock.Mocker):

--- a/src/openforms/forms/admin/mixins.py
+++ b/src/openforms/forms/admin/mixins.py
@@ -1,6 +1,7 @@
 from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
 
+from flags.state import flag_enabled
 from zgw_consumers.api_models.constants import VertrouwelijkheidsAanduidingen
 
 from openforms.config.constants import UploadFileType
@@ -29,7 +30,11 @@ class FormioConfigMixin:
                     {"label": label, "value": value}
                     for value, label in UploadFileType.choices
                 ],
-                "feature_flags": {},
+                "feature_flags": {
+                    "ZGW_APIS_INCLUDE_DRAFTS": flag_enabled(
+                        "ZGW_APIS_INCLUDE_DRAFTS", request=request
+                    ),
+                },
                 "confidentiality_levels": [
                     {"label": label, "value": value}
                     for value, label in VertrouwelijkheidsAanduidingen.choices

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2955,6 +2955,40 @@
       "value": "All Submissions Removal Limit"
     }
   ],
+  "UOofxD": [
+    {
+      "type": 1,
+      "value": "omschrijving"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "options": {
+        "false": {
+          "value": [
+            {
+              "children": [
+                {
+                  "type": 0,
+                  "value": "(not published)"
+                }
+              ],
+              "type": 8,
+              "value": "draft"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+          ]
+        }
+      },
+      "type": 5,
+      "value": "isPublished"
+    }
+  ],
   "UlVtQd": [
     {
       "type": 0,
@@ -4953,6 +4987,42 @@
     {
       "type": 0,
       "value": "Add action"
+    }
+  ],
+  "p9zrjb": [
+    {
+      "type": 0,
+      "value": "The value '"
+    },
+    {
+      "type": 1,
+      "value": "value"
+    },
+    {
+      "type": 0,
+      "value": "' is set but could not be found. "
+    },
+    {
+      "options": {
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Perhaps this document type is not published yet?"
+            }
+          ]
+        },
+        "true": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Possibly the draft was deleted."
+            }
+          ]
+        }
+      },
+      "type": 5,
+      "value": "draftsEnabled"
     }
   ],
   "pDJBaK": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2972,6 +2972,40 @@
       "value": "Bewaartermijn van inzendingen"
     }
   ],
+  "UOofxD": [
+    {
+      "type": 1,
+      "value": "omschrijving"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "options": {
+        "false": {
+          "value": [
+            {
+              "children": [
+                {
+                  "type": 0,
+                  "value": "(not published)"
+                }
+              ],
+              "type": 8,
+              "value": "draft"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+          ]
+        }
+      },
+      "type": 5,
+      "value": "isPublished"
+    }
+  ],
   "UlVtQd": [
     {
       "type": 0,
@@ -4975,6 +5009,42 @@
     {
       "type": 0,
       "value": "Actie toevoegen"
+    }
+  ],
+  "p9zrjb": [
+    {
+      "type": 0,
+      "value": "The value '"
+    },
+    {
+      "type": 1,
+      "value": "value"
+    },
+    {
+      "type": 0,
+      "value": "' is set but could not be found. "
+    },
+    {
+      "options": {
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Perhaps this document type is not published yet?"
+            }
+          ]
+        },
+        "true": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Possibly the draft was deleted."
+            }
+          ]
+        }
+      },
+      "type": 5,
+      "value": "draftsEnabled"
     }
   ],
   "pDJBaK": [

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -3,7 +3,9 @@ import React from 'react';
 const TinyMceContext = React.createContext('');
 TinyMceContext.displayName = 'TinyMceContext';
 
-const FeatureFlagsContext = React.createContext({});
+const FeatureFlagsContext = React.createContext({
+  ZGW_APIS_INCLUDE_DRAFTS: false,
+});
 FeatureFlagsContext.displayName = 'FeatureFlagsContext';
 
 const FormContext = React.createContext({

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -3,6 +3,7 @@ import {Form, Formik} from 'formik';
 import selectEvent from 'react-select-event';
 
 import {ValidationErrorsDecorator} from 'components/admin/form_design/story-decorators';
+import {FeatureFlagsDecorator} from 'components/admin/form_design/story-decorators';
 
 import ObjectsApiOptionsFormFields from './ObjectsApiOptionsFormFields';
 import {
@@ -307,5 +308,34 @@ export const DisplayPersistedConfiguration = {
 
     expect(await canvas.findByText('Catalogus 1')).toBeVisible();
     expect(await canvas.findByText('Test PDF')).toBeVisible();
+  },
+};
+
+export const DraftDocumentTypesFeatureFlagOn = {
+  args: {
+    formData: {
+      version: 2,
+      objectsApiGroup: 1,
+      catalogue: {
+        rsin: '111111111',
+        domain: 'TEST',
+      },
+      iotSubmissionReport: 'A rather long draft description',
+      iotSubmissionCsv: 'Not-found documenttype',
+    },
+  },
+  decorators: [FeatureFlagsDecorator],
+  parameters: {
+    featureFlags: {
+      ZGW_APIS_INCLUDE_DRAFTS: true,
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const fieldsetTitle = canvas.getByRole('heading', {name: 'Documenttypen (Tonen)'});
+    expect(fieldsetTitle).toBeVisible();
+    await userEvent.click(within(fieldsetTitle).getByRole('link', {name: '(Tonen)'}));
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -70,11 +70,13 @@ const DOCUMENT_TYPES = {
       url: 'https://example.com/catalogi/api/v1/iot/1',
       omschrijving: 'Test PDF',
       catalogusLabel: 'Catalogus 1',
+      isPublished: true,
     },
     {
       url: 'https://example.com/catalogi/api/v1/iot/2',
       omschrijving: 'Test attachment',
       catalogusLabel: 'Catalogus 1',
+      isPublished: true,
     },
   ],
   'https://example.com/catalogi/api/v1/catalogussen/2': [
@@ -82,11 +84,13 @@ const DOCUMENT_TYPES = {
       url: 'https://example.com/catalogi/api/v1/iot/1',
       omschrijving: 'Other PDF',
       catalogusLabel: 'Catalogus 2',
+      isPublished: true,
     },
     {
       url: 'https://example.com/catalogi/api/v1/iot/4',
       omschrijving: 'Other attachment',
       catalogusLabel: 'Catalogus 2',
+      isPublished: true,
     },
   ],
   'https://example.com/catalogi/api/v1/catalogussen/3': [
@@ -94,16 +98,25 @@ const DOCUMENT_TYPES = {
       url: 'https://example.com/catalogi/api/v1/iot/10',
       omschrijving: 'Document type 1',
       catalogusLabel: 'TEST (111111111)',
+      isPublished: false,
     },
     {
       url: 'https://example.com/catalogi/api/v1/iot/11',
       omschrijving: 'Document type 2',
       catalogusLabel: 'TEST (111111111)',
+      isPublished: true,
     },
     {
       url: 'https://example.com/catalogi/api/v1/iot/12',
       omschrijving: 'Document type 3',
       catalogusLabel: 'TEST (111111111)',
+      isPublished: true,
+    },
+    {
+      url: 'https://example.com/catalogi/api/v1/iot/13',
+      omschrijving: 'A rather long draft description',
+      catalogusLabel: 'TEST (111111111)',
+      isPublished: false,
     },
   ],
 };

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -3,8 +3,12 @@ import {ValidationErrorsProvider} from 'components/admin/forms/ValidationErrors'
 
 import {FormLogicContext} from './Context';
 
-export const FeatureFlagsDecorator = Story => (
-  <FeatureFlagsContext.Provider value={{}}>
+export const FeatureFlagsDecorator = (Story, {parameters}) => (
+  <FeatureFlagsContext.Provider
+    value={{
+      ZGW_APIS_INCLUDE_DRAFTS: parameters?.featureFlags?.ZGW_APIS_INCLUDE_DRAFTS ?? false,
+    }}
+  >
     <Story />
   </FeatureFlagsContext.Provider>
 );

--- a/src/openforms/js/components/admin/forms/ReactSelect.js
+++ b/src/openforms/js/components/admin/forms/ReactSelect.js
@@ -44,6 +44,7 @@ const Select = ({name, options, ...props}) => {
     <ReactSelect
       inputId={`id_${name}`}
       className="admin-react-select"
+      classNamePrefix="admin-react-select"
       styles={styles}
       menuPlacement="auto"
       options={options}

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1404,6 +1404,11 @@
     "description": "All Submissions Removal Limit field label",
     "originalDefault": "All Submissions Removal Limit"
   },
+  "UOofxD": {
+    "defaultMessage": "{omschrijving} {isPublished, select, false {<draft>(not published)</draft>} other {}}",
+    "description": "Document type option label",
+    "originalDefault": "{omschrijving} {isPublished, select, false {<draft>(not published)</draft>} other {}}"
+  },
   "Uq9Hbx": {
     "defaultMessage": "-",
     "description": "Registration summary no registration backend fallback message",
@@ -2258,6 +2263,11 @@
     "defaultMessage": "Add action",
     "description": "Add form logic rule action button",
     "originalDefault": "Add action"
+  },
+  "p9zrjb": {
+    "defaultMessage": "The value ''{value}' is set but could not be found. {draftsEnabled, select, true {Possibly the draft was deleted.} other {Perhaps this document type is not published yet?} }",
+    "description": "Warning message about missing document type option.",
+    "originalDefault": "The value ''{value}' is set but could not be found. {draftsEnabled, select, true {Possibly the draft was deleted.} other {Perhaps this document type is not published yet?} }"
   },
   "pGmjYH": {
     "defaultMessage": "User",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1416,6 +1416,11 @@
     "description": "All Submissions Removal Limit field label",
     "originalDefault": "All Submissions Removal Limit"
   },
+  "UOofxD": {
+    "defaultMessage": "{omschrijving} {isPublished, select, false {<draft>(not published)</draft>} other {}}",
+    "description": "Document type option label",
+    "originalDefault": "{omschrijving} {isPublished, select, false {<draft>(not published)</draft>} other {}}"
+  },
   "Uq9Hbx": {
     "defaultMessage": "-",
     "description": "Registration summary no registration backend fallback message",
@@ -2278,6 +2283,11 @@
     "defaultMessage": "Actie toevoegen",
     "description": "Add form logic rule action button",
     "originalDefault": "Add action"
+  },
+  "p9zrjb": {
+    "defaultMessage": "The value ''{value}' is set but could not be found. {draftsEnabled, select, true {Possibly the draft was deleted.} other {Perhaps this document type is not published yet?} }",
+    "description": "Warning message about missing document type option.",
+    "originalDefault": "The value ''{value}' is set but could not be found. {draftsEnabled, select, true {Possibly the draft was deleted.} other {Perhaps this document type is not published yet?} }"
   },
   "pGmjYH": {
     "defaultMessage": "Gebruiker",

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -157,6 +157,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
     iot_submission_report = serializers.CharField(
         label=_("submission report document type description"),
         required=False,
+        allow_blank=True,
         max_length=80,
         default="",
         help_text=_(
@@ -169,6 +170,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
     iot_submission_csv = serializers.CharField(
         label=_("submission report CSV document type description"),
         required=False,
+        allow_blank=True,
         max_length=80,
         default="",
         help_text=_(
@@ -181,6 +183,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
     iot_attachment = serializers.CharField(
         label=_("attachment document type description"),
         required=False,
+        allow_blank=True,
         max_length=80,
         default="",
         help_text=_(

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_allow_unpublished_document_types.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_allow_unpublished_document_types.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIxMjY0NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.485YHK4gz4-SR_HkXFxXCtTM4XuKDLFeAIOKuBddP5o
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen/aa0e0a50-33f6-4473-99a1-b92bab94e749
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/aa0e0a50-33f6-4473-99a1-b92bab94e749","domein":"DRAFT","rsin":"000000000","contactpersoonBeheerNaam":"OF","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59"],"naam":"Drafts","versie":"","begindatumVersie":null}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '451'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"70058e53ac6aa06b1ef64966509660a2"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzIxMjY0NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.485YHK4gz4-SR_HkXFxXCtTM4XuKDLFeAIOKuBddP5o
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Faa0e0a50-33f6-4473-99a1-b92bab94e749&status=alles
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/aa0e0a50-33f6-4473-99a1-b92bab94e749","omschrijving":"Unpublished","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-08-09","eindeGeldigheid":null,"concept":true,"besluittypen":[],"informatieobjectcategorie":"Tests","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-08-09","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_retrieve_filter_by_catalogus.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/GetInformatieObjecttypesViewTests/GetInformatieObjecttypesViewTests.test_retrieve_filter_by_catalogus.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzQ3MTI4MiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.C7_c3W3_ZihBnSligl_y7dlaEuSa21AZAAHWyXOXL4M
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzQ3NjU4NiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.xTPI_zjsADF8GsGPWEea3cEoq3786qGkOGsdUDq2--g
       Connection:
       - keep-alive
       User-Agent:
@@ -51,7 +51,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzQ3MTI4MiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.C7_c3W3_ZihBnSligl_y7dlaEuSa21AZAAHWyXOXL4M
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzQ3NjU4NiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.xTPI_zjsADF8GsGPWEea3cEoq3786qGkOGsdUDq2--g
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendVCRTests/ObjectsAPIBackendVCRTests.test_allow_registration_with_unpublished_document_types.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendVCRTests/ObjectsAPIBackendVCRTests.test_allow_registration_with_unpublished_document_types.yaml
@@ -1,0 +1,280 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzU0MTY2NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.vTI185EJsVVy2fcV3uQH-25OusJ-pLdriS6lq1I83_0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=DRAFT&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/aa0e0a50-33f6-4473-99a1-b92bab94e749","domein":"DRAFT","rsin":"000000000","contactpersoonBeheerNaam":"OF","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":[],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59"],"naam":"Drafts","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '503'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzU0MTY2NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.vTI185EJsVVy2fcV3uQH-25OusJ-pLdriS6lq1I83_0
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Faa0e0a50-33f6-4473-99a1-b92bab94e749&omschrijving=Unpublished&datumGeldigheid=2024-08-10&status=alles
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/aa0e0a50-33f6-4473-99a1-b92bab94e749","omschrijving":"Unpublished","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-08-09","eindeGeldigheid":null,"concept":true,"besluittypen":[],"informatieobjectcategorie":"Tests","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-08-09","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59",
+      "bronorganisatie": "000000000", "creatiedatum": "2024-08-13", "titel": "Form
+      001", "auteur": "Aanvrager", "taal": "nld", "formaat": "text/plain", "inhoud":
+      "Y29udGVudA==", "status": "definitief", "bestandsnaam": "attachment1.jpg", "ontvangstdatum":
+      "2024-08-10", "beschrijving": "Bijgevoegd document", "indicatieGebruiksrecht":
+      false, "bestandsomvang": 7}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzU0MTY2NSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.vTI185EJsVVy2fcV3uQH-25OusJ-pLdriS6lq1I83_0
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '480'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1","identificatie":"DOCUMENT-2024-0000000110","bronorganisatie":"000000000","creatiedatum":"2024-08-13","titel":"Form
+        001","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/plain","taal":"nld","versie":1,"beginRegistratie":"2024-08-13T09:34:25.181312Z","bestandsnaam":"attachment1.jpg","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-08-10","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1036'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2","uuid":"527b8408-7421-4808-a744-43ccb7bdaaa2","name":"File
+        Uploads","namePlural":"File Uploads","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2/versions/1"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '615'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Tue, 13 Aug 2024 09:34:25 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2",
+      "record": {"typeVersion": 1, "data": {"single_file": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1"},
+      "startAt": "2024-08-13"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '285'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/3c946bf8-1f1c-4f0d-bda9-4e39c3c40d6c","uuid":"3c946bf8-1f1c-4f0d-bda9-4e39c3c40d6c","type":"http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2","record":{"index":1,"typeVersion":1,"data":{"single_file":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1"},"geometry":null,"startAt":"2024-08-13","endAt":null,"registrationAt":"2024-08-13","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '515'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Tue, 13 Aug 2024 09:34:26 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/3c946bf8-1f1c-4f0d-bda9-4e39c3c40d6c
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.0
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTcyMzU0MTY2NiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.aqld0FWXQGvXGiy8-mRQI4UAEqfrx6Tqavi_mGEVGTg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1","identificatie":"DOCUMENT-2024-0000000110","bronorganisatie":"000000000","creatiedatum":"2024-08-13","titel":"Form
+        001","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/plain","taal":"nld","versie":1,"beginRegistratie":"2024-08-13T09:34:25.181312Z","bestandsnaam":"attachment1.jpg","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7f31e187-5e21-4c04-a3bb-3f28334929d1/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-08-10","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1026'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"ad2afb5c8ae7db2c03bc12db330d05fe"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/scss/components/admin/_document-type-option.scss
+++ b/src/openforms/scss/components/admin/_document-type-option.scss
@@ -1,0 +1,16 @@
+@use 'microscope-sass/lib/bem';
+
+.document-type-option {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+
+  @include bem.element('draft-suffix') {
+    color: var(--body-quiet-color);
+
+    // only display the suffix in the dropdown
+    @at-root .admin-react-select__value-container & {
+      display: none;
+    }
+  }
+}

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -19,6 +19,10 @@
 @import './column-field-value';
 @import './confirmation-email-template';
 
+// Form design UI
+@import './select';
+@import './document-type-option';
+
 // Logic editor UI
 @import './dsl-editor';
 @import './logic-rule';
@@ -43,6 +47,3 @@
 
 // Errors
 @import './error-message';
-
-// Form variables select-dropdown
-@import './select';

--- a/src/openforms/scss/vendor/_react-select.scss
+++ b/src/openforms/scss/vendor/_react-select.scss
@@ -7,8 +7,9 @@
   }
 
   @at-root .flex-container:has(&) {
-    flex-grow: 1;
-    max-inline-size: calc(170px + var(--of-admin-select-max-inline-size));
+    // flex-grow + max-inline-size causes the help text item to be pushed all the
+    // way to the right.
+    min-inline-size: calc(170px + var(--of-admin-select-max-inline-size));
   }
 
   @at-root .form-row:has(&) {


### PR DESCRIPTION
Closes #4577

**Changes**

* [x] Implement a feature flag to allow draft document types
* [x] Test using a draft document type during registration
* [x] Document the feature flag in the objects API & ZGW APIs registration docs

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
