### PR TITLE
Bug/4727 crashing form after changing user variable to array

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -3909,6 +3909,12 @@
       "value": "Login required?"
     }
   ],
+  "af22yB": [
+    {
+      "type": 0,
+      "value": "Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?"
+    }
+  ],
   "aqYeqv": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -3927,6 +3927,12 @@
       "value": "Vereist authenticatie"
     }
   ],
+  "af22yB": [
+    {
+      "type": 0,
+      "value": "Het veranderen van het datatype vereist een verandering aan de beginwaarde. Dit zal de beginwaarde terugbrengen naar de standaardwaarde. Weet je zeker dat je dit wilt doen?"
+    }
+  ],
   "aqYeqv": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -70,6 +70,7 @@ import {
   getUniqueKey,
   parseValidationErrors,
   slugify,
+  transformInitialValue,
   updateKeyReferencesInLogic,
   updateRemovedKeyInLogic,
 } from './utils';
@@ -784,6 +785,14 @@ function reducer(draft, action) {
         draft.formVariables[index][propertyName] = propertyValue;
       }
 
+      // When dataType changes, a data transformation is needed
+      if (propertyName === 'dataType') {
+        draft.formVariables[index]['initialValue'] = transformInitialValue(
+          propertyValue,
+          originalVariable.initialValue
+        );
+      }
+
       // Check if there are errors that need to be reset
       if (draft.formVariables[index].errors) {
         const errorKeys = propertyName === '' ? Object.keys(propertyValue) : [propertyName];
@@ -1229,6 +1238,42 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
       payload: pluginId,
     });
   };
+  const onUserDefinedVariableChange = async (key, propertyName, propertyValue) => {
+    const originalVariable = state.formVariables.find(variable => variable.key === key);
+    // Just dispatch if anything other than dataType changes
+    // or if the initialValue is null/undefined
+    if (
+      propertyName !== 'dataType' ||
+      originalVariable?.initialValue == null ||
+      originalVariable?.initialValue === ''
+    ) {
+      dispatch({
+        type: 'CHANGE_USER_DEFINED_VARIABLE',
+        payload: {key, propertyName, propertyValue},
+      });
+      return;
+    }
+
+    // Check if the dataType change is intentional.
+    if (
+      propertyName === 'dataType' &&
+      !window.confirm(
+        intl.formatMessage({
+          description:
+            'Changing user variable data type and transforming initial value confirmation message',
+          defaultMessage:
+            'Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?',
+        })
+      )
+    ) {
+      return;
+    }
+
+    dispatch({
+      type: 'CHANGE_USER_DEFINED_VARIABLE',
+      payload: {key, propertyName, propertyValue},
+    });
+  };
 
   if (loading || state.submitting) {
     return <Loader />;
@@ -1268,8 +1313,8 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
         <div className="fetch-error">
           <FormattedMessage
             description="Generic admin error message"
-            defaultMessage={`Sorry! Something unexpected went wrong.<br></br>Contact your 
-              technical administrator to investigate, or perhaps more information is 
+            defaultMessage={`Sorry! Something unexpected went wrong.<br></br>Contact your
+              technical administrator to investigate, or perhaps more information is
               available in the <link>outgoing request logs</link>.`}
             values={{
               br: () => <br />,
@@ -1506,12 +1551,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
                 variables={state.formVariables}
                 onAdd={() => dispatch({type: 'ADD_USER_DEFINED_VARIABLE'})}
                 onDelete={key => dispatch({type: 'DELETE_USER_DEFINED_VARIABLE', payload: key})}
-                onChange={(key, propertyName, propertyValue) =>
-                  dispatch({
-                    type: 'CHANGE_USER_DEFINED_VARIABLE',
-                    payload: {key, propertyName, propertyValue},
-                  })
-                }
+                onChange={onUserDefinedVariableChange}
                 onFieldChange={onFieldChange}
               />
             </TabPanel>

--- a/src/openforms/js/components/admin/form_design/utils.js
+++ b/src/openforms/js/components/admin/form_design/utils.js
@@ -57,6 +57,30 @@ const checkKeyChange = (mutationType, newComponent, oldComponent) => {
   return newComponent.key !== oldComponent.key;
 };
 
+const transformInitialValue = (newType, originalValue) => {
+  switch (newType) {
+    case 'array':
+      return [];
+
+    case 'boolean':
+    case 'int':
+    case 'float':
+      return undefined;
+
+    case 'object':
+      return {};
+
+    case 'string':
+    case 'datetime':
+    case 'date':
+    case 'time':
+      return '';
+
+    default:
+      return originalValue;
+  }
+};
+
 const updateKeyReferencesInLogic = (existingLogicRules, originalKey, newKey) => {
   for (const rule of existingLogicRules) {
     if (!JSON.stringify(rule).includes(originalKey)) continue;
@@ -219,6 +243,7 @@ export {
   getFormComponents,
   findComponent,
   checkKeyChange,
+  transformInitialValue,
   updateKeyReferencesInLogic,
   updateRemovedKeyInLogic,
   getUniqueKey,

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1804,6 +1804,11 @@
     "description": "Form step login required label",
     "originalDefault": "Login required?"
   },
+  "af22yB": {
+    "defaultMessage": "Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?",
+    "description": "Changing user variable data type and transforming initial value confirmation message",
+    "originalDefault": "Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?"
+  },
   "auZOcD": {
     "defaultMessage": "Mapping expression",
     "description": "Service fetch configuration modal form mapping expression field label",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1819,6 +1819,11 @@
     "description": "Form step login required label",
     "originalDefault": "Login required?"
   },
+  "af22yB": {
+    "defaultMessage": "Het veranderen van het datatype vereist een verandering aan de beginwaarde. Dit zal de beginwaarde terugbrengen naar de standaardwaarde. Weet je zeker dat je dit wilt doen?",
+    "description": "Changing user variable data type and transforming initial value confirmation message",
+    "originalDefault": "Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?"
+  },
   "auZOcD": {
     "defaultMessage": "Mappingexpressie",
     "description": "Service fetch configuration modal form mapping expression field label",


### PR DESCRIPTION
Closes #4727

**Changes**

Fixes the crashes on user variable dataType change, when a initialValue is defined. This crash happend when changing any dataType to the array dataType, because the component for the array dataType used the `.some` js array function. (It expected that the value was an array, so this function was used without any checks)

To resolve this situation, and possible similar situations in the future, the initialValue now gets transformed when the dataType changes. This transformation could result into losing the previous initialValue. To make sure that the dataType change is intentional, a confirmation message will be shown.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
