### PR TITLE
Use react-select in variable dropdown for better UX

### DIFF
--- a/src/openforms/forms/tests/e2e_tests/test_service_fetch.py
+++ b/src/openforms/forms/tests/e2e_tests/test_service_fetch.py
@@ -9,7 +9,12 @@ from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.models import Service
 
 from openforms.config.models import GlobalConfiguration
-from openforms.tests.e2e.base import E2ETestCase, browser_page, create_superuser
+from openforms.tests.e2e.base import (
+    E2ETestCase,
+    browser_page,
+    create_superuser,
+    rs_select_option,
+)
 from openforms.variables.constants import DataMappingTypes, FormVariableSources
 from openforms.variables.models import ServiceFetchConfiguration
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
@@ -29,8 +34,10 @@ async def add_new_variable_with_service_fetch(page: Page):
     await page.get_by_text("Add rule").click()
     await page.get_by_text("Simple").click()
 
-    await page.locator('select[name="variable"]').select_option(
-        label="Environment (environment)"
+    await rs_select_option(
+        page.locator(".form-variable-dropdown").get_by_role("combobox"),
+        option_label="environment",
+        exact=False,
     )
     await page.locator('select[name="operator"]').select_option(label="is equal to")
     await page.locator('select[name="operandType"]').select_option(label="value")
@@ -40,9 +47,10 @@ async def add_new_variable_with_service_fetch(page: Page):
     await page.locator('select[name="action.type"]').select_option(
         label="fetch the value for a variable from a service"
     )
-    # FIXME Name conflict with the select above
-    await page.locator('select[name="variable"]').last.select_option(
-        label="Variable 1 (variable1)"
+    await rs_select_option(
+        page.locator(".form-variable-dropdown").last.get_by_role("combobox"),
+        option_label="variable1",
+        exact=False,
     )
 
     await expect(

--- a/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.stories.js
@@ -1,4 +1,5 @@
 import {expect, fireEvent, fn, userEvent, waitFor, within} from '@storybook/test';
+import selectEvent from 'react-select-event';
 
 import {
   mockDMNDecisionDefinitionVersionsGet,
@@ -232,10 +233,16 @@ export const Empty = {
 
       const [formVarsDropdowns, dmnVarsDropdown] = dropdowns;
 
-      await userEvent.selectOptions(formVarsDropdowns, 'Name (name)');
       await userEvent.selectOptions(dmnVarsDropdown, 'camundaVar');
+      await selectEvent.select(formVarsDropdowns, (content, element) => {
+        return (
+          content === '(name)' && element.classList.contains('form-variable-dropdown__option__key')
+        );
+      });
 
-      await expect(formVarsDropdowns.value).toBe('name');
+      await expect(
+        formVarsDropdowns.closest('.form-variable-dropdown').querySelector('input[type="hidden"]')
+      ).toHaveValue('name');
       await expect(dmnVarsDropdown.value).toBe('camundaVar');
     });
 
@@ -314,12 +321,14 @@ export const withInitialValues = {
     });
 
     await step('Form variable dropdown values', async () => {
-      const formVariableDropdowns = await canvas.findAllByLabelText('Formuliervariabele');
+      const formVariableDropdownInputs = await document.querySelectorAll(
+        '.form-variable-dropdown input[type="hidden"]'
+      );
 
       await waitFor(async () => {
-        await expect(formVariableDropdowns[0]).toHaveValue('name');
-        await expect(formVariableDropdowns[1]).toHaveValue('surname');
-        await expect(formVariableDropdowns[2]).toHaveValue('canApply');
+        await expect(formVariableDropdownInputs[0]).toHaveValue('name');
+        await expect(formVariableDropdownInputs[1]).toHaveValue('surname');
+        await expect(formVariableDropdownInputs[2]).toHaveValue('canApply');
       });
     });
 

--- a/src/openforms/js/components/admin/form_design/variables/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/constants.js
@@ -85,6 +85,12 @@ const VARIABLE_SOURCES = {
   userDefined: 'user_defined',
 };
 
+const VARIABLE_SOURCES_GROUP_LABELS = {
+  userDefined: 'user variables',
+  component: 'component variables',
+  static: 'static variables',
+};
+
 const EMPTY_VARIABLE = {
   name: '',
   key: '',
@@ -113,6 +119,7 @@ const IDENTIFIER_ROLE_CHOICES = {
 export {
   COMPONENT_DATATYPES,
   VARIABLE_SOURCES,
+  VARIABLE_SOURCES_GROUP_LABELS,
   DATATYPES_CHOICES,
   EMPTY_VARIABLE,
   IDENTIFIER_ROLE_CHOICES,

--- a/src/openforms/js/components/admin/forms/ReactSelect.js
+++ b/src/openforms/js/components/admin/forms/ReactSelect.js
@@ -2,6 +2,7 @@ import {getReactSelectStyles} from '@open-formulieren/formio-builder/esm/compone
 import {useField} from 'formik';
 import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
+import classNames from 'classnames';
 
 const initialStyles = getReactSelectStyles();
 const styles = {
@@ -32,18 +33,51 @@ const styles = {
 };
 
 /**
- * A select dropdown backed by react-select for Formik forms.
+ * A select dropdown backed by react-select for legacy usage.
  *
- * Any additional props are forwarded to the underlyng ReactSelect component.
+ * Any additional props are forwarded to the underlying ReactSelect component.
+ *
+ * @deprecated - if possible, refactor the form to use Formik and use the Formik-enabled
+ * variant.
  */
-const Select = ({name, options, ...props}) => {
-  const [fieldProps, , fieldHelpers] = useField(name);
-  const {value} = fieldProps;
-  const {setValue} = fieldHelpers;
+const SelectWithoutFormik = ({name, options, value, className, onChange, ...props}) => {
+  const classes = classNames("admin-react-select", {
+    [`${className}`]: className
+  });
   return (
     <ReactSelect
       inputId={`id_${name}`}
-      className="admin-react-select"
+      name={name}
+      className={classes}
+      classNamePrefix="admin-react-select"
+      styles={styles}
+      menuPlacement="auto"
+      options={options}
+      value={options.find(opt => opt.value === value) || null}
+      onChange={selectedOption => {
+        onChange(selectedOption === null ? undefined : selectedOption.value);
+      }}
+      {...props}
+    />
+  );
+};
+
+/**
+ * A select dropdown backed by react-select for Formik forms.
+ *
+ * Any additional props are forwarded to the underlying ReactSelect component.
+ */
+const SelectWithFormik = ({name, options, className, ...props}) => {
+  const [fieldProps, , fieldHelpers] = useField(name);
+  const {value} = fieldProps;
+  const {setValue} = fieldHelpers;
+  const classes = classNames("admin-react-select", {
+    [`${className}`]: className
+  });
+  return (
+    <ReactSelect
+      inputId={`id_${name}`}
+      className={classes}
       classNamePrefix="admin-react-select"
       styles={styles}
       menuPlacement="auto"
@@ -63,9 +97,15 @@ const Select = ({name, options, ...props}) => {
   );
 };
 
-Select.propTypes = {
+SelectWithoutFormik.propTypes = {
   name: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(PropTypes.object),
 };
 
-export default Select;
+SelectWithFormik.propTypes = {
+  name: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default SelectWithFormik;
+export {SelectWithFormik, SelectWithoutFormik};

--- a/src/openforms/js/components/admin/forms/ReactSelect.js
+++ b/src/openforms/js/components/admin/forms/ReactSelect.js
@@ -1,8 +1,8 @@
 import {getReactSelectStyles} from '@open-formulieren/formio-builder/esm/components/formio/select';
+import classNames from 'classnames';
 import {useField} from 'formik';
 import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
-import classNames from 'classnames';
 
 const initialStyles = getReactSelectStyles();
 const styles = {
@@ -32,6 +32,32 @@ const styles = {
   }),
 };
 
+const getValueRecursively = (options, value) => {
+  if (!value) {
+    return null;
+  }
+
+  const option = options.find(opt => opt.value === value);
+  if (option) {
+    return option;
+  }
+
+  // Search for the option recursively
+  for (let i = 0; i < options.length; i++) {
+    const opt = options[i];
+    if (!opt.options) {
+      continue;
+    }
+
+    const option = getValueRecursively(opt.options, value);
+    if (option) {
+      return option;
+    }
+  }
+
+  return null;
+};
+
 /**
  * A select dropdown backed by react-select for legacy usage.
  *
@@ -41,8 +67,8 @@ const styles = {
  * variant.
  */
 const SelectWithoutFormik = ({name, options, value, className, onChange, ...props}) => {
-  const classes = classNames("admin-react-select", {
-    [`${className}`]: className
+  const classes = classNames('admin-react-select', {
+    [`${className}`]: className,
   });
   return (
     <ReactSelect
@@ -53,7 +79,7 @@ const SelectWithoutFormik = ({name, options, value, className, onChange, ...prop
       styles={styles}
       menuPlacement="auto"
       options={options}
-      value={options.find(opt => opt.value === value) || null}
+      value={getValueRecursively(options, value)}
       onChange={selectedOption => {
         onChange(selectedOption === null ? undefined : selectedOption.value);
       }}
@@ -71,8 +97,8 @@ const SelectWithFormik = ({name, options, className, ...props}) => {
   const [fieldProps, , fieldHelpers] = useField(name);
   const {value} = fieldProps;
   const {setValue} = fieldHelpers;
-  const classes = classNames("admin-react-select", {
-    [`${className}`]: className
+  const classes = classNames('admin-react-select', {
+    [`${className}`]: className,
   });
   return (
     <ReactSelect
@@ -83,7 +109,7 @@ const SelectWithFormik = ({name, options, className, ...props}) => {
       menuPlacement="auto"
       options={options}
       {...fieldProps}
-      value={options.find(opt => opt.value === value) || null}
+      value={getValueRecursively(options, value)}
       onChange={selectedOption => {
         // clear the value
         if (selectedOption == null) {
@@ -99,6 +125,7 @@ const SelectWithFormik = ({name, options, className, ...props}) => {
 
 SelectWithoutFormik.propTypes = {
   name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/src/openforms/js/components/admin/forms/VariableSelection.js
+++ b/src/openforms/js/components/admin/forms/VariableSelection.js
@@ -3,7 +3,7 @@ import React, {useContext} from 'react';
 
 import {FormContext} from 'components/admin/form_design/Context';
 
-import Select from './Select';
+import {SelectWithoutFormik} from './ReactSelect';
 
 const allowAny = () => true;
 
@@ -30,20 +30,16 @@ const VariableSelection = ({
       const label = formDefinitionsNames[variable.formDefinition]
         ? `${formDefinitionsNames[variable.formDefinition]}: ${variable.name} (${variable.key})`
         : `${variable.name} (${variable.key})`;
-      return [variable.key, label];
+      return {value: variable.key, label};
     });
 
-  {
-    /*TODO: This should be a searchable select for when there are a billion variables -> react-select */
-  }
   return (
-    <Select
+    <SelectWithoutFormik
       id={id}
       className="form-variable-dropdown"
       name={name}
-      choices={choices}
-      allowBlank
-      onChange={onChange}
+      options={choices}
+      onChange={newValue => onChange({target: {name, value: newValue}})}
       value={value}
       {...props}
     />

--- a/src/openforms/js/components/admin/forms/VariableSelection.stories.js
+++ b/src/openforms/js/components/admin/forms/VariableSelection.stories.js
@@ -2,8 +2,8 @@ import {useArgs} from '@storybook/preview-api';
 
 import {FormDecorator} from 'components/admin/form_design/story-decorators';
 
-import VariableSelection from './VariableSelection';
 import {VARIABLE_SOURCES} from '../form_design/variables/constants';
+import VariableSelection from './VariableSelection';
 
 const render = ({name, includeStaticVariables, filter}) => {
   const [{value}, updateArgs] = useArgs();

--- a/src/openforms/js/components/admin/forms/VariableSelection.stories.js
+++ b/src/openforms/js/components/admin/forms/VariableSelection.stories.js
@@ -3,6 +3,7 @@ import {useArgs} from '@storybook/preview-api';
 import {FormDecorator} from 'components/admin/form_design/story-decorators';
 
 import VariableSelection from './VariableSelection';
+import {VARIABLE_SOURCES} from '../form_design/variables/constants';
 
 const render = ({name, includeStaticVariables, filter}) => {
   const [{value}, updateArgs] = useArgs();
@@ -31,11 +32,17 @@ export default {
 
     availableFormSteps: [
       {
-        configuration: {
-          display: 'form',
-        },
-
         formDefinition: 'foo',
+        name: 'foo',
+        slug: '',
+        url: '',
+        _generatedId: '',
+        isNew: true,
+        validationErrors: [],
+      },
+      {
+        formDefinition: 'bar',
+        name: 'bar',
         slug: '',
         url: '',
         _generatedId: '',
@@ -56,9 +63,24 @@ export default {
     availableFormVariables: [
       {
         form: 'bar',
-        formDefinition: 'bar',
+        formDefinition: 'foo',
         name: 'name2',
         key: 'key2',
+        source: VARIABLE_SOURCES.component,
+      },
+      {
+        form: 'bar',
+        formDefinition: 'bar',
+        name: 'name3',
+        key: 'key3',
+        source: VARIABLE_SOURCES.userDefined,
+      },
+      {
+        form: 'bar',
+        formDefinition: 'bar',
+        name: 'name4',
+        key: 'key4',
+        source: VARIABLE_SOURCES.userDefined,
       },
     ],
   },

--- a/src/openforms/scss/_vars.scss
+++ b/src/openforms/scss/_vars.scss
@@ -28,6 +28,7 @@ $django-hijack-yellow: #ffe761;
   /* Dimensions */
   --of-admin-input-field-size: 40em; // original: 20em;
   --of-admin-checkbox-gap: 5px;
+  --of-admin-select-min-inline-size: 200px;
   --of-admin-select-max-inline-size: 300px;
 
   /* Tooltip */

--- a/src/openforms/scss/admin/_app_overrides.scss
+++ b/src/openforms/scss/admin/_app_overrides.scss
@@ -69,12 +69,9 @@ $djai-padding--tablet: 30px;
 .submit-row {
   position: sticky;
   bottom: 0px;
-  /* the toolbar in the text editor has z-index: 1; */
-  z-index: 2;
 
   &.submit-row-extended {
     position: relative;
-    z-index: 3;
     margin-top: -24px;
     border-top: 0;
     padding-top: 0;

--- a/src/openforms/scss/admin/_vendor-fixes.scss
+++ b/src/openforms/scss/admin/_vendor-fixes.scss
@@ -1,10 +1,12 @@
 .form-row {
-  // bootstrap styles compete with django .form-row styles...
-  display: block !important;
-
   > div > .flex-container > label {
     box-sizing: initial;
   }
+}
+
+// bootstrap styles compete with django .form-row styles...
+.model-formdefinition .form-row > .errorlist {
+  width: 100%;
 }
 
 div:has(> .help):not(:has(> .fieldBox)) {

--- a/src/openforms/scss/components/admin/_select.scss
+++ b/src/openforms/scss/components/admin/_select.scss
@@ -1,3 +1,4 @@
 .form-variable-dropdown {
+  min-inline-size: var(--of-admin-select-min-inline-size);
   max-inline-size: var(--of-admin-select-max-inline-size);
 }

--- a/src/openforms/scss/components/admin/_select.scss
+++ b/src/openforms/scss/components/admin/_select.scss
@@ -1,4 +1,35 @@
 .form-variable-dropdown {
+  --of-admin-select-min-inline-size: 300px;
   min-inline-size: var(--of-admin-select-min-inline-size);
   max-inline-size: var(--of-admin-select-max-inline-size);
+
+  &__option {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    row-gap: 4px;
+
+    &__label {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      row-gap: 4px;
+    }
+
+    &__form-definition {
+      width: 100%;
+      font-size: 12px;
+      color: var(--body-quiet-color);
+    }
+  }
+
+  // The selected option only shows the label
+  .admin-react-select__value-container & {
+    &__option {
+      &__key,
+      &__form-definition {
+        display: none;
+      }
+    }
+  }
 }

--- a/src/openforms/scss/vendor/_react-select.scss
+++ b/src/openforms/scss/vendor/_react-select.scss
@@ -20,5 +20,9 @@
     --border-color: var(--error-fg);
   }
 
-  inline-size: clamp(200px, 100%, var(--of-admin-select-max-inline-size));
+  inline-size: clamp(
+    var(--of-admin-select-min-inline-size),
+    100%,
+    var(--of-admin-select-max-inline-size)
+  );
 }

--- a/src/openforms/scss/vendor/_tinymce.scss
+++ b/src/openforms/scss/vendor/_tinymce.scss
@@ -1,6 +1,8 @@
 @import '../vars';
 
 .tox.tox-tinymce {
+  z-index: 0;
+
   @at-root .form-row .errors > & {
     border-color: $color-error;
   }


### PR DESCRIPTION
Closes #4524 

**Changes**

The variable dropdown now uses the react-select component. Allowing for searching within the options

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
