### PR TITLE
:bug: [#4600] Perform reload on language change

### DIFF
--- a/docs/developers/embedding.rst
+++ b/docs/developers/embedding.rst
@@ -100,6 +100,14 @@ Available options
     the ``lang`` attribute of the ``html`` element in the DOM - if this is not set, the
     default value of ``'nl'`` is used.
 
+``onLanguageChange``:
+    Optional function to call on language changes. By default, the SDK reloads the
+    content and changes the active language of the form. When using ``onLanguageChange``,
+    your function will be executed on language change, instead of the default logic.
+
+    The new active language will be passed as an argument to the ``onLanguageChange``
+    function as a two-letter identifier.
+
 ``sentryDSN``:
     Optional `Sentry DSN <https://docs.sentry.io/>`_ to monitor the SDK.
 
@@ -129,7 +137,7 @@ Minimal example
     <html>
     <head>
         <!-- Required for icons used by Open Forms -->
-        <meta charset="utf-8"> 
+        <meta charset="utf-8">
 
         <!-- Load stylesheet and SDK bundle -->
         <link rel="stylesheet" href="https://openforms.example.com/sdk/1.0.0/open-forms-sdk.css" />
@@ -161,7 +169,7 @@ Full example
     <html lang="nl">
     <head>
         <!-- Required for icons used by Open Forms -->
-        <meta charset="utf-8"> 
+        <meta charset="utf-8">
 
         <!-- Load stylesheet and SDK bundle -->
         <link rel="stylesheet" href="https://openforms.example.com/sdk/1.0.0/open-forms-sdk.css" />

--- a/src/openforms/forms/templates/forms/sdk_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_snippet.html
@@ -23,6 +23,7 @@
             {% if sdk_sentry_dsn %}sentryDSN,{% endif %}
             {% if sdk_sentry_env %}sentryEnv,{% endif %}
             languageSelectorTarget: '#react-portal--language-selection',
+            onlanguagechange: () => window.location.reload(),
         }
     );
     form.init();


### PR DESCRIPTION
Closes #4600 

**Changes**

Triggering a page reload after language change, using the new `onLanguageChange` property on the sdk form object. This PR requires [open-formulieren/open-forms-sdk#715]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
