### PR TITLE
[#4701] Add missing data migration for the global config and zip mimetypes

### DIFF
--- a/src/openforms/config/migrations/0059_alter_globalconfiguration_form_upload_default_file_types.py
+++ b/src/openforms/config/migrations/0059_alter_globalconfiguration_form_upload_default_file_types.py
@@ -3,6 +3,27 @@
 from django.db import migrations, models
 import django_jsonform.models.fields
 
+from openforms.config.constants import UploadFileType
+
+
+def add_extra_zip_mimetypes(apps, _):
+    """
+    Set up the correct zip mimetypes.
+
+    This ensures all the allowed mimetypes concerning zip files are included.
+    """
+    GlobalConfiguration = apps.get_model("config", "GlobalConfiguration")
+    if not GlobalConfiguration.objects.exists():
+        return
+
+    config = GlobalConfiguration.objects.get()
+    if "application/zip" not in config.form_upload_default_file_types:
+        return
+
+    config.form_upload_default_file_types.remove("application/zip")
+    config.form_upload_default_file_types.append(UploadFileType.zip)
+    config.save(update_fields=("form_upload_default_file_types",))
+
 
 class Migration(migrations.Migration):
 
@@ -58,5 +79,9 @@ class Migration(migrations.Migration):
                 size=None,
                 verbose_name="Default allowed file upload types",
             ),
+        ),
+        migrations.RunPython(
+            add_extra_zip_mimetypes,
+            migrations.RunPython.noop,
         ),
     ]


### PR DESCRIPTION
Closes #4701

**Changes**

- Added missing migration for the global configuration. When we define a global setting for the allowed file types we need to make sure the extra .zip mimetypes are in the list as well.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
