### PR TITLE
Confirm postgres 15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
@@ -130,7 +130,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
@@ -208,7 +208,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -93,7 +93,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:15
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -23,7 +23,7 @@ You need the following libraries and/or programs:
 
 * `Python`_ 3.12
 * Python `Virtualenv`_ and `Pip`_
-* `PostgreSQL`_ 10 or above
+* `PostgreSQL`_ 12 or above
 * `Redis`_ for `Celery`_ to work
 * `Node.js`_, see ``.nvmrc`` for the exact version. Using nvm_ is recommended.
 * `npm`_

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ version: '3.4'
 
 services:
   db:
-    image: postgres:${PG_VERSION:-14}
+    image: postgres:${PG_VERSION:-15}  # Minimum required version is 12
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:

--- a/docker-init-db.sql
+++ b/docker-init-db.sql
@@ -1,5 +1,2 @@
 CREATE USER openforms;
-CREATE DATABASE openforms;
-GRANT ALL PRIVILEGES ON DATABASE openforms TO openforms;
--- On Postgres 15+, connect to the database and grant schema permissions.
--- GRANT USAGE, CREATE ON SCHEMA public TO openforms;
+CREATE DATABASE openforms WITH OWNER openforms;

--- a/docs/installation/ansible.rst
+++ b/docs/installation/ansible.rst
@@ -26,7 +26,7 @@ Server preparation
 You can configure the Ansible playbook to install relevant services, do it
 manually, or have these pre-installed. You will need:
 
-* PostgreSQL 10 or above
+* PostgreSQL 12 or above
 * Nginx
 * Docker
 * Python 3.6+ (needed for Ansible, not Open Forms)


### PR DESCRIPTION
Closes #4648 

**Changes**

* Fixed outdated documentation saying PostgreSQL 10+ is needed - it's 12 or higher.
* Updated CI pipeline(s) to use PostgreSQL 15 instead of 14.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
