### PR TITLE
Upgrade to formio-builder 0.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.53.0",
-        "@open-formulieren/formio-builder": "^0.28.0",
+        "@open-formulieren/formio-builder": "^0.30.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@rjsf/core": "^4.2.1",
@@ -4429,9 +4429,9 @@
       "integrity": "sha512-3Pv32ULCuFOJZ2GaqcpvB45u6xScr0lmW5ETB9P1Ox9TG5nvMcVSwuwYe/GwxbzmvtZgiMQRMKRFT9lNYLeREQ=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.28.0.tgz",
-      "integrity": "sha512-srLYRn3bgRc1Qw2SuL+5g17bFHLKgB5G+k6O4iNH0saPdtp98uCCggrd40d4fdgVa3nwyaq0ivXH6p6KLPrAMw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.30.0.tgz",
+      "integrity": "sha512-O7gLZ/WZNkpwVdWxDWTIYFSXlJoYzj9C+Tzf91IbcAyGjsyjhHg5hgH4I7xIc9DRM2xYPwnR91G8y7/3AwivfA==",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",
@@ -23567,9 +23567,9 @@
       "integrity": "sha512-3Pv32ULCuFOJZ2GaqcpvB45u6xScr0lmW5ETB9P1Ox9TG5nvMcVSwuwYe/GwxbzmvtZgiMQRMKRFT9lNYLeREQ=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.28.0.tgz",
-      "integrity": "sha512-srLYRn3bgRc1Qw2SuL+5g17bFHLKgB5G+k6O4iNH0saPdtp98uCCggrd40d4fdgVa3nwyaq0ivXH6p6KLPrAMw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.30.0.tgz",
+      "integrity": "sha512-O7gLZ/WZNkpwVdWxDWTIYFSXlJoYzj9C+Tzf91IbcAyGjsyjhHg5hgH4I7xIc9DRM2xYPwnR91G8y7/3AwivfA==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.53.0",
-    "@open-formulieren/formio-builder": "^0.28.0",
+    "@open-formulieren/formio-builder": "^0.30.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@rjsf/core": "^4.2.1",

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2727,6 +2727,12 @@
       "value": "Whether the user is allowed to submit this form or not, and whether the overview page should be shown if they are not."
     }
   ],
+  "QXsAuR": [
+    {
+      "type": 0,
+      "value": "Product to fetch prices for"
+    }
+  ],
   "QaPqxz": [
     {
       "type": 0,
@@ -4789,6 +4795,12 @@
       "value": "Session will expire"
     }
   ],
+  "jtWzSW": [
+    {
+      "type": 0,
+      "value": "option 2: € 15,99"
+    }
+  ],
   "k1+ljn": [
     {
       "type": 0,
@@ -5509,6 +5521,12 @@
       "value": "Regular expression for city"
     }
   ],
+  "sxdJ/8": [
+    {
+      "type": 0,
+      "value": "option 1: € 10,99"
+    }
+  ],
   "t5fg/K": [
     {
       "type": 0,
@@ -5679,6 +5697,12 @@
     {
       "type": 0,
       "value": "Do not display the configured label and top line as the header in the fieldset."
+    }
+  ],
+  "uuKVtO": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "vAZDY4": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2744,6 +2744,12 @@
       "value": "Geeft aan of de gebruiker het formulier kan inzenden of niet, en of een overzichtspagina getoond wordt indien niet."
     }
   ],
+  "QXsAuR": [
+    {
+      "type": 0,
+      "value": "Product waarvoor prijzen worden opgehaald"
+    }
+  ],
   "QaPqxz": [
     {
       "type": 0,
@@ -4811,6 +4817,12 @@
       "value": "Sessie gaat vervallen"
     }
   ],
+  "jtWzSW": [
+    {
+      "type": 0,
+      "value": "optie 2: € 15,99"
+    }
+  ],
   "k1+ljn": [
     {
       "type": 0,
@@ -5531,6 +5543,12 @@
       "value": "Reguliere expressie"
     }
   ],
+  "sxdJ/8": [
+    {
+      "type": 0,
+      "value": "optie 1: € 10,99"
+    }
+  ],
   "t5fg/K": [
     {
       "type": 0,
@@ -5701,6 +5719,12 @@
     {
       "type": 0,
       "value": "Verberg de koptekst en de lijn boven de veldengroep in het formulier."
+    }
+  ],
+  "uuKVtO": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "vAZDY4": [


### PR DESCRIPTION
Closes #4636
Closes #4637

**Changes**

* Upgraded bundled formio-builder from 0.28.0 to 0.30.0 which contains necessary fixes.

This also exposes the ProductPrice experimental component, which will likely be gated behind a feature flag for the full 3.0 release.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
