### PR TITLE
Fix performance regression in FormioData data structure

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -363,7 +363,7 @@ django-sessionprofile==2.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-digid-eherkenning
-django-silk==5.1.0
+django-silk==5.2.0
     # via -r requirements/dev.in
 django-simple-certmanager==2.4.1
     # via

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -1,6 +1,5 @@
 import re
 from collections import UserDict
-from collections.abc import Hashable
 from typing import Iterator, cast
 
 from glom import PathAccessError, assign, glom
@@ -162,16 +161,45 @@ class FormioData(UserDict):
     """
 
     data: dict[str, JSONValue]
+    _keys: set[str]
+    """
+    A collection of flattened key names, for quicker __contains__ access
+    """
 
-    def __getitem__(self, key: Hashable):
-        return cast(JSONValue, glom(self.data, key))
+    def __init__(self, *args, **kwargs):
+        self._keys = set()
+        super().__init__(*args, **kwargs)
 
-    def __setitem__(self, key: Hashable, value: JSONValue):
+    def __getitem__(self, key: str):
+        if "." not in key:
+            return self.data[key]
+        try:
+            return cast(JSONValue, glom(self.data, key))
+        except PathAccessError as exc:
+            raise KeyError(f"Key '{key}' is not present in the data") from exc
+
+    def __setitem__(self, key: str, value: JSONValue):
         assign(self.data, key, value, missing=dict)
+        self._keys.add(key)
 
-    def __contains__(self, key: Hashable) -> bool:
+    def __contains__(self, key: object) -> bool:
+        """
+        Check if the key is present in the data container.
+
+        This gets called via ``formio_data.get(...)`` to check if the default needs to
+        be returned or not. Keys are expected to be strings taken from ``variable.key``
+        fields.
+        """
+        if not isinstance(key, str):
+            raise TypeError("Only string keys are supported")
+
+        # for direct keys, we can optimize access and bypass glom + its exception
+        # throwing.
+        if "." not in key:
+            return key in self._keys
+
         try:
             self[key]
-        except PathAccessError:
+            return True
+        except KeyError:
             return False
-        return True

--- a/src/openforms/formio/tests/test_datastructures.py
+++ b/src/openforms/formio/tests/test_datastructures.py
@@ -89,6 +89,34 @@ class FormioDataTests(TestCase):
 
         self.assertEqual(formio_data, expected)
 
+    def test_key_access_must_be_string(self):
+        formio_data = FormioData({"foo": "bar"})
+
+        bad_keys = (
+            3,
+            None,
+            4.3,
+            ("foo",),
+        )
+
+        for key in bad_keys:
+            with self.assertRaises(TypeError):
+                key in formio_data  # type: ignore
+
+    def test_keyerror_for_absent_keys(self):
+        formio_data = FormioData({})
+        bad_keys = (
+            "foo",
+            "bar.baz",
+        )
+
+        for key in bad_keys:
+            with (
+                self.subTest(key=key),
+                self.assertRaises(KeyError),
+            ):
+                formio_data[key]
+
 
 class FormioConfigurationWrapperTests(TestCase):
 

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -9,7 +9,6 @@ from typing import Any, Generic, Iterator, Literal, TypeVar, cast, override
 from django.db.models import F
 
 import glom
-from glom import PathAccessError
 
 from openforms.authentication.service import AuthAttribute
 from openforms.contrib.objects_api.clients import (
@@ -537,7 +536,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
         for key, variable in state.variables.items():
             try:
                 submission_value = dynamic_values[key]
-            except PathAccessError:
+            except KeyError:
                 continue
 
             # special casing documents - we transform the formio file upload data into


### PR DESCRIPTION
Closes #4744

**Changes**

Optimized key access in the `FormioData` data structure.

Performance results - the last column are the numbers for this PR. The gains are massive compared to `master` and they improve even on 2.7.x.

| Form step                   | version: master (0ea7bfa) | version: 2.7.x | Perf patch |
| --------------------------- | ------------------------- | -------------- | ---------- |
| Inleiding                   | 1540                      | 736            | 448        |
| Verklaring van waarheid     | 1520                      | 751            | 464        |
| Uw gegevens                 | 1727                      | 879            | 551        |
| Uw situatie                 | 1730                      | 827            | 483        |
| Gezinssamenstelling         | 1660                      | 823            | 558        |
| Uw inkomsten                | 1790                      | 991            | 637        |
| Uw inkomsten overzicht      | 1740                      | 836            | 565        |
| Inkomsten partner           | 1840                      | 909            | 585        |
| Inkomsten partner overzicht | 1720                      | 864            | 540        |
| Bezit en schulden           | 1620                      | 859            | 508        |
| Bezit en schulden overzicht | 1600                      | 817            | 637        |
| Post                        | 1560                      | 769            | 485        |
| Overzicht                   | 10350                     | 4850           | 3330       |


**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
