### PR TITLE
:bug: [#4726] Fixing the styling for form delete buttons

### DIFF
--- a/src/openforms/scss/components/builder/_admin-fixes.scss
+++ b/src/openforms/scss/components/builder/_admin-fixes.scss
@@ -9,6 +9,10 @@
   height: auto;
 }
 
+.submit-row .deletelink {
+  box-sizing: content-box;
+}
+
 .formio-dialog-content {
   margin: 50px auto !important;
 }


### PR DESCRIPTION
Closes #4726 

**Changes**

Fixing the broken styling of delete buttons (`.deletelink`) inside the `.submit-row` element.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
