### PR TITLE
Feature/4717 accessibility improvements aria

### DIFF
--- a/src/openforms/emails/tests/test_confirmation_email.py
+++ b/src/openforms/emails/tests/test_confirmation_email.py
@@ -323,7 +323,7 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
         context = get_confirmation_email_context_data(submission)
         rendered_content = render_email_template("{% summary %}", context)
 
-        self.assertIn("Value 1; Value 2", rendered_content)
+        self.assertInHTML("<ul><li>Value 1</li><li>Value 2</li></ul>", rendered_content)
 
     def test_get_confirmation_email_templates(self):
         email_template1 = ConfirmationEmailTemplateFactory.create(

--- a/src/openforms/formio/formatters/formio.py
+++ b/src/openforms/formio/formatters/formio.py
@@ -5,7 +5,7 @@ from typing import Any
 from django.template.defaultfilters import date as fmt_date, time as fmt_time, yesno
 from django.utils.dateparse import parse_date, parse_time
 from django.utils.formats import number_format
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext, gettext_lazy as _
 
 from glom import glom
@@ -120,6 +120,18 @@ class SelectBoxesFormatter(FormatterBase):
         selected_labels = [
             entry["label"] for entry in component["values"] if value.get(entry["value"])
         ]
+        if self.as_html:
+            # For the html output, wrap the values in li tags and put it inside an ul tag.
+            # The selectboxes formatter handles all values at the same time,
+            # so handle the full html formatting here.
+            return format_html(
+                "<ul>{values}</ul>",
+                values=format_html_join(
+                    "",
+                    "<li>{}</li>",
+                    ((selected_label,) for selected_label in selected_labels),
+                ),
+            )
         return self.multiple_separator.join(selected_labels)
 
 

--- a/src/openforms/js/components/errors/ErrorMessage.js
+++ b/src/openforms/js/components/errors/ErrorMessage.js
@@ -6,7 +6,7 @@ import {ErrorIcon} from 'components/admin/icons';
 const ErrorMessage = ({children}) => {
   if (!children) return null;
   return (
-    <div className="error-message">
+    <div className="error-message" role="alert">
       <span className="error-message__icon icon icon--danger icon--as-lead">
         <ErrorIcon text="error" />
       </span>

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -217,7 +217,9 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         self.assertTagWithTextIn("td", "foo", message_html)
         self.assertTagWithTextIn("td", "bar", message_html)
         self.assertTagWithTextIn("td", "some_list", message_html)
-        self.assertTagWithTextIn("td", "value1; value2", message_html)
+        self.assertTagWithTextIn(
+            "td", "<ul><li>value1</li><li>value2</li></ul>", message_html
+        )
 
         cosigner_line = f"{_('Co-signed by')}: Demo Person"
 
@@ -777,7 +779,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         message = mail.outbox[0]
 
         message_html = message.alternatives[0][0]
-        self.assertIn("Backend; Frontend", message_html)
+        self.assertInHTML("<ul><li>Backend</li><li>Frontend</li></ul>", message_html)
 
     @patch("openforms.registrations.contrib.email.plugin.EmailConfig.get_solo")
     def test_with_global_config_attach_files(self, mock_get_solo):

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -25,13 +25,21 @@
         {% include 'includes/design-tokens.html' with skip_csp=True %}
     </head>
 
+    {% if config.organization_name %}
+        {% blocktranslate with name=config.organization_name asvar logo_alt trimmed %}
+            Logo {{ name }}
+        {% endblocktranslate %}
+    {% else %}
+        {% trans "Logo" as logo_alt %}
+    {% endif %}
+
     <body class="A4">
 
         <section class="sheet padding-10mm">
             <header class="header {% if theme.logo %}header--has-logo{% endif %}">
                 <span
                     class="header__logo"
-                    {% if theme.logo %}role="img"{% endif %}
+                    {% if theme.logo %}role="img" aria-label="{{ logo_alt }}"{% endif %}
                 ></span>
             </header>
 

--- a/src/openforms/submissions/tests/test_submission_report.py
+++ b/src/openforms/submissions/tests/test_submission_report.py
@@ -138,7 +138,7 @@ class DownloadSubmissionReportTests(APITestCase):
             ("postcode", "3744 AA"),
             ("radio", "Radio number one"),
             ("select", "A fine selection"),
-            ("selectboxes", "This; That; The Other"),
+            ("selectboxes", "<ul><li>This</li><li>That</li><li>The Other</li></ul>"),
             ("signature", SIGNATURE),
             ("textarea", "Largish predetermined ASCII"),
             ("textfield", "Short predetermined ASCII"),

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -262,6 +262,201 @@ class SubmissionReportGenerationTests(TestCase):
 
         self.assertEqual(reference_node.text, "Report created on: Jan. 1, 2024, 1 a.m.")
 
+    def test_textfield_component_with_multiple_is_rendered_as_html(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "textfield",
+                    "key": "textfield-single",
+                    "label": "Textfield single",
+                    "multiple": False,
+                },
+                {
+                    "type": "textfield",
+                    "key": "textfield-multiple",
+                    "label": "Textfield multiple",
+                    "multiple": True,
+                },
+            ],
+            submitted_data={
+                "textfield-single": "foo",
+                "textfield-multiple": ["foo", "bar"],
+            },
+            with_report=True,
+        )
+        html = submission.report.generate_submission_report_pdf()
+
+        expected = format_html(
+            """
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">Textfield single</div>
+                <div class="submission-step-row__value">
+                    foo
+                </div>
+            </div>
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">Textfield multiple</div>
+                <div class="submission-step-row__value">
+                    <ul><li>foo</li><li>bar</li></ul>
+                </div>
+            </div>
+            """,
+        )
+        self.assertInHTML(expected, html, count=1)
+
+    def test_select_component_with_multiple_is_rendered_as_html(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "select",
+                    "key": "select-single",
+                    "label": "Select single",
+                    "multiple": False,
+                    "openForms": {
+                        "dataSrc": "manual",
+                    },
+                    "data": {
+                        "values": [
+                            {"label": "Single select Option 1", "value": "option1"},
+                            {"label": "Single select Option 2", "value": "option2"},
+                        ]
+                    },
+                },
+                {
+                    "type": "select",
+                    "key": "select-multiple",
+                    "label": "Select multiple",
+                    "multiple": True,
+                    "openForms": {
+                        "dataSrc": "manual",
+                    },
+                    "data": {
+                        "values": [
+                            {
+                                "label": "Multiple select Option 1",
+                                "value": "option1",
+                            },
+                            {
+                                "label": "Multiple select Option 2",
+                                "value": "option2",
+                            },
+                            {
+                                "label": "Multiple select Option 3",
+                                "value": "option3",
+                            },
+                        ]
+                    },
+                },
+            ],
+            submitted_data={
+                "select-single": "option1",
+                "select-multiple": ["option1", "option3"],
+            },
+            with_report=True,
+        )
+        html = submission.report.generate_submission_report_pdf()
+
+        expected = format_html(
+            """
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">Select single</div>
+                <div class="submission-step-row__value">
+                    Single select Option 1
+                </div>
+            </div>
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">Select multiple</div>
+                <div class="submission-step-row__value">
+                    <ul><li>Multiple select Option 1</li><li>Multiple select Option 3</li></ul>
+                </div>
+            </div>
+            """,
+        )
+        self.assertInHTML(expected, html, count=1)
+
+    def test_selectboxes_component_is_rendered_as_html(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "selectboxes",
+                    "key": "selectboxes",
+                    "label": "Selectboxes",
+                    "values": [
+                        {
+                            "value": "option1",
+                            "label": "Selectbox Option 1",
+                        },
+                        {
+                            "value": "option2",
+                            "label": "Selectbox Option 2",
+                        },
+                        {
+                            "value": "option3",
+                            "label": "Selectbox Option 3",
+                        },
+                    ],
+                },
+            ],
+            submitted_data={
+                "selectboxes": {
+                    "option1": True,
+                    "option3": True,
+                },
+            },
+            with_report=True,
+        )
+        html = submission.report.generate_submission_report_pdf()
+
+        expected = format_html(
+            """
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">Selectboxes</div>
+                <div class="submission-step-row__value">
+                    <ul><li>Selectbox Option 1</li><li>Selectbox Option 3</li></ul>
+                </div>
+            </div>
+            """,
+        )
+        self.assertInHTML(expected, html, count=1)
+
+    def test_radio_component_is_rendered_as_plain_text(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "radio",
+                    "key": "radio",
+                    "label": "Radio",
+                    "values": [
+                        {
+                            "value": "firstradiooption",
+                            "label": "First radio option",
+                        },
+                        {
+                            "value": "secondradiooption",
+                            "label": "Second radio option",
+                        },
+                    ],
+                },
+            ],
+            submitted_data={
+                "radio": "secondradiooption",
+            },
+            with_report=True,
+        )
+        html = submission.report.generate_submission_report_pdf()
+
+        expected = format_html(
+            """
+            <div class="submission-step-row">
+                <div class="submission-step-row__label">Radio</div>
+                <div class="submission-step-row__value">
+                    Second radio option
+                </div>
+            </div>
+            """,
+        )
+        self.assertInHTML(expected, html, count=1)
+
 
 @temp_private_root()
 class SubmissionReportCoSignTests(TestCase):

--- a/src/openforms/templates/includes/page-header.html
+++ b/src/openforms/templates/includes/page-header.html
@@ -8,9 +8,13 @@ include the SDK snippet directly.
 {% get_solo 'config.GlobalConfiguration' as config %}
 {% get_theme as theme %}
 
-{% blocktranslate with name=config.organization_name asvar logo_alt trimmed %}
-Back to website of {{ name }}
-{% endblocktranslate %}
+{% if config.organization_name %}
+    {% blocktranslate with name=config.organization_name asvar logo_alt trimmed %}
+        Back to website of {{ name }}
+    {% endblocktranslate %}
+{% else %}
+    {% trans "Back to website" as logo_alt %}
+{% endif %}
 
 <header class="utrecht-page-header {% if theme.logo %}utrecht-page-header--openforms-with-logo{% endif %}">
     <a
@@ -18,7 +22,7 @@ Back to website of {{ name }}
         href="{% firstof config.main_website '#' %}"
         title="{{ logo_alt }}"
         aria-label="{{ logo_alt }}"
-    >{% if config.main_website %}{% trans "Back to website" %}{% endif %}</a>
+    >{% if config.main_website %}{{ logo_alt }}{% endif %}</a>
 
     <div id="react-portal--language-selection"></div>
 </header>

--- a/src/openforms/utils/pdf.py
+++ b/src/openforms/utils/pdf.py
@@ -106,5 +106,5 @@ def render_to_pdf(template_name: str, context: dict) -> tuple[str, bytes]:
         url_fetcher=UrlFetcher(),
         base_url=settings.BASE_URL,
     )
-    pdf: bytes = html_object.write_pdf()
+    pdf: bytes = html_object.write_pdf(pdf_variant="pdf/ua-1")
     return rendered_html, pdf


### PR DESCRIPTION
Closes #4717

**Changes**

The site logo now provides a better textual alternative, the error message element now has the appropriate `role` and the PDF's are now screenreader friendly :)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
