### PR TITLE
Ensure submissions tablib.Dataset generation doesn't crash

### DIFF
--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -229,7 +229,15 @@ class EditGridNode(ContainerMixin, ComponentNode):
     display_value: str = ""
 
     @property
+    def is_layout(self) -> bool:
+        if self.mode == RenderModes.export:
+            return False
+        return True
+
+    @property
     def value(self):
+        if self.mode == RenderModes.export:
+            return super().value
         return None
 
     @property
@@ -268,6 +276,10 @@ class EditGridNode(ContainerMixin, ComponentNode):
         So we need to repeat the child nodes of the configuration and associate them with the data
         provided by the user.
         """
+        # during exports, treat the entire repeating group as a single component/column
+        if self.mode == RenderModes.export:
+            return
+
         repeats = len(self._value) if self._value else 0
 
         for node_index in range(repeats):

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -235,10 +235,7 @@ class ComponentNode(Node):
             return
 
         # in export mode, only emit if the component is not a layout component
-        if self.mode != RenderModes.export or (
-            not is_layout_component(self.component)
-            and self.component["type"] != "editgrid"
-        ):
+        if self.mode != RenderModes.export or (not is_layout_component(self.component)):
             yield self
 
         for child in self.get_children():

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -410,7 +410,7 @@ class FormNodeTests(TestCase):
             )
             nodelist += list(component_node)
 
-        self.assertEqual(len(nodelist), 19)
+        self.assertEqual(len(nodelist), 16)
         labels = [node.label for node in nodelist]
         # The fieldset/editgrid components have no labels
         self.assertEqual(
@@ -427,13 +427,10 @@ class FormNodeTests(TestCase):
                 "input8",
                 "input9",
                 "input10",
-                # The editgrid components have 2 entries each in the data
-                "input11",
-                "input11",
-                "input12",
-                "input12",
-                "input13",
-                "input13",
+                # edit grid must be treated as a leaf node instead of a layout node
+                "visibleEditGridWithVisibleChildren",
+                "hiddenEditGridWithVisibleChildren",
+                "visibleEditGridWithHiddenChildren",
                 "input14",
                 "input15",
             ],

--- a/src/openforms/formio/tests/factories.py
+++ b/src/openforms/formio/tests/factories.py
@@ -36,7 +36,7 @@ class SubmittedFileFactory(factory.DictFactory):
                 else TemporaryFileUploadFactory.build
             )
             temporary_upload = create_temporary_upload(
-                file_name=obj["name"], file_size=obj["size"]
+                file_name=obj["name"], file_size=obj["size"], **kwargs
             )
         new_url = f"http://localhost/api/v2/submissions/files/{temporary_upload.uuid}"
         obj["url"] = obj["data"]["url"] = new_url

--- a/src/openforms/submissions/rendering/nodes.py
+++ b/src/openforms/submissions/rendering/nodes.py
@@ -51,6 +51,8 @@ class SubmissionStepNode(Node):
 
     @property
     def is_visible(self) -> bool:
+        if self.mode == RenderModes.export:
+            return True
         # determine if the step as a whole is relevant or not. The stap may be not
         # applicable because of form logic.
         logic_evaluated = getattr(self.step, "_form_logic_evaluated", False)

--- a/src/openforms/submissions/tests/test_exports.py
+++ b/src/openforms/submissions/tests/test_exports.py
@@ -309,6 +309,10 @@ class ExportTests(TestCase):
         dataset = create_submission_export(Submission.objects.order_by("pk"))
 
         self.assertEqual(len(dataset), 2)
+        self.assertEqual(len(dataset.headers), 3)
+        self.assertEqual(dataset.headers[2], "repeatingGroup")
+        self.assertIsNotNone(dataset[0][2])
+        self.assertIsNotNone(dataset[1][2])
 
     @tag("gh-3629")
     @temp_private_root()


### PR DESCRIPTION
Closes #3629

**Changes**

* Added regression tests for repeating group and file upload components that can cause the submission export to crash.
* Ensure that (hidden/skipped) submission steps because of logic are not skipped during export
* Ensure that editgrid components are considered a single component during export instead of recursing into them

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
