### PR TITLE
:globe_with_meridians: [#4602] Translation for Selectboxes minSelectedCount error

### DIFF
--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -35,5 +35,6 @@
   "maxFileSizeMessage": "The maximum file size is {{maxFileSize}}.",
   "The uploaded file is not of an allowed type. It must be: {{ pattern }}.": "The uploaded file is not of an allowed type. It must be: {{ pattern }}.",
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} or {{ lastLabel }}",
+  "You must select at least {{minCount}} items.": "Ensure this field has at least {{minCount}} checked options.",
   "": ""
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -403,5 +403,6 @@
   "invalidDatetime": "Ongeldige datum/tijd",
   "maxDatetime": "De opgegeven datum/tijd liggen te ver in de toekomst.",
   "minDatetime": "De opgegeven datum/tijd liggen te ver in het verleden.",
+  "You must select at least {{minCount}} items.": "Zorg dat dit veld {{minCount}} of meer opties aangevinkt heeft.",
   "": ""
 }


### PR DESCRIPTION
Backport-Of: https://github.com/open-formulieren/open-forms/pull/4665

Closes #4602 partially

**Changes**

* Translation for Selectboxes minSelectedCount error

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
