### PR TITLE
:globe_with_meridians: [#4716] Added formio translations

### DIFF
--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -33,6 +33,7 @@
   "npFamilyMembers": "Family members",
   "array_nonempty": "This field must have at least one value.",
   "maxFileSizeMessage": "The maximum file size is {{maxFileSize}}.",
+  "removeFileMessage": "Remove {{fileName}}",
   "The uploaded file is not of an allowed type. It must be: {{ pattern }}.": "The uploaded file is not of an allowed type. It must be: {{ pattern }}.",
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} or {{ lastLabel }}",
   "invalid_time": "Only times between {{ minTime }} and {{ maxTime }} are allowed.",

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -31,6 +31,7 @@
   "Component": "component",
   "Save": "Opslaan",
   "Remove": "Verwijderen",
+  "removeFileMessage": "Verwijder {{fileName}}",
   "Preview": "Voorbeeld",
   "Drag and Drop a form component": "Sleep een component in het formulier en laat de muisknop los",
   "No Matches Found": "Geen overeenkomsten gevonden",


### PR DESCRIPTION
Closes #4716 

**Changes**

Added a new formio translation

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
