### PR TITLE
[#4709] Update generic error message text for erros in a form

### DIFF
--- a/src/openforms/forms/templates/admin/forms/form/change_form.html
+++ b/src/openforms/forms/templates/admin/forms/form/change_form.html
@@ -30,6 +30,7 @@
     data-form-history-url="{{ history_url }}"
     data-csrftoken="{{ csrf_token }}"
     data-tinymce-url="{% static 'tinymce/tinymce.min.js' %}"
+    data-outgoing-requests-url="{% url 'admin:log_outgoing_requests_outgoingrequestslog_changelist' %}"
 > {# Managed by React #} </div>
 {% endblock %}
 

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -1061,6 +1061,36 @@
       "value": "and"
     }
   ],
+  "9fW2NX": [
+    {
+      "type": 0,
+      "value": "Sorry! Something unexpected went wrong."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": "Contact your technical administrator to investigate, or perhaps more information is available in the "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "outgoing request logs"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "9lk1eS": [
     {
       "type": 0,
@@ -5163,12 +5193,6 @@
     {
       "type": 0,
       "value": "The regular expression pattern test that the city field value must pass before the form can be submitted."
-    }
-  ],
-  "ow5AAO": [
-    {
-      "type": 0,
-      "value": "The form is invalid. Please correct the errors below."
     }
   ],
   "oxYXJX": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -1065,6 +1065,36 @@
       "value": "en"
     }
   ],
+  "9fW2NX": [
+    {
+      "type": 0,
+      "value": "Sorry! Er is iets onverwachts misgegaan."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": "Neem contact op met je technische beheerder om dit te onderzoeken, of misschien is er meer informatie beschikbaar in de "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "logboeken van uitgaande verzoeken"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "9lk1eS": [
     {
       "type": 0,
@@ -5185,12 +5215,6 @@
     {
       "type": 0,
       "value": "Het patroon van reguliere expressie waar de stad aan moet voldoen voor het formulier kan verstuurd worden."
-    }
-  ],
-  "ow5AAO": [
-    {
-      "type": 0,
-      "value": "De gegevens zijn ongeldig. Los de problemen hieronder op."
     }
   ],
   "oxYXJX": [

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -990,7 +990,7 @@ StepsFieldSet.propTypes = {
 /**
  * Component to render the form edit page.
  */
-const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
+const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUrl}) => {
   const {csrftoken} = useContext(APIContext);
   const intl = useIntl();
   const initialState = {
@@ -1267,8 +1267,18 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl}) => {
       {Object.keys(state.errors).length ? (
         <div className="fetch-error">
           <FormattedMessage
-            defaultMessage="The form is invalid. Please correct the errors below."
-            description="Generic error message"
+            description="Generic admin error message"
+            defaultMessage={`Sorry! Something unexpected went wrong.<br></br>Contact your 
+              technical administrator to investigate, or perhaps more information is 
+              available in the <link>outgoing request logs</link>.`}
+            values={{
+              br: () => <br />,
+              link: chunks => (
+                <a href={outgoingRequestsUrl} target="_blank">
+                  {chunks}
+                </a>
+              ),
+            }}
           />
         </div>
       ) : null}

--- a/src/openforms/js/components/admin/index.js
+++ b/src/openforms/js/components/admin/index.js
@@ -18,7 +18,8 @@ const mountForm = wrapperProps => {
   if (!formCreationFormNodes.length) return;
 
   for (const formCreationFormNode of formCreationFormNodes) {
-    const {csrftoken, formUuid, formUrl, tinymceUrl, formHistoryUrl} = formCreationFormNode.dataset;
+    const {csrftoken, formUuid, formUrl, tinymceUrl, formHistoryUrl, outgoingRequestsUrl} =
+      formCreationFormNode.dataset;
 
     ReactModal.setAppElement(formCreationFormNode);
     const root = createRoot(formCreationFormNode);
@@ -28,7 +29,12 @@ const mountForm = wrapperProps => {
       // Strict mode is likely only viable once we've simplified the code substantially.
       <AppWrapper {...wrapperProps} csrftoken={csrftoken} strict={false}>
         <TinyMceContext.Provider value={tinymceUrl}>
-          <FormCreationForm formUuid={formUuid} formUrl={formUrl} formHistoryUrl={formHistoryUrl} />
+          <FormCreationForm
+            formUuid={formUuid}
+            formUrl={formUrl}
+            formHistoryUrl={formHistoryUrl}
+            outgoingRequestsUrl={outgoingRequestsUrl}
+          />
         </TinyMceContext.Provider>
       </AppWrapper>
     );

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -434,6 +434,11 @@
     "description": "Extra logic action prefix",
     "originalDefault": "and"
   },
+  "9fW2NX": {
+    "defaultMessage": "Sorry! Something unexpected went wrong.<br></br>Contact your technical administrator to investigate, or perhaps more information is available in the <link>outgoing request logs</link>.",
+    "description": "Generic admin error message",
+    "originalDefault": "Sorry! Something unexpected went wrong.<br></br>Contact your technical administrator to investigate, or perhaps more information is available in the <link>outgoing request logs</link>."
+  },
   "9y3/ek": {
     "defaultMessage": "Confirm",
     "description": "JSON editor: confirm edited variable definition",
@@ -2308,11 +2313,6 @@
     "defaultMessage": "Whether to include the content of the confirmation page in the PDF.",
     "description": "Include confirmation page content in PDF",
     "originalDefault": "Whether to include the content of the confirmation page in the PDF."
-  },
-  "ow5AAO": {
-    "defaultMessage": "The form is invalid. Please correct the errors below.",
-    "description": "Generic error message",
-    "originalDefault": "The form is invalid. Please correct the errors below."
   },
   "oxYXJX": {
     "defaultMessage": "How successful submissions of this form will be removed after the limit. Leave blank to use value in General Configuration.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -438,6 +438,11 @@
     "description": "Extra logic action prefix",
     "originalDefault": "and"
   },
+  "9fW2NX": {
+    "defaultMessage": "Sorry! Er is iets onverwachts misgegaan.<br></br>Neem contact op met je technische beheerder om dit te onderzoeken, of misschien is er meer informatie beschikbaar in de <link>logboeken van uitgaande verzoeken</link>.",
+    "description": "Generic admin error message",
+    "originalDefault": "Sorry! Something unexpected went wrong.<br></br>Contact your technical administrator to investigate, or perhaps more information is available in the <link>outgoing request logs</link>."
+  },
   "9y3/ek": {
     "defaultMessage": "Bevestigen",
     "description": "JSON editor: confirm edited variable definition",
@@ -2327,11 +2332,6 @@
     "defaultMessage": "Vink aan om de inhoud toe te voegen aan de PDF die mensen op het eind kunnen downloaden.",
     "description": "Include confirmation page content in PDF",
     "originalDefault": "Whether to include the content of the confirmation page in the PDF."
-  },
-  "ow5AAO": {
-    "defaultMessage": "De gegevens zijn ongeldig. Los de problemen hieronder op.",
-    "description": "Generic error message",
-    "originalDefault": "The form is invalid. Please correct the errors below."
   },
   "oxYXJX": {
     "defaultMessage": "Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn. Laat leeg om de waarde van de algemene configuratie te gebruiken.",


### PR DESCRIPTION
Closes #4709

**Changes**

- Updated the generic message error
- Added a link to the requests logs

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
