### PR TITLE
:bug: [#4653] Add blocks dropdown to TinyMCE toolbar (2.5.x backport)

### DIFF
--- a/src/openforms/conf/tinymce_config.json
+++ b/src/openforms/conf/tinymce_config.json
@@ -5,10 +5,11 @@
         "searchreplace visualblocks code fullscreen",
         "insertdatetime media table paste code help wordcount"
     ],
-    "toolbar": "undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | table bullist numlist outdent indent | link unlink removeformat | help",
+    "toolbar": "undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | table bullist numlist outdent indent | link unlink removeformat | help",
     "content_style": "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
     "default_link_target": "_blank",
     "link_default_protocol": "https",
     "link_assume_external_targets": true,
-    "convert_urls": false
+    "convert_urls": false,
+    "block_formats": "Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6"
 }


### PR DESCRIPTION
this was implemented in https://github.com/open-formulieren/open-forms/commit/103e511979080910fb98cc9d6e97500faac45f91, but that commit also introduces extra changes that we do not want to backport

partially closes #4653 

**Changes**

* Add blocks dropdown to TinyMCE toolbar

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
