### PR TITLE
Feature/4686 email and StUF-ZDS inline form

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -171,6 +171,12 @@
       "value": "Whether to show this value in the confirmation PDF"
     }
   ],
+  "01mWK2": [
+    {
+      "type": 0,
+      "value": "The format(s) of the attachment(s) containing the submission details"
+    }
+  ],
   "0D+m56": [
     {
       "type": 0,
@@ -329,6 +335,12 @@
       "value": "RSIN of the organization, which creates and owns the case and documents."
     }
   ],
+  "1z/bNS": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype code"
+    }
+  ],
   "2/2h2C": [
     {
       "type": 0,
@@ -363,6 +375,12 @@
     {
       "type": 0,
       "value": "Number"
+    }
+  ],
+  "2P7mDI": [
+    {
+      "type": 0,
+      "value": "Content of the registration email message (as text)."
     }
   ],
   "2Z/hNo": [
@@ -471,6 +489,12 @@
     {
       "type": 0,
       "value": "Ask statement of truth"
+    }
+  ],
+  "3baawY": [
+    {
+      "type": 0,
+      "value": "StUF-ZDS name"
     }
   ],
   "3h215E": [
@@ -865,6 +889,12 @@
       "value": "Next text"
     }
   ],
+  "7ZdEaP": [
+    {
+      "type": 0,
+      "value": "Documenttype description for newly created zaken in StUF-ZDS"
+    }
+  ],
   "7b9pD8": [
     {
       "type": 0,
@@ -887,6 +917,12 @@
     {
       "type": 0,
       "value": "Registration"
+    }
+  ],
+  "7hc31v": [
+    {
+      "type": 0,
+      "value": "The email addresses to which the payment status update will be sent (defaults to general registration addresses)"
     }
   ],
   "7qqbU9": [
@@ -915,6 +951,12 @@
     {
       "type": 0,
       "value": "Is reusable?"
+    }
+  ],
+  "8IItwi": [
+    {
+      "type": 0,
+      "value": "The name in StUF-ZDS to which the form variable should be mapped"
     }
   ],
   "8LLxRg": [
@@ -969,6 +1011,12 @@
     {
       "type": 0,
       "value": " in the simple logic."
+    }
+  ],
+  "8nY+h7": [
+    {
+      "type": 0,
+      "value": "Zaaktype description for newly created Zaken in StUF-ZDS"
     }
   ],
   "8pemD3": [
@@ -1047,6 +1095,12 @@
     {
       "type": 0,
       "value": "Changing the objecttype will remove the existing variables mapping. Are you sure you want to continue?"
+    }
+  ],
+  "9akVrT": [
+    {
+      "type": 0,
+      "value": "Zds documenttype omschrijving inzending"
     }
   ],
   "9bGp7h": [
@@ -1179,6 +1233,12 @@
     {
       "type": 0,
       "value": "Location"
+    }
+  ],
+  "B5RSyi": [
+    {
+      "type": 0,
+      "value": "Email payment subject"
     }
   ],
   "BCjZNo": [
@@ -1383,6 +1443,12 @@
     {
       "type": 0,
       "value": "Delete"
+    }
+  ],
+  "CNJ2TT": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
     }
   ],
   "CRN74c": [
@@ -1763,6 +1829,12 @@
       "value": "Label"
     }
   ],
+  "FQ1JZc": [
+    {
+      "type": 0,
+      "value": "Zaaktype code for newly created Zaken in StUF-ZDS"
+    }
+  ],
   "FQswyM": [
     {
       "type": 0,
@@ -2069,6 +2141,12 @@
       "value": "Decision definition ID"
     }
   ],
+  "Ihbi6N": [
+    {
+      "type": 0,
+      "value": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+    }
+  ],
   "Ika4IH": [
     {
       "type": 0,
@@ -2347,6 +2425,12 @@
       "value": "Add variable"
     }
   ],
+  "LeVpdf": [
+    {
+      "type": 0,
+      "value": "Plugin configuration: Email"
+    }
+  ],
   "LiXrER": [
     {
       "type": 0,
@@ -2619,6 +2703,12 @@
       "value": "Datetime"
     }
   ],
+  "P4JMHA": [
+    {
+      "type": 0,
+      "value": "Zaaktype status code for newly created zaken in StUF-ZDS"
+    }
+  ],
   "PC7ICN": [
     {
       "type": 0,
@@ -2641,6 +2731,12 @@
     {
       "type": 0,
       "value": "Add rule"
+    }
+  ],
+  "PhN977": [
+    {
+      "type": 0,
+      "value": "Plugin configuration: StUF-ZDS"
     }
   ],
   "PhXIai": [
@@ -2731,6 +2827,12 @@
     {
       "type": 0,
       "value": "Preview"
+    }
+  ],
+  "QljfI7": [
+    {
+      "type": 0,
+      "value": "Email subject"
     }
   ],
   "Qr2wnR": [
@@ -2829,6 +2931,12 @@
     {
       "type": 0,
       "value": "You must specify a date."
+    }
+  ],
+  "RjWycp": [
+    {
+      "type": 0,
+      "value": "Form variable"
     }
   ],
   "Rk13i+": [
@@ -3301,6 +3409,12 @@
       "value": "Sensitive data"
     }
   ],
+  "Vu09Ne": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype status omschrijving"
+    }
+  ],
   "VyA4fK": [
     {
       "type": 0,
@@ -3575,6 +3689,12 @@
     {
       "type": 0,
       "value": "Are you sure you want to delete this?"
+    }
+  ],
+  "Z/wFhz": [
+    {
+      "type": 0,
+      "value": "Content of the registration email message (as html)."
     }
   ],
   "Z5lydZ": [
@@ -4253,6 +4373,12 @@
       "value": "Advanced options"
     }
   ],
+  "eO6MNT": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype status code"
+    }
+  ],
   "eUowhH": [
     {
       "type": 0,
@@ -4299,6 +4425,12 @@
     {
       "type": 0,
       "value": "Begin text"
+    }
+  ],
+  "f8lihY": [
+    {
+      "type": 0,
+      "value": "Subject of the email sent to the registration backend. You can use the expressions {{ form_name }} and {{ public_reference }} to include the form name and the reference number to the submission in the subject."
     }
   ],
   "f9Zr9D": [
@@ -4367,6 +4499,12 @@
       "value": "A JSON logic expression returning a variable (of array type) whose items should be used as the options for this component."
     }
   ],
+  "ffvbQm": [
+    {
+      "type": 0,
+      "value": "payment status update variable mapping"
+    }
+  ],
   "fhVFUY": [
     {
       "type": 0,
@@ -4415,6 +4553,12 @@
       "value": "Set the text of the 'Remove row' button."
     }
   ],
+  "gDAZQ1": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype status omschrijving"
+    }
+  ],
   "gGNIdG": [
     {
       "type": 0,
@@ -4451,6 +4595,12 @@
     {
       "type": 0,
       "value": "App version"
+    }
+  ],
+  "gtjPWc": [
+    {
+      "type": 0,
+      "value": "The name of the form variable to be mapped"
     }
   ],
   "guySt0": [
@@ -4531,6 +4681,18 @@
     {
       "type": 0,
       "value": "Add registration backend"
+    }
+  ],
+  "hQ7xjd": [
+    {
+      "type": 0,
+      "value": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+    }
+  ],
+  "hSvi+z": [
+    {
+      "type": 0,
+      "value": "Email content template text"
     }
   ],
   "hWRRHx": [
@@ -4831,6 +4993,12 @@
       "value": "disabled"
     }
   ],
+  "kWAxhF": [
+    {
+      "type": 0,
+      "value": "Subject of the email sent to the registration backend to notify a change in the payment status."
+    }
+  ],
   "kg/eh1": [
     {
       "type": 0,
@@ -5057,6 +5225,12 @@
       "value": "Trigger condition"
     }
   ],
+  "nNbK3G": [
+    {
+      "type": 0,
+      "value": "Email content template HTML"
+    }
+  ],
   "nSRkSW": [
     {
       "type": 0,
@@ -5099,6 +5273,12 @@
       "value": "Include children"
     }
   ],
+  "o6Ju6l": [
+    {
+      "type": 0,
+      "value": "The email addresses to which the submission details will be sent"
+    }
+  ],
   "o83CBr": [
     {
       "type": 0,
@@ -5121,6 +5301,12 @@
     {
       "type": 0,
       "value": "Minimum selected checkboxes (e.g. 1)"
+    }
+  ],
+  "oVwrVo": [
+    {
+      "type": 0,
+      "value": "Attach files to email"
     }
   ],
   "oWJX5K": [
@@ -5301,6 +5487,12 @@
       "value": "Form definition"
     }
   ],
+  "ppZHsm": [
+    {
+      "type": 0,
+      "value": "Configure options"
+    }
+  ],
   "pq7q6N": [
     {
       "type": 0,
@@ -5455,6 +5647,12 @@
     {
       "type": 0,
       "value": "Whether to send a confirmation email to the end-user who submitted the form."
+    }
+  ],
+  "sNGN82": [
+    {
+      "type": 0,
+      "value": "Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit."
     }
   ],
   "sR9GVQ": [
@@ -5929,6 +6127,40 @@
       "value": "Authorizee"
     }
   ],
+  "yJiaOl": [
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "There is a validation error."
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "There are "
+            },
+            {
+              "type": 1,
+              "value": "numErrors"
+            },
+            {
+              "type": 0,
+              "value": " validation errors."
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numErrors"
+    }
+  ],
   "yL9Ql7": [
     {
       "type": 0,
@@ -6005,6 +6237,12 @@
     {
       "type": 0,
       "value": "Value in decimal degrees, between -180 and +180."
+    }
+  ],
+  "z4zEf7": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype omschrijving"
     }
   ],
   "z7HXSS": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -171,6 +171,12 @@
       "value": "Geef aan of deze waarde in de (bevestigings-)PDF moet getoond worden. Deze PDF wordt vaak ook als bijlage meegestuurd tijdens de registratie."
     }
   ],
+  "01mWK2": [
+    {
+      "type": 0,
+      "value": "The format(s) of the attachment(s) containing the submission details"
+    }
+  ],
   "0D+m56": [
     {
       "type": 0,
@@ -329,6 +335,12 @@
       "value": "RSIN van de organisatie die eigenaar is van de zaak en documenten en deze aanmaakt."
     }
   ],
+  "1z/bNS": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype code"
+    }
+  ],
   "2/2h2C": [
     {
       "type": 0,
@@ -363,6 +375,12 @@
     {
       "type": 0,
       "value": "Getal (number)"
+    }
+  ],
+  "2P7mDI": [
+    {
+      "type": 0,
+      "value": "Content of the registration email message (as text)."
     }
   ],
   "2Z/hNo": [
@@ -471,6 +489,12 @@
     {
       "type": 0,
       "value": "Vraag verklaring invullen naar waarheid"
+    }
+  ],
+  "3baawY": [
+    {
+      "type": 0,
+      "value": "StUF-ZDS name"
     }
   ],
   "3h215E": [
@@ -869,6 +893,12 @@
       "value": "'Volgende' tekst"
     }
   ],
+  "7ZdEaP": [
+    {
+      "type": 0,
+      "value": "Documenttype description for newly created zaken in StUF-ZDS"
+    }
+  ],
   "7b9pD8": [
     {
       "type": 0,
@@ -891,6 +921,12 @@
     {
       "type": 0,
       "value": "Registratie"
+    }
+  ],
+  "7hc31v": [
+    {
+      "type": 0,
+      "value": "The email addresses to which the payment status update will be sent (defaults to general registration addresses)"
     }
   ],
   "7qqbU9": [
@@ -919,6 +955,12 @@
     {
       "type": 0,
       "value": "Is herbruikbaar?"
+    }
+  ],
+  "8IItwi": [
+    {
+      "type": 0,
+      "value": "The name in StUF-ZDS to which the form variable should be mapped"
     }
   ],
   "8LLxRg": [
@@ -973,6 +1015,12 @@
     {
       "type": 0,
       "value": " in de eenvoudige logica."
+    }
+  ],
+  "8nY+h7": [
+    {
+      "type": 0,
+      "value": "Zaaktype description for newly created Zaken in StUF-ZDS"
     }
   ],
   "8pemD3": [
@@ -1051,6 +1099,12 @@
     {
       "type": 0,
       "value": "Let op! Als je een ander objecttype selecteert, dan worden de bestaande koppelingen gereset. Ben je zeker dat je door wil gaan?"
+    }
+  ],
+  "9akVrT": [
+    {
+      "type": 0,
+      "value": "Zds documenttype omschrijving inzending"
     }
   ],
   "9bGp7h": [
@@ -1183,6 +1237,12 @@
     {
       "type": 0,
       "value": "Locatie"
+    }
+  ],
+  "B5RSyi": [
+    {
+      "type": 0,
+      "value": "Email payment subject"
     }
   ],
   "BCjZNo": [
@@ -1387,6 +1447,12 @@
     {
       "type": 0,
       "value": "Verwijderen"
+    }
+  ],
+  "CNJ2TT": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
     }
   ],
   "CRN74c": [
@@ -1784,6 +1850,12 @@
       "value": "Label"
     }
   ],
+  "FQ1JZc": [
+    {
+      "type": 0,
+      "value": "Zaaktype code for newly created Zaken in StUF-ZDS"
+    }
+  ],
   "FQswyM": [
     {
       "type": 0,
@@ -2090,6 +2162,12 @@
       "value": "Beslisdefinitie-ID"
     }
   ],
+  "Ihbi6N": [
+    {
+      "type": 0,
+      "value": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+    }
+  ],
   "Ika4IH": [
     {
       "type": 0,
@@ -2368,6 +2446,12 @@
       "value": "Variabele toevoegen"
     }
   ],
+  "LeVpdf": [
+    {
+      "type": 0,
+      "value": "Plugin configuration: Email"
+    }
+  ],
   "LiXrER": [
     {
       "type": 0,
@@ -2640,6 +2724,12 @@
       "value": "Datumtijd (datetime)"
     }
   ],
+  "P4JMHA": [
+    {
+      "type": 0,
+      "value": "Zaaktype status code for newly created zaken in StUF-ZDS"
+    }
+  ],
   "PC7ICN": [
     {
       "type": 0,
@@ -2662,6 +2752,12 @@
     {
       "type": 0,
       "value": "Regel toevoegen"
+    }
+  ],
+  "PhN977": [
+    {
+      "type": 0,
+      "value": "Plugin configuration: StUF-ZDS"
     }
   ],
   "PhXIai": [
@@ -2748,6 +2844,12 @@
     {
       "type": 0,
       "value": "Voorbeeld"
+    }
+  ],
+  "QljfI7": [
+    {
+      "type": 0,
+      "value": "Email subject"
     }
   ],
   "Qr2wnR": [
@@ -2846,6 +2948,12 @@
     {
       "type": 0,
       "value": "Je moet een datum opgeven."
+    }
+  ],
+  "RjWycp": [
+    {
+      "type": 0,
+      "value": "Form variable"
     }
   ],
   "Rk13i+": [
@@ -3318,6 +3426,12 @@
       "value": "Gevoelige gegevens"
     }
   ],
+  "Vu09Ne": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype status omschrijving"
+    }
+  ],
   "VyA4fK": [
     {
       "type": 0,
@@ -3592,6 +3706,12 @@
     {
       "type": 0,
       "value": "Weet u zeker dat u dit wilt verwijderen?"
+    }
+  ],
+  "Z/wFhz": [
+    {
+      "type": 0,
+      "value": "Content of the registration email message (as html)."
     }
   ],
   "Z5lydZ": [
@@ -4275,6 +4395,12 @@
       "value": "Geavanceerde opties"
     }
   ],
+  "eO6MNT": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype status code"
+    }
+  ],
   "eUowhH": [
     {
       "type": 0,
@@ -4321,6 +4447,12 @@
     {
       "type": 0,
       "value": "'Start' tekst"
+    }
+  ],
+  "f8lihY": [
+    {
+      "type": 0,
+      "value": "Subject of the email sent to the registration backend. You can use the expressions {{ form_name }} and {{ public_reference }} to include the form name and the reference number to the submission in the subject."
     }
   ],
   "f9Zr9D": [
@@ -4389,6 +4521,12 @@
       "value": "Geef een JsonLogic expressie voor de lijst van mogelijke opties. Evaluatie van de expressie moet een lijst teruggeven, waarbij elk element een lijst (array) is van [waarde, label] combinaties."
     }
   ],
+  "ffvbQm": [
+    {
+      "type": 0,
+      "value": "payment status update variable mapping"
+    }
+  ],
   "fhVFUY": [
     {
       "type": 0,
@@ -4437,6 +4575,12 @@
       "value": "Geef de knoptekst om een groep te verwijderen op."
     }
   ],
+  "gDAZQ1": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype status omschrijving"
+    }
+  ],
   "gGNIdG": [
     {
       "type": 0,
@@ -4473,6 +4617,12 @@
     {
       "type": 0,
       "value": "Applicatieversie"
+    }
+  ],
+  "gtjPWc": [
+    {
+      "type": 0,
+      "value": "The name of the form variable to be mapped"
     }
   ],
   "guySt0": [
@@ -4553,6 +4703,18 @@
     {
       "type": 0,
       "value": "Registratiepluginoptie toevoegen"
+    }
+  ],
+  "hQ7xjd": [
+    {
+      "type": 0,
+      "value": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+    }
+  ],
+  "hSvi+z": [
+    {
+      "type": 0,
+      "value": "Email content template text"
     }
   ],
   "hWRRHx": [
@@ -4853,6 +5015,12 @@
       "value": "uitgeschakeld"
     }
   ],
+  "kWAxhF": [
+    {
+      "type": 0,
+      "value": "Subject of the email sent to the registration backend to notify a change in the payment status."
+    }
+  ],
   "kg/eh1": [
     {
       "type": 0,
@@ -5079,6 +5247,12 @@
       "value": "Triggervoorwaarde"
     }
   ],
+  "nNbK3G": [
+    {
+      "type": 0,
+      "value": "Email content template HTML"
+    }
+  ],
   "nSRkSW": [
     {
       "type": 0,
@@ -5121,6 +5295,12 @@
       "value": "Inclusief kinderen"
     }
   ],
+  "o6Ju6l": [
+    {
+      "type": 0,
+      "value": "The email addresses to which the submission details will be sent"
+    }
+  ],
   "o83CBr": [
     {
       "type": 0,
@@ -5143,6 +5323,12 @@
     {
       "type": 0,
       "value": "Minimaal aantal aangevinkte opties (bijv. 1)"
+    }
+  ],
+  "oVwrVo": [
+    {
+      "type": 0,
+      "value": "Attach files to email"
     }
   ],
   "oWJX5K": [
@@ -5323,6 +5509,12 @@
       "value": "Formulierdefinitie"
     }
   ],
+  "ppZHsm": [
+    {
+      "type": 0,
+      "value": "Configure options"
+    }
+  ],
   "pq7q6N": [
     {
       "type": 0,
@@ -5477,6 +5669,12 @@
     {
       "type": 0,
       "value": "Vink aan om een bevestigingsmail te sturen naar de inzender(s) van het formulier."
+    }
+  ],
+  "sNGN82": [
+    {
+      "type": 0,
+      "value": "Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit."
     }
   ],
   "sR9GVQ": [
@@ -5951,6 +6149,40 @@
       "value": "Gemachtigde"
     }
   ],
+  "yJiaOl": [
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "There is a validation error."
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "There are "
+            },
+            {
+              "type": 1,
+              "value": "numErrors"
+            },
+            {
+              "type": 0,
+              "value": " validation errors."
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numErrors"
+    }
+  ],
   "yL9Ql7": [
     {
       "type": 0,
@@ -6027,6 +6259,12 @@
     {
       "type": 0,
       "value": "Waarde in decimale graden, tussen -180 en +180."
+    }
+  ],
+  "z4zEf7": [
+    {
+      "type": 0,
+      "value": "Zds zaaktype omschrijving"
     }
   ],
   "z7HXSS": [

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -57,6 +57,114 @@ export default {
         },
       },
       {
+        id: 'stuf-zds-create-zaak',
+        label: 'StUF-ZDS',
+        // real schema is defined, but irrelevant because of our react components
+        schema: {
+          type: 'object',
+          properties: {
+            zdsZaaktypeCode: {
+              type: 'string',
+              minLength: 1,
+              title: 'Zds zaaktype code',
+              description: 'Zaaktype code for newly created Zaken in StUF-ZDS',
+            },
+            zdsZaaktypeOmschrijving: {
+              type: 'string',
+              minLength: 1,
+              title: 'Zds zaaktype omschrijving',
+              description: 'Zaaktype description for newly created Zaken in StUF-ZDS',
+            },
+            zdsZaaktypeStatusCode: {
+              type: 'string',
+              minLength: 1,
+              title: 'Zds zaaktype status code',
+              description: 'Zaaktype status code for newly created zaken in StUF-ZDS',
+            },
+            zdsZaaktypeStatusOmschrijving: {
+              type: 'string',
+              minLength: 1,
+              title: 'Zds zaaktype status omschrijving',
+              description: 'Zaaktype status omschrijving for newly created zaken in StUF-ZDS',
+            },
+            zdsDocumenttypeOmschrijvingInzending: {
+              type: 'string',
+              minLength: 1,
+              title: 'Zds documenttype omschrijving inzending',
+              description: 'Documenttype description for newly created zaken in StUF-ZDS',
+            },
+            zdsZaakdocVertrouwelijkheid: {
+              type: 'string',
+              enum: [
+                'ZEER GEHEIM',
+                'GEHEIM',
+                'CONFIDENTIEEL',
+                'VERTROUWELIJK',
+                'ZAAKVERTROUWELIJK',
+                'INTERN',
+                'BEPERKT OPENBAAR',
+                'OPENBAAR',
+              ],
+              enumNames: [
+                'Zeer geheim',
+                'Geheim',
+                'Confidentieel',
+                'Vertrouwelijk',
+                'Zaakvertrouwelijk',
+                'Intern',
+                'Beperkt openbaar',
+                'Openbaar',
+              ],
+              title: 'Document confidentiality level',
+              description:
+                'Indication of the level to which extend the dossier of the ZAAK is meant to be public. This is set on the documents created for the ZAAK.',
+            },
+            paymentStatusUpdateMapping: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  formVariable: {
+                    type: 'string',
+                    minLength: 1,
+                    title: 'Form variable',
+                    description: 'The name of the form variable to be mapped',
+                  },
+                  stufName: {
+                    type: 'string',
+                    minLength: 1,
+                    title: 'StUF-ZDS name',
+                    description: 'The name in StUF-ZDS to which the form variable should be mapped',
+                  },
+                },
+                required: ['formVariable', 'stufName'],
+              },
+              title: 'payment status update variable mapping',
+              description:
+                'This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen.',
+              default: [
+                {
+                  formVariable: 'payment_completed',
+                  stufName: 'payment_completed',
+                },
+                {
+                  formVariable: 'payment_amount',
+                  stufName: 'payment_amount',
+                },
+                {
+                  formVariable: 'payment_public_order_ids',
+                  stufName: 'payment_public_order_ids',
+                },
+                {
+                  formVariable: 'provider_payment_ids',
+                  stufName: 'provider_payment_ids',
+                },
+              ],
+            },
+          },
+        },
+      },
+      {
         id: 'email',
         label: 'Email registration',
         schema: {
@@ -282,6 +390,37 @@ export const ConfiguredBackends = {
         options: {
           driveId: '',
           folderPath: '',
+        },
+      },
+      {
+        key: 'backend6',
+        name: 'StUF ZDS',
+        backend: 'stuf-zds-create-zaak',
+        options: {
+          paymentStatusUpdateMapping: [
+            {
+              formVariable: 'payment_completed',
+              stufName: 'payment_completed',
+            },
+            {
+              formVariable: 'payment_amount',
+              stufName: 'payment_amount',
+            },
+            {
+              formVariable: 'payment_public_order_ids',
+              stufName: 'payment_public_order_ids',
+            },
+            {
+              formVariable: 'provider_payment_ids',
+              stufName: 'provider_payment_ids',
+            },
+          ],
+          zdsDocumenttypeOmschrijvingInzending: '',
+          zdsZaakdocVertrouwelijkheid: 'OPENBAAR',
+          zdsZaaktypeCode: '',
+          zdsZaaktypeOmschrijving: '',
+          zdsZaaktypeStatusCode: '',
+          zdsZaaktypeStatusOmschrijving: '',
         },
       },
     ],

--- a/src/openforms/js/components/admin/form_design/registrations/email/EmailOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/EmailOptionsForm.js
@@ -1,0 +1,123 @@
+import {Formik} from 'formik';
+import PropTypes from 'prop-types';
+import React, {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {SubmitAction} from 'components/admin/forms/ActionButton';
+import Field from 'components/admin/forms/Field';
+import SubmitRow from 'components/admin/forms/SubmitRow';
+import {ValidationErrorContext} from 'components/admin/forms/ValidationErrors';
+import {ErrorIcon} from 'components/admin/icons';
+import {FormModal} from 'components/admin/modals';
+
+import EmailOptionsFormFields from './EmailOptionsFormFields';
+import {filterErrors} from './utils';
+
+const EmailOptionsForm = ({name, label, schema, formData, onChange}) => {
+  const intl = useIntl();
+  const [modalOpen, setModalOpen] = useState(false);
+  const validationErrors = useContext(ValidationErrorContext);
+  const numErrors = filterErrors(name, validationErrors).length;
+
+  return (
+    <Field name={name} label={label}>
+      <>
+        <span style={{display: 'inline-flex', gap: '10px', alignItems: 'center'}}>
+          <button
+            type="button"
+            className="button"
+            onClick={e => {
+              e.preventDefault();
+              setModalOpen(true);
+            }}
+            // admin style overrides...
+            style={{
+              paddingInline: '15px',
+              paddingBlock: '10px',
+            }}
+          >
+            <FormattedMessage
+              description="Link label to open registration options modal"
+              defaultMessage="Configure options"
+            />
+          </button>
+
+          {numErrors > 0 && (
+            <ErrorIcon
+              text={intl.formatMessage(
+                {
+                  description: 'Objects API registration validation errors icon next to button',
+                  defaultMessage: `{numErrors, plural,
+              one {There is a validation error.}
+              other {There are {numErrors} validation errors.}
+            }`,
+                },
+                {numErrors}
+              )}
+              extraClassname="fa-lg icon icon--danger icon--compact icon--no-pointer"
+            />
+          )}
+        </span>
+
+        <FormModal
+          isOpen={modalOpen}
+          title={
+            <FormattedMessage
+              description="Email registration options modal title"
+              defaultMessage="Plugin configuration: Email"
+            />
+          }
+          closeModal={() => setModalOpen(false)}
+          extraModifiers={['large']}
+        >
+          <Formik
+            initialValues={formData}
+            onSubmit={(values, actions) => {
+              onChange({formData: values});
+              actions.setSubmitting(false);
+              setModalOpen(false);
+            }}
+          >
+            {({handleSubmit}) => (
+              <>
+                <EmailOptionsFormFields name={name} schema={schema} />
+
+                <SubmitRow>
+                  <SubmitAction
+                    onClick={event => {
+                      event.preventDefault();
+                      handleSubmit(event);
+                    }}
+                  />
+                </SubmitRow>
+              </>
+            )}
+          </Formik>
+        </FormModal>
+      </>
+    </Field>
+  );
+};
+
+EmailOptionsForm.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  schema: PropTypes.shape({
+    type: PropTypes.oneOf(['object']),
+    properties: PropTypes.object,
+    required: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  formData: PropTypes.shape({
+    attachFilesToEmail: PropTypes.bool,
+    attachmentFormats: PropTypes.arrayOf(PropTypes.string),
+    emailContentTemplateHtml: PropTypes.string,
+    emailContentTemplateText: PropTypes.string,
+    emailPaymentSubject: PropTypes.string,
+    emailSubject: PropTypes.string,
+    paymentEmails: PropTypes.arrayOf(PropTypes.string),
+    toEmails: PropTypes.arrayOf(PropTypes.string),
+  }),
+  onChange: PropTypes.func.isRequired,
+};
+
+export default EmailOptionsForm;

--- a/src/openforms/js/components/admin/form_design/registrations/email/EmailOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/EmailOptionsFormFields.js
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+import {useContext} from 'react';
+
+import Fieldset from 'components/admin/forms/Fieldset';
+import {
+  ValidationErrorContext,
+  ValidationErrorsProvider,
+} from 'components/admin/forms/ValidationErrors';
+
+import EmailAttachmentFormatsSelect from './fields/EmailAttachmentFormatsSelect';
+import EmailContentTemplateHTML from './fields/EmailContentTemplateHTML';
+import EmailContentTemplateText from './fields/EmailContentTemplateText';
+import EmailHasAttachmentSelect from './fields/EmailHasAttachmentSelect';
+import EmailPaymentSubject from './fields/EmailPaymentSubject';
+import EmailPaymentUpdateRecipients from './fields/EmailPaymentUpdateRecipients';
+import EmailRecipients from './fields/EmailRecipients';
+import EmailSubject from './fields/EmailSubject';
+import {filterErrors, getChoicesFromSchema} from './utils';
+
+const EmailOptionsFormFields = ({name, schema}) => {
+  const validationErrors = useContext(ValidationErrorContext);
+
+  const {attachFilesToEmail, attachmentFormats} = schema.properties;
+  const attachFilesToEmailChoices = getChoicesFromSchema(
+    attachFilesToEmail.enum,
+    attachFilesToEmail.enumNames
+  ).map(([value, label]) => ({value, label}));
+  const attachmentFormatsChoices = getChoicesFromSchema(
+    attachmentFormats.items.enum,
+    attachmentFormats.items.enumNames
+  ).map(([value, label]) => ({value, label}));
+
+  const relevantErrors = filterErrors(name, validationErrors);
+  return (
+    <ValidationErrorsProvider errors={relevantErrors}>
+      <Fieldset>
+        <EmailRecipients />
+      </Fieldset>
+      <Fieldset>
+        <EmailAttachmentFormatsSelect options={attachmentFormatsChoices} />
+      </Fieldset>
+      <Fieldset>
+        <EmailPaymentUpdateRecipients />
+      </Fieldset>
+      <Fieldset>
+        <EmailHasAttachmentSelect options={attachFilesToEmailChoices} />
+
+        <EmailSubject />
+        <EmailPaymentSubject />
+
+        <EmailContentTemplateHTML />
+        <EmailContentTemplateText />
+      </Fieldset>
+    </ValidationErrorsProvider>
+  );
+};
+
+EmailOptionsFormFields.propTypes = {
+  name: PropTypes.string.isRequired,
+  schema: PropTypes.shape({
+    type: PropTypes.oneOf(['object']), // it's the JSON schema root, it has to be
+    properties: PropTypes.object,
+    required: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+};
+
+export default EmailOptionsFormFields;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailAttachmentFormatsSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailAttachmentFormatsSelect.js
@@ -1,0 +1,58 @@
+import {useField} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import ReactSelect from 'components/admin/forms/ReactSelect';
+
+const EmailAttachmentFormatsSelect = ({options}) => {
+  const [fieldProps, , fieldHelpers] = useField('attachmentFormats');
+  const {setValue} = fieldHelpers;
+
+  const values = [];
+  if (fieldProps.value && fieldProps.value.length) {
+    fieldProps.value.forEach(item => {
+      const selectedOption = options.find(option => option.value === item);
+      if (selectedOption) {
+        values.push(selectedOption);
+      }
+    });
+  }
+
+  return (
+    <FormRow>
+      <Field
+        name="attachmentFormats"
+        label={
+          <FormattedMessage
+            description="Email registration options 'attachmentFormats' label"
+            defaultMessage="The format(s) of the attachment(s) containing the submission details"
+          />
+        }
+      >
+        <ReactSelect
+          name="attachmentFormats"
+          options={options}
+          isMulti
+          required
+          value={values}
+          onChange={newValue => {
+            setValue(newValue.map(item => item.value));
+          }}
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailAttachmentFormatsSelect.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+    })
+  ).isRequired,
+};
+
+export default EmailAttachmentFormatsSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailContentTemplateHTML.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailContentTemplateHTML.js
@@ -1,0 +1,40 @@
+import {useField} from 'formik';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import TinyMCEEditor from 'components/admin/form_design/Editor';
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+
+const EmailContentTemplateHTML = () => {
+  const [fieldProps, , fieldHelpers] = useField('emailContentTemplateHtml');
+  const {setValue} = fieldHelpers;
+  return (
+    <FormRow>
+      <Field
+        name="emailContentTemplateHtml"
+        label={
+          <FormattedMessage
+            description="Email registration options 'emailContentTemplateHtml' label"
+            defaultMessage="Email content template HTML"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Email registration options 'emailContentTemplateHtml' helpText"
+            defaultMessage="Content of the registration email message (as html)."
+          />
+        }
+      >
+        <TinyMCEEditor
+          content={fieldProps.value}
+          onEditorChange={(newValue, editor) => setValue(newValue)}
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailContentTemplateHTML.propTypes = {};
+
+export default EmailContentTemplateHTML;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailContentTemplateText.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailContentTemplateText.js
@@ -1,0 +1,41 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextArea} from 'components/admin/forms/Inputs';
+
+const EmailContentTemplateText = () => {
+  const [fieldProps] = useField('emailContentTemplateText');
+  return (
+    <FormRow>
+      <Field
+        name="emailContentTemplateText"
+        label={
+          <FormattedMessage
+            description="Email registration options 'emailContentTemplateText' label"
+            defaultMessage="Email content template text"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Email registration options 'emailContentTemplateText' helpText"
+            defaultMessage="Content of the registration email message (as text)."
+          />
+        }
+      >
+        <TextArea
+          id="id_emailContentTemplateText"
+          rows={5}
+          cols={85}
+          {...fieldProps}
+          style={{fontFamily: 'monospace'}}
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailContentTemplateText.propTypes = {};
+
+export default EmailContentTemplateText;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailHasAttachmentSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailHasAttachmentSelect.js
@@ -1,0 +1,52 @@
+import {useField} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import ReactSelect from 'components/admin/forms/ReactSelect';
+
+const EmailHasAttachmentSelect = ({options}) => {
+  const [fieldProps, , fieldHelpers] = useField('attachFilesToEmail');
+  const {setValue} = fieldHelpers;
+
+  return (
+    <FormRow>
+      <Field
+        name="attachFilesToEmail"
+        label={
+          <FormattedMessage
+            description="Email registration options 'attachFilesToEmail' label"
+            defaultMessage="Attach files to email"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Email registration options 'attachFilesToEmail' helpText"
+            defaultMessage="Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit."
+          />
+        }
+      >
+        <ReactSelect
+          name="attachFilesToEmail"
+          options={options}
+          value={options.find(option => option.value === fieldProps.value)}
+          required
+          onChange={newValue => {
+            setValue(newValue.value);
+          }}
+        />
+      </Field>
+    </FormRow>
+  );
+};
+EmailHasAttachmentSelect.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.bool,
+      label: PropTypes.node.isRequired,
+    })
+  ).isRequired,
+};
+
+export default EmailHasAttachmentSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailPaymentSubject.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailPaymentSubject.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const EmailPaymentSubject = () => {
+  const [fieldProps] = useField('emailPaymentSubject');
+  return (
+    <FormRow>
+      <Field
+        name="emailPaymentSubject"
+        label={
+          <FormattedMessage
+            description="Email registration options 'emailPaymentSubject' label"
+            defaultMessage="Email payment subject"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Email registration options 'emailPaymentSubject' helpText"
+            defaultMessage="Subject of the email sent to the registration backend to notify a change in the payment status."
+          />
+        }
+      >
+        <TextInput id="id_emailPaymentSubject" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailPaymentSubject.propTypes = {};
+
+export default EmailPaymentSubject;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailPaymentUpdateRecipients.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailPaymentUpdateRecipients.js
@@ -1,0 +1,38 @@
+import {useField} from 'formik';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import ArrayInput from 'components/admin/forms/ArrayInput';
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+
+const EmailPaymentUpdateRecipients = () => {
+  const [fieldProps, , fieldHelpers] = useField('paymentEmails');
+  const {setValue} = fieldHelpers;
+  return (
+    <FormRow>
+      <Field
+        name="paymentEmails"
+        label={
+          <FormattedMessage
+            description="Email registration options 'paymentEmails' label"
+            defaultMessage="The email addresses to which the payment status update will be sent (defaults to general registration addresses)"
+          />
+        }
+      >
+        <ArrayInput
+          name="paymentEmails"
+          values={fieldProps.value}
+          onChange={value => {
+            setValue(value);
+          }}
+          inputType="text"
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailPaymentUpdateRecipients.propTypes = {};
+
+export default EmailPaymentUpdateRecipients;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailRecipients.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailRecipients.js
@@ -1,0 +1,38 @@
+import {useField} from 'formik';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import ArrayInput from 'components/admin/forms/ArrayInput';
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+
+const EmailRecipients = () => {
+  const [fieldProps, , fieldHelpers] = useField('toEmails');
+  const {setValue} = fieldHelpers;
+  return (
+    <FormRow>
+      <Field
+        name="toEmails"
+        label={
+          <FormattedMessage
+            description="Email registration options 'attachFilesToEmail' label"
+            defaultMessage="The email addresses to which the submission details will be sent"
+          />
+        }
+      >
+        <ArrayInput
+          name="toEmails"
+          values={fieldProps.value}
+          onChange={value => {
+            setValue(value);
+          }}
+          inputType="text"
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailRecipients.propTypes = {};
+
+export default EmailRecipients;

--- a/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailSubject.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/fields/EmailSubject.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const EmailSubject = () => {
+  const [fieldProps] = useField('emailSubject');
+  return (
+    <FormRow>
+      <Field
+        name="emailSubject"
+        label={
+          <FormattedMessage
+            description="Email registration options 'emailSubject' label"
+            defaultMessage="Email subject"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Email registration options 'emailSubject' helpText"
+            defaultMessage="Subject of the email sent to the registration backend. You can use the expressions '{{ form_name }}' and '{{ public_reference }}' to include the form name and the reference number to the submission in the subject."
+          />
+        }
+      >
+        <TextInput id="id_emailSubject" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+EmailSubject.propTypes = {};
+
+export default EmailSubject;

--- a/src/openforms/js/components/admin/form_design/registrations/email/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/index.js
@@ -1,0 +1,3 @@
+import EmailOptionsForm from './EmailOptionsForm';
+
+export default EmailOptionsForm;

--- a/src/openforms/js/components/admin/form_design/registrations/email/utils.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/utils.js
@@ -1,0 +1,16 @@
+const getChoicesFromSchema = (enums, enumNames) => {
+  const finalChoices = [];
+  Object.keys(enums).forEach(key => {
+    finalChoices.push([enums[key], enumNames[key]]);
+  });
+
+  return finalChoices;
+};
+
+const filterErrors = (name, errors) => {
+  return errors
+    .filter(([key]) => key.startsWith(`${name}.`))
+    .map(([key, msg]) => [key.slice(name.length + 1), msg]);
+};
+
+export {getChoicesFromSchema, filterErrors};

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -4,7 +4,7 @@ import ObjectsApiOptionsForm from './objectsapi/ObjectsApiOptionsForm';
 import ObjectsApiSummaryHandler from './objectsapi/ObjectsApiSummaryHandler';
 import ObjectsApiVariableConfigurationEditor from './objectsapi/ObjectsApiVariableConfigurationEditor';
 import {onCamundaStepEdit, onObjectsAPIStepEdit, onZGWStepEdit} from './stepEditHandlers';
-import StufZDSOptionsForm from './stufzds/StufZDSOptionsForm';
+import StufZDSOptionsForm from './stufzds';
 import {onObjectsAPIUserDefinedVariableEdit} from './userDefinedVariableEditHandlers';
 import ZGWOptionsForm from './zgw';
 

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -1,6 +1,5 @@
-import {WysiwygWidget} from 'components/admin/RJSFWrapper';
-
 import CamundaOptionsForm from './camunda';
+import EmailOptionsForm from './email';
 import ObjectsApiOptionsForm from './objectsapi/ObjectsApiOptionsForm';
 import ObjectsApiSummaryHandler from './objectsapi/ObjectsApiSummaryHandler';
 import ObjectsApiVariableConfigurationEditor from './objectsapi/ObjectsApiVariableConfigurationEditor';
@@ -35,15 +34,7 @@ export const BACKEND_OPTIONS_FORMS = {
     variableConfigurationEditor: ObjectsApiVariableConfigurationEditor,
   },
   email: {
-    uiSchema: {
-      emailContentTemplateText: {
-        'ui:widget': 'textarea',
-        'ui:options': {
-          rows: 5,
-        },
-      },
-      emailContentTemplateHtml: {'ui:widget': WysiwygWidget},
-    },
+    form: EmailOptionsForm,
   },
   'zgw-create-zaak': {
     form: ZGWOptionsForm,

--- a/src/openforms/js/components/admin/form_design/registrations/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/index.js
@@ -4,6 +4,7 @@ import ObjectsApiOptionsForm from './objectsapi/ObjectsApiOptionsForm';
 import ObjectsApiSummaryHandler from './objectsapi/ObjectsApiSummaryHandler';
 import ObjectsApiVariableConfigurationEditor from './objectsapi/ObjectsApiVariableConfigurationEditor';
 import {onCamundaStepEdit, onObjectsAPIStepEdit, onZGWStepEdit} from './stepEditHandlers';
+import StufZDSOptionsForm from './stufzds/StufZDSOptionsForm';
 import {onObjectsAPIUserDefinedVariableEdit} from './userDefinedVariableEditHandlers';
 import ZGWOptionsForm from './zgw';
 
@@ -41,14 +42,6 @@ export const BACKEND_OPTIONS_FORMS = {
     onStepEdit: onZGWStepEdit,
   },
   'stuf-zds-create-zaak:ext-utrecht': {
-    uiSchema: {
-      paymentStatusUpdateMapping: {
-        'ui:orderable': false,
-        items: {
-          'ui:orderable': false,
-          'ui:removable': false,
-        },
-      },
-    },
+    form: StufZDSOptionsForm,
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
@@ -1,0 +1,137 @@
+import {Formik} from 'formik';
+import PropTypes from 'prop-types';
+import React, {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {SubmitAction} from 'components/admin/forms/ActionButton';
+import Field from 'components/admin/forms/Field';
+import SubmitRow from 'components/admin/forms/SubmitRow';
+import {ValidationErrorContext} from 'components/admin/forms/ValidationErrors';
+import {ErrorIcon} from 'components/admin/icons';
+import {FormModal} from 'components/admin/modals';
+
+import StufZDSOptionsFormFields from './StufZDSOptionsFormFields';
+import {filterErrors} from './utils';
+
+const StufZDSOptionsForm = ({name, label, schema, formData, onChange}) => {
+  const intl = useIntl();
+  const [modalOpen, setModalOpen] = useState(false);
+  const validationErrors = useContext(ValidationErrorContext);
+  const numErrors = filterErrors(name, validationErrors).length;
+
+  let initialFormData = {...formData};
+  const isNew = !Object.keys(formData).length;
+  if (isNew) {
+    Object.keys(schema.properties).forEach(propertyKey => {
+      if (schema.properties[propertyKey].default) {
+        initialFormData[propertyKey] = schema.properties[propertyKey].default;
+      }
+    });
+  }
+  console.log({schema});
+
+  return (
+    <Field name={name} label={label}>
+      <>
+        <span style={{display: 'inline-flex', gap: '10px', alignItems: 'center'}}>
+          <button
+            type="button"
+            className="button"
+            onClick={e => {
+              e.preventDefault();
+              setModalOpen(true);
+            }}
+            // admin style overrides...
+            style={{
+              paddingInline: '15px',
+              paddingBlock: '10px',
+            }}
+          >
+            <FormattedMessage
+              description="Link label to open StUF-ZDS options modal"
+              defaultMessage="Configure options"
+            />
+          </button>
+          {numErrors > 0 && (
+            <ErrorIcon
+              text={intl.formatMessage(
+                {
+                  description: 'StUF-ZDS registration validation errors icon next to button',
+                  defaultMessage: `{numErrors, plural,
+              one {There is a validation error.}
+              other {There are {numErrors} validation errors.}
+            }`,
+                },
+                {numErrors}
+              )}
+              extraClassname="fa-lg icon icon--danger icon--compact icon--no-pointer"
+            />
+          )}
+        </span>
+
+        <FormModal
+          isOpen={modalOpen}
+          title={
+            <FormattedMessage
+              description="StUF-ZDS registration options modal title"
+              defaultMessage="Plugin configuration: StUF-ZDS"
+            />
+          }
+          closeModal={() => setModalOpen(false)}
+          extraModifiers={['large']}
+        >
+          <Formik
+            initialValues={initialFormData}
+            onSubmit={(values, actions) => {
+              onChange({formData: values});
+              actions.setSubmitting(false);
+              setModalOpen(false);
+            }}
+          >
+            {({handleSubmit}) => (
+              <>
+                <StufZDSOptionsFormFields name={name} schema={schema} />
+
+                <SubmitRow>
+                  <SubmitAction
+                    onClick={event => {
+                      event.preventDefault();
+                      handleSubmit(event);
+                    }}
+                  />
+                </SubmitRow>
+              </>
+            )}
+          </Formik>
+        </FormModal>
+      </>
+    </Field>
+  );
+};
+
+StufZDSOptionsForm.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  schema: PropTypes.shape({
+    type: PropTypes.oneOf(['object']),
+    properties: PropTypes.object,
+    required: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  formData: PropTypes.shape({
+    paymentStatusUpdateMapping: PropTypes.arrayOf(
+      PropTypes.shape({
+        formVariable: PropTypes.string,
+        stufName: PropTypes.string,
+      })
+    ),
+    zdsDocumenttypeOmschrijvingInzending: PropTypes.string,
+    zdsZaakdocVertrouwelijkheid: PropTypes.string,
+    zdsZaaktypeCode: PropTypes.string,
+    zdsZaaktypeOmschrijving: PropTypes.string,
+    zdsZaaktypeStatusCode: PropTypes.string,
+    zdsZaaktypeStatusOmschrijving: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
+};
+
+export default StufZDSOptionsForm;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
@@ -28,7 +28,6 @@ const StufZDSOptionsForm = ({name, label, schema, formData, onChange}) => {
       }
     });
   }
-  console.log({schema});
 
   return (
     <Field name={name} label={label}>

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import {useContext} from 'react';
+import {FormattedMessage} from 'react-intl';
 
 import Fieldset from 'components/admin/forms/Fieldset';
 import {
@@ -35,7 +36,24 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
         <CaseStatusDescription />
         <DocumentDescription />
         <DocumentConfidentialityLevel options={zdsZaakdocVertrouwelijkheidChoices} />
-        <PaymentStatusUpdateMapping schema={schema} />
+      </Fieldset>
+
+      <Fieldset
+        title={
+          <FormattedMessage
+            description="StUF-ZDS registration paymentStatusUpdateMapping label"
+            defaultMessage="payment status update variable mapping"
+          />
+        }
+        fieldNames={['paymentStatusUpdateMapping']}
+      >
+        <div className="description mb-2">
+          <FormattedMessage
+            description="StUF-ZDS registration paymentStatusUpdateMapping message"
+            defaultMessage="This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
+          />
+        </div>
+        <PaymentStatusUpdateMapping />
       </Fieldset>
     </ValidationErrorsProvider>
   );

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import {useContext} from 'react';
+
+import Fieldset from 'components/admin/forms/Fieldset';
+import {
+  ValidationErrorContext,
+  ValidationErrorsProvider,
+} from 'components/admin/forms/ValidationErrors';
+
+import CaseCode from './fields/CaseCode';
+import CaseDescription from './fields/CaseDescription';
+import CaseStatusCode from './fields/CaseStatusCode';
+import CaseStatusDescription from './fields/CaseStatusDescription';
+import DocumentConfidentialityLevel from './fields/DocumentConfidentialityLevel';
+import DocumentDescription from './fields/DocumentDescription';
+import PaymentStatusUpdateMapping from './fields/PaymentStatusUpdateMapping';
+import {filterErrors, getChoicesFromSchema} from './utils';
+
+const StufZDSOptionsFormFields = ({name, schema}) => {
+  const validationErrors = useContext(ValidationErrorContext);
+
+  const {zdsZaakdocVertrouwelijkheid} = schema.properties;
+  const zdsZaakdocVertrouwelijkheidChoices = getChoicesFromSchema(
+    zdsZaakdocVertrouwelijkheid.enum,
+    zdsZaakdocVertrouwelijkheid.enumNames
+  ).map(([value, label]) => ({value, label}));
+
+  const relevantErrors = filterErrors(name, validationErrors);
+  return (
+    <ValidationErrorsProvider errors={relevantErrors}>
+      <Fieldset>
+        <CaseCode />
+        <CaseDescription />
+        <CaseStatusCode />
+        <CaseStatusDescription />
+        <DocumentDescription />
+        <DocumentConfidentialityLevel options={zdsZaakdocVertrouwelijkheidChoices} />
+        <PaymentStatusUpdateMapping schema={schema} />
+      </Fieldset>
+    </ValidationErrorsProvider>
+  );
+};
+
+StufZDSOptionsFormFields.propTypes = {
+  name: PropTypes.string.isRequired,
+  schema: PropTypes.shape({
+    type: PropTypes.oneOf(['object']), // it's the JSON schema root, it has to be
+    properties: PropTypes.object,
+    required: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+};
+
+export default StufZDSOptionsFormFields;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseCode.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseCode.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const CaseCode = () => {
+  const [fieldProps] = useField('zdsZaaktypeCode');
+  return (
+    <FormRow>
+      <Field
+        name="zdsZaaktypeCode"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeCode' label"
+            defaultMessage="Zds zaaktype code"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeCode' helpText"
+            defaultMessage="Zaaktype code for newly created Zaken in StUF-ZDS"
+          />
+        }
+      >
+        <TextInput id="id_zdsZaaktypeCode" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+CaseCode.propTypes = {};
+
+export default CaseCode;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseDescription.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseDescription.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const CaseDescription = () => {
+  const [fieldProps] = useField('zdsZaaktypeOmschrijving');
+  return (
+    <FormRow>
+      <Field
+        name="zdsZaaktypeOmschrijving"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeOmschrijving' label"
+            defaultMessage="Zds zaaktype omschrijving"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeOmschrijving' helpText"
+            defaultMessage="Zaaktype description for newly created Zaken in StUF-ZDS"
+          />
+        }
+      >
+        <TextInput id="id_zdsZaaktypeOmschrijving" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+CaseDescription.propTypes = {};
+
+export default CaseDescription;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseStatusCode.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseStatusCode.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const CaseStatusCode = () => {
+  const [fieldProps] = useField('zdsZaaktypeStatusCode');
+  return (
+    <FormRow>
+      <Field
+        name="zdsZaaktypeStatusCode"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeStatusCode' label"
+            defaultMessage="Zds zaaktype status code"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeStatusCode' helpText"
+            defaultMessage="Zaaktype status code for newly created zaken in StUF-ZDS"
+          />
+        }
+      >
+        <TextInput id="id_zdsZaaktypeStatusCode" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+CaseStatusCode.propTypes = {};
+
+export default CaseStatusCode;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseStatusDescription.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/CaseStatusDescription.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const CaseStatusDescription = () => {
+  const [fieldProps] = useField('zdsZaaktypeStatusOmschrijving');
+  return (
+    <FormRow>
+      <Field
+        name="zdsZaaktypeStatusOmschrijving"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeStatusOmschrijving' label"
+            defaultMessage="Zds zaaktype status omschrijving"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaaktypeStatusOmschrijving' helpText"
+            defaultMessage="Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+          />
+        }
+      >
+        <TextInput id="id_zdsZaaktypeStatusOmschrijving" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+CaseStatusDescription.propTypes = {};
+
+export default CaseStatusDescription;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/DocumentConfidentialityLevel.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/DocumentConfidentialityLevel.js
@@ -1,0 +1,53 @@
+import {useField} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import ReactSelect from 'components/admin/forms/ReactSelect';
+
+const DocumentConfidentialityLevel = ({options}) => {
+  const [fieldProps, , fieldHelpers] = useField('zdsZaakdocVertrouwelijkheid');
+  const {setValue} = fieldHelpers;
+
+  return (
+    <FormRow>
+      <Field
+        name="zdsZaakdocVertrouwelijkheid"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label"
+            defaultMessage="Zds zaaktype status omschrijving"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' helpText"
+            defaultMessage="Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+          />
+        }
+      >
+        <ReactSelect
+          name="zdsZaakdocVertrouwelijkheid"
+          options={options}
+          required
+          value={options.find(option => option.value === fieldProps.value)}
+          onChange={newValue => {
+            setValue(newValue.value);
+          }}
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+DocumentConfidentialityLevel.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+    })
+  ).isRequired,
+};
+
+export default DocumentConfidentialityLevel;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/DocumentDescription.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/DocumentDescription.js
@@ -1,0 +1,35 @@
+import {useField} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
+
+const DocumentDescription = () => {
+  const [fieldProps] = useField('zdsDocumenttypeOmschrijvingInzending');
+  return (
+    <FormRow>
+      <Field
+        name="zdsDocumenttypeOmschrijvingInzending"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsDocumenttypeOmschrijvingInzending' label"
+            defaultMessage="Zds documenttype omschrijving inzending"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'zdsDocumenttypeOmschrijvingInzending' helpText"
+            defaultMessage="Documenttype description for newly created zaken in StUF-ZDS"
+          />
+        }
+      >
+        <TextInput id="id_zdsDocumenttypeOmschrijvingInzending" {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+DocumentDescription.propTypes = {};
+
+export default DocumentDescription;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/PaymentStatusUpdateMapping.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/PaymentStatusUpdateMapping.js
@@ -1,0 +1,48 @@
+import {useField} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+
+import PaymentStatusUpdateMappingInputs from './inputs/PaymentStatusUpdateMappingInputs';
+
+const PaymentStatusUpdateMapping = ({schema}) => {
+  const [fieldProps, , fieldHelpers] = useField('paymentStatusUpdateMapping');
+  const {setValue} = fieldHelpers;
+  return (
+    <FormRow>
+      <Field
+        name="paymentStatusUpdateMapping"
+        label={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'paymentStatusUpdateMapping' label"
+            defaultMessage="payment status update variable mapping"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="StUF-ZDS registration options 'paymentStatusUpdateMapping' helpText"
+            defaultMessage="This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
+          />
+        }
+      >
+        <PaymentStatusUpdateMappingInputs
+          name="paymentStatusUpdateMapping"
+          onChange={newValue => setValue(newValue)}
+          values={fieldProps.value}
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+PaymentStatusUpdateMapping.propTypes = {
+  schema: PropTypes.shape({
+    type: PropTypes.oneOf(['object']), // it's the JSON schema root, it has to be
+    properties: PropTypes.object,
+    required: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+};
+
+export default PaymentStatusUpdateMapping;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/PaymentStatusUpdateMapping.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/PaymentStatusUpdateMapping.js
@@ -1,48 +1,23 @@
 import {useField} from 'formik';
-import PropTypes from 'prop-types';
-import {FormattedMessage} from 'react-intl';
 
-import Field from 'components/admin/forms/Field';
 import FormRow from 'components/admin/forms/FormRow';
 
 import PaymentStatusUpdateMappingInputs from './inputs/PaymentStatusUpdateMappingInputs';
 
-const PaymentStatusUpdateMapping = ({schema}) => {
+const PaymentStatusUpdateMapping = () => {
   const [fieldProps, , fieldHelpers] = useField('paymentStatusUpdateMapping');
   const {setValue} = fieldHelpers;
   return (
     <FormRow>
-      <Field
+      <PaymentStatusUpdateMappingInputs
         name="paymentStatusUpdateMapping"
-        label={
-          <FormattedMessage
-            description="StUF-ZDS registration options 'paymentStatusUpdateMapping' label"
-            defaultMessage="payment status update variable mapping"
-          />
-        }
-        helpText={
-          <FormattedMessage
-            description="StUF-ZDS registration options 'paymentStatusUpdateMapping' helpText"
-            defaultMessage="This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
-          />
-        }
-      >
-        <PaymentStatusUpdateMappingInputs
-          name="paymentStatusUpdateMapping"
-          onChange={newValue => setValue(newValue)}
-          values={fieldProps.value}
-        />
-      </Field>
+        onChange={newValue => setValue(newValue)}
+        values={fieldProps.value}
+      />
     </FormRow>
   );
 };
 
-PaymentStatusUpdateMapping.propTypes = {
-  schema: PropTypes.shape({
-    type: PropTypes.oneOf(['object']), // it's the JSON schema root, it has to be
-    properties: PropTypes.object,
-    required: PropTypes.arrayOf(PropTypes.string),
-  }).isRequired,
-};
+PaymentStatusUpdateMapping.propTypes = {};
 
 export default PaymentStatusUpdateMapping;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/inputs/PaymentStatusUpdateMappingInputs.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/inputs/PaymentStatusUpdateMappingInputs.js
@@ -1,0 +1,133 @@
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import ButtonContainer from 'components/admin/forms/ButtonContainer';
+import Field from 'components/admin/forms/Field';
+import {TextInput} from 'components/admin/forms/Inputs';
+import {DeleteIcon} from 'components/admin/icons';
+import useOnChanged from 'hooks/useOnChanged';
+
+const PaymentStatusUpdateMappingInputs = ({
+  name,
+  values = [],
+  onChange,
+  deleteConfirmationMessage,
+  addButtonMessage,
+  wrapEvent = false,
+}) => {
+  const intl = useIntl();
+  const [inputGroups, setInputGroups] = useState([...values]);
+
+  const onAdd = event => {
+    setInputGroups(
+      inputGroups.concat({
+        formVariable: '',
+        stufName: '',
+      })
+    );
+  };
+
+  const onDelete = index => {
+    const modifiedInputGroups = [...inputGroups];
+    modifiedInputGroups.splice(index, 1);
+    setInputGroups(modifiedInputGroups);
+  };
+
+  const onInputChange = (index, event) => {
+    const inputNameWithoutIndex = event.target.name.split('-')[0];
+    setInputGroups(
+      inputGroups.map((value, groupIndex) => {
+        if (groupIndex === index) {
+          return {...value, [inputNameWithoutIndex]: event.target.value};
+        }
+        return value;
+      })
+    );
+  };
+
+  useOnChanged(inputGroups, () => {
+    const event = wrapEvent ? {target: {name, value: inputGroups}} : inputGroups;
+    onChange(event);
+  });
+
+  return (
+    <div className="array-multiple-inputs">
+      {inputGroups.map(({formVariable, stufName}, index) => (
+        <div key={index} className="array-multiple-inputs__item">
+          <DeleteIcon
+            onConfirm={onDelete.bind(null, index)}
+            message={
+              deleteConfirmationMessage ||
+              intl.formatMessage({
+                description: 'Confirmation message to delete an item from a multi-value input',
+                defaultMessage: 'Are you sure you want to delete this item?',
+              })
+            }
+            icon="times"
+          />
+          <div>
+            <Field
+              name={`formVariable-${index}`}
+              label={
+                <FormattedMessage
+                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' label"
+                  defaultMessage="Form variable"
+                />
+              }
+              helpText={
+                <FormattedMessage
+                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' helpText"
+                  defaultMessage="The name of the form variable to be mapped"
+                />
+              }
+            >
+              <TextInput
+                type="string"
+                value={formVariable}
+                onChange={onInputChange.bind(null, index)}
+              />
+            </Field>
+            <Field
+              name={`stufName-${index}`}
+              label={
+                <FormattedMessage
+                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' label"
+                  defaultMessage="StUF-ZDS name"
+                />
+              }
+              helpText={
+                <FormattedMessage
+                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' helpText"
+                  defaultMessage="The name in StUF-ZDS to which the form variable should be mapped"
+                />
+              }
+            >
+              <TextInput
+                type="string"
+                value={stufName}
+                onChange={onInputChange.bind(null, index)}
+              />
+            </Field>
+          </div>
+        </div>
+      ))}
+      <ButtonContainer onClick={onAdd}>
+        {addButtonMessage || (
+          <FormattedMessage description="Add item to multi-input field" defaultMessage="Add item" />
+        )}
+      </ButtonContainer>
+    </div>
+  );
+};
+
+PaymentStatusUpdateMappingInputs.propTypes = {
+  name: PropTypes.string.isRequired,
+  values: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string.isRequired)),
+  onChange: PropTypes.func.isRequired,
+  deleteConfirmationMessage: PropTypes.node,
+  addButtonMessage: PropTypes.node,
+  wrapEvent: PropTypes.bool,
+};
+
+export default PaymentStatusUpdateMappingInputs;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/inputs/PaymentStatusUpdateMappingInputs.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/inputs/PaymentStatusUpdateMappingInputs.js
@@ -52,72 +52,74 @@ const PaymentStatusUpdateMappingInputs = ({
   });
 
   return (
-    <div className="array-multiple-inputs">
-      {inputGroups.map(({formVariable, stufName}, index) => (
-        <div key={index} className="array-multiple-inputs__item">
-          <DeleteIcon
-            onConfirm={onDelete.bind(null, index)}
-            message={
-              deleteConfirmationMessage ||
-              intl.formatMessage({
-                description: 'Confirmation message to delete an item from a multi-value input',
-                defaultMessage: 'Are you sure you want to delete this item?',
-              })
-            }
-            icon="times"
-          />
-          <div>
-            <Field
-              name={`formVariable-${index}`}
-              label={
-                <FormattedMessage
-                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' label"
-                  defaultMessage="Form variable"
+    <>
+      <ul className="payment-status-mapping-fields">
+        {inputGroups.map(({formVariable, stufName}, index) => (
+          <li key={index} className="payment-status-mapping-fields__item">
+            <div>
+              <Field
+                name={`formVariable-${index}`}
+                label={
+                  <FormattedMessage
+                    description="StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' label"
+                    defaultMessage="Form variable"
+                  />
+                }
+                helpText={
+                  <FormattedMessage
+                    description="StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' helpText"
+                    defaultMessage="The name of the form variable to be mapped"
+                  />
+                }
+              >
+                <TextInput
+                  type="string"
+                  value={formVariable}
+                  onChange={onInputChange.bind(null, index)}
                 />
-              }
-              helpText={
-                <FormattedMessage
-                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' helpText"
-                  defaultMessage="The name of the form variable to be mapped"
+              </Field>
+              <Field
+                name={`stufName-${index}`}
+                label={
+                  <FormattedMessage
+                    description="StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' label"
+                    defaultMessage="StUF-ZDS name"
+                  />
+                }
+                helpText={
+                  <FormattedMessage
+                    description="StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' helpText"
+                    defaultMessage="The name in StUF-ZDS to which the form variable should be mapped"
+                  />
+                }
+              >
+                <TextInput
+                  type="string"
+                  value={stufName}
+                  onChange={onInputChange.bind(null, index)}
                 />
+              </Field>
+            </div>
+            <DeleteIcon
+              onConfirm={onDelete.bind(null, index)}
+              message={
+                deleteConfirmationMessage ||
+                intl.formatMessage({
+                  description: 'Confirmation message to delete an item from a multi-value input',
+                  defaultMessage: 'Are you sure you want to delete this item?',
+                })
               }
-            >
-              <TextInput
-                type="string"
-                value={formVariable}
-                onChange={onInputChange.bind(null, index)}
-              />
-            </Field>
-            <Field
-              name={`stufName-${index}`}
-              label={
-                <FormattedMessage
-                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' label"
-                  defaultMessage="StUF-ZDS name"
-                />
-              }
-              helpText={
-                <FormattedMessage
-                  description="StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' helpText"
-                  defaultMessage="The name in StUF-ZDS to which the form variable should be mapped"
-                />
-              }
-            >
-              <TextInput
-                type="string"
-                value={stufName}
-                onChange={onInputChange.bind(null, index)}
-              />
-            </Field>
-          </div>
-        </div>
-      ))}
+              icon="times"
+            />
+          </li>
+        ))}
+      </ul>
       <ButtonContainer onClick={onAdd}>
         {addButtonMessage || (
           <FormattedMessage description="Add item to multi-input field" defaultMessage="Add item" />
         )}
       </ButtonContainer>
-    </div>
+    </>
   );
 };
 

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/index.js
@@ -1,0 +1,3 @@
+import StufZDSOptionsForm from './StufZDSOptionsForm';
+
+export default StufZDSOptionsForm;

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/utils.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/utils.js
@@ -1,0 +1,16 @@
+const getChoicesFromSchema = (enums, enumNames) => {
+  const finalChoices = [];
+  Object.keys(enums).forEach(key => {
+    finalChoices.push([enums[key], enumNames[key]]);
+  });
+
+  return finalChoices;
+};
+
+const filterErrors = (name, errors) => {
+  return errors
+    .filter(([key]) => key.startsWith(`${name}.`))
+    .map(([key, msg]) => [key.slice(name.length + 1), msg]);
+};
+
+export {getChoicesFromSchema, filterErrors};

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -69,6 +69,11 @@
     "description": "Case type option label",
     "originalDefault": "{description} {isPublished, select, false {<draft>(not published)</draft>} other {}}"
   },
+  "01mWK2": {
+    "defaultMessage": "The format(s) of the attachment(s) containing the submission details",
+    "description": "Email registration options 'attachmentFormats' label",
+    "originalDefault": "The format(s) of the attachment(s) containing the submission details"
+  },
   "0M2B7B": {
     "defaultMessage": "DMN variable",
     "description": "DMN variable label",
@@ -139,6 +144,11 @@
     "description": "ZGW APIs registration options 'organisationRSIN' help text",
     "originalDefault": "RSIN of the organization, which creates and owns the case and documents."
   },
+  "1z/bNS": {
+    "defaultMessage": "Zds zaaktype code",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeCode' label",
+    "originalDefault": "Zds zaaktype code"
+  },
   "20K9To": {
     "defaultMessage": "Service fetch configuration",
     "description": "Service fetch configuration selection modal title",
@@ -153,6 +163,11 @@
     "defaultMessage": "Number",
     "description": "JSON variable type \"number\" representation",
     "originalDefault": "Number"
+  },
+  "2P7mDI": {
+    "defaultMessage": "Content of the registration email message (as text).",
+    "description": "Email registration options 'emailContentTemplateText' helpText",
+    "originalDefault": "Content of the registration email message (as text)."
   },
   "2Z/hNo": {
     "defaultMessage": "Type",
@@ -198,6 +213,11 @@
     "defaultMessage": "Ask statement of truth",
     "description": "Form askStatementOfTruth field label",
     "originalDefault": "Ask statement of truth"
+  },
+  "3baawY": {
+    "defaultMessage": "StUF-ZDS name",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' label",
+    "originalDefault": "StUF-ZDS name"
   },
   "3z1hhJ": {
     "defaultMessage": "Toggle JSON Schema",
@@ -339,6 +359,11 @@
     "description": "Form step next text label",
     "originalDefault": "Next text"
   },
+  "7ZdEaP": {
+    "defaultMessage": "Documenttype description for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsDocumenttypeOmschrijvingInzending' helpText",
+    "originalDefault": "Documenttype description for newly created zaken in StUF-ZDS"
+  },
   "7cfkp6": {
     "defaultMessage": "Expected input expressions",
     "description": "DMN input expressions title",
@@ -354,6 +379,11 @@
     "description": "Variable table registration title",
     "originalDefault": "Registration"
   },
+  "7hc31v": {
+    "defaultMessage": "The email addresses to which the payment status update will be sent (defaults to general registration addresses)",
+    "description": "Email registration options 'paymentEmails' label",
+    "originalDefault": "The email addresses to which the payment status update will be sent (defaults to general registration addresses)"
+  },
   "833GAg": {
     "defaultMessage": "Input mapping",
     "description": "Input mapping title",
@@ -363,6 +393,11 @@
     "defaultMessage": "Is reusable?",
     "description": "Form step is reusable label",
     "originalDefault": "Is reusable?"
+  },
+  "8IItwi": {
+    "defaultMessage": "The name in StUF-ZDS to which the form variable should be mapped",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' helpText",
+    "originalDefault": "The name in StUF-ZDS to which the form variable should be mapped"
   },
   "8LLxRg": {
     "defaultMessage": "The text that will be displayed in the form step to save the current information. Leave blank to get value from global configuration.",
@@ -388,6 +423,11 @@
     "defaultMessage": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic.",
     "description": "Wrong simple logic warning",
     "originalDefault": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic."
+  },
+  "8nY+h7": {
+    "defaultMessage": "Zaaktype description for newly created Zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeOmschrijving' helpText",
+    "originalDefault": "Zaaktype description for newly created Zaken in StUF-ZDS"
   },
   "8pemD3": {
     "defaultMessage": "Edit variable {name}",
@@ -423,6 +463,11 @@
     "defaultMessage": "Changing the objecttype will remove the existing variables mapping. Are you sure you want to continue?",
     "description": "Objects API registration options: warning message when changing the object type",
     "originalDefault": "Changing the objecttype will remove the existing variables mapping. Are you sure you want to continue?"
+  },
+  "9akVrT": {
+    "defaultMessage": "Zds documenttype omschrijving inzending",
+    "description": "StUF-ZDS registration options 'zdsDocumenttypeOmschrijvingInzending' label",
+    "originalDefault": "Zds documenttype omschrijving inzending"
   },
   "9bGp7h": {
     "defaultMessage": "Active",
@@ -493,6 +538,11 @@
     "defaultMessage": "Confirm",
     "description": "Form definition select confirm button",
     "originalDefault": "Confirm"
+  },
+  "B5RSyi": {
+    "defaultMessage": "Email payment subject",
+    "description": "Email registration options 'emailPaymentSubject' label",
+    "originalDefault": "Email payment subject"
   },
   "BCjZNo": {
     "defaultMessage": "Component where the phone number should be entered",
@@ -573,6 +623,11 @@
     "defaultMessage": "Delete",
     "description": "Delete icon title",
     "originalDefault": "Delete"
+  },
+  "CNJ2TT": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen.",
+    "description": "StUF-ZDS registration paymentStatusUpdateMapping message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
   },
   "CXKQZZ": {
     "defaultMessage": "Confirmation",
@@ -723,6 +778,11 @@
     "defaultMessage": "The co-sign component requires at least one authentication plugin to be enabled.",
     "description": "MissingAuthCosignWarning message",
     "originalDefault": "The co-sign component requires at least one authentication plugin to be enabled."
+  },
+  "FQ1JZc": {
+    "defaultMessage": "Zaaktype code for newly created Zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeCode' helpText",
+    "originalDefault": "Zaaktype code for newly created Zaken in StUF-ZDS"
   },
   "FQswyM": {
     "defaultMessage": "Mode",
@@ -904,6 +964,11 @@
     "description": "Decision definition ID label",
     "originalDefault": "Decision definition ID"
   },
+  "Ihbi6N": {
+    "defaultMessage": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' helpText",
+    "originalDefault": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+  },
   "Ika4IH": {
     "defaultMessage": "Submissions will be deleted",
     "description": "delete_permanently removal method option label",
@@ -1074,6 +1139,11 @@
     "description": "Add process variable button",
     "originalDefault": "Add variable"
   },
+  "LeVpdf": {
+    "defaultMessage": "Plugin configuration: Email",
+    "description": "Email registration options modal title",
+    "originalDefault": "Plugin configuration: Email"
+  },
   "LiXrER": {
     "defaultMessage": "The selected trigger step could not be found in this form! Please change it!",
     "description": "Warning missing trigger step",
@@ -1229,6 +1299,11 @@
     "description": "data type datetime",
     "originalDefault": "Datetime"
   },
+  "P4JMHA": {
+    "defaultMessage": "Zaaktype status code for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' helpText",
+    "originalDefault": "Zaaktype status code for newly created zaken in StUF-ZDS"
+  },
   "PC7ICN": {
     "defaultMessage": "Enabled",
     "description": "Manage process vars enabled checkbox column title",
@@ -1248,6 +1323,11 @@
     "defaultMessage": "Add rule",
     "description": "Add form logic rule button",
     "originalDefault": "Add rule"
+  },
+  "PhN977": {
+    "defaultMessage": "Plugin configuration: StUF-ZDS",
+    "description": "StUF-ZDS registration options modal title",
+    "originalDefault": "Plugin configuration: StUF-ZDS"
   },
   "PiB6Y1": {
     "defaultMessage": "Times Component",
@@ -1294,6 +1374,11 @@
     "description": "option \"no_with_overview\" of \"submission_allowed\"",
     "originalDefault": "No (with overview page)"
   },
+  "QljfI7": {
+    "defaultMessage": "Email subject",
+    "description": "Email registration options 'emailSubject' label",
+    "originalDefault": "Email subject"
+  },
   "Qr2wnR": {
     "defaultMessage": "Payment backend options",
     "description": "Payment backend options label",
@@ -1333,6 +1418,11 @@
     "defaultMessage": "Language",
     "description": "Readable label for the language",
     "originalDefault": "Language"
+  },
+  "RjWycp": {
+    "defaultMessage": "Form variable",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' label",
+    "originalDefault": "Form variable"
   },
   "Rk13i+": {
     "defaultMessage": "Initial value",
@@ -1504,6 +1594,11 @@
     "description": "Variable table sensitive data title",
     "originalDefault": "Sensitive data"
   },
+  "Vu09Ne": {
+    "defaultMessage": "Zds zaaktype status omschrijving",
+    "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label",
+    "originalDefault": "Zds zaaktype status omschrijving"
+  },
   "WHqkYA": {
     "defaultMessage": "Date/time",
     "description": "Date/time column header",
@@ -1613,6 +1708,11 @@
     "defaultMessage": "Are you sure you want to delete this?",
     "description": "Default delete confirmation message",
     "originalDefault": "Are you sure you want to delete this?"
+  },
+  "Z/wFhz": {
+    "defaultMessage": "Content of the registration email message (as html).",
+    "description": "Email registration options 'emailContentTemplateHtml' helpText",
+    "originalDefault": "Content of the registration email message (as html)."
   },
   "Z5lydZ": {
     "defaultMessage": "Introduction page",
@@ -1899,6 +1999,11 @@
     "description": "Logic rule advanced options icon title",
     "originalDefault": "Advanced options"
   },
+  "eO6MNT": {
+    "defaultMessage": "Zds zaaktype status code",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
+    "originalDefault": "Zds zaaktype status code"
+  },
   "evbysh": {
     "defaultMessage": "Variable definition",
     "description": "Camunda complex variable definition title",
@@ -1908,6 +2013,11 @@
     "defaultMessage": "Begin text",
     "description": "literals.beginText form label",
     "originalDefault": "Begin text"
+  },
+  "f8lihY": {
+    "defaultMessage": "Subject of the email sent to the registration backend. You can use the expressions '{{ form_name }}' and '{{ public_reference }}' to include the form name and the reference number to the submission in the subject.",
+    "description": "Email registration options 'emailSubject' helpText",
+    "originalDefault": "Subject of the email sent to the registration backend. You can use the expressions '{{ form_name }}' and '{{ public_reference }}' to include the form name and the reference number to the submission in the subject."
   },
   "f9Zr9D": {
     "defaultMessage": "Amount of days incomplete submissions of this form will remain before being removed. Leave blank to use value in General Configuration.",
@@ -1928,6 +2038,11 @@
     "defaultMessage": "Object",
     "description": "data type object",
     "originalDefault": "Object"
+  },
+  "ffvbQm": {
+    "defaultMessage": "payment status update variable mapping",
+    "description": "StUF-ZDS registration paymentStatusUpdateMapping label",
+    "originalDefault": "payment status update variable mapping"
   },
   "fpX4ei": {
     "defaultMessage": "Mapping expression language",
@@ -1959,6 +2074,11 @@
     "description": "No service fetch configuration configured yet message",
     "originalDefault": "(not configured yet)"
   },
+  "gDAZQ1": {
+    "defaultMessage": "Zds zaaktype status omschrijving",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusOmschrijving' label",
+    "originalDefault": "Zds zaaktype status omschrijving"
+  },
   "gGNIdG": {
     "defaultMessage": "The text that will be displayed in the overview page to go to the previous step. Leave blank to get value from global configuration.",
     "description": "literals.previousText help text",
@@ -1983,6 +2103,11 @@
     "defaultMessage": "App version",
     "description": "App version column header",
     "originalDefault": "App version"
+  },
+  "gtjPWc": {
+    "defaultMessage": "The name of the form variable to be mapped",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' helpText",
+    "originalDefault": "The name of the form variable to be mapped"
   },
   "gz32s2": {
     "defaultMessage": "If desired, you can specify a different process variable name.",
@@ -2018,6 +2143,16 @@
     "defaultMessage": "Add registration backend",
     "description": "Button text to add registration backend",
     "originalDefault": "Add registration backend"
+  },
+  "hQ7xjd": {
+    "defaultMessage": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusOmschrijving' helpText",
+    "originalDefault": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+  },
+  "hSvi+z": {
+    "defaultMessage": "Email content template text",
+    "description": "Email registration options 'emailContentTemplateText' label",
+    "originalDefault": "Email content template text"
   },
   "hWRRHx": {
     "defaultMessage": "Form design",
@@ -2179,6 +2314,11 @@
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
   },
+  "kWAxhF": {
+    "defaultMessage": "Subject of the email sent to the registration backend to notify a change in the payment status.",
+    "description": "Email registration options 'emailPaymentSubject' helpText",
+    "originalDefault": "Subject of the email sent to the registration backend to notify a change in the payment status."
+  },
   "klKZV5": {
     "defaultMessage": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead.",
     "description": "Objects API registration: updateExistingObject helpText",
@@ -2269,6 +2409,11 @@
     "description": "Logic trigger heading",
     "originalDefault": "Trigger condition"
   },
+  "nNbK3G": {
+    "defaultMessage": "Email content template HTML",
+    "description": "Email registration options 'emailContentTemplateHtml' label",
+    "originalDefault": "Email content template HTML"
+  },
   "neCqv9": {
     "defaultMessage": "The registration result will be an object from the selected type.",
     "description": "Objects API registration options 'Objecttype' helpText",
@@ -2284,6 +2429,11 @@
     "description": "Form 'BRP Personen purpose limitation header value' field help text",
     "originalDefault": "The purpose limitation (\"doelbinding\") for queries to the BRP Persoon API."
   },
+  "o6Ju6l": {
+    "defaultMessage": "The email addresses to which the submission details will be sent",
+    "description": "Email registration options 'attachFilesToEmail' label",
+    "originalDefault": "The email addresses to which the submission details will be sent"
+  },
   "o8CfuS": {
     "defaultMessage": "String",
     "description": "JSON variable type \"string\" representation",
@@ -2293,6 +2443,11 @@
     "defaultMessage": "Save",
     "description": "Save service fetch configuration button label",
     "originalDefault": "Save"
+  },
+  "oVwrVo": {
+    "defaultMessage": "Attach files to email",
+    "description": "Email registration options 'attachFilesToEmail' label",
+    "originalDefault": "Attach files to email"
   },
   "oYmpN5": {
     "defaultMessage": "Whether to include the content of the confirmation page in the PDF.",
@@ -2358,6 +2513,11 @@
     "defaultMessage": "Form definition",
     "description": "Variable table form definition title",
     "originalDefault": "Form definition"
+  },
+  "ppZHsm": {
+    "defaultMessage": "Configure options",
+    "description": "Link label to open StUF-ZDS options modal",
+    "originalDefault": "Configure options"
   },
   "pqCru3": {
     "defaultMessage": "Fetch configuration:",
@@ -2463,6 +2623,11 @@
     "defaultMessage": "Whether to send a confirmation email to the end-user who submitted the form.",
     "description": "Help text of form field 'Send the confirmation email'",
     "originalDefault": "Whether to send a confirmation email to the end-user who submitted the form."
+  },
+  "sNGN82": {
+    "defaultMessage": "Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit.",
+    "description": "Email registration options 'attachFilesToEmail' helpText",
+    "originalDefault": "Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit."
   },
   "sptpzv": {
     "defaultMessage": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?",
@@ -2674,6 +2839,11 @@
     "description": "Identifier role (for mandate context) label for authorizee",
     "originalDefault": "Authorizee"
   },
+  "yJiaOl": {
+    "defaultMessage": "{numErrors, plural, one {There is a validation error.} other {There are {numErrors} validation errors.} }",
+    "description": "StUF-ZDS registration validation errors icon next to button",
+    "originalDefault": "{numErrors, plural, one {There is a validation error.} other {There are {numErrors} validation errors.} }"
+  },
   "yLt2lv": {
     "defaultMessage": "JSON template for the body of the request sent to the Objects API.",
     "description": "Legacy objects API registration options: 'contentJSON' helpText",
@@ -2703,6 +2873,11 @@
     "defaultMessage": "Action",
     "description": "Action column header",
     "originalDefault": "Action"
+  },
+  "z4zEf7": {
+    "defaultMessage": "Zds zaaktype omschrijving",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeOmschrijving' label",
+    "originalDefault": "Zds zaaktype omschrijving"
   },
   "zGMQ75": {
     "defaultMessage": "User defined",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -69,6 +69,11 @@
     "description": "Case type option label",
     "originalDefault": "{description} {isPublished, select, false {<draft>(not published)</draft>} other {}}"
   },
+  "01mWK2": {
+    "defaultMessage": "The format(s) of the attachment(s) containing the submission details",
+    "description": "Email registration options 'attachmentFormats' label",
+    "originalDefault": "The format(s) of the attachment(s) containing the submission details"
+  },
   "0M2B7B": {
     "defaultMessage": "DMN-variabele",
     "description": "DMN variable label",
@@ -139,6 +144,11 @@
     "description": "ZGW APIs registration options 'organisationRSIN' help text",
     "originalDefault": "RSIN of the organization, which creates and owns the case and documents."
   },
+  "1z/bNS": {
+    "defaultMessage": "Zds zaaktype code",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeCode' label",
+    "originalDefault": "Zds zaaktype code"
+  },
   "20K9To": {
     "defaultMessage": "Servicebevraging instellen",
     "description": "Service fetch configuration selection modal title",
@@ -153,6 +163,11 @@
     "defaultMessage": "Getal (number)",
     "description": "JSON variable type \"number\" representation",
     "originalDefault": "Number"
+  },
+  "2P7mDI": {
+    "defaultMessage": "Content of the registration email message (as text).",
+    "description": "Email registration options 'emailContentTemplateText' helpText",
+    "originalDefault": "Content of the registration email message (as text)."
   },
   "2Z/hNo": {
     "defaultMessage": "Type",
@@ -199,6 +214,11 @@
     "defaultMessage": "Vraag verklaring invullen naar waarheid",
     "description": "Form askStatementOfTruth field label",
     "originalDefault": "Ask statement of truth"
+  },
+  "3baawY": {
+    "defaultMessage": "StUF-ZDS name",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' label",
+    "originalDefault": "StUF-ZDS name"
   },
   "3z1hhJ": {
     "defaultMessage": "Toon/verberg JSON Schema",
@@ -342,6 +362,11 @@
     "description": "Form step next text label",
     "originalDefault": "Next text"
   },
+  "7ZdEaP": {
+    "defaultMessage": "Documenttype description for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsDocumenttypeOmschrijvingInzending' helpText",
+    "originalDefault": "Documenttype description for newly created zaken in StUF-ZDS"
+  },
   "7cfkp6": {
     "defaultMessage": "Verwachte invoer-expressies",
     "description": "DMN input expressions title",
@@ -357,6 +382,11 @@
     "description": "Variable table registration title",
     "originalDefault": "Registration"
   },
+  "7hc31v": {
+    "defaultMessage": "The email addresses to which the payment status update will be sent (defaults to general registration addresses)",
+    "description": "Email registration options 'paymentEmails' label",
+    "originalDefault": "The email addresses to which the payment status update will be sent (defaults to general registration addresses)"
+  },
   "833GAg": {
     "defaultMessage": "Invoerparameters",
     "description": "Input mapping title",
@@ -366,6 +396,11 @@
     "defaultMessage": "Is herbruikbaar?",
     "description": "Form step is reusable label",
     "originalDefault": "Is reusable?"
+  },
+  "8IItwi": {
+    "defaultMessage": "The name in StUF-ZDS to which the form variable should be mapped",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping stufName' helpText",
+    "originalDefault": "The name in StUF-ZDS to which the form variable should be mapped"
   },
   "8LLxRg": {
     "defaultMessage": "De tekst op de knop om de gegevens van de huidige stap op te slaan en het formulier te onderbreken. Laat dit veld leeg om de standaardinstelling te gebruiken.",
@@ -392,6 +427,11 @@
     "defaultMessage": "Component {label} ({key}) steunt op een niet-bestaande component key {missingKey} in de eenvoudige logica.",
     "description": "Wrong simple logic warning",
     "originalDefault": "Component {label} ({key}) uses a non-existent component key {missingKey} in the simple logic."
+  },
+  "8nY+h7": {
+    "defaultMessage": "Zaaktype description for newly created Zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeOmschrijving' helpText",
+    "originalDefault": "Zaaktype description for newly created Zaken in StUF-ZDS"
   },
   "8pemD3": {
     "defaultMessage": "Wijzig variabele {name}",
@@ -427,6 +467,11 @@
     "defaultMessage": "Let op! Als je een ander objecttype selecteert, dan worden de bestaande koppelingen gereset. Ben je zeker dat je door wil gaan?",
     "description": "Objects API registration options: warning message when changing the object type",
     "originalDefault": "Changing the objecttype will remove the existing variables mapping. Are you sure you want to continue?"
+  },
+  "9akVrT": {
+    "defaultMessage": "Zds documenttype omschrijving inzending",
+    "description": "StUF-ZDS registration options 'zdsDocumenttypeOmschrijvingInzending' label",
+    "originalDefault": "Zds documenttype omschrijving inzending"
   },
   "9bGp7h": {
     "defaultMessage": "Actief",
@@ -497,6 +542,11 @@
     "defaultMessage": "Bevestigen",
     "description": "Form definition select confirm button",
     "originalDefault": "Confirm"
+  },
+  "B5RSyi": {
+    "defaultMessage": "Email payment subject",
+    "description": "Email registration options 'emailPaymentSubject' label",
+    "originalDefault": "Email payment subject"
   },
   "BCjZNo": {
     "defaultMessage": "Veld waar het telefoonnummer voor een afspraak komt te staan",
@@ -578,6 +628,11 @@
     "defaultMessage": "Verwijderen",
     "description": "Delete icon title",
     "originalDefault": "Delete"
+  },
+  "CNJ2TT": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen.",
+    "description": "StUF-ZDS registration paymentStatusUpdateMapping message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in extraElementen."
   },
   "CXKQZZ": {
     "defaultMessage": "Bevestiging",
@@ -730,6 +785,11 @@
     "defaultMessage": "Er moet minstens één authenticatiemethode ingeschakeld zijn voor de mede-ondertekencomponent.",
     "description": "MissingAuthCosignWarning message",
     "originalDefault": "The co-sign component requires at least one authentication plugin to be enabled."
+  },
+  "FQ1JZc": {
+    "defaultMessage": "Zaaktype code for newly created Zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeCode' helpText",
+    "originalDefault": "Zaaktype code for newly created Zaken in StUF-ZDS"
   },
   "FQswyM": {
     "defaultMessage": "Modus",
@@ -911,6 +971,11 @@
     "description": "Decision definition ID label",
     "originalDefault": "Decision definition ID"
   },
+  "Ihbi6N": {
+    "defaultMessage": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' helpText",
+    "originalDefault": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+  },
   "Ika4IH": {
     "defaultMessage": "Inzendingen worden permanent verwijderd",
     "description": "delete_permanently removal method option label",
@@ -1081,6 +1146,11 @@
     "description": "Add process variable button",
     "originalDefault": "Add variable"
   },
+  "LeVpdf": {
+    "defaultMessage": "Plugin configuration: Email",
+    "description": "Email registration options modal title",
+    "originalDefault": "Plugin configuration: Email"
+  },
   "LiXrER": {
     "defaultMessage": "De gekozen trigger-stap bestaat niet (meer) in het formulier. Gelieve deze te wijzigen.",
     "description": "Warning missing trigger step",
@@ -1240,6 +1310,11 @@
     "description": "data type datetime",
     "originalDefault": "Datetime"
   },
+  "P4JMHA": {
+    "defaultMessage": "Zaaktype status code for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' helpText",
+    "originalDefault": "Zaaktype status code for newly created zaken in StUF-ZDS"
+  },
   "PC7ICN": {
     "defaultMessage": "Ingeschakeld",
     "description": "Manage process vars enabled checkbox column title",
@@ -1259,6 +1334,11 @@
     "defaultMessage": "Regel toevoegen",
     "description": "Add form logic rule button",
     "originalDefault": "Add rule"
+  },
+  "PhN977": {
+    "defaultMessage": "Plugin configuration: StUF-ZDS",
+    "description": "StUF-ZDS registration options modal title",
+    "originalDefault": "Plugin configuration: StUF-ZDS"
   },
   "PiB6Y1": {
     "defaultMessage": "Tijd veld",
@@ -1306,6 +1386,11 @@
     "description": "option \"no_with_overview\" of \"submission_allowed\"",
     "originalDefault": "No (with overview page)"
   },
+  "QljfI7": {
+    "defaultMessage": "Email subject",
+    "description": "Email registration options 'emailSubject' label",
+    "originalDefault": "Email subject"
+  },
   "Qr2wnR": {
     "defaultMessage": "Betaalprovider backendopties",
     "description": "Payment backend options label",
@@ -1345,6 +1430,11 @@
     "defaultMessage": "Taal",
     "description": "Readable label for the language",
     "originalDefault": "Language"
+  },
+  "RjWycp": {
+    "defaultMessage": "Form variable",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' label",
+    "originalDefault": "Form variable"
   },
   "Rk13i+": {
     "defaultMessage": "Beginwaarde",
@@ -1517,6 +1607,11 @@
     "description": "Variable table sensitive data title",
     "originalDefault": "Sensitive data"
   },
+  "Vu09Ne": {
+    "defaultMessage": "Zds zaaktype status omschrijving",
+    "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label",
+    "originalDefault": "Zds zaaktype status omschrijving"
+  },
   "WHqkYA": {
     "defaultMessage": "Datum/tijd",
     "description": "Date/time column header",
@@ -1628,6 +1723,11 @@
     "defaultMessage": "Weet u zeker dat u dit wilt verwijderen?",
     "description": "Default delete confirmation message",
     "originalDefault": "Are you sure you want to delete this?"
+  },
+  "Z/wFhz": {
+    "defaultMessage": "Content of the registration email message (as html).",
+    "description": "Email registration options 'emailContentTemplateHtml' helpText",
+    "originalDefault": "Content of the registration email message (as html)."
   },
   "Z5lydZ": {
     "defaultMessage": "Introductiepagina",
@@ -1917,6 +2017,11 @@
     "description": "Logic rule advanced options icon title",
     "originalDefault": "Advanced options"
   },
+  "eO6MNT": {
+    "defaultMessage": "Zds zaaktype status code",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
+    "originalDefault": "Zds zaaktype status code"
+  },
   "evbysh": {
     "defaultMessage": "Variabeledefinitie",
     "description": "Camunda complex variable definition title",
@@ -1926,6 +2031,11 @@
     "defaultMessage": "'Start' tekst",
     "description": "literals.beginText form label",
     "originalDefault": "Begin text"
+  },
+  "f8lihY": {
+    "defaultMessage": "Subject of the email sent to the registration backend. You can use the expressions '{{ form_name }}' and '{{ public_reference }}' to include the form name and the reference number to the submission in the subject.",
+    "description": "Email registration options 'emailSubject' helpText",
+    "originalDefault": "Subject of the email sent to the registration backend. You can use the expressions '{{ form_name }}' and '{{ public_reference }}' to include the form name and the reference number to the submission in the subject."
   },
   "f9Zr9D": {
     "defaultMessage": "Aantal dagen dat een sessie bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken.",
@@ -1946,6 +2056,11 @@
     "defaultMessage": "Sleutel-waarde paar (object)",
     "description": "data type object",
     "originalDefault": "Object"
+  },
+  "ffvbQm": {
+    "defaultMessage": "payment status update variable mapping",
+    "description": "StUF-ZDS registration paymentStatusUpdateMapping label",
+    "originalDefault": "payment status update variable mapping"
   },
   "fpX4ei": {
     "defaultMessage": "Soort mappingexpressie",
@@ -1977,6 +2092,11 @@
     "description": "No service fetch configuration configured yet message",
     "originalDefault": "(not configured yet)"
   },
+  "gDAZQ1": {
+    "defaultMessage": "Zds zaaktype status omschrijving",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusOmschrijving' label",
+    "originalDefault": "Zds zaaktype status omschrijving"
+  },
   "gGNIdG": {
     "defaultMessage": "De tekst op de overzichtspagina om naar de vorige stap terug te gaan. Laat dit veld leeg om de standaardinstelling te gebruiken.",
     "description": "literals.previousText help text",
@@ -2001,6 +2121,11 @@
     "defaultMessage": "Applicatieversie",
     "description": "App version column header",
     "originalDefault": "App version"
+  },
+  "gtjPWc": {
+    "defaultMessage": "The name of the form variable to be mapped",
+    "description": "StUF-ZDS registration options 'paymentStatusUpdateMapping formVariable' helpText",
+    "originalDefault": "The name of the form variable to be mapped"
   },
   "gz32s2": {
     "defaultMessage": "Indien gewenst, dan kunt u een alternatieve naam opgeven voor de procesvariabele.",
@@ -2036,6 +2161,16 @@
     "defaultMessage": "Registratiepluginoptie toevoegen",
     "description": "Button text to add registration backend",
     "originalDefault": "Add registration backend"
+  },
+  "hQ7xjd": {
+    "defaultMessage": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeStatusOmschrijving' helpText",
+    "originalDefault": "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
+  },
+  "hSvi+z": {
+    "defaultMessage": "Email content template text",
+    "description": "Email registration options 'emailContentTemplateText' label",
+    "originalDefault": "Email content template text"
   },
   "hWRRHx": {
     "defaultMessage": "Formulierontwerp",
@@ -2198,6 +2333,11 @@
     "description": "component property \"disabled\" label",
     "originalDefault": "disabled"
   },
+  "kWAxhF": {
+    "defaultMessage": "Subject of the email sent to the registration backend to notify a change in the payment status.",
+    "description": "Email registration options 'emailPaymentSubject' helpText",
+    "originalDefault": "Subject of the email sent to the registration backend to notify a change in the payment status."
+  },
   "klKZV5": {
     "defaultMessage": "Geeft aan of een bestaande record (verkregen van de eventuele voor-invulreferentie) bijgewerkt moet worden in plaats van een nieuw object aan te maken. Als er geen bestaand object is, dan wordt een nieuwe aangemaakt.",
     "description": "Objects API registration: updateExistingObject helpText",
@@ -2288,6 +2428,11 @@
     "description": "Logic trigger heading",
     "originalDefault": "Trigger condition"
   },
+  "nNbK3G": {
+    "defaultMessage": "Email content template HTML",
+    "description": "Email registration options 'emailContentTemplateHtml' label",
+    "originalDefault": "Email content template HTML"
+  },
   "neCqv9": {
     "defaultMessage": "Het registratieresultaat zal een object van dit type zijn.",
     "description": "Objects API registration options 'Objecttype' helpText",
@@ -2303,6 +2448,11 @@
     "description": "Form 'BRP Personen purpose limitation header value' field help text",
     "originalDefault": "The purpose limitation (\"doelbinding\") for queries to the BRP Persoon API."
   },
+  "o6Ju6l": {
+    "defaultMessage": "The email addresses to which the submission details will be sent",
+    "description": "Email registration options 'attachFilesToEmail' label",
+    "originalDefault": "The email addresses to which the submission details will be sent"
+  },
   "o8CfuS": {
     "defaultMessage": "Tekst (string)",
     "description": "JSON variable type \"string\" representation",
@@ -2312,6 +2462,11 @@
     "defaultMessage": "Opslaan",
     "description": "Save service fetch configuration button label",
     "originalDefault": "Save"
+  },
+  "oVwrVo": {
+    "defaultMessage": "Attach files to email",
+    "description": "Email registration options 'attachFilesToEmail' label",
+    "originalDefault": "Attach files to email"
   },
   "oYmpN5": {
     "defaultMessage": "Vink aan om de inhoud toe te voegen aan de PDF die mensen op het eind kunnen downloaden.",
@@ -2377,6 +2532,11 @@
     "defaultMessage": "Formulierdefinitie",
     "description": "Variable table form definition title",
     "originalDefault": "Form definition"
+  },
+  "ppZHsm": {
+    "defaultMessage": "Configure options",
+    "description": "Link label to open StUF-ZDS options modal",
+    "originalDefault": "Configure options"
   },
   "pqCru3": {
     "defaultMessage": "Servicebevraging:",
@@ -2482,6 +2642,11 @@
     "defaultMessage": "Vink aan om een bevestigingsmail te sturen naar de inzender(s) van het formulier.",
     "description": "Help text of form field 'Send the confirmation email'",
     "originalDefault": "Whether to send a confirmation email to the end-user who submitted the form."
+  },
+  "sNGN82": {
+    "defaultMessage": "Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit.",
+    "description": "Email registration options 'attachFilesToEmail' helpText",
+    "originalDefault": "Enable to attach file uploads to the registration email. If set, this overrides the global default. Form designers should take special care to ensure that the total file upload sizes do not exceed the email size limit."
   },
   "sptpzv": {
     "defaultMessage": "Let op! Migreren naar het nieuwe configuratieformaat maakt de bestaande JSON-sjablonen leeg. Daarnaast kan je het formulier pas opslaan als alle verplichte variabelen goed gekoppeld zijn. Ben je zeker dat je wil migreren?",
@@ -2693,6 +2858,11 @@
     "description": "Identifier role (for mandate context) label for authorizee",
     "originalDefault": "Authorizee"
   },
+  "yJiaOl": {
+    "defaultMessage": "{numErrors, plural, one {There is a validation error.} other {There are {numErrors} validation errors.} }",
+    "description": "StUF-ZDS registration validation errors icon next to button",
+    "originalDefault": "{numErrors, plural, one {There is a validation error.} other {There are {numErrors} validation errors.} }"
+  },
   "yLt2lv": {
     "defaultMessage": "JSON-sjabloon voor de inhoud van het verzoek wat naar de Objecten-API gestuurd wordt.",
     "description": "Legacy objects API registration options: 'contentJSON' helpText",
@@ -2723,6 +2893,11 @@
     "defaultMessage": "Actie",
     "description": "Action column header",
     "originalDefault": "Action"
+  },
+  "z4zEf7": {
+    "defaultMessage": "Zds zaaktype omschrijving",
+    "description": "StUF-ZDS registration options 'zdsZaaktypeOmschrijving' label",
+    "originalDefault": "Zds zaaktype omschrijving"
   },
   "zGMQ75": {
     "defaultMessage": "Gebruikersvariabelen",

--- a/src/openforms/scss/components/admin/_ReactModal.scss
+++ b/src/openforms/scss/components/admin/_ReactModal.scss
@@ -7,7 +7,7 @@
     align-items: center;
 
     position: fixed;
-    z-index: 10000000;
+    z-index: 1000;
     top: 0;
     right: 0;
     bottom: 0;

--- a/src/openforms/scss/components/admin/_array-multiple-inputs.scss
+++ b/src/openforms/scss/components/admin/_array-multiple-inputs.scss
@@ -1,7 +1,0 @@
-.array-multiple-inputs {
-  &__item {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    margin-bottom: 0.5em;
-  }
-}

--- a/src/openforms/scss/components/admin/_array-multiple-inputs.scss
+++ b/src/openforms/scss/components/admin/_array-multiple-inputs.scss
@@ -1,0 +1,7 @@
+.array-multiple-inputs {
+  &__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    margin-bottom: 0.5em;
+  }
+}

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -10,6 +10,7 @@
 @import './form-object-tools';
 @import './json-data-preview';
 @import './array-input';
+@import './array-multiple-inputs';
 @import './json-widget';
 @import './plugin-config-react';
 @import './session-status';

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -10,8 +10,8 @@
 @import './form-object-tools';
 @import './json-data-preview';
 @import './array-input';
-@import './array-multiple-inputs';
 @import './json-widget';
+@import './payment-status-mapping-field';
 @import './plugin-config-react';
 @import './session-status';
 @import './variables-editor';

--- a/src/openforms/scss/components/admin/_payment-status-mapping-field.scss
+++ b/src/openforms/scss/components/admin/_payment-status-mapping-field.scss
@@ -1,0 +1,14 @@
+.payment-status-mapping-fields {
+  &,
+  // Making sure that the spacing left is zero
+  .aligned & {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  &__item {
+    display: flex;
+    margin-bottom: 0.5em;
+  }
+}


### PR DESCRIPTION
Closes #4686

**Changes**

The registration forms for Email and StUF-ZDS now use React components, instead of react-json-schema-form generated forms. This allows us to share styling and keep the styling uniform across forms. These changes also improve the user experience, by providing a simular form layout/logic as the other registration inline forms.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
