### PR TITLE
:globe_with_meridians: [#4602] Translation for Selectboxes minSelectedCount error

### DIFF
--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -36,5 +36,6 @@
   "The uploaded file is not of an allowed type. It must be: {{ pattern }}.": "The uploaded file is not of an allowed type. It must be: {{ pattern }}.",
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} or {{ lastLabel }}",
   "invalid_time": "Only times between {{ minTime }} and {{ maxTime }} are allowed.",
+  "You must select at least {{minCount}} items.": "Ensure this field has at least {{minCount}} checked options.",
   "": ""
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -403,5 +403,6 @@
   "invalidDatetime": "Ongeldige datum/tijd",
   "Verify": "Bevestigen",
   "You must verify this email address to continue.": "Om door te gaan moet je dit e-mailadres bevestigen.",
+  "You must select at least {{minCount}} items.": "Zorg dat dit veld {{minCount}} of meer opties aangevinkt heeft.",
   "": ""
 }


### PR DESCRIPTION
Closes #4602

**Changes**

* Translation for Selectboxes minSelectedCount error

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages_js.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
