### PR TITLE
 🐛 [#4587] Copy Form.product when copying Form

### DIFF
--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -491,7 +491,7 @@ class Form(models.Model):
             else ""
         )
         copy.slug = _("{slug}-copy").format(slug=self.slug)
-        copy.product = None
+        copy.product = self.product
 
         # name translations
 

--- a/src/openforms/forms/tests/test_copy.py
+++ b/src/openforms/forms/tests/test_copy.py
@@ -12,13 +12,14 @@ from .factories import (
     FormRegistrationBackendFactory,
     FormStepFactory,
     FormVariableFactory,
+    ProductFactory,
 )
 
 
 class CopyFormTests(TestCase):
 
     def test_form_copy_with_reusable_definition(self):
-        form = FormFactory.create()
+        form = FormFactory.create(product=None)
         form_definition = FormDefinitionFactory.create(is_reusable=True)
         form_step = FormStepFactory.create(form=form, form_definition=form_definition)
 
@@ -171,3 +172,11 @@ class CopyFormTests(TestCase):
         self.assertEqual(
             new_form_logic_action["form_step_uuid"], str(new_form_step_uuid)
         )
+
+    def test_form_copy_with_product(self):
+        product = ProductFactory.create()
+        form = FormFactory.create(product=product)
+
+        copied_form = form.copy()
+
+        self.assertEqual(copied_form.product, product)


### PR DESCRIPTION
Closes #4587 

**Changes**

* Copy Form.product when copying Form

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
