### PR TITLE
Polish backend for soft-required validation

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -364,7 +364,7 @@ Other settings
   
 .. _django-sendfile documentation: https://django-sendfile2.readthedocs.io/en/stable/backends.html
 
-.. _`Django DATABASE settings`: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-DATABASE-ENGINE
+.. _`Django DATABASE settings`: https://docs.djangoproject.com/en/4.2/ref/settings/#engine
 
 .. _installation_environment_config_feature_flags:
 

--- a/docs/manual/forms/soft_required_fields.rst
+++ b/docs/manual/forms/soft_required_fields.rst
@@ -18,7 +18,7 @@ ze niet om het formulier in te zenden.
 Formulierconfiguratie
 =====================
 
-.. note:: deze documentatie gaat ervan uit dat je bekend met de basis van
+.. note:: Deze documentatie gaat ervan uit dat je bekend met de basis van
    :ref:`formulieren beheren <manual_forms_basics>`.
 
 Het is belangrijk dat je in de betreffende formulierstap(pen) een component toevoegt

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -336,3 +336,17 @@ class EditGridGroupNode(ContainerMixin, ComponentNode):
 
     def render(self) -> str:
         return f"{self.indent}{self.label}"
+
+
+@register("softRequiredErrors")
+class SoftRequiredErrors(ComponentNode):
+
+    @property
+    def is_visible(self) -> bool:
+        """
+        Mark soft required errors nodes as never visible.
+
+        They are rendered client-side only, so should not show in summaries, PDF,
+        registration data...
+        """
+        return False

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -11,7 +11,7 @@ from ..registry import Registry
 from ..structured import render_json
 
 
-class FormNodeTests(TestCase):
+class ComponentNodeTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -203,6 +203,13 @@ class FormNodeTests(TestCase):
                     },
                 },
                 # TODO columns
+                # soft required validation errors -> always ignored
+                {
+                    "key": "softRequiredErrors",
+                    "type": "softRequiredErrors",
+                    "html": "<p>I am hidden</p>",
+                    "label": "Soft required errors",
+                },
             ]
         }
         data = {
@@ -451,7 +458,7 @@ class FormNodeTests(TestCase):
                 )
                 nodelist += list(component_node)
 
-        self.assertEqual(len(nodelist), 10)
+        self.assertEqual(len(nodelist), 11)
         labels = [node.label for node in nodelist]
         expected_labels = [
             "Input 1",
@@ -464,6 +471,7 @@ class FormNodeTests(TestCase):
             "Input 11",
             "Visible editgrid with hidden children",
             "Input 14",
+            "Soft required errors",  # not actually rendered in full render mode
         ]
         self.assertEqual(labels, expected_labels)
 
@@ -497,6 +505,7 @@ class FormNodeTests(TestCase):
             "Input 11",
             "Visible editgrid with hidden children",
             "Input 14",
+            "Soft required errors",  # not actually rendered in full render mode
         ]
         self.assertEqual(labels, expected_labels)
 

--- a/src/openforms/formio/tests/test_variables_injection.py
+++ b/src/openforms/formio/tests/test_variables_injection.py
@@ -184,3 +184,21 @@ class VariableInjectionTests(SimpleTestCase):
             result,
             {"topLevel": {"nested": "yepp"}},
         )
+
+    def test_soft_required_errors_no_server_side_template_evaluation(self):
+        configuration = {
+            "components": [
+                {
+                    "key": "softRequiredErrors",
+                    "type": "softRequiredErrors",
+                    "html": "<p>I am hidden</p>{{ missingFields }}{% now %}",
+                },
+            ]
+        }
+
+        inject_variables(FormioConfigurationWrapper(configuration), {})
+
+        self.assertEqual(
+            configuration["components"][0]["html"],
+            "<p>I am hidden</p>{{ missingFields }}{% now %}",
+        )

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -37,6 +37,10 @@ def iter_template_properties(component: Component) -> Iterator[tuple[str, JSONVa
 
     Each item returns a tuple with the key and value of the formio component.
     """
+    # no server-side template evaluation here
+    if component["type"] == "softRequiredErrors":
+        return
+
     for property_name in SUPPORTED_TEMPLATE_PROPERTIES:
         property_value = component.get(property_name)
         yield (property_name, property_value)

--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -40,5 +40,6 @@
   "{{ labels }} or {{ lastLabel }}": "{{ labels }} or {{ lastLabel }}",
   "invalid_time": "Only times between {{ minTime }} and {{ maxTime }} are allowed.",
   "You must select at least {{minCount}} items.": "Ensure this field has at least {{minCount}} checked options.",
+  "Empty fields": "Fields without a value",
   "": ""
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -408,5 +408,6 @@
   "You must verify this email address to continue.": "Om door te gaan moet je dit e-mailadres bevestigen.",
   "You must select at least {{minCount}} items.": "Zorg dat dit veld {{minCount}} of meer opties aangevinkt heeft.",
   "Soft required errors": "Foutmeldingen aangeraden velden",
+  "Empty fields": "Velden zonder antwoord",
   "": ""
 }

--- a/src/openforms/submissions/tests/test_submission_report.py
+++ b/src/openforms/submissions/tests/test_submission_report.py
@@ -424,6 +424,8 @@ class DownloadSubmissionReportTests(APITestCase):
         plugins = set(ct for ct, _ in register.items())
         # WYSIWIG seems untranslated in SDK TODO after/in issue #2475
         plugins.remove("content")
+        # soft-required errors are not shown in PDF report
+        plugins.remove("softRequiredErrors")
 
         tested_plugins = set(ct for ct, _ in fields if ct in plugins)
         # add checked structural "layout" components that don't require


### PR DESCRIPTION
Closes #4546

**Changes**

Tested this end-to-end with the SDK PR and noticed some more tweaks were needed.

* Make sure the HTML for the content is not treated as Django template
* Make sure the component is not displayed in summary page/PDF report/
   registration data etc.
* Added tests
*  Added translations for accessible list label/heading

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
