### PR TITLE
[2.8.x backport] :bug: [#4528] Disable OIDC SessionRefresh middleware

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -267,7 +267,6 @@ MIDDLEWARE = [
     "openforms.translations.middleware.AdminLocaleMiddleware",
     "hijack.middleware.HijackUserMiddleware",
     "openforms.middleware.SessionTimeoutMiddleware",
-    "mozilla_django_oidc_db.middleware.SessionRefresh",
     "maykin_2fa.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -1044,15 +1043,6 @@ OIDC_STORE_ID_TOKEN = True
 
 # Access token required for performing the Token exchange
 OIDC_STORE_ACCESS_TOKEN = True
-
-# Paths that are exempt from the SessionRefresh middleware
-# these must be explicitly added to avoid infinite redirects from happening (#4435)
-if _USE_LEGACY_OIDC_ENDPOINTS:
-    OIDC_EXEMPT_URLS = [
-        "legacy_oidc:oidc_authentication_init",
-        "legacy_oidc:oidc_authentication_callback",
-        "legacy_oidc:oidc_logout",
-    ]
 
 # TODO: remove once 2.7 is released, this is required for data migration(s)
 MOZILLA_DJANGO_OIDC_DB_CACHE = "solo"


### PR DESCRIPTION
previously, if the session in the OIDC provider expired and the sessionrefresh middleware is triggered, the user can not automatically re-authenticate, causing to 403s (and losing changes made in the form designer). In order to avoid session synchronization issues, we remove the SessionRefresh completely, meaning that OIDC is used for logging in, but Open Forms itself is then in charge of managing the session.

Backport-Of: open-formulieren/open-forms#4528

Closes #4528 partially