### PR TITLE
Server side email verification validation

### DIFF
--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -43,6 +43,7 @@ class OpenFormsConfig(TypedDict):
     maxDate: NotRequired[DateConstraintConfiguration | None]
     translations: NotRequired[TranslationsDict]
     components: NotRequired[AddressValidationComponents]
+    requireVerification: NotRequired[bool]
 
 
 class OpenFormsOptionExtension(TypedDict):

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -401,5 +401,7 @@
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} of {{ lastLabel }}",
   "Note that any family member without a BSN will not be displayed.": "Let op, gezinsleden zonder BSN worden niet getoond.",
   "invalidDatetime": "Ongeldige datum/tijd",
+  "Verify": "Bevestigen",
+  "You must verify this email address to continue.": "Om door te gaan moet je dit e-mailadres bevestigen.",
   "": ""
 }


### PR DESCRIPTION
Closes #4542

**Changes**

Added formio email component validation on the server side that checks the `requireVerification` option.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
