### PR TITLE
:recycle: [#4588] Reduce code duplication in payment related code

### DIFF
--- a/src/openforms/payments/models.py
+++ b/src/openforms/payments/models.py
@@ -21,12 +21,16 @@ class SubmissionPaymentQuerySet(models.QuerySet["SubmissionPayment"]):
         qs = self.filter(status=PaymentStatus.completed)
         return qs.update(status=PaymentStatus.registered)
 
-    def get_completed_public_order_ids(self) -> list[str]:
-        return list(
-            self.filter(
-                status__in=(PaymentStatus.registered, PaymentStatus.completed)
-            ).values_list("public_order_id", flat=True)
+    def paid(self) -> models.QuerySet["SubmissionPayment"]:
+        return self.filter(
+            status__in=(PaymentStatus.registered, PaymentStatus.completed)
         )
+
+    def get_completed_public_order_ids(self) -> list[str]:
+        return list(self.paid().values_list("public_order_id", flat=True))
+
+    def get_completed_provider_payment_ids(self) -> list[str]:
+        return list(self.paid().values_list("provider_payment_id", flat=True))
 
 
 class SubmissionPaymentManager(models.Manager.from_queryset(SubmissionPaymentQuerySet)):
@@ -79,6 +83,10 @@ class SubmissionPaymentManager(models.Manager.from_queryset(SubmissionPaymentQue
     if TYPE_CHECKING:
 
         def mark_registered(self) -> int: ...
+
+        def paid(self) -> models.QuerySet["SubmissionPayment"]: ...
+
+        def get_completed_provider_payment_ids(self) -> list[str]: ...
 
         def get_completed_public_order_ids(self) -> list[str]: ...
 

--- a/src/openforms/registrations/contrib/objects_api/registration_variables.py
+++ b/src/openforms/registrations/contrib/objects_api/registration_variables.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from django.utils.translation import gettext_lazy as _
 
 from openforms.authentication.service import AuthAttribute, BaseAuth
-from openforms.payments.constants import PaymentStatus
 from openforms.plugins.registry import BaseRegistry
 from openforms.variables.base import BaseStaticVariable
 from openforms.variables.constants import FormVariableDataTypes
@@ -104,11 +103,7 @@ class ProviderPaymentIds(BaseStaticVariable):
         if submission is None:
             return None
 
-        return list(
-            submission.payments.filter(
-                status__in=(PaymentStatus.registered, PaymentStatus.completed)
-            ).values_list("provider_payment_id", flat=True)
-        )
+        return submission.payments.get_completed_provider_payment_ids()
 
 
 @register("cosign_data")

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -28,7 +28,6 @@ from openforms.contrib.zgw.service import (
 )
 from openforms.formio.service import FormioData
 from openforms.formio.typing import Component
-from openforms.payments.constants import PaymentStatus
 from openforms.registrations.exceptions import RegistrationFailed
 from openforms.submissions.exports import create_submission_export
 from openforms.submissions.mapping import SKIP, FieldConf, apply_data_mapping
@@ -361,11 +360,7 @@ class ObjectsAPIV1Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV1]):
             "completed": submission.payment_user_has_paid,
             "amount": str(amount),
             "public_order_ids": submission.payments.get_completed_public_order_ids(),
-            "provider_payment_ids": list(
-                submission.payments.filter(
-                    status__in=(PaymentStatus.registered, PaymentStatus.completed)
-                ).values_list("provider_payment_id", flat=True)
-            ),
+            "provider_payment_ids": submission.payments.get_completed_provider_payment_ids(),
         }
 
     @staticmethod

--- a/src/openforms/registrations/contrib/stuf_zds/registration_variables.py
+++ b/src/openforms/registrations/contrib/stuf_zds/registration_variables.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext_lazy as _
 
-from openforms.payments.constants import PaymentStatus
 from openforms.plugins.registry import BaseRegistry
 from openforms.variables.base import BaseStaticVariable
 from openforms.variables.constants import FormVariableDataTypes
@@ -69,8 +68,4 @@ class ProviderPaymentIds(BaseStaticVariable):
         if submission is None:
             return None
 
-        return list(
-            submission.payments.filter(
-                status__in=(PaymentStatus.registered, PaymentStatus.completed)
-            ).values_list("provider_payment_id", flat=True)
-        )
+        return submission.payments.get_completed_provider_payment_ids()

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -753,9 +753,7 @@ class Submission(models.Model):
     @property
     def payment_user_has_paid(self) -> bool:
         # TODO support partial payments
-        return self.payments.filter(
-            status__in=(PaymentStatus.registered, PaymentStatus.completed)
-        ).exists()
+        return self.payments.paid().exists()
 
     @property
     def payment_registered(self) -> bool:


### PR DESCRIPTION
in different places, the same query was being done to find successful SubmissionPayments, this has been moved to a method on the queryset to avoid duplication

Closes #4588 

**Changes**
* Reduce code duplication in payment related code

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
