### PR TITLE
Accessibility improvement - Descriptive postcode field error message

### DIFF
--- a/src/openforms/js/components/formio_builder/builder.js
+++ b/src/openforms/js/components/formio_builder/builder.js
@@ -161,12 +161,17 @@ const getBuilderOptions = () => {
               input: true,
               inputMask: '9999 AA',
               validateOn: 'blur',
+              // The validate config doesn't seem to be used. Its also missing in the form definition BD
               validate: {
                 customMessage: 'Invalid Postcode',
                 // Dutch postcode has 4 numbers and 2 letters (case insensitive). Letter combinations SS, SD and SA
                 // are not used due to the Nazi-association.
                 // See https://stackoverflow.com/a/17898538/7146757 and https://nl.wikipedia.org/wiki/Postcodes_in_Nederland
                 pattern: '^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$',
+              },
+              // This is needed to show the 'Invalid Postcode' error message on mask errors
+              errors: {
+                mask: 'Invalid Postcode',
               },
             },
           },

--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -38,5 +38,6 @@
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} or {{ lastLabel }}",
   "invalid_time": "Only times between {{ minTime }} and {{ maxTime }} are allowed.",
   "You must select at least {{minCount}} items.": "Ensure this field has at least {{minCount}} checked options.",
+  "Invalid Postcode": "The submitted value does not match the postcode pattern: 1234 AB",
   "": ""
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -358,7 +358,7 @@
   "Form fields": "Formuliervelden",
   "Presets": "Voorgedefinieerd",
   "Deprecated": "Verouderd",
-  "Invalid Postcode": "Ongeldige Postcode",
+  "Invalid Postcode": "De opgegeven waarde voldoet niet aan het postcode formaat: 1234 AB",
   "Clear on hide": "Wissen als veld verborgen is",
   "Remove the value of this field from the submission if it is hidden. Note: the value of this field is then also not used in logic rules!": "Verwijder de waarde van dit veld van de inzending als dit veld verborgen is. Let op: De waarde van dit veld wordt dan ook niet gebruikt in logica regels!",
   "Column sizes": "Grootte van de kolommen",


### PR DESCRIPTION
Closes #4719

**Changes**

Providing postcode fields with descriptive error messages

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
