### PR TITLE
[#4656] Make parent's serializer context available to the children (FileSerializer)

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -845,6 +845,11 @@ class EditGridField(serializers.Field):
             # conditional.when values resolve, as these look like `editgridparent.child`.
             data = FormioData({**self.root.initial_data, self.field_name: item}).data
             nested_serializer = self._build_child(data=data)
+
+            # this is explicitly bound to the parent because we need to have access to the
+            # context of the parent in the children
+            nested_serializer.bind(field_name=self.field_name, parent=self)
+
             try:
                 result.append(nested_serializer.run_validation(item))
             except serializers.ValidationError as e:


### PR DESCRIPTION
Closes #4656

**Changes**

- Added regression test for the editgrid (didn't make context available to the children)
- Made parent's serializer context available to children (`EditGrid`)
- The other nested layout components work with files as expected (`fieldset` and `columns`)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
