### PR TITLE
Fix migration/import crash

### DIFF
--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -227,6 +227,10 @@
                 "certificate"
             ],
             [
+                "simple_certmanager",
+                "signingrequest"
+            ],
+            [
                 "soap",
                 "soapservice"
             ],

--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -210,6 +210,12 @@ def convert_simple_conditionals(configuration: JSONObject) -> bool:
             # only strings can be loaded
             if not isinstance(eq, str):
                 continue
+
+            if eq == "":
+                component["conditional"]["eq"] = None
+                config_modified = True
+                continue
+
             component["conditional"]["eq"] = json.loads(eq)
             config_modified = True
 

--- a/src/openforms/formio/tests/test_simple_conditionals_converter.py
+++ b/src/openforms/formio/tests/test_simple_conditionals_converter.py
@@ -1,6 +1,7 @@
 from django.test import SimpleTestCase, tag
 
 from openforms.formio.typing import EditGridComponent
+from openforms.formio.typing.base import Component
 from openforms.typing import JSONObject
 
 from ..migration_converters import convert_simple_conditionals
@@ -94,5 +95,29 @@ class RegressionTests(SimpleTestCase):
 
         try:
             convert_simple_conditionals(configuration)
+        except Exception as exc:
+            raise self.failureException("Unexpected crash") from exc
+
+    @tag("gh-4680")
+    def test_malformed_eq_json(self):
+        reference: Component = {
+            "type": "number",
+            "key": "watIsHetZaaknummer",
+            "label": "Wat is het zaaknummer?",
+        }
+        component: Component = {
+            "type": "content",
+            "key": "contentOgenblikGeduld",
+            "label": "Content",
+            "conditional": {  # type: ignore
+                "eq": "",
+                "show": False,
+                "when": "watIsHetZaaknummer",
+            },
+        }
+        configuration = {"components": [reference, component]}
+
+        try:
+            convert_simple_conditionals(configuration)  # type: ignore
         except Exception as exc:
             raise self.failureException("Unexpected crash") from exc


### PR DESCRIPTION
Closes #4680

**Changes**

* Reproduced and fixed the crash when empty strings are used in certain simple conditional configurations.
* Expanded the component issue reporting helper script so that we can get a summary of all broken situations, if similar things happen again.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
