### PR TITLE
[#4418] Add addressNl specific mappings to Objects API registration (variables tab)

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2019,6 +2019,12 @@
       "value": "Successful Submissions Removal Method field label"
     }
   ],
+  "I3bGFV": [
+    {
+      "type": 0,
+      "value": "House number Schema target"
+    }
+  ],
   "I3zyib": [
     {
       "type": 0,
@@ -4247,6 +4253,12 @@
       "value": "Name of the product request type. It is available in the JSON template as the 'productaanvraag_type' variable."
     }
   ],
+  "eD5x1W": [
+    {
+      "type": 0,
+      "value": "House letter Schema target"
+    }
+  ],
   "eJEu3L": [
     {
       "type": 0,
@@ -4919,6 +4931,12 @@
       "value": "Authentication method"
     }
   ],
+  "lT3yf5": [
+    {
+      "type": 0,
+      "value": "Define specific targets"
+    }
+  ],
   "lVEpR9": [
     {
       "type": 0,
@@ -5079,6 +5097,12 @@
     {
       "type": 0,
       "value": "Something went wrong while retrieving the available object type versions."
+    }
+  ],
+  "ndWy6O": [
+    {
+      "type": 0,
+      "value": "City Schema target"
     }
   ],
   "neCqv9": [
@@ -5475,6 +5499,12 @@
       "value": "If specified, the user must check at most this many options."
     }
   ],
+  "sTZk2h": [
+    {
+      "type": 0,
+      "value": "Street name Schema target"
+    }
+  ],
   "sU/n0S": [
     {
       "type": 0,
@@ -5611,6 +5641,12 @@
     {
       "type": 0,
       "value": "Footer"
+    }
+  ],
+  "u7m/jP": [
+    {
+      "type": 0,
+      "value": "Postcode Schema target"
     }
   ],
   "uBO/Al": [
@@ -5881,6 +5917,12 @@
     {
       "type": 0,
       "value": "Create definition"
+    }
+  ],
+  "xhwyFo": [
+    {
+      "type": 0,
+      "value": "House number addition Schema target"
     }
   ],
   "xxVNeU": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2040,6 +2040,12 @@
       "value": "Opschoonmethode voor voltooide inzendingen"
     }
   ],
+  "I3bGFV": [
+    {
+      "type": 0,
+      "value": "House number Schema target"
+    }
+  ],
   "I3zyib": [
     {
       "type": 0,
@@ -4269,6 +4275,12 @@
       "value": "Naam van het productaanvraagtype. Deze naam is in het JSON-inhoudsjabloon beschikbaar als de 'productaanvraag_type' variabele."
     }
   ],
+  "eD5x1W": [
+    {
+      "type": 0,
+      "value": "House letter Schema target"
+    }
+  ],
   "eJEu3L": [
     {
       "type": 0,
@@ -4941,6 +4953,12 @@
       "value": "Authenticatiemethode"
     }
   ],
+  "lT3yf5": [
+    {
+      "type": 0,
+      "value": "Define specific targets"
+    }
+  ],
   "lVEpR9": [
     {
       "type": 0,
@@ -5101,6 +5119,12 @@
     {
       "type": 0,
       "value": "Something went wrong while retrieving the available object type versions."
+    }
+  ],
+  "ndWy6O": [
+    {
+      "type": 0,
+      "value": "City Schema target"
     }
   ],
   "neCqv9": [
@@ -5497,6 +5521,12 @@
       "value": "Indien opgegeven, dan mag de gebruiker maximaal dit aantal opties aanvinken."
     }
   ],
+  "sTZk2h": [
+    {
+      "type": 0,
+      "value": "Street name Schema target"
+    }
+  ],
   "sU/n0S": [
     {
       "type": 0,
@@ -5633,6 +5663,12 @@
     {
       "type": 0,
       "value": "Voettekst"
+    }
+  ],
+  "u7m/jP": [
+    {
+      "type": 0,
+      "value": "Postcode Schema target"
     }
   ],
   "uBO/Al": [
@@ -5903,6 +5939,12 @@
     {
       "type": 0,
       "value": "Formulierdefinitie aanmaken"
+    }
+  ],
+  "xhwyFo": [
+    {
+      "type": 0,
+      "value": "House number addition Schema target"
     }
   ],
   "xxVNeU": [

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -1,7 +1,7 @@
 import {FieldArray, useFormikContext} from 'formik';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
-import React, {useContext} from 'react';
+import React, {useContext, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useAsync, useToggle} from 'react-use';
 
@@ -38,6 +38,9 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
   const {components} = useContext(FormContext);
   const [jsonSchemaVisible, toggleJsonSchemaVisible] = useToggle(false);
   const {values: backendOptions, getFieldProps, setFieldValue} = useFormikContext();
+
+  const hasAnyAddressNlValue = Object.values(variable.initialValue).some(value => value !== '');
+  const [isSpecificTargetsChecked, setSpecificTargets] = useState(hasAnyAddressNlValue);
 
   /** @type {ObjectsAPIRegistrationBackendOptions} */
   const {
@@ -110,6 +113,13 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
       </ErrorMessage>
     );
 
+  const isAddressNlComponent = components[variable?.key].type === 'addressNL';
+  const deriveAddress = components[variable?.key]['deriveAddress'];
+
+  const onSpecificTargetsChange = event => {
+    setSpecificTargets(event.target.checked);
+  };
+
   return (
     <Fieldset>
       <FormRow>
@@ -126,33 +136,35 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
           />
         </Field>
       </FormRow>
-      <FormRow>
-        <Field
-          label={
-            <FormattedMessage
-              defaultMessage="Map to geometry field"
-              description="'Map to geometry field' checkbox label"
+      {!isAddressNlComponent && (
+        <FormRow>
+          <Field
+            label={
+              <FormattedMessage
+                defaultMessage="Map to geometry field"
+                description="'Map to geometry field' checkbox label"
+              />
+            }
+            helpText={
+              <FormattedMessage
+                description="'Map to geometry field' checkbox help text"
+                defaultMessage="Whether to map this variable to the {geometryPath} attribute"
+                values={{geometryPath: <code>record.geometry</code>}}
+              />
+            }
+            name="geometryVariableKey"
+            disabled={!!mappedVariable.targetPath}
+          >
+            <Checkbox
+              checked={isGeometry}
+              onChange={event => {
+                const newValue = event.target.checked ? variable.key : undefined;
+                setFieldValue('geometryVariableKey', newValue);
+              }}
             />
-          }
-          helpText={
-            <FormattedMessage
-              description="'Map to geometry field' checkbox help text"
-              defaultMessage="Whether to map this variable to the {geometryPath} attribute"
-              values={{geometryPath: <code>record.geometry</code>}}
-            />
-          }
-          name="geometryVariableKey"
-          disabled={!!mappedVariable.targetPath}
-        >
-          <Checkbox
-            checked={isGeometry}
-            onChange={event => {
-              const newValue = event.target.checked ? variable.key : undefined;
-              setFieldValue('geometryVariableKey', newValue);
-            }}
-          />
-        </Field>
-      </FormRow>
+          </Field>
+        </FormRow>
+      )}
       <FormRow>
         <Field
           name={`${namePrefix}.targetPath`}
@@ -173,6 +185,30 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
           />
         </Field>
       </FormRow>
+      {isAddressNlComponent && (
+        <FormRow>
+          <Field
+            name={`${namePrefix}.nestedMapping`}
+            label={
+              <FormattedMessage
+                defaultMessage="Define specific targets"
+                description="Define specific targets for all the fields of AddressNL component"
+              />
+            }
+          >
+            <Checkbox checked={isSpecificTargetsChecked} onChange={onSpecificTargetsChange} />
+          </Field>
+        </FormRow>
+      )}
+      {isSpecificTargetsChecked && (
+        <SpecificTargetsDisplay
+          namePrefix={namePrefix}
+          index={index}
+          choices={choices}
+          mappedVariable={mappedVariable}
+          deriveAddress={deriveAddress}
+        />
+      )}
       <div style={{marginTop: '1em'}}>
         <a href="#" onClick={e => e.preventDefault() || toggleJsonSchemaVisible()}>
           <FormattedMessage
@@ -200,7 +236,7 @@ ObjectsApiVariableConfigurationEditor.propTypes = {
   }).isRequired,
 };
 
-const TargetPathSelect = ({name, index, choices, mappedVariable, disabled}) => {
+const TargetPathSelect = ({id = 'targetPath', name, index, choices, mappedVariable, disabled}) => {
   // To avoid having an incomplete variable mapping added in the `variablesMapping` array,
   // It is added only when an actual target path is selected. This way, having the empty
   // option selected means the variable is unmapped (hence the `arrayHelpers.remove` call below).
@@ -217,7 +253,7 @@ const TargetPathSelect = ({name, index, choices, mappedVariable, disabled}) => {
       name="variablesMapping"
       render={arrayHelpers => (
         <Select
-          id="targetPath"
+          id={id}
           name={name}
           allowBlank
           choices={choices}
@@ -264,6 +300,132 @@ TargetPathDisplay.propTypes = {
     targetPath: PropTypes.arrayOf(PropTypes.string).isRequired,
     isRequired: PropTypes.bool.isRequired,
   }).isRequired,
+};
+
+const SpecificTargetsDisplay = ({namePrefix, index, choices, mappedVariable, deriveAddress}) => {
+  console.log(mappedVariable);
+  return (
+    <Fieldset>
+      <FormRow>
+        <Field
+          name={`${namePrefix}.postcodeTargetPath`}
+          label={
+            <FormattedMessage
+              defaultMessage="Postcode Schema target"
+              description="'Postcode Schema target' label"
+            />
+          }
+        >
+          <TargetPathSelect
+            id="postcodeTargetPath"
+            name={`${namePrefix}.postcodeTargetPath`}
+            index={index}
+            choices={choices}
+            mappedVariable={mappedVariable}
+          />
+        </Field>
+      </FormRow>
+      <FormRow>
+        <Field
+          name={`${namePrefix}.houseNumberTargetPath`}
+          label={
+            <FormattedMessage
+              defaultMessage="House number Schema target"
+              description="'House number Schema target' label"
+            />
+          }
+        >
+          <TargetPathSelect
+            id="houseNumberTargetPath"
+            name={`${namePrefix}.houseNumberTargetPath`}
+            index={index}
+            choices={choices}
+            mappedVariable={mappedVariable}
+          />
+        </Field>
+      </FormRow>
+      <FormRow>
+        <Field
+          name={`${namePrefix}.houseLetterTargetPath`}
+          label={
+            <FormattedMessage
+              defaultMessage="House letter Schema target"
+              description="'House letter Schema target' label"
+            />
+          }
+        >
+          <TargetPathSelect
+            id="houseLetterTargetPath"
+            name={`${namePrefix}.houseLetterTargetPath`}
+            index={index}
+            choices={choices}
+            mappedVariable={mappedVariable}
+          />
+        </Field>
+      </FormRow>
+      <FormRow>
+        <Field
+          name={`${namePrefix}.houseNumberAdditionTargetPath`}
+          label={
+            <FormattedMessage
+              defaultMessage="House number addition Schema target"
+              description="'House number addition Schema target' label"
+            />
+          }
+        >
+          <TargetPathSelect
+            id="houseNumberAdditionTargetPath"
+            name={`${namePrefix}.houseNumberAdditionTargetPath`}
+            index={index}
+            choices={choices}
+            mappedVariable={mappedVariable}
+          />
+        </Field>
+      </FormRow>
+      <FormRow>
+        <Field
+          name={`${namePrefix}.cityTargetPath`}
+          label={
+            <FormattedMessage
+              defaultMessage="City Schema target"
+              description="'City Schema target' label"
+            />
+          }
+          disabled={!deriveAddress}
+        >
+          <TargetPathSelect
+            id="cityTargetPath"
+            name={`${namePrefix}.cityTargetPath`}
+            index={index}
+            choices={choices}
+            mappedVariable={mappedVariable}
+            disabled={!deriveAddress}
+          />
+        </Field>
+      </FormRow>
+      <FormRow>
+        <Field
+          name={`${namePrefix}.streetNameTargetPath`}
+          label={
+            <FormattedMessage
+              defaultMessage="Street name Schema target"
+              description="'Street name Schema target' label"
+            />
+          }
+          disabled={!deriveAddress}
+        >
+          <TargetPathSelect
+            id="streetNameTargetPath"
+            name={`${namePrefix}.streetNameTargetPath`}
+            index={index}
+            choices={choices}
+            mappedVariable={mappedVariable}
+            disabled={!deriveAddress}
+          />
+        </Field>
+      </FormRow>
+    </Fieldset>
+  );
 };
 
 export default ObjectsApiVariableConfigurationEditor;

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -85,6 +85,21 @@ const VARIABLES = [
       variablesMapping: [{formVariable: 'formioComponent', prefillProperty: ['firstName']}],
     },
   },
+  {
+    form: 'http://localhost:8000/api/v2/forms/36612390',
+    formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
+    name: 'AddressNL',
+    key: 'addressNl',
+    source: 'component',
+    prefillPlugin: '',
+    prefillAttribute: '',
+    prefillIdentifierRole: 'main',
+    dataType: 'string',
+    dataFormat: undefined,
+    isSensitiveData: false,
+    serviceFetchConfiguration: undefined,
+    initialValue: {postcode: '', house_letter: '', house_number: '', house_number_addition: ''},
+  },
 ];
 
 export default {
@@ -671,5 +686,155 @@ export const WithValidationErrors = {
     // open modal for configuration
     const editIcon = canvas.getByTitle('Prefill instellen');
     await userEvent.click(editIcon);
+  },
+};
+
+export const AddressNLMappingSpecificTargetsNoDeriveAddress = {
+  args: {
+    availableComponents: {
+      addressNl: {
+        key: 'addresNl',
+        type: 'addressNL',
+        deriveAddress: false,
+      },
+    },
+    registrationBackends: [
+      {
+        backend: 'objects_api',
+        key: 'objects_api_1',
+        name: 'Example Objects API reg.',
+        options: {
+          version: 2,
+          objectsApiGroup: 1,
+          objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+          objecttypeVersion: 2,
+          variablesMapping: [
+            {
+              variableKey: 'addresNl',
+              targetPath: ['path', 'to.the', 'target'],
+            },
+          ],
+        },
+      },
+    ],
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        mockTargetPathsPost({
+          string: [
+            {
+              targetPath: ['path', 'to.the', 'target'],
+              isRequired: true,
+              jsonSchema: {type: 'string'},
+            },
+          ],
+        }),
+      ],
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const editIcons = canvas.getAllByTitle('Registratie-instellingen bewerken');
+    userEvent.click(editIcons[3]);
+
+    const specificTargetsCheckbox = await screen.findByRole('checkbox');
+    userEvent.click(specificTargetsCheckbox);
+
+    const postcodeSelect = await screen.findByLabelText('Postcode Schema target');
+    const houseNumberSelect = await screen.findByLabelText('House number Schema target');
+    const houseLetterSelect = await screen.findByLabelText('House letter Schema target');
+    const houseNumberAdditionSelect = await screen.findByLabelText(
+      'House number addition Schema target'
+    );
+    const citySelect = await screen.findByLabelText('City Schema target');
+    const streetNameSelect = await screen.findByLabelText('Street name Schema target');
+
+    await expect(postcodeSelect).toBeVisible();
+    await expect(houseNumberSelect).toBeVisible();
+    await expect(houseLetterSelect).toBeVisible();
+    await expect(houseNumberAdditionSelect).toBeVisible();
+    await expect(citySelect).toBeVisible();
+    await expect(streetNameSelect).toBeVisible();
+
+    await expect(citySelect).toBeDisabled();
+    await expect(streetNameSelect).toBeDisabled();
+  },
+};
+
+export const AddressNLMappingSpecificTargetsDeriveAddress = {
+  args: {
+    availableComponents: {
+      addressNl: {
+        key: 'addresNl',
+        type: 'addressNL',
+        deriveAddress: true,
+      },
+    },
+    registrationBackends: [
+      {
+        backend: 'objects_api',
+        key: 'objects_api_1',
+        name: 'Example Objects API reg.',
+        options: {
+          version: 2,
+          objectsApiGroup: 1,
+          objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+          objecttypeVersion: 2,
+          variablesMapping: [
+            {
+              variableKey: 'addresNl',
+              targetPath: ['path', 'to.the', 'target'],
+            },
+          ],
+        },
+      },
+    ],
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        mockTargetPathsPost({
+          string: [
+            {
+              targetPath: ['path', 'to.the', 'target'],
+              isRequired: true,
+              jsonSchema: {type: 'string'},
+            },
+          ],
+        }),
+      ],
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const editIcons = canvas.getAllByTitle('Registratie-instellingen bewerken');
+    userEvent.click(editIcons[3]);
+
+    const specificTargetsCheckbox = await screen.findByRole('checkbox');
+    userEvent.click(specificTargetsCheckbox);
+
+    const postcodeSelect = await screen.findByLabelText('Postcode Schema target');
+    const houseNumberSelect = await screen.findByLabelText('House number Schema target');
+    const houseLetterSelect = await screen.findByLabelText('House letter Schema target');
+    const houseNumberAdditionSelect = await screen.findByLabelText(
+      'House number addition Schema target'
+    );
+    const citySelect = await screen.findByLabelText('City Schema target');
+    const streetNameSelect = await screen.findByLabelText('Street name Schema target');
+
+    await expect(postcodeSelect).toBeVisible();
+    await expect(houseNumberSelect).toBeVisible();
+    await expect(houseLetterSelect).toBeVisible();
+    await expect(houseNumberAdditionSelect).toBeVisible();
+    await expect(citySelect).toBeVisible();
+    await expect(streetNameSelect).toBeVisible();
+
+    await expect(citySelect).not.toBeDisabled();
+    await expect(streetNameSelect).not.toBeDisabled();
   },
 };

--- a/src/openforms/js/components/admin/forms/Inputs.js
+++ b/src/openforms/js/components/admin/forms/Inputs.js
@@ -119,8 +119,8 @@ const Checkbox = ({name, label, helpText, noVCheckbox = false, ...extraProps}) =
 };
 
 Checkbox.propTypes = {
-  name: PropTypes.string.isRequired,
-  label: PropTypes.node.isRequired,
+  name: PropTypes.string,
+  label: PropTypes.node,
   helpText: PropTypes.node,
   noVCheckbox: PropTypes.bool,
 };

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -889,6 +889,11 @@
     "description": "Successful Submissions Removal Method",
     "originalDefault": "Successful Submissions Removal Method field label"
   },
+  "I3bGFV": {
+    "defaultMessage": "House number Schema target",
+    "description": "'House number Schema target' label",
+    "originalDefault": "House number Schema target"
+  },
   "I3zyib": {
     "defaultMessage": "Select form definition",
     "description": "Form definition select label",
@@ -1894,6 +1899,11 @@
     "description": "Legacy objects API registration options: 'productaanvraagType' helpText",
     "originalDefault": "Name of the product request type. It is available in the JSON template as the 'productaanvraag_type' variable."
   },
+  "eD5x1W": {
+    "defaultMessage": "House letter Schema target",
+    "description": "'House letter Schema target' label",
+    "originalDefault": "House letter Schema target"
+  },
   "eJEu3L": {
     "defaultMessage": "Are you sure you want to delete this rule?",
     "description": "Price rule deletion confirm message",
@@ -2209,6 +2219,11 @@
     "description": "Label for 'value' in MappingArrayInput table column",
     "originalDefault": "Value"
   },
+  "lT3yf5": {
+    "defaultMessage": "Define specific targets",
+    "description": "Define specific targets for all the fields of AddressNL component",
+    "originalDefault": "Define specific targets"
+  },
   "lcR5L6": {
     "defaultMessage": "Add item",
     "description": "Add item to multi-input field",
@@ -2278,6 +2293,11 @@
     "defaultMessage": "Something went wrong while retrieving the available object type versions.",
     "description": "Objects API registrations options: object type version select error",
     "originalDefault": "Something went wrong while retrieving the available object type versions."
+  },
+  "ndWy6O": {
+    "defaultMessage": "City Schema target",
+    "description": "'City Schema target' label",
+    "originalDefault": "City Schema target"
   },
   "neCqv9": {
     "defaultMessage": "The registration result will be an object from the selected type.",
@@ -2474,6 +2494,11 @@
     "description": "Help text of form field 'Send the confirmation email'",
     "originalDefault": "Whether to send a confirmation email to the end-user who submitted the form."
   },
+  "sTZk2h": {
+    "defaultMessage": "Street name Schema target",
+    "description": "'Street name Schema target' label",
+    "originalDefault": "Street name Schema target"
+  },
   "sptpzv": {
     "defaultMessage": "Switching to the new registration options will remove the existing JSON templates. You will also not be able to save the form until the variables are correctly mapped. Are you sure you want to continue?",
     "description": "Objects API registration backend: v2 switch warning message",
@@ -2538,6 +2563,11 @@
     "defaultMessage": "RSIN of the organization, which creates and owns the INFORMATIEOBJECTs.",
     "description": "Objects API registration options 'organisationRSIN' helpText",
     "originalDefault": "RSIN of the organization, which creates and owns the INFORMATIEOBJECTs."
+  },
+  "u7m/jP": {
+    "defaultMessage": "Postcode Schema target",
+    "description": "'Postcode Schema target' label",
+    "originalDefault": "Postcode Schema target"
   },
   "uBO/Al": {
     "defaultMessage": "Select a step to view or modify.",
@@ -2668,6 +2698,11 @@
     "defaultMessage": "Create definition",
     "description": "create form definition icon title",
     "originalDefault": "Create definition"
+  },
+  "xhwyFo": {
+    "defaultMessage": "House number addition Schema target",
+    "description": "'House number addition Schema target' label",
+    "originalDefault": "House number addition Schema target"
   },
   "xyVtKp": {
     "defaultMessage": "Plugin configuration: Objects API",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -896,6 +896,11 @@
     "description": "Successful Submissions Removal Method",
     "originalDefault": "Successful Submissions Removal Method field label"
   },
+  "I3bGFV": {
+    "defaultMessage": "House number Schema target",
+    "description": "'House number Schema target' label",
+    "originalDefault": "House number Schema target"
+  },
   "I3zyib": {
     "defaultMessage": "Selecteer formulierdefinitie",
     "description": "Form definition select label",
@@ -1912,6 +1917,11 @@
     "description": "Legacy objects API registration options: 'productaanvraagType' helpText",
     "originalDefault": "Name of the product request type. It is available in the JSON template as the 'productaanvraag_type' variable."
   },
+  "eD5x1W": {
+    "defaultMessage": "House letter Schema target",
+    "description": "'House letter Schema target' label",
+    "originalDefault": "House letter Schema target"
+  },
   "eJEu3L": {
     "defaultMessage": "Weet u zeker dat u deze regel wil verwijderen?",
     "description": "Price rule deletion confirm message",
@@ -2228,6 +2238,11 @@
     "description": "Label for 'value' in MappingArrayInput table column",
     "originalDefault": "Value"
   },
+  "lT3yf5": {
+    "defaultMessage": "Define specific targets",
+    "description": "Define specific targets for all the fields of AddressNL component",
+    "originalDefault": "Define specific targets"
+  },
   "lcR5L6": {
     "defaultMessage": "Item toevoegen",
     "description": "Add item to multi-input field",
@@ -2297,6 +2312,11 @@
     "defaultMessage": "Something went wrong while retrieving the available object type versions.",
     "description": "Objects API registrations options: object type version select error",
     "originalDefault": "Something went wrong while retrieving the available object type versions."
+  },
+  "ndWy6O": {
+    "defaultMessage": "City Schema target",
+    "description": "'City Schema target' label",
+    "originalDefault": "City Schema target"
   },
   "neCqv9": {
     "defaultMessage": "Het registratieresultaat zal een object van dit type zijn.",
@@ -2493,6 +2513,11 @@
     "description": "Help text of form field 'Send the confirmation email'",
     "originalDefault": "Whether to send a confirmation email to the end-user who submitted the form."
   },
+  "sTZk2h": {
+    "defaultMessage": "Street name Schema target",
+    "description": "'Street name Schema target' label",
+    "originalDefault": "Street name Schema target"
+  },
   "sptpzv": {
     "defaultMessage": "Let op! Migreren naar het nieuwe configuratieformaat maakt de bestaande JSON-sjablonen leeg. Daarnaast kan je het formulier pas opslaan als alle verplichte variabelen goed gekoppeld zijn. Ben je zeker dat je wil migreren?",
     "description": "Objects API registration backend: v2 switch warning message",
@@ -2557,6 +2582,11 @@
     "defaultMessage": "RSIN van de organisatie die eigenaar is van en het INFORMATIEOBJECT aanmaakt.",
     "description": "Objects API registration options 'organisationRSIN' helpText",
     "originalDefault": "RSIN of the organization, which creates and owns the INFORMATIEOBJECTs."
+  },
+  "u7m/jP": {
+    "defaultMessage": "Postcode Schema target",
+    "description": "'Postcode Schema target' label",
+    "originalDefault": "Postcode Schema target"
   },
   "uBO/Al": {
     "defaultMessage": "Kies een stap om te bekijken of aan te passen.",
@@ -2687,6 +2717,11 @@
     "defaultMessage": "Formulierdefinitie aanmaken",
     "description": "create form definition icon title",
     "originalDefault": "Create definition"
+  },
+  "xhwyFo": {
+    "defaultMessage": "House number addition Schema target",
+    "description": "'House number addition Schema target' label",
+    "originalDefault": "House number addition Schema target"
   },
   "xyVtKp": {
     "defaultMessage": "Plugin-instellingen: Objecten-API",


### PR DESCRIPTION
Closes #4418 partly

**Changes**

This PR handles the frontend part of the task

- Added specific addressNL fields/mappings to the Objects API registration 
- Added stories

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages_js.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
