### PR TITLE
Issue/4765 default value migration fail

### DIFF
--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -280,6 +280,10 @@ def fix_empty_default_value(component: Component) -> bool:
     changed = False
 
     if component.get("multiple", False):
+        if default_value is None:
+            component["defaultValue"] = []
+            return True
+
         for index, value in enumerate(default_value):
             if value is None:
                 component["defaultValue"][index] = ""

--- a/src/openforms/formio/tests/test_migration_converters.py
+++ b/src/openforms/formio/tests/test_migration_converters.py
@@ -222,7 +222,7 @@ class TextTests(SimpleTestCase):
 
         self.assertFalse(changed)
 
-    def test_multiple_default_value_none_changed(self):
+    def test_multiple_default_value_none_in_array_changed(self):
         component: Component = {
             "type": "textfield",
             "key": "textField",
@@ -249,6 +249,20 @@ class TextTests(SimpleTestCase):
 
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], ["foo", "", "bar"])
+
+    def test_multiple_default_value_none_changed(self):
+        component: Component = {
+            "key": "textField",
+            "label": "Text Field",
+            "type": "textfield",
+            "multiple": True,
+            "defaultValue": None,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
 
 
 class EmailTests(SimpleTestCase):


### PR DESCRIPTION
Closes #4765

**Changes**

Fixes bug in the `fix_empty_default_value` migration transformer

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
