### PR TITLE
Add script to fix globalconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ COPY \
     ./bin/report_component_problems.py \
     ./bin/check_objecttype_urls.py \
     ./bin/check_zgw_groups.py \
+    ./bin/fix_globalconfig_zip.py \
     ./bin/
 
 # prevent writing to the container layer, which would degrade performance.

--- a/bin/fix_globalconfig_zip.py
+++ b/bin/fix_globalconfig_zip.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import sys
+from pathlib import Path
+
+import django
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR.resolve()))
+
+
+def main() -> None:
+    from openforms.setup import setup_env
+
+    setup_env()
+    django.setup()
+
+    from openforms.config.constants import UploadFileType
+    from openforms.config.models import GlobalConfiguration
+
+    config = GlobalConfiguration.get_solo()
+    if "application/zip" not in config.form_upload_default_file_types:
+        return
+
+    config.form_upload_default_file_types.remove("application/zip")
+    config.form_upload_default_file_types.append(UploadFileType.zip)
+    config.save(update_fields=("form_upload_default_file_types",))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hotfix for data migration being patched, but this one can easily be deployed via Ansible without needing to revert migrations.