### PR TITLE
Broken react select styling for large values

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -325,7 +325,7 @@ export const DraftDocumentTypesFeatureFlagOn = {
         rsin: '111111111',
         domain: 'TEST',
       },
-      iotSubmissionReport: 'A rather long draft description',
+      iotSubmissionReport: 'Document type 4 with a rather long draft description',
       iotSubmissionCsv: 'Not-found documenttype',
     },
   },

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
@@ -3,6 +3,7 @@ import {useField, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import {useContext, useEffect} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
+import {components} from 'react-select';
 import {useAsync, usePrevious} from 'react-use';
 
 import {FeatureFlagsContext} from 'components/admin/form_design/Context';
@@ -42,7 +43,17 @@ const getDocumentTypes = async (apiGroupID, catalogueUrl) => {
   const documentTypes = response.data.sort((a, b) => a.omschrijving.localeCompare(b.omschrijving));
   return documentTypes.map(({omschrijving, isPublished}) => ({
     value: omschrijving,
-    label: (
+    label: omschrijving,
+    isPublished: isPublished,
+  }));
+};
+
+// Components
+
+const DocumentTypeSelectOption = props => {
+  const {isPublished, label} = props.data;
+  return (
+    <components.Option {...props}>
       <span
         className={classNames('catalogi-type-option', {
           'catalogi-type-option--draft': !isPublished,
@@ -50,19 +61,17 @@ const getDocumentTypes = async (apiGroupID, catalogueUrl) => {
       >
         <FormattedMessage
           description="Document type option label"
-          defaultMessage={`{omschrijving} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
+          defaultMessage={`{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
           values={{
-            omschrijving,
+            label,
             isPublished,
             draft: chunks => <span className="catalogi-type-option__draft-suffix">{chunks}</span>,
           }}
         />
       </span>
-    ),
-  }));
+    </components.Option>
+  );
 };
-
-// Components
 
 const DocumentType = ({name, label, loading, options, isDisabled, helpText}) => {
   const intl = useIntl();
@@ -91,6 +100,7 @@ const DocumentType = ({name, label, loading, options, isDisabled, helpText}) => 
               setValue(selectedOption ? selectedOption.value : undefined);
             }}
             isClearable
+            components={{Option: DocumentTypeSelectOption}}
           />
           {showWarning && (
             <WarningIcon

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/mocks.js
@@ -105,7 +105,7 @@ const DOCUMENT_TYPES = {
     },
     {
       url: 'https://example.com/catalogi/api/v1/iot/13',
-      omschrijving: 'A rather long draft description',
+      omschrijving: 'Document type 4 with a rather long draft description',
       catalogusLabel: 'TEST (111111111)',
       isPublished: false,
     },

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/fields/CaseTypeSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/fields/CaseTypeSelect.js
@@ -1,7 +1,9 @@
 import classNames from 'classnames';
 import {useField, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {FormattedMessage} from 'react-intl';
+import {components} from 'react-select';
 import useAsync from 'react-use/esm/useAsync';
 
 import Field from 'components/admin/forms/Field';
@@ -22,7 +24,17 @@ const getAvailableCaseTypes = async (apiGroupID, catalogueUrl) => {
   const caseTypes = response.data.sort((a, b) => a.description.localeCompare(b.description));
   return caseTypes.map(({identification, description, isPublished}) => ({
     value: identification,
-    label: (
+    label: description,
+    isPublished: isPublished,
+  }));
+};
+
+// Components
+
+const CaseTypeSelectOption = props => {
+  const {isPublished, label} = props.data;
+  return (
+    <components.Option {...props}>
       <span
         className={classNames('catalogi-type-option', {
           'catalogi-type-option--draft': !isPublished,
@@ -30,16 +42,16 @@ const getAvailableCaseTypes = async (apiGroupID, catalogueUrl) => {
       >
         <FormattedMessage
           description="Case type option label"
-          defaultMessage={`{description} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
+          defaultMessage={`{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
           values={{
-            description,
+            label,
             isPublished,
             draft: chunks => <span className="catalogi-type-option__draft-suffix">{chunks}</span>,
           }}
         />
       </span>
-    ),
-  }));
+    </components.Option>
+  );
 };
 
 const CaseTypeSelect = ({catalogueUrl = ''}) => {
@@ -88,6 +100,7 @@ const CaseTypeSelect = ({catalogueUrl = ''}) => {
           // TODO: make required once legacy config is dropped
           required={false}
           isClearable
+          components={{Option: CaseTypeSelectOption}}
           onChange={selectedOption => {
             setValue(selectedOption ? selectedOption.value : undefined);
           }}

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/mocks.js
@@ -65,6 +65,11 @@ const CASE_TYPES = {
       description: 'Draft case type',
       isPublished: false,
     },
+    {
+      identification: 'ZT23',
+      description: 'Published case type with a rather long description',
+      isPublished: true,
+    },
   ],
 };
 

--- a/src/openforms/scss/components/admin/_catalogi-type-option.scss
+++ b/src/openforms/scss/components/admin/_catalogi-type-option.scss
@@ -7,10 +7,5 @@
 
   @include bem.element('draft-suffix') {
     color: var(--body-quiet-color);
-
-    // only display the suffix in the dropdown
-    @at-root .admin-react-select__value-container & {
-      display: none;
-    }
   }
 }

--- a/src/openforms/scss/vendor/_react-select.scss
+++ b/src/openforms/scss/vendor/_react-select.scss
@@ -25,4 +25,5 @@
     100%,
     var(--of-admin-select-max-inline-size)
   );
+  max-inline-size: var(--of-admin-select-max-inline-size);
 }


### PR DESCRIPTION
Closes #4802

**Changes**

- Fixing the bug by ensuring that the `.admin-react-select` element can't grow beyond its max-inline-size
- Replaced the `DocumentTypes` and `CaseTypeSelect` select option html labels with simple text labels. The html labels are now added as a custom Option component for the ReactSelect. This means that the html labels will only be used when the option is presented in the dropdown, otherwise the simple text label will be used.
- Updated the storybook mock data to showcase large option labels for DocumentTypes and CaseTypeSelect

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
