### PR TITLE
:bug: [#4763] Allow temporary file uploads to be deleted

### DIFF
--- a/src/openforms/submissions/admin.py
+++ b/src/openforms/submissions/admin.py
@@ -22,7 +22,6 @@ from openforms.logging.logevent import (
 from openforms.logging.models import TimelineLogProxy
 from openforms.payments.models import SubmissionPayment
 
-from ..utils.admin import ReadOnlyAdminMixin
 from .constants import IMAGE_COMPONENTS, PostSubmissionEvents, RegistrationStatuses
 from .exports import ExportFileTypes, export_submissions
 from .models import (
@@ -485,7 +484,7 @@ class TemporaryFileUploadMediaView(PrivateMediaView):
 
 
 @admin.register(TemporaryFileUpload)
-class TemporaryFileUploadAdmin(ReadOnlyAdminMixin, PrivateMediaMixin, admin.ModelAdmin):
+class TemporaryFileUploadAdmin(PrivateMediaMixin, admin.ModelAdmin):
     list_display = (
         "uuid",
         "file_name",
@@ -518,6 +517,12 @@ class TemporaryFileUploadAdmin(ReadOnlyAdminMixin, PrivateMediaMixin, admin.Mode
 
     def file_size(self, obj):
         return filesizeformat(obj.content.size)
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
 
     file_size.short_description = _("File size")
 


### PR DESCRIPTION
Closes #4763 

**Changes**

Temporary file uploads can now be deleted, solving the deletion issue of form submissions with file uploads

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
