### PR TITLE
Add Product to the ZGW API registration

### DIFF
--- a/docker/docker-compose.rx-mission.yml
+++ b/docker/docker-compose.rx-mission.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+name: rx-mission
+
+services:
+  flask_app:
+    build: ./rx-mission
+    ports:
+      - "80:80"
+    volumes:
+      - ./rx-mission/:/app/
+
+networks:
+  open-forms-dev:
+    name: open-forms-dev

--- a/docker/open-zaak/fixtures/open_zaak_fixtures.json
+++ b/docker/open-zaak/fixtures/open_zaak_fixtures.json
@@ -18,10 +18,17 @@
     }
 },
 {
+    "model": "config.featureflags",
+    "pk": 1,
+    "fields": {
+        "allow_unpublished_typen": true
+    }
+},
+{
     "model": "catalogi.catalogus",
     "pk": 1,
     "fields": {
-        "_etag": "e1d589174bfd280d29dbce6ab0450e18",
+        "_etag": "ef26c6f8e32dd9cd50809442b635bb26",
         "naam": "Test catalog",
         "uuid": "bd58635c-793e-446d-a7e0-460d7b04829d",
         "domein": "TEST",
@@ -109,6 +116,22 @@
     }
 },
 {
+    "model": "catalogi.eigenschap",
+    "pk": 4,
+    "fields": {
+        "_etag": "588430a1d4a69b9470231c498f96ea2a",
+        "datum_begin_geldigheid": null,
+        "datum_einde_geldigheid": null,
+        "uuid": "3a094e33-7a20-4018-bd60-3c15d06a1555",
+        "eigenschapnaam": "a property name",
+        "definitie": "a definition",
+        "specificatie_van_eigenschap": 1,
+        "toelichting": "",
+        "zaaktype": 5,
+        "statustype": null
+    }
+},
+{
     "model": "catalogi.informatieobjecttype",
     "pk": 1,
     "fields": {
@@ -154,7 +177,7 @@
     "model": "catalogi.informatieobjecttype",
     "pk": 3,
     "fields": {
-        "_etag": "9b92accfbfdb5c0d2c8d040a5825abfd",
+        "_etag": "6185cc7af26276b5562929eea87cb2cc",
         "datum_begin_geldigheid": "2024-03-19",
         "datum_einde_geldigheid": "2024-07-10",
         "concept": false,
@@ -303,6 +326,19 @@
     }
 },
 {
+    "model": "catalogi.zaaktypeinformatieobjecttype",
+    "pk": 4,
+    "fields": {
+        "_etag": "ca748511ae63aec4a6bad264b394af3f",
+        "uuid": "eb78b6f6-0721-442d-b97a-074c66b5953c",
+        "zaaktype": 5,
+        "informatieobjecttype": 3,
+        "volgnummer": 1,
+        "richting": "inkomend",
+        "statustype": null
+    }
+},
+{
     "model": "catalogi.resultaattype",
     "pk": 1,
     "fields": {
@@ -341,6 +377,36 @@
         "datum_einde_geldigheid": null,
         "uuid": "ec03d4e6-c010-4163-9c05-8247def5f45c",
         "zaaktype": 3,
+        "omschrijving": "Geslaagd",
+        "resultaattypeomschrijving": "https://selectielijst.openzaak.nl/api/v1/resultaattypeomschrijvingen/43ac0469-e0c0-4985-a6ce-8ec285d2df47",
+        "omschrijving_generiek": "Vastgesteld",
+        "selectielijstklasse": "https://selectielijst.openzaak.nl/api/v1/resultaten/afa30940-855b-4a7e-aa21-9e15a8078814",
+        "archiefnominatie": "vernietigen",
+        "archiefactietermijn": "P10Y",
+        "brondatum_archiefprocedure_afleidingswijze": "afgehandeld",
+        "brondatum_archiefprocedure_datumkenmerk": "",
+        "brondatum_archiefprocedure_einddatum_bekend": false,
+        "brondatum_archiefprocedure_objecttype": "",
+        "brondatum_archiefprocedure_registratie": "",
+        "brondatum_archiefprocedure_procestermijn": "P0D",
+        "toelichting": "",
+        "procesobjectaard": "",
+        "indicatie_specifiek": null,
+        "procestermijn": null,
+        "informatieobjecttypen": [],
+        "besluittypen": [],
+        "zaakobjecttypen": []
+    }
+},
+{
+    "model": "catalogi.resultaattype",
+    "pk": 4,
+    "fields": {
+        "_etag": "61528e205cb91999e1fff62165c9e620",
+        "datum_begin_geldigheid": null,
+        "datum_einde_geldigheid": null,
+        "uuid": "e84e6028-c52a-420b-a098-d10897395c52",
+        "zaaktype": 5,
         "omschrijving": "Geslaagd",
         "resultaattypeomschrijving": "https://selectielijst.openzaak.nl/api/v1/resultaattypeomschrijvingen/43ac0469-e0c0-4985-a6ce-8ec285d2df47",
         "omschrijving_generiek": "Vastgesteld",
@@ -415,6 +481,32 @@
     }
 },
 {
+    "model": "catalogi.roltype",
+    "pk": 7,
+    "fields": {
+        "_etag": "becf13f6816136b448a03c8cc7484f80",
+        "datum_begin_geldigheid": null,
+        "datum_einde_geldigheid": null,
+        "uuid": "bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8",
+        "omschrijving": "Initiator",
+        "omschrijving_generiek": "initiator",
+        "zaaktype": 5
+    }
+},
+{
+    "model": "catalogi.roltype",
+    "pk": 8,
+    "fields": {
+        "_etag": "c370045099a0d44ef4459a2596739ce0",
+        "datum_begin_geldigheid": null,
+        "datum_einde_geldigheid": null,
+        "uuid": "d44d68c2-1e06-461e-9657-adf174a922fb",
+        "omschrijving": "Baliemedewerker",
+        "omschrijving_generiek": "klantcontacter",
+        "zaaktype": 5
+    }
+},
+{
     "model": "catalogi.statustype",
     "pk": 1,
     "fields": {
@@ -436,7 +528,7 @@
     "model": "catalogi.statustype",
     "pk": 2,
     "fields": {
-        "_etag": "431dc899b7400782cfb86f5cc2fa0236",
+        "_etag": "360e002e252b85e8d064d9c28f2984a0",
         "datum_begin_geldigheid": null,
         "datum_einde_geldigheid": null,
         "uuid": "1de05b57-a938-47e4-b808-f129c6406b60",
@@ -487,12 +579,48 @@
     }
 },
 {
+    "model": "catalogi.statustype",
+    "pk": 7,
+    "fields": {
+        "_etag": "8a46302bb4a487f8abe164ccfbcd9052",
+        "datum_begin_geldigheid": null,
+        "datum_einde_geldigheid": null,
+        "uuid": "018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b",
+        "zaaktype": 5,
+        "statustype_omschrijving": "Afgerond",
+        "statustype_omschrijving_generiek": "",
+        "statustypevolgnummer": 2,
+        "doorlooptijd": null,
+        "informeren": false,
+        "statustekst": "",
+        "toelichting": null
+    }
+},
+{
+    "model": "catalogi.statustype",
+    "pk": 8,
+    "fields": {
+        "_etag": "e34511d093b82feb1fde24f2da13d330",
+        "datum_begin_geldigheid": null,
+        "datum_einde_geldigheid": null,
+        "uuid": "2937ee1d-9ea1-4048-b642-5a4dfd51fb47",
+        "zaaktype": 5,
+        "statustype_omschrijving": "Ontvangen",
+        "statustype_omschrijving_generiek": "",
+        "statustypevolgnummer": 1,
+        "doorlooptijd": null,
+        "informeren": false,
+        "statustekst": "",
+        "toelichting": null
+    }
+},
+{
     "model": "catalogi.zaaktype",
     "pk": 1,
     "fields": {
-        "_etag": "4b7814375796d28f29fea94ee27127b8",
+        "_etag": "49244222344d1a50479929320e8702ca",
         "datum_begin_geldigheid": "2024-03-26",
-        "datum_einde_geldigheid": null,
+        "datum_einde_geldigheid": "2024-10-29",
         "concept": false,
         "uuid": "1f41885e-23fc-4462-bbc8-80be4ae484dc",
         "identificatie": "ZT-001",
@@ -625,10 +753,49 @@
     }
 },
 {
-    "model": "config.featureflags",
-    "pk": 1,
+    "model": "catalogi.zaaktype",
+    "pk": 5,
     "fields": {
-        "allow_unpublished_typen": true
+        "_etag": "fde03886a89d769c02e66a24fb47e991",
+        "datum_begin_geldigheid": "2024-10-31",
+        "datum_einde_geldigheid": null,
+        "concept": false,
+        "uuid": "f609b6fe-449a-46dc-a0af-de55dc5f6774",
+        "identificatie": "ZT-001",
+        "zaaktype_omschrijving": "Test",
+        "zaaktype_omschrijving_generiek": "",
+        "vertrouwelijkheidaanduiding": "intern",
+        "doel": "testen",
+        "aanleiding": "integratietests",
+        "toelichting": "",
+        "indicatie_intern_of_extern": "intern",
+        "handeling_initiator": "Formulier indienen",
+        "onderwerp": "Testformulier",
+        "handeling_behandelaar": "Controleren",
+        "doorlooptijd_behandeling": "P1D",
+        "servicenorm_behandeling": "P0D",
+        "opschorting_en_aanhouding_mogelijk": false,
+        "verlenging_mogelijk": false,
+        "verlengingstermijn": null,
+        "trefwoorden": "[]",
+        "publicatie_indicatie": false,
+        "publicatietekst": "",
+        "verantwoordingsrelatie": "[]",
+        "versiedatum": "2024-10-31",
+        "verantwoordelijke": "Ontwikkelaar",
+        "producten_of_diensten": "[\"http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10\"]",
+        "selectielijst_procestype": "https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0",
+        "selectielijst_procestype_jaar": 2020,
+        "referentieproces_naam": "Testen",
+        "referentieproces_link": "",
+        "broncatalogus_url": "",
+        "broncatalogus_domein": "",
+        "broncatalogus_rsin": "",
+        "bronzaaktype_url": "",
+        "bronzaaktype_identificatie": "",
+        "bronzaaktype_omschrijving": "",
+        "catalogus": 1,
+        "deelzaaktypen": []
     }
 }
 ]

--- a/docker/rx-mission/Dockerfile
+++ b/docker/rx-mission/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official Python image from the Docker Hub
+FROM python:3.12-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install the dependencies
+RUN pip install Flask
+
+# Make port 80 available to the world outside this container
+EXPOSE 80
+
+# Run app.py when the container launches
+CMD ["python", "app.py"]

--- a/docker/rx-mission/README.md
+++ b/docker/rx-mission/README.md
@@ -1,0 +1,28 @@
+# RX Mission
+
+The `docker-compose.rx-mission.yml` compose file is available to run a mock services intended
+to replicate some Roxit interfaces. Currently only containing a mock product detail endpoint.
+
+The compose file takes some serious creative liberty, and doesn't represent a real Roxit environment.
+At the moment we cannot use a real Roxit products environment,
+so this mock service shall have to do for the development and testing of #4796.
+
+The data returned from `/product/<product_uuid>` is a stripped example provided by Roxit,
+and very loosely depicts real products.
+
+When development of the Roxit products environment is completed, this docker environment must be updated.
+
+## docker compose
+
+Start an instance in your local environment from the parent directory:
+
+```bash
+docker compose -f docker-compose.rx-mission.yml up -d
+```
+
+This starts a flask application at http://localhost:80/product/<product_uuid>.
+To recognized `uuid's` can be found in the `rx-mission/fixtures/rx-mission-products.json` file.
+
+## Load fixtures
+
+The flask app uses the fixtures in `rx-mission/fixtures` as a simple database.

--- a/docker/rx-mission/app.py
+++ b/docker/rx-mission/app.py
@@ -1,0 +1,23 @@
+import json
+
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+products = {}
+
+
+@app.route("/product/<string:product_uuid>", methods=["GET"])
+def handle_request(product_uuid):
+    if product_uuid not in products:
+        return jsonify({"message": "Product not found"}), 404
+
+    product = products[product_uuid]
+    return jsonify(product)
+
+
+if __name__ == "__main__":
+    with open("./fixtures/rx-mission-products.json", encoding="utf-8") as json_file:
+        parsed_json = json.load(json_file)
+        products = {product["id"]: product for product in parsed_json["products"]}
+
+    app.run(host="0.0.0.0", port=80, debug=True)

--- a/docker/rx-mission/fixtures/rx-mission-products.json
+++ b/docker/rx-mission/fixtures/rx-mission-products.json
@@ -1,0 +1,572 @@
+{
+  "products": [
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde0a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde0a",
+      "code": "RX-0",
+      "description": "Informatieplicht incident",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde1a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde1a",
+      "code": "RX-1",
+      "description": "Advies vergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde2a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde2a",
+      "code": "RX-2",
+      "description": "Verkennen en begeleiden initiatief",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde3a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde3a",
+      "code": "RX-3",
+      "description": "Klacht",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde4a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde4a",
+      "code": "RX-4",
+      "description": "Zienswijze",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde5a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde5a",
+      "code": "RX-5",
+      "description": "Beroep",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde6a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde6a",
+      "code": "RX-6",
+      "description": "Strijdigheid Besluit bouwwerken leefomgeving (BBL)",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde7a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde7a",
+      "code": "RX-7",
+      "description": "Informatieplicht starten of wijzigen milieu-belastende-activiteit",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde8a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde8a",
+      "code": "RX-8",
+      "description": "Periodieke controle",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde9a",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde9a",
+      "code": "RX-9",
+      "description": "Hercontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde10",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde10",
+      "code": "RX-10",
+      "description": "Advies vergunning met instemming",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde11",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde11",
+      "code": "RX-11",
+      "description": "Evenementenmelding",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde12",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde12",
+      "code": "RX-12",
+      "description": "Advies",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde13",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde13",
+      "code": "RX-13",
+      "description": "Informatieplicht ongewone voorvallen",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde14",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde14",
+      "code": "RX-14",
+      "description": "Kansspelvergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde15",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde15",
+      "code": "RX-15",
+      "description": "Intrekken dwangsom",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde16",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde16",
+      "code": "RX-16",
+      "description": "Vooroverleg",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde17",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde17",
+      "code": "RX-17",
+      "description": "Melding brandveilig gebruik",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde18",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde18",
+      "code": "RX-18",
+      "description": "Toepassen bestuursdwang",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde19",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde19",
+      "code": "RX-19",
+      "description": "Bestuursdwangcontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde20",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde20",
+      "code": "RX-20",
+      "description": "Drank- en horecamelding",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde21",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde21",
+      "code": "RX-21",
+      "description": "Drank- en horecavergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde22",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde22",
+      "code": "RX-22",
+      "description": "Klachtcontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde23",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde23",
+      "code": "RX-23",
+      "description": "Bibob onderzoek",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde24",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde24",
+      "code": "RX-24",
+      "description": "Participatietraject",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde25",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde25",
+      "code": "RX-25",
+      "description": "WKB-50 Informatieplicht beëindiging bouwwerkzaamheden",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde26",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde26",
+      "code": "RX-26",
+      "description": "Themacontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde27",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde27",
+      "code": "RX-27",
+      "description": "Voorlopige voorziening",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde28",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde28",
+      "code": "RX-28",
+      "description": "Intrekken Omgevingsvergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde29",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde29",
+      "code": "RX-29",
+      "description": "WKB-20 Informatieplicht start bouw",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde30",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde30",
+      "code": "RX-30",
+      "description": "Advies melding",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde31",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde31",
+      "code": "RX-31",
+      "description": "Bezwaarschriftprocedure",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde32",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde32",
+      "code": "RX-32",
+      "description": "APV-melding",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde33",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde33",
+      "code": "RX-33",
+      "description": "Gedoogcontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde34",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde34",
+      "code": "RX-34",
+      "description": "Advies informatiebericht",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde35",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde35",
+      "code": "RX-35",
+      "description": "Revisievergunning (ambtshalve)",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde36",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde36",
+      "code": "RX-36",
+      "description": "Melding MBA",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde37",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde37",
+      "code": "RX-37",
+      "description": "Melding Omgevingswet",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde38",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde38",
+      "code": "RX-38",
+      "description": "Last onder dwangsom",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde39",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde39",
+      "code": "RX-39",
+      "description": "Sloopmelding",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde40",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde40",
+      "code": "RX-40",
+      "description": "Voornemen last onder bestuursdwang",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde41",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde41",
+      "code": "RX-41",
+      "description": "Bouwmelding Wkb (risicobeoordeling en borgingsplan)",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde42",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde42",
+      "code": "RX-42",
+      "description": "Dwangsomcontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde43",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde43",
+      "code": "RX-43",
+      "description": "Gedogen",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde44",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde44",
+      "code": "RX-44",
+      "description": "Last onder bestuursdwang",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde45",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde45",
+      "code": "RX-45",
+      "description": "APV-ontheffing",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde46",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde46",
+      "code": "RX-46",
+      "description": "Gereed melding Wkb (dossier bevoegd gezag)",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde47",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde47",
+      "code": "RX-47",
+      "description": "Wijzigen Omgevingsvergunning (ambtshalve)",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde48",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde48",
+      "code": "RX-48",
+      "description": "Kansspelmelding",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde49",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde49",
+      "code": "RX-49",
+      "description": "Hoger beroep",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde50",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde50",
+      "code": "RX-50",
+      "description": "Drank- en horecaontheffing",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde51",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde51",
+      "code": "RX-51",
+      "description": "Nagekomen stukken",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde52",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde52",
+      "code": "RX-52",
+      "description": "Voorval",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde53",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde53",
+      "code": "RX-53",
+      "description": "Bestuurlijke strafbeschikking",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde54",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde54",
+      "code": "RX-54",
+      "description": "Actualisatieonderzoek",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde55",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde55",
+      "code": "RX-55",
+      "description": "Ad hoc controle",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde56",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde56",
+      "code": "RX-56",
+      "description": "Innen dwangsom",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde57",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde57",
+      "code": "RX-57",
+      "description": "Beoordelen document informatieplicht",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde58",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde58",
+      "code": "RX-58",
+      "description": "Evenementenvergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde59",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde59",
+      "code": "RX-59",
+      "description": "Melding bodemsanering",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde60",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde60",
+      "code": "RX-60",
+      "description": "Omgevingsvergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde61",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde61",
+      "code": "RX-61",
+      "description": "Nadeelcompensatieverzoek",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde62",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde62",
+      "code": "RX-62",
+      "description": "Doorgeven strafrechtpartner",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde63",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde63",
+      "code": "RX-63",
+      "description": "Bestuurlijke boete",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde64",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde64",
+      "code": "RX-64",
+      "description": "WKB-30-Informatieplicht afwijking bouwbesluit/Wkb",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde65",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde65",
+      "code": "RX-65",
+      "description": "Voornemen last onder dwangsom",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde66",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde66",
+      "code": "RX-66",
+      "description": "APV-vergunning",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde67",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde67",
+      "code": "RX-67",
+      "description": "Melding toepassing bouwstoffen",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde68",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde68",
+      "code": "RX-68",
+      "description": "Opleveringscontrole",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde69",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde69",
+      "code": "RX-69",
+      "description": "Intrekken Omgevingsvergunning (ambtshalve)",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    },
+    {
+      "url": "https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde70",
+      "id": "1234abcd-12ab-34cd-56ef-12345abcde70",
+      "code": "RX-70",
+      "description": "Handhavingsverzoek",
+      "streeftermijn": "P0D",
+      "uiterlijkeTermijn": "P0D"
+    }
+  ]
+}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4235,6 +4235,62 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+  /api/v2/registration/plugins/zgw-api/products:
+    get:
+      operationId: registration_plugins_zgw_api_products_list
+      description: |-
+        Fetch and serialize a list of objects.
+
+        Alternative to :class:`rest_framework.mixins.ListModelMixin` for non-database
+        backed collections of objects.
+      summary: List the available products bound to a case type within a catalogue
+        (ZGW APIs)
+      parameters:
+      - in: query
+        name: case_type_identification
+        schema:
+          type: string
+          minLength: 1
+        description: Filter case types against this identification.
+        required: true
+      - in: query
+        name: catalogue_url
+        schema:
+          type: string
+          format: uri
+          title: catalogus URL
+          minLength: 1
+        description: Filter case types against this catalogue URL.
+        required: true
+      - in: query
+        name: zgw_api_group
+        schema:
+          type: integer
+        description: The primary key of the ZGW API group to use. The informatieobjecttypen
+          from the Catalogi API in this group will be returned.
+        required: true
+      tags:
+      - registration
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CaseTypeProduct'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/service-fetch-configurations:
     get:
       operationId: service_fetch_configurations_list
@@ -7042,6 +7098,17 @@ components:
       - description
       - identification
       - isPublished
+    CaseTypeProduct:
+      type: object
+      properties:
+        url:
+          type: string
+          description: 'The url of a product bound to a case type. '
+        description:
+          type: string
+          description: 'The description of a product bound to a case type. '
+      required:
+      - url
     Catalogue:
       type: object
       properties:

--- a/src/openforms/contrib/zgw/api/serializers.py
+++ b/src/openforms/contrib/zgw/api/serializers.py
@@ -56,6 +56,18 @@ class CaseTypeSerializer(serializers.Serializer):
     )
 
 
+class CaseTypeProductSerializer(serializers.Serializer):
+    url = serializers.CharField(
+        label=_("url"),
+        help_text=_("The url of a product bound to a case type. "),
+    )
+    description = serializers.CharField(
+        label=_("description"),
+        help_text=_("The description of a product bound to a case type. "),
+        required=False,
+    )
+
+
 # TODO: OF 3.0 -> use English instead of Dutch.
 class InformatieObjectTypeSerializer(serializers.Serializer):
     url = serializers.URLField(label=_("url"))

--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -48,6 +48,7 @@ class CaseType(TypedDict):
     beginGeldigheid: str  # ISO 8601 date string
     eindeGeldigheid: NotRequired[str | None]  # ISO 8601 date string or empty
     concept: NotRequired[bool]
+    productenOfDiensten: list[str]  # URL pointers to products
     informatieobjecttypen: NotRequired[list[str]]  # URL pointers to document types
 
 

--- a/src/openforms/contrib/zgw/clients/zaken.py
+++ b/src/openforms/contrib/zgw/clients/zaken.py
@@ -22,6 +22,7 @@ class ZakenClient(NLXClient):
         vertrouwelijkheidaanduiding: str = "",
         payment_required: bool = False,
         existing_reference: str = "",
+        product_url: str = "",
         **overrides,
     ):
         today = get_today()
@@ -31,6 +32,7 @@ class ZakenClient(NLXClient):
             "verantwoordelijkeOrganisatie": bronorganisatie,
             "registratiedatum": today,
             "startdatum": today,
+            "productenOfDiensten": [product_url] if product_url else [],
             "omschrijving": "Zaak naar aanleiding van ingezonden formulier",
             "toelichting": "Aangemaakt door Open Formulieren",
             "betalingsindicatie": "nog_niet" if payment_required else "nvt",

--- a/src/openforms/contrib/zgw/products_and_services.py
+++ b/src/openforms/contrib/zgw/products_and_services.py
@@ -1,0 +1,41 @@
+"""
+Support resolving products and services referenced by case types.
+
+.. warning:: Products and services integration is experimental. There is no standard for it yet.
+"""
+
+from typing import TypedDict
+
+from zgw_consumers.client import build_client
+from zgw_consumers.models import Service
+
+from openforms.contrib.zgw.clients.catalogi import CaseType
+
+
+class Product(TypedDict):
+    # This configuration is based on sample test data. This will have to be revisited when there is a real API spec.
+    # The sample data shows more attributes, but we currently don't use them.
+    url: str
+    description: str
+
+
+def resolve_case_type_products(case_type_versions: list[CaseType]) -> list[Product]:
+    all_urls: set[str] = set(
+        sum((version["productenOfDiensten"] for version in case_type_versions), [])
+    )
+    products: list[Product] = []
+
+    for url in all_urls:
+        description = ""
+
+        # Fetch product content
+        service = Service.get_service(url)
+        if service:
+            client = build_client(service)
+            response = client.get(url)
+            if response.ok:
+                description = response.json().get("description")
+
+        products.append(Product(url=url, description=description))
+
+    return products

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2623,6 +2623,12 @@
       "value": "The API group specifies which ZGW services to use."
     }
   ],
+  "O+M71I": [
+    {
+      "type": 0,
+      "value": "This product will be set on the created case."
+    }
+  ],
   "O/wKJh": [
     {
       "type": 0,
@@ -2733,6 +2739,12 @@
     {
       "type": 0,
       "value": "Yes"
+    }
+  ],
+  "Ox/rkB": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "P/njxS": [
@@ -5079,6 +5091,12 @@
       "value": "Subject of the email sent to the registration backend to notify a change in the payment status."
     }
   ],
+  "kWw9qL": [
+    {
+      "type": 0,
+      "value": "This product will be send allong form submits."
+    }
+  ],
   "kg/eh1": [
     {
       "type": 0,
@@ -5233,6 +5251,12 @@
     {
       "type": 0,
       "value": "Add item"
+    }
+  ],
+  "ln2iyc": [
+    {
+      "type": 0,
+      "value": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly."
     }
   ],
   "ln72CJ": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2644,6 +2644,12 @@
       "value": "De API-groep die bepaalt welke ZGW services gebruikt moeten worden."
     }
   ],
+  "O+M71I": [
+    {
+      "type": 0,
+      "value": "Dit product wordt op de aangemaakte zaak gezet."
+    }
+  ],
   "O/wKJh": [
     {
       "type": 0,
@@ -2754,6 +2760,12 @@
     {
       "type": 0,
       "value": "Ja"
+    }
+  ],
+  "Ox/rkB": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "P/njxS": [
@@ -5101,6 +5113,12 @@
       "value": "Subject of the email sent to the registration backend to notify a change in the payment status."
     }
   ],
+  "kWw9qL": [
+    {
+      "type": 0,
+      "value": "Dit product wordt met inzendingen meegestuurd."
+    }
+  ],
   "kg/eh1": [
     {
       "type": 0,
@@ -5255,6 +5273,12 @@
     {
       "type": 0,
       "value": "Item toevoegen"
+    }
+  ],
+  "ln2iyc": [
+    {
+      "type": 0,
+      "value": "Er ging iets fout bij het ophalen van de beschikbare catalogi of geselecteerde zaak producten. Controleer of de services in de geselecteerde API-groep goed ingesteld zijn."
     }
   ],
   "ln72CJ": [

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -10,6 +10,7 @@ import {
 } from 'components/admin/form_design/registrations/objectsapi/mocks';
 import {
   mockCaseTypesGet,
+  mockProductsGet,
   mockCataloguesGet as mockZGWApisCataloguesGet,
 } from 'components/admin/form_design/registrations/zgw/mocks';
 import {
@@ -510,7 +511,7 @@ export default {
           mockObjectsApiCataloguesGet(),
           mockDocumentTypesGet(),
         ],
-        zgwMocks: [mockZGWApisCataloguesGet(), mockCaseTypesGet()],
+        zgwMocks: [mockZGWApisCataloguesGet(), mockCaseTypesGet(), mockProductsGet()],
         camundaMocks: [mockProcessDefinitionsGet()],
       },
     },

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
@@ -5,23 +5,11 @@ import {useAsync} from 'react-use';
 
 import useConfirm from 'components/admin/form_design/useConfirm';
 import Fieldset from 'components/admin/forms/Fieldset';
-import {getCatalogueOption, groupAndSortCatalogueOptions} from 'components/admin/forms/zgw';
+import {getCatalogueOption} from 'components/admin/forms/zgw';
 import ErrorBoundary from 'components/errors/ErrorBoundary';
-import {get} from 'utils/fetch';
 
 import {CaseTypeSelect, CatalogueSelect, ZGWAPIGroup} from './fields';
-
-// Data fetching
-
-const CATALOGUES_ENDPOINT = '/api/v2/registration/plugins/zgw-api/catalogues';
-
-const getCatalogues = async apiGroupID => {
-  const response = await get(CATALOGUES_ENDPOINT, {zgw_api_group: apiGroupID});
-  if (!response.ok) {
-    throw new Error('Loading available catalogues failed');
-  }
-  return groupAndSortCatalogueOptions(response.data);
-};
+import {getCatalogues} from './utils';
 
 // Components
 

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/OptionalOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/OptionalOptionsFieldset.js
@@ -1,0 +1,74 @@
+import {useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+import {useAsync} from 'react-use';
+
+import Fieldset from 'components/admin/forms/Fieldset';
+import {getCatalogueOption} from 'components/admin/forms/zgw';
+import ErrorBoundary from 'components/errors/ErrorBoundary';
+
+import {ConfidentialityLevel, MedewerkerRoltype, OrganisationRSIN, ProductSelect} from './fields';
+import {getCatalogues} from './utils';
+
+const OptionalOptionsFieldset = ({confidentialityLevelChoices}) => {
+  return (
+    <Fieldset
+      title={
+        <FormattedMessage
+          description="ZGW APIs registration: default overrides fieldset title"
+          defaultMessage="Optional ZGW configuration"
+        />
+      }
+      fieldNames={['organisatieRsin']}
+    >
+      <div className="description">
+        <FormattedMessage
+          description="ZGW APIs defaults override informative message"
+          defaultMessage={`Any configuration option specified here overrides the
+          matching option of the selected API group.`}
+        />
+      </div>
+      <OrganisationRSIN />
+      <ConfidentialityLevel options={confidentialityLevelChoices} />
+      <MedewerkerRoltype />
+
+      <ErrorBoundary
+        errorMessage={
+          <FormattedMessage
+            description="ZGW APIs registrations options: case product error"
+            defaultMessage={`Something went wrong while retrieving the available
+            catalogues or products defined in the selected case. Please
+            check that the services in the selected API group are configured correctly.`}
+          />
+        }
+      >
+        <CatalogiApiField />
+      </ErrorBoundary>
+    </Fieldset>
+  );
+};
+
+const CatalogiApiField = () => {
+  const {
+    values: {zgwApiGroup = null, catalogue = undefined},
+  } = useFormikContext();
+
+  // fetch available catalogues and re-use the result
+  const {value: catalogueOptionGroups = [], error: cataloguesError} = useAsync(async () => {
+    if (!zgwApiGroup) return [];
+    return await getCatalogues(zgwApiGroup);
+  }, [zgwApiGroup]);
+  if (cataloguesError) throw cataloguesError;
+
+  const catalogueValue = getCatalogueOption(catalogueOptionGroups, catalogue || {});
+  const catalogueUrl = catalogueValue?.url;
+  return <ProductSelect catalogueUrl={catalogueUrl} />;
+};
+
+OptionalOptionsFieldset.propTypes = {
+  confidentialityLevelChoices: PropTypes.arrayOf(
+    PropTypes.arrayOf(PropTypes.string) // value & label are both string
+  ).isRequired,
+};
+
+export default OptionalOptionsFieldset;

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsForm.js
@@ -45,6 +45,7 @@ const ZGWOptionsForm = ({name, label, schema, formData, onChange}) => {
         zaakVertrouwelijkheidaanduiding: '',
         medewerkerRoltype: '',
         propertyMappings: [],
+        productUrl: '',
         // Ensure that this is explicitly set to null instead of undefined,
         // because the field is required by the serializer
         objectsApiGroup: null,

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.js
@@ -1,7 +1,7 @@
 import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {TabList, TabPanel, Tabs} from 'react-tabs';
 
 import Tab from 'components/admin/form_design/Tab';
@@ -16,15 +16,8 @@ import {ObjectsAPIGroup} from 'components/admin/forms/objects_api';
 
 import BasicOptionsFieldset from './BasicOptionsFieldset';
 import ManageVariableToPropertyMappings from './ManageVariableToPropertyMappings';
-import {
-  ConfidentialityLevel,
-  DocumentType,
-  LegacyCaseType,
-  MedewerkerRoltype,
-  ObjectType,
-  ObjectTypeVersion,
-  OrganisationRSIN,
-} from './fields';
+import OptionalOptionsFieldset from './OptionalOptionsFieldset';
+import {DocumentType, LegacyCaseType, ObjectType, ObjectTypeVersion} from './fields';
 
 /**
  * Callback to invoke when the API group changes - used to reset the dependent fields.
@@ -96,26 +89,7 @@ const ZGWFormFields = ({
             <DocumentType />
           </Fieldset>
 
-          <Fieldset
-            title={
-              <FormattedMessage
-                description="ZGW APIs registration: default overrides fieldset title"
-                defaultMessage="Optional ZGW configuration"
-              />
-            }
-            fieldNames={['organisatieRsin']}
-          >
-            <div className="description">
-              <FormattedMessage
-                description="ZGW APIs defaults override informative message"
-                defaultMessage={`Any configuration option specified here overrides the
-                matching option of the selected API group.`}
-              />
-            </div>
-            <OrganisationRSIN />
-            <ConfidentialityLevel options={confidentialityLevelChoices} />
-            <MedewerkerRoltype />
-          </Fieldset>
+          <OptionalOptionsFieldset confidentialityLevelChoices={confidentialityLevelChoices} />
 
           <Fieldset
             title={

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -9,7 +9,7 @@ import {
 } from 'components/admin/form_design/story-decorators';
 
 import ZGWFormFields from './ZGWOptionsFormFields';
-import {mockCaseTypesGet, mockCataloguesGet} from './mocks';
+import {mockCaseTypesGet, mockCataloguesGet, mockProductsGet} from './mocks';
 
 const NAME = 'form.registrationBackends.0.options';
 
@@ -54,7 +54,7 @@ export default {
   },
   parameters: {
     msw: {
-      handlers: [mockCataloguesGet(), mockCaseTypesGet()],
+      handlers: [mockCataloguesGet(), mockCaseTypesGet(), mockProductsGet()],
     },
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/fields/ProductSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/fields/ProductSelect.js
@@ -1,0 +1,79 @@
+import {useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+import useAsync from 'react-use/esm/useAsync';
+
+import Field from 'components/admin/forms/Field';
+import FormRow from 'components/admin/forms/FormRow';
+import ReactSelect from 'components/admin/forms/ReactSelect';
+import {get} from 'utils/fetch';
+
+const PRODUCTS_ENDPOINT = '/api/v2/registration/plugins/zgw-api/products';
+
+const getAvailableProducts = async (apiGroupID, catalogueUrl, caseTypeIdentification) => {
+  const response = await get(PRODUCTS_ENDPOINT, {
+    zgw_api_group: apiGroupID,
+    catalogue_url: catalogueUrl,
+    case_type_identification: caseTypeIdentification,
+  });
+  if (!response.ok) {
+    throw new Error('Loading available case type products failed');
+  }
+  return response.data.map(({url, description}) => ({
+    value: url,
+    label: description || url,
+  }));
+};
+
+const ProductSelect = ({catalogueUrl = ''}) => {
+  const {
+    values: {zgwApiGroup = null, caseTypeIdentification = ''},
+  } = useFormikContext();
+
+  const {
+    loading,
+    value: options = [],
+    error,
+  } = useAsync(async () => {
+    if (!zgwApiGroup || !catalogueUrl || !caseTypeIdentification) return [];
+    return await getAvailableProducts(zgwApiGroup, catalogueUrl, caseTypeIdentification);
+  }, [zgwApiGroup, catalogueUrl, caseTypeIdentification]);
+  if (error) throw error;
+
+  return (
+    <FormRow>
+      <Field
+        name="productUrl"
+        required={false}
+        label={
+          <FormattedMessage
+            description="ZGW APIs registration options 'product' label"
+            defaultMessage="Product"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="ZGW APIs registration options 'product' helpText"
+            defaultMessage="This product will be set on the created case."
+          />
+        }
+        noManageChildProps
+      >
+        <ReactSelect
+          name="productUrl"
+          options={options}
+          isLoading={loading}
+          isDisabled={!caseTypeIdentification}
+          required={false}
+          isClearable
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+ProductSelect.propTypes = {
+  catalogueUrl: PropTypes.string,
+};
+
+export default ProductSelect;

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/fields/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/fields/index.js
@@ -8,3 +8,4 @@ export {default as ConfidentialityLevel} from './ConfidentialityLevel';
 export {default as MedewerkerRoltype} from './MedewerkerRoltype';
 export {default as ObjectType} from './ObjectType';
 export {default as ObjectTypeVersion} from './ObjectTypeVersion';
+export {default as ProductSelect} from './ProductSelect';

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/mocks.js
@@ -79,3 +79,22 @@ export const mockCaseTypesGet = () =>
     const match = CASE_TYPES[catalogueUrl] ?? [];
     return res(ctx.json(match));
   });
+
+const PRODUCTS = [
+  {
+    uri: 'https://example.com/product/1234',
+  },
+  {
+    uri: 'https://example.com/product/4321',
+    description: undefined,
+  },
+  {
+    uri: 'https://example.com/product/1423',
+    description: 'Product 1423',
+  },
+];
+
+export const mockProductsGet = () =>
+  rest.get(`${API_BASE_URL}/api/v2/registration/plugins/zgw-api/products`, (req, res, ctx) => {
+    return res(ctx.json(PRODUCTS));
+  });

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/utils.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/utils.js
@@ -1,0 +1,14 @@
+import {groupAndSortCatalogueOptions} from 'components/admin/forms/zgw';
+import {get} from 'utils/fetch';
+
+const CATALOGUES_ENDPOINT = '/api/v2/registration/plugins/zgw-api/catalogues';
+
+const getCatalogues = async apiGroupID => {
+  const response = await get(CATALOGUES_ENDPOINT, {zgw_api_group: apiGroupID});
+  if (!response.ok) {
+    throw new Error('Loading available catalogues failed');
+  }
+  return groupAndSortCatalogueOptions(response.data);
+};
+
+export {getCatalogues};

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1274,6 +1274,11 @@
     "description": "ZGW APIs group field help text",
     "originalDefault": "The API group specifies which ZGW services to use."
   },
+  "O+M71I": {
+    "defaultMessage": "This product will be set on the created case.",
+    "description": "ZGW APIs registration options 'product' helpText",
+    "originalDefault": "This product will be set on the created case."
+  },
   "O/wKJh": {
     "defaultMessage": "Value",
     "description": "JSON (primitive) value label",
@@ -1323,6 +1328,11 @@
     "defaultMessage": "Yes",
     "description": "Component property boolean value \"true\"",
     "originalDefault": "Yes"
+  },
+  "Ox/rkB": {
+    "defaultMessage": "Product",
+    "description": "ZGW APIs registration options 'product' label",
+    "originalDefault": "Product"
   },
   "P/njxS": {
     "defaultMessage": "Datetime",
@@ -2374,6 +2384,11 @@
     "description": "Email registration options 'emailPaymentSubject' helpText",
     "originalDefault": "Subject of the email sent to the registration backend to notify a change in the payment status."
   },
+  "kWw9qL": {
+    "defaultMessage": "This product will be send allong form submits.",
+    "description": "ZGW APIs registration options 'product' helpText",
+    "originalDefault": "This product will be send allong form submits."
+  },
   "klKZV5": {
     "defaultMessage": "Indicates whether the existing object (retrieved from an optional initial data reference) should be updated, instead of creating a new one. If no existing object exists, a new one will be created instead.",
     "description": "Objects API registration: updateExistingObject helpText",
@@ -2408,6 +2423,11 @@
     "defaultMessage": "Add item",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
+  },
+  "ln2iyc": {
+    "defaultMessage": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly.",
+    "description": "ZGW APIs registrations options: case product error",
+    "originalDefault": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly."
   },
   "ln72CJ": {
     "defaultMessage": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1282,6 +1282,11 @@
     "description": "ZGW APIs group field help text",
     "originalDefault": "The API group specifies which ZGW services to use."
   },
+  "O+M71I": {
+    "defaultMessage": "Dit product wordt op de aangemaakte zaak gezet.",
+    "description": "ZGW APIs registration options 'product' helpText",
+    "originalDefault": "This product will be set on the created case."
+  },
   "O/wKJh": {
     "defaultMessage": "Waarde",
     "description": "JSON (primitive) value label",
@@ -1334,6 +1339,11 @@
     "defaultMessage": "Ja",
     "description": "Component property boolean value \"true\"",
     "originalDefault": "Yes"
+  },
+  "Ox/rkB": {
+    "defaultMessage": "Product",
+    "description": "ZGW APIs registration options 'product' label",
+    "originalDefault": "Product"
   },
   "P/njxS": {
     "defaultMessage": "Datumtijd (datetime)",
@@ -2392,6 +2402,11 @@
     "description": "Email registration options 'emailPaymentSubject' helpText",
     "originalDefault": "Subject of the email sent to the registration backend to notify a change in the payment status."
   },
+  "kWw9qL": {
+    "defaultMessage": "Dit product wordt met inzendingen meegestuurd.",
+    "description": "ZGW APIs registration options 'product' helpText",
+    "originalDefault": "This product will be send allong form submits."
+  },
   "klKZV5": {
     "defaultMessage": "Geeft aan of een bestaande record (verkregen van de eventuele voor-invulreferentie) bijgewerkt moet worden in plaats van een nieuw object aan te maken. Als er geen bestaand object is, dan wordt een nieuwe aangemaakt.",
     "description": "Objects API registration: updateExistingObject helpText",
@@ -2426,6 +2441,11 @@
     "defaultMessage": "Item toevoegen",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
+  },
+  "ln2iyc": {
+    "defaultMessage": "Er ging iets fout bij het ophalen van de beschikbare catalogi of geselecteerde zaak producten. Controleer of de services in de geselecteerde API-groep goed ingesteld zijn.",
+    "description": "ZGW APIs registrations options: case product error",
+    "originalDefault": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly."
   },
   "ln72CJ": {
     "defaultMessage": "Objecttyperesource-URL in de Objecttypen-API. Wanneer dit ingesteld is, dan wordt een object van dit type aangemaakt en aan de zaak gerelateerd.",

--- a/src/openforms/registrations/contrib/zgw_apis/api/filters.py
+++ b/src/openforms/registrations/contrib/zgw_apis/api/filters.py
@@ -54,3 +54,16 @@ class ListCaseTypesQueryParamsSerializer(ZGWAPIGroupMixin, serializers.Serialize
             "Catalogi API in this group will be returned."
         )
         return fields
+
+
+class ListProductsQueryParamsSerializer(ZGWAPIGroupMixin, serializers.Serializer):
+    catalogue_url = serializers.URLField(
+        label=_("catalogus URL"),
+        help_text=_("Filter case types against this catalogue URL."),
+        required=True,
+    )
+    case_type_identification = serializers.CharField(
+        label=_("case type identification"),
+        help_text=_("Filter case types against this identification."),
+        required=True,
+    )

--- a/src/openforms/registrations/contrib/zgw_apis/api/urls.py
+++ b/src/openforms/registrations/contrib/zgw_apis/api/urls.py
@@ -1,12 +1,18 @@
 from django.urls import path
 
-from .views import CaseTypesListView, CatalogueListView, InformatieObjectTypenListView
+from .views import (
+    CaseTypesListView,
+    CatalogueListView,
+    InformatieObjectTypenListView,
+    ProductsListView,
+)
 
 app_name = "zgw_apis"
 
 urlpatterns = [
     path("catalogues", CatalogueListView.as_view(), name="catalogue-list"),
     path("case-types", CaseTypesListView.as_view(), name="case-type-list"),
+    path("products", ProductsListView.as_view(), name="product-list"),
     path(
         "informatieobjecttypen",
         InformatieObjectTypenListView.as_view(),

--- a/src/openforms/registrations/contrib/zgw_apis/api/views.py
+++ b/src/openforms/registrations/contrib/zgw_apis/api/views.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -7,16 +8,22 @@ from rest_framework import authentication, permissions
 from rest_framework.views import APIView
 
 from openforms.api.views.mixins import ListMixin
-from openforms.contrib.zgw.api.serializers import CaseTypeSerializer
+from openforms.contrib.zgw.api.serializers import (
+    CaseTypeProductSerializer,
+    CaseTypeSerializer,
+)
 from openforms.contrib.zgw.api.views import (
     BaseCatalogueListView,
     BaseInformatieObjectTypenListView,
 )
+from openforms.contrib.zgw.products_and_services import resolve_case_type_products
+from openforms.utils.date import datetime_in_amsterdam
 
 from .filters import (
     APIGroupQueryParamsSerializer,
     ListCaseTypesQueryParamsSerializer,
     ListInformatieObjectTypenQueryParamsSerializer,
+    ListProductsQueryParamsSerializer,
 )
 
 
@@ -71,6 +78,60 @@ class CaseTypesListView(ListMixin[CaseType], APIView):
                 case_types.append(case_type)
 
         return case_types
+
+
+@dataclass
+class Product:
+    url: str
+    description: str = ""
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary=_(
+            "List the available products bound to a case type within a catalogue (ZGW APIs)"
+        ),
+        parameters=[ListProductsQueryParamsSerializer],
+    ),
+)
+class ProductsListView(ListMixin[Product], APIView):
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = CaseTypeProductSerializer
+
+    def get_objects(self):
+        filter_serializer = ListProductsQueryParamsSerializer(
+            data=self.request.query_params
+        )
+        filter_serializer.is_valid(raise_exception=True)
+
+        catalogue_url = filter_serializer.validated_data["catalogue_url"]
+        case_type_identification = filter_serializer.validated_data[
+            "case_type_identification"
+        ]
+        today = datetime_in_amsterdam(timezone.now()).date()
+
+        products: list[Product] = []
+        with filter_serializer.get_ztc_client() as client:
+            case_type_versions = client.find_case_types(
+                catalogus=catalogue_url,
+                identification=case_type_identification,
+                valid_on=today,
+            )
+            case_type_products = (
+                resolve_case_type_products(case_type_versions)
+                if case_type_versions
+                else []
+            )
+            for case_type_product in case_type_products:
+                products.append(
+                    Product(
+                        url=case_type_product["url"],
+                        description=case_type_product["description"],
+                    )
+                )
+
+        return products
 
 
 @extend_schema_view(

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -73,6 +73,15 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         ),
         default="",
     )
+    product_url = serializers.URLField(
+        required=False,
+        label=_("Product url"),
+        help_text=_(
+            "The product url will be retrieved from the specified case type "
+            "and the version that is active at that moment. "
+        ),
+        default="",
+    )
 
     # DeprecationWarning - deprecated, will be removed in OF 3.0 or 4.0
     zaaktype = serializers.URLField(

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -213,6 +213,7 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
                 vertrouwelijkheidaanduiding=options.get(
                     "zaak_vertrouwelijkheidaanduiding", ""
                 ),
+                product_url=options["product_url"],
                 payment_required=submission.payment_required,
                 existing_reference=submission.public_registration_reference,
                 **zaak_data,

--- a/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetProductsListViewTests/GetProductsListViewTests.test_fetch_products_by_case_type.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetProductsListViewTests/GetProductsListViewTests.test_fetch_products_by_case_type.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMDM5MDQwMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.oODonAK5RayuHVCDxPTAPXPPceRsFjhdHh0piNtOJbk
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=VRSN
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMDM5MDQwMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.oODonAK5RayuHVCDxPTAPXPPceRsFjhdHh0piNtOJbk
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&identificatie=ZT-001&datumGeldigheid=2024-10-31
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '2033'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetProductsListViewTests/GetProductsListViewTests.test_find_case_types_deduplicates_versions.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetProductsListViewTests/GetProductsListViewTests.test_find_case_types_deduplicates_versions.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMDM5MDQwMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.oODonAK5RayuHVCDxPTAPXPPceRsFjhdHh0piNtOJbk
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=VRSN
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMDM5MDQwMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.oODonAK5RayuHVCDxPTAPXPPceRsFjhdHh0piNtOJbk
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&identificatie=ZT-001&datumGeldigheid=2024-10-31
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '2033'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/ZGWBackendVCRTests/ZGWBackendVCRTests.test_create_zaak_with_case_identification_reference_and_product.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/ZGWBackendVCRTests/ZGWBackendVCRTests.test_create_zaak_with_case_identification_reference_and_product.yaml
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjEwODAwNiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.pZHlIr4P8BT4Tr3lHk3Ci61It5N4ladXIDKTlyoVfU4
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1072'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjEwODAwNiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.pZHlIr4P8BT4Tr3lHk3Ci61It5N4ladXIDKTlyoVfU4
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&identificatie=ZT-001&datumGeldigheid=2024-11-01
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '2033'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaaktype": "http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774",
+      "bronorganisatie": "000000000", "verantwoordelijkeOrganisatie": "000000000",
+      "registratiedatum": "2024-11-20", "startdatum": "2024-11-20", "productenOfDiensten":
+      ["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"], "omschrijving":
+      "Form 000", "toelichting": "Aangemaakt door Open Formulieren", "betalingsindicatie":
+      "nvt"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Crs:
+      - EPSG:4326
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjEwODAwNiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.pZHlIr4P8BT4Tr3lHk3Ci61It5N4ladXIDKTlyoVfU4
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '437'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaken
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/067ef050-d895-406c-b3f5-59863892908c","uuid":"067ef050-d895-406c-b3f5-59863892908c","identificatie":"ZAAK-2024-0000000014","bronorganisatie":"000000000","omschrijving":"Form
+        000","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","registratiedatum":"2024-11-20","verantwoordelijkeOrganisatie":"000000000","startdatum":"2024-11-20","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"vertrouwelijkheidaanduiding":"intern","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+        is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '1452'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaken/067ef050-d895-406c-b3f5-59863892908c
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Crs:
+      - EPSG:4326
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjEwODAwNiwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.pZHlIr4P8BT4Tr3lHk3Ci61It5N4ladXIDKTlyoVfU4
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8003/zaken/api/v1/zaken/067ef050-d895-406c-b3f5-59863892908c
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/067ef050-d895-406c-b3f5-59863892908c","uuid":"067ef050-d895-406c-b3f5-59863892908c","identificatie":"ZAAK-2024-0000000014","bronorganisatie":"000000000","omschrijving":"Form
+        000","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","registratiedatum":"2024-11-20","verantwoordelijkeOrganisatie":"000000000","startdatum":"2024-11-20","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"vertrouwelijkheidaanduiding":"intern","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+        is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '1452'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"caad4f655235604cf6a6e8a2f29ed5c1"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -248,6 +248,7 @@ class ZGWBackendTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -471,6 +472,7 @@ class ZGWBackendTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -680,6 +682,7 @@ class ZGWBackendTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -759,6 +762,7 @@ class ZGWBackendTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -969,6 +973,7 @@ class ZGWBackendTests(TestCase):
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "medewerker_roltype": "Some description",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
         m.get(
@@ -1042,6 +1047,7 @@ class ZGWBackendTests(TestCase):
             "zaaktype": "https://catalogi.nl/api/v1/zaaktypen/1",
             "informatieobjecttype": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
             "product_url": "https://example.com",
+            "objects_api_group": None,
         }
         self.install_mocks(m)
 
@@ -1093,6 +1099,7 @@ class ZGWBackendTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
         roltypen_url = furl("https://catalogus.nl/api/v1/roltypen").set(
@@ -1167,6 +1174,7 @@ class ZGWBackendTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "doc_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
         m.patch(
@@ -1252,6 +1260,7 @@ class ZGWBackendTests(TestCase):
             "organisatie_rsin": "000000000",
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         SubmissionFileAttachmentFactory.create(
             submission_step=SubmissionStep.objects.first(),
@@ -1360,6 +1369,7 @@ class ZGWBackendTests(TestCase):
             "zaaktype": "https://catalogi.nl/api/v1/zaaktypen/1",
             "informatieobjecttype": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -1433,6 +1443,7 @@ class ZGWBackendTests(TestCase):
             "zaaktype": "https://catalogi.nl/api/v1/zaaktypen/1",
             "informatieobjecttype": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -1487,6 +1498,7 @@ class ZGWBackendTests(TestCase):
             "informatieobjecttype": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
             "auteur": "",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -1522,6 +1534,7 @@ class ZGWBackendTests(TestCase):
             "auteur": "",
             "zaak_vertrouwelijkheidaanduiding": "",  # type: ignore
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
         plugin = ZGWRegistration("zgw")
@@ -1582,6 +1595,7 @@ class ZGWBackendTests(TestCase):
             "organisatie_rsin": "000000000",
             "zaak_vertrouwelijkheidaanduiding": "openbaar",
             "objects_api_group": None,
+            "product_url": "",
         }
         SubmissionFileAttachmentFactory.create(
             submission_step=SubmissionStep.objects.first(),
@@ -1796,6 +1810,7 @@ class ZGWBackendTests(TestCase):
             "objects_api_group": objects_api_group,
             "objecttype": "https://objecttypen.nl/api/v1/objecttypes/2",
             "objecttype_version": 1,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -1910,6 +1925,7 @@ class ZGWBackendTests(TestCase):
                 {"component_key": "textField2", "eigenschap": "second property"},
             ],
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -2116,6 +2132,7 @@ class ZGWBackendTests(TestCase):
                 {"component_key": "textField3.blah", "eigenschap": "third property"},
             ],
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -2339,6 +2356,7 @@ class ZGWBackendTests(TestCase):
                 "auteur": "",
                 "zaak_vertrouwelijkheidaanduiding": "",  # type: ignore
                 "objects_api_group": None,
+                "product_url": "",
             }
             self.install_mocks(m)
             plugin = ZGWRegistration("zgw")
@@ -2365,6 +2383,7 @@ class ZGWBackendTests(TestCase):
                 "auteur": "",
                 "zaak_vertrouwelijkheidaanduiding": "",  # type: ignore
                 "objects_api_group": None,
+                "product_url": "",
             }
             self.install_mocks(m)
             plugin = ZGWRegistration("zgw")
@@ -2424,6 +2443,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 "http://localhost:8003/catalogi/api/v1/"
                 "informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7"
             ),
+            "product_url": "",
             "medewerker_roltype": "Baliemedewerker",
             "property_mappings": [
                 {
@@ -2487,6 +2507,56 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 "7f1887e8-bf22-47e7-ae52-ed6848d7e70e",
             )
 
+    def test_create_zaak_with_case_identification_reference_and_product(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "textfield",
+                    "key": "someText",
+                    "label": "Some text",
+                }
+            ],
+            submitted_data={
+                "someText": "Foo",
+            },
+            bsn="123456782",
+            completed=True,
+            # Pin to a known case type version
+            completed_on=datetime(2024, 11, 1, 15, 30, 0).replace(tzinfo=timezone.utc),
+        )
+        options: RegistrationOptions = {
+            "zgw_api_group": self.zgw_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "ZT-001",
+            "zaaktype": "",
+            "informatieobjecttype": (
+                "http://localhost:8003/catalogi/api/v1/"
+                "informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            "product_url": "http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10",
+            "objects_api_group": None,
+        }
+        plugin = ZGWRegistration("zgw")
+
+        result = plugin.pre_register_submission(submission, options)
+
+        assert result.data is not None
+        zaak_url = result.data["zaak"]["url"]
+        with get_zaken_client(self.zgw_group) as client:
+            zaak_data = client.get(zaak_url, headers=CRS_HEADERS).json()
+
+        self.assertEqual(
+            zaak_data["zaaktype"],
+            "http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774",
+        )
+        self.assertEqual(
+            zaak_data["productenOfDiensten"],
+            ["http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10"],
+        )
+
     @enable_feature_flag("ZGW_APIS_INCLUDE_DRAFTS")
     def test_allow_registration_with_unpublished_case_types(self):
         zgw_group = ZGWApiGroupConfigFactory.create(
@@ -2519,6 +2589,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 "http://localhost:8003/catalogi/api/v1/"
                 "informatieobjecttypen/3628d25f-f491-4375-a752-39d16bf2dd59"
             ),
+            "product_url": "",
             "objects_api_group": None,
         }
         plugin = ZGWRegistration("zgw")

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_zgw_api_config.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_zgw_api_config.py
@@ -325,6 +325,7 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
             "zaaktype": "https://catalogi-2.nl/api/v1/zaaktypen/1",
             "informatieobjecttype": "https://catalogi-2.nl/api/v1/informatieobjecttypen/1",
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 
@@ -364,6 +365,7 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.confidentieel,  # type: ignore
             "doc_vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.geheim,  # type: ignore
             "objects_api_group": None,
+            "product_url": "",
         }
 
         self.install_mocks(m)
@@ -455,6 +457,7 @@ class ZGWRegistrationMultipleZGWAPIsTests(TestCase):
             "zaak_vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.confidentieel,  # type: ignore
             "doc_vertrouwelijkheidaanduiding": VertrouwelijkheidsAanduidingen.geheim,  # type: ignore
             "objects_api_group": None,
+            "product_url": "",
         }
         self.install_mocks(m)
 

--- a/src/openforms/registrations/contrib/zgw_apis/typing.py
+++ b/src/openforms/registrations/contrib/zgw_apis/typing.py
@@ -34,6 +34,7 @@ class RegistrationOptions(TypedDict):
     zgw_api_group: ZGWApiGroupConfig
     catalogue: NotRequired[CatalogueOption]
     case_type_identification: str
+    product_url: str  # URL reference to a product in the case type
     zaaktype: str  # DeprecationWarning
     informatieobjecttype: str
     organisatie_rsin: NotRequired[str]

--- a/src/openforms/submissions/tests/test_on_completion_retry_chain.py
+++ b/src/openforms/submissions/tests/test_on_completion_retry_chain.py
@@ -248,6 +248,7 @@ class OnCompletionRetryFailedRegistrationTests(TestCase):
                 "zaaktype": "https://catalogi.nl/api/v1/zaaktypen/1",
                 "informatieobjecttype": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
                 "objects_api_group": None,
+                "product_url": "http://example.com",
             },
             # registration failed, so an internal reference was created
             public_registration_reference="OF-1234",
@@ -283,6 +284,7 @@ class OnCompletionRetryFailedRegistrationTests(TestCase):
                 "zaaktype": "https://catalogi.nl/api/v1/zaaktypen/1",
                 "informatieobjecttype": "https://catalogi.nl/api/v1/informatieobjecttypen/1",
                 "objects_api_group": None,
+                "product_url": "http://example.com",
             },
         )
         self.assertNotEqual(submission.last_register_date, original_register_date)


### PR DESCRIPTION
Closes #4796 

**Changes**

Added product as a configuration option to the ZGW API registration. The product select gets populated from the selected case type. If there are multiple versions of the case type, then the case type version that is active at the moment of configuring is chosen.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
