### PR TITLE
[#4774] Normalize textfield component's value

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -91,6 +91,12 @@ class Default(BasePlugin):
 class TextField(BasePlugin[TextFieldComponent]):
     formatter = TextFieldFormatter
 
+    @staticmethod
+    def normalizer(component: Component, value: str) -> str:
+        if isinstance(value, (int, float)):
+            return str(value)
+        return value
+
     def build_serializer_field(
         self, component: TextFieldComponent
     ) -> serializers.CharField | serializers.ListField:

--- a/src/openforms/formio/tests/test_normalization.py
+++ b/src/openforms/formio/tests/test_normalization.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, tag
 
 from ..service import normalize_value_for_component
 
@@ -63,3 +63,13 @@ class NormalizationTests(SimpleTestCase):
         result = normalize_value_for_component(component, "foo.bar-baz")
 
         self.assertEqual(result, "foo.bar-baz")  # unmodified
+
+    @tag("gh-4774")
+    def test_textfield_normalization_non_str(self):
+        component = {"type": "textfield"}
+
+        int_result = normalize_value_for_component(component, 9)
+        float_result = normalize_value_for_component(component, 9.9)
+
+        self.assertEqual(int_result, "9")
+        self.assertEqual(float_result, "9.9")


### PR DESCRIPTION
Closes #4774 

**Changes**

- Added a regression test for the component's normalizer
- Implemented the `normalizer` method for the component

The `prefill` module was already normalizing the components' values but for the `textfield` component we were missing the normalizer method.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
