### PR TITLE
Feature/4798 custom confirmation modal

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import '../src/openforms/scss/screen.scss';
 import '../src/openforms/scss/admin/admin_overrides.scss';
+import {withModalDecorator} from 'components/admin/form_design/story-decorators';
 import {initialize, mswDecorator, mswLoader} from 'msw-storybook-addon';
 import {reactIntl} from './reactIntl.js';
 import ReactModal from 'react-modal';
@@ -14,7 +15,7 @@ initialize({
 ReactModal.setAppElement(document.getElementById('storybook-root'));
 
 export default {
-  decorators: [mswDecorator],
+  decorators: [mswDecorator, withModalDecorator],
   parameters: {
     controls: {
       matchers: {

--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -1112,10 +1112,10 @@ class FormDesignerRegressionTests(E2ETestCase):
             await page.get_by_role("button", name="Confirm").click()
 
             # Delete initial form definition
-            page.on("dialog", lambda dialog: dialog.accept())
             sidebar = page.locator("css=.edit-panel__nav").get_by_role("list")
             bin_icon = sidebar.get_by_role("listitem").nth(0).get_by_title("Delete")
             await bin_icon.click()
+            await page.get_by_role("button", name="Confirm").click()
 
             await expect(page.get_by_text("Form definition 1")).not_to_be_visible()
 
@@ -1164,10 +1164,10 @@ class FormDesignerRegressionTests(E2ETestCase):
             await page.get_by_role("tab", name="Steps and fields").click()
 
             # Delete the second step
-            page.on("dialog", lambda dialog: dialog.accept())
             sidebar = page.locator("css=.edit-panel__nav").get_by_role("list")
             bin_icon = sidebar.get_by_role("listitem").nth(1).get_by_title("Delete")
             await bin_icon.click()
+            await page.get_by_role("button", name="Confirm").click()
 
             await page.get_by_role("tab", name="Logic").click()
 
@@ -1804,9 +1804,9 @@ class SelectReuseableFormDefinitionsTests(E2ETestCase):
             await page.get_by_title("Sluiten").click()
 
             # Delete the second step
-            page.on("dialog", lambda dialog: dialog.accept())
             sidebar = page.locator("css=.edit-panel__nav").get_by_role("list")
             await sidebar.get_by_role("listitem").nth(1).get_by_title("Delete").click()
+            await page.get_by_role("button", name="Confirm").click()
 
             # Select third form step and open selectbox
             await sidebar.get_by_role("listitem").nth(1).get_by_text(

--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -1801,7 +1801,7 @@ class SelectReuseableFormDefinitionsTests(E2ETestCase):
             await expect(selectbox).not_to_contain_text("FORM DEFINITION #3")
 
             # Close model
-            await page.get_by_title("Sluiten").click()
+            await page.get_by_role("button", name="Sluiten").click()
 
             # Delete the second step
             sidebar = page.locator("css=.edit-panel__nav").get_by_role("list")

--- a/src/openforms/forms/tests/e2e_tests/test_service_fetch.py
+++ b/src/openforms/forms/tests/e2e_tests/test_service_fetch.py
@@ -214,7 +214,7 @@ class FormDesignerServiceFetchConfigurationTests(E2ETestCase):
             ).to_be_visible()
             await page.get_by_role("button", name="Configure").click()
             await check_service_fetch_form_values(page, data)
-            await page.get_by_title("Sluiten").click()
+            await page.get_by_role("button", name="Sluiten").click()
 
             await page.get_by_text("Save and continue editing").click()
             await page.get_by_role("tab", name="Logic").click()
@@ -297,7 +297,7 @@ class FormDesignerServiceFetchConfigurationTests(E2ETestCase):
             ).to_be_visible()
             await page.get_by_role("button", name="Configure").click()
             await check_service_fetch_form_values(page, data)
-            await page.get_by_title("Sluiten").click()
+            await page.get_by_role("button", name="Sluiten").click()
 
             await page.get_by_text("Save and continue editing").click()
             await page.get_by_role("tab", name="Logic").click()
@@ -427,7 +427,7 @@ class FormDesignerServiceFetchConfigurationTests(E2ETestCase):
                     mapping_expression=".bar",
                 ),
             )
-            await page.get_by_title("Sluiten").click()
+            await page.get_by_role("button", name="Sluiten").click()
 
             await page.get_by_text("Save and continue editing").click()
             await page.get_by_role("tab", name="Logic").click()
@@ -565,7 +565,7 @@ class FormDesignerServiceFetchConfigurationTests(E2ETestCase):
                     mapping_expression=".bar",
                 ),
             )
-            await page.get_by_title("Sluiten").click()
+            await page.get_by_role("button", name="Sluiten").click()
 
             await page.get_by_text("Save and continue editing").click()
             await page.get_by_role("tab", name="Logic").click()

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2499,6 +2499,12 @@
       "value": "Change text"
     }
   ],
+  "M9JbDC": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
   "MEkGHD": [
     {
       "type": 0,
@@ -4599,6 +4605,12 @@
     {
       "type": 0,
       "value": "."
+    }
+  ],
+  "gpiYPI": [
+    {
+      "type": 0,
+      "value": "Confirm"
     }
   ],
   "gqVGbb": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2520,6 +2520,12 @@
       "value": "'Wijzigen' tekst"
     }
   ],
+  "M9JbDC": [
+    {
+      "type": 0,
+      "value": "Annuleren"
+    }
+  ],
   "MEkGHD": [
     {
       "type": 0,
@@ -4621,6 +4627,12 @@
     {
       "type": 0,
       "value": "."
+    }
+  ],
+  "gpiYPI": [
+    {
+      "type": 0,
+      "value": "Accepteren"
     }
   ],
   "gqVGbb": [

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -61,6 +61,7 @@ import {
   initialFormTranslations,
   initialStepTranslations,
 } from './translations';
+import useConfirm from './useConfirm';
 import {
   checkKeyChange,
   findComponent,
@@ -1071,6 +1072,15 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
     }
   }, [loading]);
 
+  const [UserVariableConfirmationModal, confirmUserVariableChange] = useConfirm(
+    intl.formatMessage({
+      description:
+        'Changing user variable data type and transforming initial value confirmation message',
+      defaultMessage:
+        'Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?',
+    })
+  );
+
   /**
    * Functions for handling events
    */
@@ -1255,17 +1265,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
     }
 
     // Check if the dataType change is intentional.
-    if (
-      propertyName === 'dataType' &&
-      !window.confirm(
-        intl.formatMessage({
-          description:
-            'Changing user variable data type and transforming initial value confirmation message',
-          defaultMessage:
-            'Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?',
-        })
-      )
-    ) {
+    if (propertyName === 'dataType' && !(await confirmUserVariableChange())) {
       return;
     }
 
@@ -1567,6 +1567,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
         </Tabs>
       </FormContext.Provider>
 
+      <UserVariableConfirmationModal />
       <FormSubmit onSubmit={onSubmit} displayActions={!state.newForm} />
     </ValidationErrorsProvider>
   );

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1072,14 +1072,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
     }
   }, [loading]);
 
-  const [UserVariableConfirmationModal, confirmUserVariableChange] = useConfirm(
-    intl.formatMessage({
-      description:
-        'Changing user variable data type and transforming initial value confirmation message',
-      defaultMessage:
-        'Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?',
-    })
-  );
+  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
 
   /**
    * Functions for handling events
@@ -1265,7 +1258,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
     }
 
     // Check if the dataType change is intentional.
-    if (propertyName === 'dataType' && !(await confirmUserVariableChange())) {
+    if (propertyName === 'dataType' && !(await openConfirmationModal())) {
       return;
     }
 
@@ -1567,7 +1560,15 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
         </Tabs>
       </FormContext.Provider>
 
-      <UserVariableConfirmationModal />
+      <ConfirmationModal
+        {...confirmationModalProps}
+        message={
+          <FormattedMessage
+            description="Changing user variable data type and transforming initial value confirmation message"
+            defaultMessage="Changing the data type requires the initial value to be changed. This will reset the initial value back to the empty value. Are you sure that you want to do this?"
+          />
+        }
+      />
       <FormSubmit onSubmit={onSubmit} displayActions={!state.newForm} />
     </ValidationErrorsProvider>
   );

--- a/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.stories.js
@@ -1,4 +1,4 @@
-import {expect, fireEvent, fn, screen, userEvent, waitFor, within} from '@storybook/test';
+import {expect, fireEvent, fn, userEvent, waitFor, within} from '@storybook/test';
 import selectEvent from 'react-select-event';
 
 import {
@@ -271,7 +271,7 @@ export const Empty = {
       await userEvent.click(button);
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );

--- a/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNActionConfig.stories.js
@@ -1,4 +1,4 @@
-import {expect, findByRole, fireEvent, fn, userEvent, waitFor, within} from '@storybook/test';
+import {expect, fireEvent, fn, screen, userEvent, waitFor, within} from '@storybook/test';
 import selectEvent from 'react-select-event';
 
 import {
@@ -189,8 +189,6 @@ export const Empty = {
   },
   play: async ({canvasElement, step, args}) => {
     const canvas = within(canvasElement);
-    const originalConfirm = window.confirm;
-    window.confirm = () => true;
 
     const pluginDropdown = canvas.getByLabelText('Plugin');
     const decisionDefDropdown = canvas.getByLabelText('Beslisdefinitie-ID');
@@ -271,6 +269,12 @@ export const Empty = {
       const button = canvas.getByTitle('Verwijderen');
 
       await userEvent.click(button);
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
 
       const varsDropdowns = within(
         document.querySelector('.logic-dmn__mapping-config')
@@ -282,8 +286,6 @@ export const Empty = {
       await expect(varsDropdowns.length).toBe(0);
       await expect(textInput.length).toBe(0);
     });
-
-    window.confirm = originalConfirm;
   },
 };
 

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -36,8 +36,16 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
     description: 'Objects API registration backend: v2 switch warning message',
   });
 
-  const [ConfirmationModalV1, confirmUsingV1] = useConfirm(v1SwitchMessage);
-  const [ConfirmationModalV2, confirmUsingV2] = useConfirm(v2SwitchMessage);
+  const {
+    ConfirmationModal: ConfirmationModalV1,
+    confirmationModalProps: confirmationModalV1Props,
+    openConfirmationModal: confirmUsingV1,
+  } = useConfirm();
+  const {
+    ConfirmationModal: ConfirmationModalV2,
+    confirmationModalProps: confirmationModalV2Props,
+    openConfirmationModal: confirmUsingV2,
+  } = useConfirm();
 
   const changeVersion = async tabIndex => {
     const newVersion = tabIndex + 1;
@@ -100,8 +108,8 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
           <V2ConfigFields apiGroupChoices={apiGroupChoices} />
         </TabPanel>
       </Tabs>
-      <ConfirmationModalV1 />
-      <ConfirmationModalV2 />
+      <ConfirmationModalV1 {...confirmationModalV1Props} message={v1SwitchMessage} />
+      <ConfirmationModalV2 {...confirmationModalV2Props} message={v2SwitchMessage} />
     </ValidationErrorsProvider>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -5,6 +5,7 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {TabList, TabPanel, Tabs} from 'react-tabs';
 
 import Tab from 'components/admin/form_design/Tab';
+import useConfirm from 'components/admin/form_design/useConfirm';
 import {
   ValidationErrorContext,
   ValidationErrorsProvider,
@@ -35,7 +36,10 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
     description: 'Objects API registration backend: v2 switch warning message',
   });
 
-  const changeVersion = tabIndex => {
+  const [ConfirmationModalV1, confirmUsingV1] = useConfirm(v1SwitchMessage);
+  const [ConfirmationModalV2, confirmUsingV2] = useConfirm(v2SwitchMessage);
+
+  const changeVersion = async tabIndex => {
     const newVersion = tabIndex + 1;
 
     // change form fields values depending on the newly selected version
@@ -43,14 +47,14 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
 
     switch (newVersion) {
       case 1: {
-        const confirmV1Switch = window.confirm(v1SwitchMessage);
+        const confirmV1Switch = await confirmUsingV1();
         if (!confirmV1Switch) return;
         delete newValues.variablesMapping;
         delete newValues.geometryVariableKey;
         break;
       }
       case 2: {
-        const confirmV2Switch = window.confirm(v2SwitchMessage);
+        const confirmV2Switch = await confirmUsingV2();
         if (!confirmV2Switch) return;
         newValues.variablesMapping = [];
         newValues.geometryVariableKey = '';
@@ -96,6 +100,8 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
           <V2ConfigFields apiGroupChoices={apiGroupChoices} />
         </TabPanel>
       </Tabs>
+      <ConfirmationModalV1 />
+      <ConfirmationModalV2 />
     </ValidationErrorsProvider>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -1,4 +1,4 @@
-import {expect, fn, userEvent, waitFor, within} from '@storybook/test';
+import {expect, fn, screen, userEvent, waitFor, within} from '@storybook/test';
 import {Form, Formik} from 'formik';
 import selectEvent from 'react-select-event';
 
@@ -74,11 +74,22 @@ export const Default = {};
 
 export const SwitchToV2Empty = {
   play: async ({canvasElement}) => {
-    window.confirm = fn(() => true);
     const canvas = within(canvasElement);
 
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
     await userEvent.click(v2Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v2Tab to be the selected tab
+      expect(v2Tab).toHaveAttribute('aria-selected', 'true');
+    });
 
     const groupSelect = canvas.getByLabelText('API-groep');
     await selectEvent.select(groupSelect, 'Objects API group 1');
@@ -95,6 +106,19 @@ export const SwitchToV2Empty = {
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v1Tab to be the selected tab
+      expect(v1Tab).toHaveAttribute('aria-selected', 'true');
+    });
+
     await waitFor(() => {
       expect(testForm).toHaveFormValues({
         objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
@@ -113,11 +137,22 @@ export const SwitchToV2Existing = {
     },
   },
   play: async ({canvasElement}) => {
-    window.confirm = fn(() => true);
     const canvas = within(canvasElement);
 
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
     await userEvent.click(v2Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v2Tab to be the selected tab
+      expect(v2Tab).toHaveAttribute('aria-selected', 'true');
+    });
 
     const testForm = await canvas.findByTestId('test-form');
 
@@ -133,6 +168,19 @@ export const SwitchToV2Existing = {
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v1Tab to be the selected tab
+      expect(v1Tab).toHaveAttribute('aria-selected', 'true');
+    });
+
     await waitFor(() => {
       expect(testForm).toHaveFormValues({
         objectsApiGroup: '1',
@@ -152,11 +200,22 @@ export const SwitchToV2NonExisting = {
     },
   },
   play: async ({canvasElement}) => {
-    window.confirm = fn(() => true);
     const canvas = within(canvasElement);
 
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
     await userEvent.click(v2Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v2Tab to be the selected tab
+      expect(v2Tab).toHaveAttribute('aria-selected', 'true');
+    });
 
     const testForm = await canvas.findByTestId('test-form');
     await waitFor(() => {
@@ -170,6 +229,19 @@ export const SwitchToV2NonExisting = {
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v2Tab to be the selected tab
+      expect(v1Tab).toHaveAttribute('aria-selected', 'true');
+    });
+
     await waitFor(() => {
       expect(testForm).toHaveFormValues({
         objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
@@ -189,11 +261,22 @@ export const APIFetchError = {
     },
   },
   play: async ({canvasElement, step}) => {
-    window.confirm = fn(() => true);
     const canvas = within(canvasElement);
 
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
     await userEvent.click(v2Tab);
+
+    await waitFor(async () => {
+      // Close the confirmation modal
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', {
+          name: 'Accepteren',
+        })
+      );
+
+      // Expect v2Tab to be the selected tab
+      expect(v2Tab).toHaveAttribute('aria-selected', 'true');
+    });
 
     await step('Retrieving object types', async () => {
       const groupSelect = canvas.getByLabelText('API-groep');

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -1,4 +1,4 @@
-import {expect, fn, screen, userEvent, waitFor, within} from '@storybook/test';
+import {expect, fn, userEvent, waitFor, within} from '@storybook/test';
 import {Form, Formik} from 'formik';
 import selectEvent from 'react-select-event';
 
@@ -82,7 +82,7 @@ export const SwitchToV2Empty = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );
@@ -110,7 +110,7 @@ export const SwitchToV2Empty = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );
@@ -145,7 +145,7 @@ export const SwitchToV2Existing = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );
@@ -172,7 +172,7 @@ export const SwitchToV2Existing = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );
@@ -208,7 +208,7 @@ export const SwitchToV2NonExisting = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );
@@ -233,7 +233,7 @@ export const SwitchToV2NonExisting = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );
@@ -269,7 +269,7 @@ export const APIFetchError = {
     await waitFor(async () => {
       // Close the confirmation modal
       await userEvent.click(
-        within(await screen.findByRole('dialog')).getByRole('button', {
+        within(await canvas.findByRole('dialog')).getByRole('button', {
           name: 'Accepteren',
         })
       );

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -2,6 +2,7 @@ import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import {FormattedMessage, useIntl} from 'react-intl';
 
+import useConfirm from 'components/admin/form_design/useConfirm';
 import Fieldset from 'components/admin/forms/Fieldset';
 import {
   ObjectTypeSelect,
@@ -35,21 +36,30 @@ const V2ConfigFields = ({apiGroupChoices}) => {
     setFieldValue,
   } = useFormikContext();
 
+  const [ApiGroupConfirmationModal, confirmApiGroupChange] = useConfirm(
+    intl.formatMessage({
+      description: 'Objects API registration options: warning message when changing the api group',
+      defaultMessage: `Changing the api group will remove the existing variables mapping.
+                Are you sure you want to continue?`,
+    })
+  );
+  const [ObjectTypeConfirmationModal, confirmObjectTypeChange] = useConfirm(
+    intl.formatMessage({
+      description:
+        'Objects API registration options: warning message when changing the object type',
+      defaultMessage: `Changing the objecttype will remove the existing variables mapping.
+                  Are you sure you want to continue?`,
+    })
+  );
+
   return (
     <>
       <Fieldset>
         <ObjectsAPIGroup
           apiGroupChoices={apiGroupChoices}
-          onChangeCheck={() => {
+          onChangeCheck={async () => {
             if (variablesMapping.length === 0) return true;
-            const confirmSwitch = window.confirm(
-              intl.formatMessage({
-                description:
-                  'Objects API registration options: warning message when changing the api group',
-                defaultMessage: `Changing the api group will remove the existing variables mapping.
-                Are you sure you want to continue?`,
-              })
-            );
+            const confirmSwitch = await confirmApiGroupChange();
             if (!confirmSwitch) return false;
             setFieldValue('variablesMapping', []);
             return true;
@@ -65,16 +75,9 @@ const V2ConfigFields = ({apiGroupChoices}) => {
           }
         >
           <ObjectTypeSelect
-            onChangeCheck={() => {
+            onChangeCheck={async () => {
               if (variablesMapping.length === 0) return true;
-              const confirmSwitch = window.confirm(
-                intl.formatMessage({
-                  description:
-                    'Objects API registration options: warning message when changing the object type',
-                  defaultMessage: `Changing the objecttype will remove the existing variables mapping.
-                  Are you sure you want to continue?`,
-                })
-              );
+              const confirmSwitch = await confirmObjectTypeChange();
               if (!confirmSwitch) return false;
               setFieldValue('variablesMapping', []);
               return true;
@@ -121,6 +124,9 @@ const V2ConfigFields = ({apiGroupChoices}) => {
         <UpdateExistingObject />
         <OrganisationRSIN />
       </Fieldset>
+
+      <ApiGroupConfirmationModal />
+      <ObjectTypeConfirmationModal />
     </>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -1,6 +1,6 @@
 import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import useConfirm from 'components/admin/form_design/useConfirm';
 import Fieldset from 'components/admin/forms/Fieldset';
@@ -30,27 +30,21 @@ const onApiGroupChange = prevValues => ({
 });
 
 const V2ConfigFields = ({apiGroupChoices}) => {
-  const intl = useIntl();
   const {
     values: {variablesMapping = []},
     setFieldValue,
   } = useFormikContext();
 
-  const [ApiGroupConfirmationModal, confirmApiGroupChange] = useConfirm(
-    intl.formatMessage({
-      description: 'Objects API registration options: warning message when changing the api group',
-      defaultMessage: `Changing the api group will remove the existing variables mapping.
-                Are you sure you want to continue?`,
-    })
-  );
-  const [ObjectTypeConfirmationModal, confirmObjectTypeChange] = useConfirm(
-    intl.formatMessage({
-      description:
-        'Objects API registration options: warning message when changing the object type',
-      defaultMessage: `Changing the objecttype will remove the existing variables mapping.
-                  Are you sure you want to continue?`,
-    })
-  );
+  const {
+    ConfirmationModal: ApiGroupConfirmationModal,
+    confirmationModalProps: apiGroupConfirmationModalProps,
+    openConfirmationModal: openApiGroupConfirmation,
+  } = useConfirm();
+  const {
+    ConfirmationModal: ObjectTypeConfirmationModal,
+    confirmationModalProps: objectTypeConfirmationModalProps,
+    openConfirmationModal: openObjectTypeConfirmation,
+  } = useConfirm();
 
   return (
     <>
@@ -59,7 +53,7 @@ const V2ConfigFields = ({apiGroupChoices}) => {
           apiGroupChoices={apiGroupChoices}
           onChangeCheck={async () => {
             if (variablesMapping.length === 0) return true;
-            const confirmSwitch = await confirmApiGroupChange();
+            const confirmSwitch = await openApiGroupConfirmation();
             if (!confirmSwitch) return false;
             setFieldValue('variablesMapping', []);
             return true;
@@ -77,7 +71,7 @@ const V2ConfigFields = ({apiGroupChoices}) => {
           <ObjectTypeSelect
             onChangeCheck={async () => {
               if (variablesMapping.length === 0) return true;
-              const confirmSwitch = await confirmObjectTypeChange();
+              const confirmSwitch = await openObjectTypeConfirmation();
               if (!confirmSwitch) return false;
               setFieldValue('variablesMapping', []);
               return true;
@@ -125,8 +119,26 @@ const V2ConfigFields = ({apiGroupChoices}) => {
         <OrganisationRSIN />
       </Fieldset>
 
-      <ApiGroupConfirmationModal />
-      <ObjectTypeConfirmationModal />
+      <ApiGroupConfirmationModal
+        {...apiGroupConfirmationModalProps}
+        message={
+          <FormattedMessage
+            description="Objects API registration options: warning message when changing the api group"
+            defaultMessage="Changing the api group will remove the existing variables mapping.
+                Are you sure you want to continue?"
+          />
+        }
+      />
+      <ObjectTypeConfirmationModal
+        {...objectTypeConfirmationModalProps}
+        message={
+          <FormattedMessage
+            description="Objects API registration options: warning message when changing the object type"
+            defaultMessage="Changing the objecttype will remove the existing variables mapping.
+                  Are you sure you want to continue?"
+          />
+        }
+      />
     </>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useAsync} from 'react-use';
 
+import useConfirm from 'components/admin/form_design/useConfirm';
 import Fieldset from 'components/admin/forms/Fieldset';
 import {getCatalogueOption, groupAndSortCatalogueOptions} from 'components/admin/forms/zgw';
 import ErrorBoundary from 'components/errors/ErrorBoundary';
@@ -47,22 +48,21 @@ const BasicOptionsFieldset = ({apiGroupChoices}) => {
       objecttypeVersion,
       contentJson,
     ].some(v => !!v) || propertyMappings.length > 0;
+  const [ConfirmationModal, confirm] = useConfirm(
+    intl.formatMessage({
+      description: 'ZGW APIs registration options: warning message when changing the api group',
+      defaultMessage: `Changing the api group will clear the existing configuration.
+              Are you sure you want to continue?`,
+    })
+  );
 
   return (
     <Fieldset>
       <ZGWAPIGroup
         apiGroupChoices={apiGroupChoices}
-        onChangeCheck={() => {
+        onChangeCheck={async () => {
           if (!hasAnyFieldConfigured) return true;
-          const confirmSwitch = window.confirm(
-            intl.formatMessage({
-              description:
-                'ZGW APIs registration options: warning message when changing the api group',
-              defaultMessage: `Changing the api group will clear the existing configuration.
-              Are you sure you want to continue?`,
-            })
-          );
-          return confirmSwitch;
+          return confirm();
         }}
       />
 
@@ -78,6 +78,7 @@ const BasicOptionsFieldset = ({apiGroupChoices}) => {
       >
         <CatalogiApiFields />
       </ErrorBoundary>
+      <ConfirmationModal />
     </Fieldset>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
@@ -1,6 +1,6 @@
 import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {useAsync} from 'react-use';
 
 import useConfirm from 'components/admin/form_design/useConfirm';
@@ -26,7 +26,6 @@ const getCatalogues = async apiGroupID => {
 // Components
 
 const BasicOptionsFieldset = ({apiGroupChoices}) => {
-  const intl = useIntl();
   const {
     values: {
       zaaktype,
@@ -48,13 +47,7 @@ const BasicOptionsFieldset = ({apiGroupChoices}) => {
       objecttypeVersion,
       contentJson,
     ].some(v => !!v) || propertyMappings.length > 0;
-  const [ConfirmationModal, confirm] = useConfirm(
-    intl.formatMessage({
-      description: 'ZGW APIs registration options: warning message when changing the api group',
-      defaultMessage: `Changing the api group will clear the existing configuration.
-              Are you sure you want to continue?`,
-    })
-  );
+  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
 
   return (
     <Fieldset>
@@ -62,7 +55,7 @@ const BasicOptionsFieldset = ({apiGroupChoices}) => {
         apiGroupChoices={apiGroupChoices}
         onChangeCheck={async () => {
           if (!hasAnyFieldConfigured) return true;
-          return confirm();
+          return openConfirmationModal();
         }}
       />
 
@@ -78,7 +71,16 @@ const BasicOptionsFieldset = ({apiGroupChoices}) => {
       >
         <CatalogiApiFields />
       </ErrorBoundary>
-      <ConfirmationModal />
+      <ConfirmationModal
+        {...confirmationModalProps}
+        message={
+          <FormattedMessage
+            description="ZGW APIs registration options: warning message when changing the api group"
+            defaultMessage="Changing the api group will clear the existing configuration.
+              Are you sure you want to continue?"
+          />
+        }
+      />
     </Fieldset>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -33,7 +33,10 @@ export default {
   decorators: [ValidationErrorsDecorator, FormDecorator, FeatureFlagsDecorator],
   render,
   args: {
-    apiGroups: [[1, 'ZGW API']],
+    apiGroups: [
+      [1, 'ZGW API'],
+      [2, 'ZGW API 2'],
+    ],
     objectsApiGroupChoices: [[1, 'Objects API']],
     confidentialityLevelChoices: [
       ['openbaar', 'Openbaar'],

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/fields/ZGWAPIGroup.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/fields/ZGWAPIGroup.js
@@ -48,9 +48,9 @@ const ZGWAPIGroup = ({apiGroupChoices, onChangeCheck}) => {
           name="zgwApiGroup"
           options={options}
           required
-          onChange={selectedOption => {
-            const okToProceed = onChangeCheck === undefined || onChangeCheck();
-            if (okToProceed) setValue(selectedOption.value);
+          onChange={async selectedOption => {
+            const okToProceed = onChangeCheck === undefined || (await onChangeCheck());
+            if (okToProceed) setValue(selectedOption?.value);
           }}
         />
       </Field>

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -3,6 +3,7 @@ import {Form, Formik} from 'formik';
 
 import {FeatureFlagsContext, FormContext} from 'components/admin/form_design/Context';
 import {ValidationErrorsProvider} from 'components/admin/forms/ValidationErrors';
+import {ModalContext} from 'components/admin/modals';
 
 import {FormLogicContext} from './Context';
 
@@ -91,3 +92,15 @@ export const FormikDecorator = (Story, context) => {
     </Formik>
   );
 };
+
+export const withModalDecorator = Story => (
+  <ModalContext.Provider
+    value={{
+      // only for storybook integration, do not use this in real apps!
+      parentSelector: () => document.getElementById('storybook-root'),
+      ariaHideApp: false,
+    }}
+  >
+    <Story />
+  </ModalContext.Provider>
+);

--- a/src/openforms/js/components/admin/form_design/useConfirm.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.js
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {useIntl} from 'react-intl';
 
 import ActionButton from 'components/admin/forms/ActionButton';
 import {Modal} from 'components/admin/modals';
@@ -25,20 +26,31 @@ const useConfirm = (message, title = '') => {
     handleClose();
   };
 
-  const ConfirmationModal = () => (
-    <Modal
-      title={title}
-      isOpen={promise !== null}
-      contentModifiers={['with-form', 'small']}
-      closeModal={handleCancel}
-    >
-      <div style={{flexGrow: 1}}>{message}</div>
-      <div className="button-group">
-        <ActionButton text="confirm" className="default" onClick={handleConfirm} />
-        <ActionButton text="cancel" onClick={handleCancel} />
-      </div>
-    </Modal>
-  );
+  const ConfirmationModal = () => {
+    const intl = useIntl();
+    const confirmBtnText = intl.formatMessage({
+      description: 'Confirmation modal confirm button',
+      defaultMessage: 'Confirm',
+    });
+    const cancelBtnText = intl.formatMessage({
+      description: 'Confirmation modal cancel button',
+      defaultMessage: 'Cancel',
+    });
+    return (
+      <Modal
+        title={title}
+        isOpen={promise !== null}
+        contentModifiers={['with-form', 'small']}
+        closeModal={handleCancel}
+      >
+        <div style={{flexGrow: 1}}>{message}</div>
+        <div className="button-group">
+          <ActionButton text={confirmBtnText} className="default" onClick={handleConfirm} />
+          <ActionButton text={cancelBtnText} onClick={handleCancel} />
+        </div>
+      </Modal>
+    );
+  };
   return [ConfirmationModal, confirm];
 };
 

--- a/src/openforms/js/components/admin/form_design/useConfirm.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.js
@@ -1,13 +1,13 @@
 import {useState} from 'react';
 
-import ActionButton from '../forms/ActionButton';
-import {Modal} from '../modals';
+import ActionButton from 'components/admin/forms/ActionButton';
+import {Modal} from 'components/admin/modals';
 
-const useConfirm = (title, message) => {
+const useConfirm = (message, title = '') => {
   const [promise, setPromise] = useState(null);
 
   const confirm = () =>
-    new Promise((resolve, reject) => {
+    new Promise(resolve => {
       setPromise({resolve});
     });
 
@@ -29,7 +29,7 @@ const useConfirm = (title, message) => {
     <Modal
       title={title}
       isOpen={promise !== null}
-      contentModifiers={['with-form']}
+      contentModifiers={['with-form', 'small']}
       closeModal={handleCancel}
     >
       <div style={{flexGrow: 1}}>{message}</div>

--- a/src/openforms/js/components/admin/form_design/useConfirm.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.js
@@ -40,11 +40,11 @@ const useConfirm = (message, title = '') => {
       <Modal
         title={title}
         isOpen={promise !== null}
-        contentModifiers={['with-form', 'small']}
+        contentModifiers={['confirmation']}
         closeModal={handleCancel}
       >
-        <div style={{flexGrow: 1}}>{message}</div>
-        <div className="button-group">
+        <p>{message}</p>
+        <div className="react-modal__actions">
           <ActionButton text={confirmBtnText} className="default" onClick={handleConfirm} />
           <ActionButton text={cancelBtnText} onClick={handleCancel} />
         </div>

--- a/src/openforms/js/components/admin/form_design/useConfirm.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.js
@@ -1,13 +1,14 @@
+import PropTypes from 'prop-types';
 import {useState} from 'react';
 import {useIntl} from 'react-intl';
 
 import ActionButton from 'components/admin/forms/ActionButton';
 import {Modal} from 'components/admin/modals';
 
-const useConfirm = (message, title = '') => {
+const useConfirm = () => {
   const [promise, setPromise] = useState(null);
 
-  const confirm = () =>
+  const openConfirmationModal = () =>
     new Promise(resolve => {
       setPromise({resolve});
     });
@@ -26,32 +27,42 @@ const useConfirm = (message, title = '') => {
     handleClose();
   };
 
-  const ConfirmationModal = () => {
-    const intl = useIntl();
-    const confirmBtnText = intl.formatMessage({
-      description: 'Confirmation modal confirm button',
-      defaultMessage: 'Confirm',
-    });
-    const cancelBtnText = intl.formatMessage({
-      description: 'Confirmation modal cancel button',
-      defaultMessage: 'Cancel',
-    });
-    return (
-      <Modal
-        title={title}
-        isOpen={promise !== null}
-        contentModifiers={['confirmation']}
-        closeModal={handleCancel}
-      >
-        <p>{message}</p>
-        <div className="react-modal__actions">
-          <ActionButton text={confirmBtnText} className="default" onClick={handleConfirm} />
-          <ActionButton text={cancelBtnText} onClick={handleCancel} />
-        </div>
-      </Modal>
-    );
+  const confirmationModalProps = {
+    isOpen: promise !== null,
+    onConfirm: handleConfirm,
+    onCancel: handleCancel,
   };
-  return [ConfirmationModal, confirm];
+
+  return {ConfirmationModal, confirmationModalProps, openConfirmationModal};
+};
+
+const ConfirmationModal = ({title, message, isOpen, onConfirm, onCancel}) => {
+  const intl = useIntl();
+  const confirmBtnText = intl.formatMessage({
+    description: 'Confirmation modal confirm button',
+    defaultMessage: 'Confirm',
+  });
+  const cancelBtnText = intl.formatMessage({
+    description: 'Confirmation modal cancel button',
+    defaultMessage: 'Cancel',
+  });
+  return (
+    <Modal title={title} isOpen={isOpen} contentModifiers={['confirmation']} closeModal={onCancel}>
+      <p>{message}</p>
+      <div className="react-modal__actions">
+        <ActionButton text={confirmBtnText} className="default" onClick={onConfirm} />
+        <ActionButton text={cancelBtnText} onClick={onCancel} />
+      </div>
+    </Modal>
+  );
+};
+
+ConfirmationModal.propTypes = {
+  title: PropTypes.node,
+  message: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
 };
 
 export default useConfirm;

--- a/src/openforms/js/components/admin/form_design/useConfirm.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.js
@@ -1,0 +1,45 @@
+import {useState} from 'react';
+
+import ActionButton from '../forms/ActionButton';
+import {Modal} from '../modals';
+
+const useConfirm = (title, message) => {
+  const [promise, setPromise] = useState(null);
+
+  const confirm = () =>
+    new Promise((resolve, reject) => {
+      setPromise({resolve});
+    });
+
+  const handleClose = () => {
+    setPromise(null);
+  };
+
+  const handleConfirm = () => {
+    promise?.resolve(true);
+    handleClose();
+  };
+
+  const handleCancel = () => {
+    promise?.resolve(false);
+    handleClose();
+  };
+
+  const ConfirmationModal = () => (
+    <Modal
+      title={title}
+      isOpen={promise !== null}
+      contentModifiers={['with-form']}
+      closeModal={handleCancel}
+    >
+      <div style={{flexGrow: 1}}>{message}</div>
+      <div className="button-group">
+        <ActionButton text="confirm" className="default" onClick={handleConfirm} />
+        <ActionButton text="cancel" onClick={handleCancel} />
+      </div>
+    </Modal>
+  );
+  return [ConfirmationModal, confirm];
+};
+
+export default useConfirm;

--- a/src/openforms/js/components/admin/form_design/useConfirm.stories.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.stories.js
@@ -6,24 +6,25 @@ import ActionButton from 'components/admin/forms/ActionButton';
 import useConfirm from './useConfirm';
 
 const ButtonWithUseConfirm = () => {
-  const [ConfirmationModal, confirm] = useConfirm(
-    'A sample confirmation message',
-    'The confirmation title'
-  );
+  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
   const [confirmationResult, setConfirmationResult] = useState(null);
   return (
     <div>
       <ActionButton
         text="Open confirmation modal"
         onClick={async () => {
-          const result = await confirm();
+          const result = await openConfirmationModal();
           setConfirmationResult(result);
         }}
       />
       {confirmationResult !== null ? (
         <p>Confirmation result: {confirmationResult.toString()}</p>
       ) : null}
-      <ConfirmationModal />
+      <ConfirmationModal
+        {...confirmationModalProps}
+        title="The confirmation title"
+        message="A sample confirmation message"
+      />
     </div>
   );
 };

--- a/src/openforms/js/components/admin/form_design/useConfirm.stories.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.stories.js
@@ -1,0 +1,81 @@
+import {expect, screen, userEvent, within} from '@storybook/test';
+import {useState} from 'react';
+
+import ActionButton from 'components/admin/forms/ActionButton';
+
+import useConfirm from './useConfirm';
+
+const ButtonWithUseConfirm = () => {
+  const [ConfirmationModal, confirm] = useConfirm(
+    'A sample confirmation message',
+    'The confirmation title'
+  );
+  const [confirmationResult, setConfirmationResult] = useState(null);
+  return (
+    <div>
+      <ActionButton
+        text="Open confirmation modal"
+        onClick={async () => {
+          const result = await confirm();
+          setConfirmationResult(result);
+        }}
+      />
+      {confirmationResult !== null ? (
+        <p>Confirmation result: {confirmationResult.toString()}</p>
+      ) : null}
+      <ConfirmationModal />
+    </div>
+  );
+};
+
+export default {
+  title: 'Admin / Custom / UseConfirm',
+  render: () => <ButtonWithUseConfirm />,
+  component: useConfirm,
+};
+
+export const Default = {
+  name: 'Default',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Open confirmation modal'}));
+
+    // The confirmation modal is opened, and shows the title and message
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeVisible();
+    expect(within(confirmationModal).getByText('The confirmation title')).toBeVisible();
+    expect(within(confirmationModal).getByText('A sample confirmation message')).toBeVisible();
+
+    await step('Closing the modal returns false', async () => {
+      // Close the modal using the close button
+      const closeBtn = await screen.findByRole('button', {name: 'Sluiten'});
+      await userEvent.click(closeBtn);
+
+      expect(await canvas.findByText('Confirmation result: false')).toBeVisible();
+    });
+
+    await step('Confirming the modal returns true', async () => {
+      // Open the modal
+      await userEvent.click(canvas.getByRole('button', {name: 'Open confirmation modal'}));
+
+      // Close the modal using the confirm button
+      const confirmBtn = await screen.findByRole('button', {name: 'Accepteren'});
+      await userEvent.click(confirmBtn);
+
+      expect(await canvas.findByText('Confirmation result: true')).toBeVisible();
+    });
+
+    await step('Cancelling the modal returns false', async () => {
+      // Open the modal
+      await userEvent.click(canvas.getByRole('button', {name: 'Open confirmation modal'}));
+
+      // Close the modal using the cancel button
+      const cancelBtn = await screen.findByRole('button', {name: 'Annuleren'});
+      await userEvent.click(cancelBtn);
+
+      expect(await canvas.findByText('Confirmation result: false')).toBeVisible();
+    });
+  },
+};

--- a/src/openforms/js/components/admin/form_design/useConfirm.stories.js
+++ b/src/openforms/js/components/admin/form_design/useConfirm.stories.js
@@ -1,4 +1,4 @@
-import {expect, screen, userEvent, within} from '@storybook/test';
+import {expect, userEvent, within} from '@storybook/test';
 import {useState} from 'react';
 
 import ActionButton from 'components/admin/forms/ActionButton';
@@ -44,14 +44,16 @@ export const Default = {
     await userEvent.click(canvas.getByRole('button', {name: 'Open confirmation modal'}));
 
     // The confirmation modal is opened, and shows the title and message
-    const confirmationModal = screen.getByRole('dialog');
+    const confirmationModal = canvas.getByRole('dialog');
     expect(confirmationModal).toBeVisible();
     expect(within(confirmationModal).getByText('The confirmation title')).toBeVisible();
     expect(within(confirmationModal).getByText('A sample confirmation message')).toBeVisible();
 
     await step('Closing the modal returns false', async () => {
       // Close the modal using the close button
-      const closeBtn = await screen.findByRole('button', {name: 'Sluiten'});
+      const closeBtn = await within(canvas.getByRole('dialog')).findByRole('button', {
+        name: 'Sluiten',
+      });
       await userEvent.click(closeBtn);
 
       expect(await canvas.findByText('Confirmation result: false')).toBeVisible();
@@ -62,7 +64,9 @@ export const Default = {
       await userEvent.click(canvas.getByRole('button', {name: 'Open confirmation modal'}));
 
       // Close the modal using the confirm button
-      const confirmBtn = await screen.findByRole('button', {name: 'Accepteren'});
+      const confirmBtn = await within(canvas.getByRole('dialog')).findByRole('button', {
+        name: 'Accepteren',
+      });
       await userEvent.click(confirmBtn);
 
       expect(await canvas.findByText('Confirmation result: true')).toBeVisible();
@@ -73,7 +77,9 @@ export const Default = {
       await userEvent.click(canvas.getByRole('button', {name: 'Open confirmation modal'}));
 
       // Close the modal using the cancel button
-      const cancelBtn = await screen.findByRole('button', {name: 'Annuleren'});
+      const cancelBtn = await within(canvas.getByRole('dialog')).findByRole('button', {
+        name: 'Annuleren',
+      });
       await userEvent.click(cancelBtn);
 
       expect(await canvas.findByText('Confirmation result: false')).toBeVisible();

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -600,11 +600,11 @@ export const ConfigurePrefillObjectsAPI = {
       // open modal for configuration
       const editIcon = canvas.getByTitle('Prefill instellen');
       await userEvent.click(editIcon);
-      expect(await screen.findByRole('dialog')).toBeVisible();
+      expect(await canvas.findByRole('dialog')).toBeVisible();
     });
 
     await step('Configure Objects API prefill', async () => {
-      const modal = within(await screen.findByRole('dialog'));
+      const modal = within(await canvas.findByRole('dialog'));
       const pluginDropdown = await screen.findByLabelText('Plugin');
       expect(pluginDropdown).toBeVisible();
       await userEvent.selectOptions(pluginDropdown, 'Objects API');

--- a/src/openforms/js/components/admin/form_design/variables/prefill/ObjectsAPIFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/ObjectsAPIFields.js
@@ -10,6 +10,7 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import useAsync from 'react-use/esm/useAsync';
 
 import {FormContext} from 'components/admin/form_design/Context';
+import useConfirm from 'components/admin/form_design/useConfirm';
 import Field from 'components/admin/forms/Field';
 import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
@@ -62,6 +63,22 @@ const ObjectsAPIFields = ({errors}) => {
   } = useFormikContext();
   const intl = useIntl();
 
+  const [ApiGroupConfirmationModal, confirmApiGroupChange] = useConfirm(
+    intl.formatMessage({
+      description: 'Objects API registration options: warning message when changing the api group',
+      defaultMessage: `Changing the api group will remove the existing variables mapping.
+                Are you sure you want to continue?`,
+    })
+  );
+  const [ObjectTypeConfirmationModal, confirmObjectTypeChange] = useConfirm(
+    intl.formatMessage({
+      description:
+        'Objects API registration options: warning message when changing the object type',
+      defaultMessage: `Changing the objecttype will remove the existing variables mapping.
+                  Are you sure you want to continue?`,
+    })
+  );
+
   const {
     plugins: {availablePrefillPlugins},
   } = useContext(FormContext);
@@ -91,16 +108,9 @@ const ObjectsAPIFields = ({errors}) => {
       <Fieldset>
         <ObjectsAPIGroup
           apiGroupChoices={apiGroups}
-          onChangeCheck={() => {
+          onChangeCheck={async () => {
             if (values.options.variablesMapping.length === 0) return true;
-            const confirmSwitch = window.confirm(
-              intl.formatMessage({
-                description:
-                  'Objects API registration options: warning message when changing the api group',
-                defaultMessage: `Changing the api group will remove the existing variables mapping.
-                Are you sure you want to continue?`,
-              })
-            );
+            const confirmSwitch = await confirmApiGroupChange();
             if (!confirmSwitch) return false;
             setFieldValue('options.variablesMapping', []);
             return true;
@@ -121,16 +131,9 @@ const ObjectsAPIFields = ({errors}) => {
             name="options.objecttype"
             apiGroupFieldName="options.objectsApiGroup"
             versionFieldName="options.objecttypeVersion"
-            onChangeCheck={() => {
+            onChangeCheck={async () => {
               if (values.options.variablesMapping.length === 0) return true;
-              const confirmSwitch = window.confirm(
-                intl.formatMessage({
-                  description:
-                    'Objects API registration options: warning message when changing the object type',
-                  defaultMessage: `Changing the objecttype will remove the existing variables mapping.
-                  Are you sure you want to continue?`,
-                })
-              );
+              const confirmSwitch = await confirmObjectTypeChange();
               if (!confirmSwitch) return false;
               setFieldValue('options.variablesMapping', []);
               return true;
@@ -183,6 +186,9 @@ const ObjectsAPIFields = ({errors}) => {
           />
         </FormRow>
       </Fieldset>
+
+      <ApiGroupConfirmationModal />
+      <ObjectTypeConfirmationModal />
     </>
   );
 };

--- a/src/openforms/js/components/admin/form_design/variables/prefill/ObjectsAPIFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/ObjectsAPIFields.js
@@ -63,21 +63,16 @@ const ObjectsAPIFields = ({errors}) => {
   } = useFormikContext();
   const intl = useIntl();
 
-  const [ApiGroupConfirmationModal, confirmApiGroupChange] = useConfirm(
-    intl.formatMessage({
-      description: 'Objects API registration options: warning message when changing the api group',
-      defaultMessage: `Changing the api group will remove the existing variables mapping.
-                Are you sure you want to continue?`,
-    })
-  );
-  const [ObjectTypeConfirmationModal, confirmObjectTypeChange] = useConfirm(
-    intl.formatMessage({
-      description:
-        'Objects API registration options: warning message when changing the object type',
-      defaultMessage: `Changing the objecttype will remove the existing variables mapping.
-                  Are you sure you want to continue?`,
-    })
-  );
+  const {
+    ConfirmationModal: ApiGroupConfirmationModal,
+    confirmationModalProps: apiGroupConfirmationModalProps,
+    openConfirmationModal: openApiGroupConfirmationModal,
+  } = useConfirm();
+  const {
+    ConfirmationModal: ObjectTypeConfirmationModal,
+    confirmationModalProps: objectTypeConfirmationModalProps,
+    openConfirmationModal: openObjectTypeConfirmationModal,
+  } = useConfirm();
 
   const {
     plugins: {availablePrefillPlugins},
@@ -110,7 +105,7 @@ const ObjectsAPIFields = ({errors}) => {
           apiGroupChoices={apiGroups}
           onChangeCheck={async () => {
             if (values.options.variablesMapping.length === 0) return true;
-            const confirmSwitch = await confirmApiGroupChange();
+            const confirmSwitch = await openApiGroupConfirmationModal();
             if (!confirmSwitch) return false;
             setFieldValue('options.variablesMapping', []);
             return true;
@@ -133,7 +128,7 @@ const ObjectsAPIFields = ({errors}) => {
             versionFieldName="options.objecttypeVersion"
             onChangeCheck={async () => {
               if (values.options.variablesMapping.length === 0) return true;
-              const confirmSwitch = await confirmObjectTypeChange();
+              const confirmSwitch = await openObjectTypeConfirmationModal();
               if (!confirmSwitch) return false;
               setFieldValue('options.variablesMapping', []);
               return true;
@@ -187,8 +182,24 @@ const ObjectsAPIFields = ({errors}) => {
         </FormRow>
       </Fieldset>
 
-      <ApiGroupConfirmationModal />
-      <ObjectTypeConfirmationModal />
+      <ApiGroupConfirmationModal
+        {...apiGroupConfirmationModalProps}
+        message={
+          <FormattedMessage
+            description="Objects API registration options: warning message when changing the api group"
+            defaultMessage="Changing the api group will remove the existing variables mapping. Are you sure you want to continue?"
+          />
+        }
+      />
+      <ObjectTypeConfirmationModal
+        {...objectTypeConfirmationModalProps}
+        message={
+          <FormattedMessage
+            description="Objects API registration options: warning message when changing the object type"
+            defaultMessage="Changing the objecttype will remove the existing variables mapping. Are you sure you want to continue?"
+          />
+        }
+      />
     </>
   );
 };

--- a/src/openforms/js/components/admin/icons/DeleteIcon.js
+++ b/src/openforms/js/components/admin/icons/DeleteIcon.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {useIntl} from 'react-intl';
 
+import useConfirm from 'components/admin/form_design/useConfirm';
+
 import FAIcon from './FAIcon';
 
 const DeleteIcon = ({onConfirm, message, icon = 'trash-can'}) => {
@@ -17,19 +19,23 @@ const DeleteIcon = ({onConfirm, message, icon = 'trash-can'}) => {
     defaultMessage: 'Delete',
   });
 
-  const onClick = () => {
-    if (window.confirm(confirmMessage)) {
+  const [ConfirmationModal, confirm] = useConfirm(confirmMessage);
+  const onClick = async () => {
+    if (await confirm()) {
       onConfirm();
     }
   };
 
   return (
-    <FAIcon
-      icon={icon}
-      extraClassname="icon icon--danger actions__action"
-      title={iconTitle}
-      onClick={onClick}
-    />
+    <>
+      <FAIcon
+        icon={icon}
+        extraClassname="icon icon--danger actions__action"
+        title={iconTitle}
+        onClick={onClick}
+      />
+      <ConfirmationModal />
+    </>
   );
 };
 

--- a/src/openforms/js/components/admin/icons/DeleteIcon.js
+++ b/src/openforms/js/components/admin/icons/DeleteIcon.js
@@ -19,9 +19,9 @@ const DeleteIcon = ({onConfirm, message, icon = 'trash-can'}) => {
     defaultMessage: 'Delete',
   });
 
-  const [ConfirmationModal, confirm] = useConfirm(confirmMessage);
+  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
   const onClick = async () => {
-    if (await confirm()) {
+    if (await openConfirmationModal()) {
       onConfirm();
     }
   };
@@ -34,7 +34,7 @@ const DeleteIcon = ({onConfirm, message, icon = 'trash-can'}) => {
         title={iconTitle}
         onClick={onClick}
       />
-      <ConfirmationModal />
+      <ConfirmationModal {...confirmationModalProps} message={confirmMessage} />
     </>
   );
 };

--- a/src/openforms/js/components/admin/modals/Modal.js
+++ b/src/openforms/js/components/admin/modals/Modal.js
@@ -29,12 +29,9 @@ const Modal = ({
     >
       <header className="react-modal__header">
         {title ? <h2 className="react-modal__title">{title}</h2> : null}
-        <FAIcon
-          icon="close"
-          extraClassname="fa-lg react-modal__close"
-          title="Sluiten"
-          onClick={closeModal}
-        />
+        <button className="react-modal__close" aria-label="Sluiten" onClick={closeModal}>
+          <FAIcon icon="close" extraClassname="fa-lg" aria-hidden="true" />
+        </button>
       </header>
       {children}
     </ReactModal>

--- a/src/openforms/js/components/admin/modals/Modal.js
+++ b/src/openforms/js/components/admin/modals/Modal.js
@@ -7,7 +7,7 @@ import {FAIcon} from 'components/admin/icons';
 
 const CONTENT_CLASS_NAME = 'react-modal__content';
 
-export const CONTENT_MODIFIERS = ['small', 'large', 'with-form'];
+export const CONTENT_MODIFIERS = ['small', 'confirmation', 'large', 'with-form'];
 
 const Modal = ({
   isOpen = false,

--- a/src/openforms/js/components/admin/modals/Modal.js
+++ b/src/openforms/js/components/admin/modals/Modal.js
@@ -1,9 +1,12 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {createContext, useContext} from 'react';
 import ReactModal from 'react-modal';
 
 import {FAIcon} from 'components/admin/icons';
+
+export const ModalContext = createContext({});
+ModalContext.displayName = 'ModalContext';
 
 const CONTENT_CLASS_NAME = 'react-modal__content';
 
@@ -17,6 +20,7 @@ const Modal = ({
   contentModifiers = [],
   ...props
 }) => {
+  const {parentSelector, ariaHideApp} = useContext(ModalContext);
   const modifiedClassNames = contentModifiers.map(modifier => `${CONTENT_CLASS_NAME}--${modifier}`);
   const className = classNames(CONTENT_CLASS_NAME, ...modifiedClassNames);
   return (
@@ -25,6 +29,8 @@ const Modal = ({
       onRequestClose={closeModal}
       className={className}
       overlayClassName="react-modal__overlay"
+      parentSelector={parentSelector}
+      ariaHideApp={ariaHideApp}
       {...props}
     >
       <header className="react-modal__header">

--- a/src/openforms/js/components/admin/modals/index.js
+++ b/src/openforms/js/components/admin/modals/index.js
@@ -1,2 +1,2 @@
-export {default as Modal} from './Modal';
+export {default as Modal, ModalContext} from './Modal';
 export {default as FormModal} from './FormModal';

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1199,6 +1199,11 @@
     "description": "literals.changeText form label",
     "originalDefault": "Change text"
   },
+  "M9JbDC": {
+    "defaultMessage": "Cancel",
+    "description": "Confirmation modal cancel button",
+    "originalDefault": "Cancel"
+  },
   "MEkGHD": {
     "defaultMessage": "Component",
     "description": "Formio component selection label",
@@ -2123,6 +2128,11 @@
     "defaultMessage": "Detected some problems in this action: {problems}.",
     "description": "Logic action warning icon text",
     "originalDefault": "Detected some problems in this action: {problems}."
+  },
+  "gpiYPI": {
+    "defaultMessage": "Confirm",
+    "description": "Confirmation modal confirm button",
+    "originalDefault": "Confirm"
   },
   "gqVGbb": {
     "defaultMessage": "Edit prefill configuration",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1206,6 +1206,11 @@
     "description": "literals.changeText form label",
     "originalDefault": "Change text"
   },
+  "M9JbDC": {
+    "defaultMessage": "Annuleren",
+    "description": "Confirmation modal cancel button",
+    "originalDefault": "Cancel"
+  },
   "MEkGHD": {
     "defaultMessage": "Veld",
     "description": "Formio component selection label",
@@ -2140,6 +2145,11 @@
     "defaultMessage": "Er zijn problemen in deze actie: {problems}.",
     "description": "Logic action warning icon text",
     "originalDefault": "Detected some problems in this action: {problems}."
+  },
+  "gpiYPI": {
+    "defaultMessage": "Accepteren",
+    "description": "Confirmation modal confirm button",
+    "originalDefault": "Confirm"
   },
   "gqVGbb": {
     "defaultMessage": "Prefill instellen",

--- a/src/openforms/scss/components/admin/_ReactModal.scss
+++ b/src/openforms/scss/components/admin/_ReactModal.scss
@@ -61,9 +61,12 @@
 
   &__close {
     position: absolute;
-    top: 20px;
-    right: 20px;
+    top: 12px;
+    right: 12px;
+    padding: 8px;
     cursor: pointer;
+    background: transparent;
+    border: none;
     opacity: 0.5;
     line-height: 1;
 

--- a/src/openforms/scss/components/admin/_ReactModal.scss
+++ b/src/openforms/scss/components/admin/_ReactModal.scss
@@ -47,6 +47,13 @@
       }
     }
 
+    &--confirmation {
+      width: 25vw;
+      min-width: 400px;
+      height: auto;
+      max-height: 25vh;
+    }
+
     &--large {
       width: 75vw;
       height: 75vh;
@@ -128,5 +135,12 @@
     .collapse:not(.show) {
       display: inherit;
     }
+  }
+
+  &__actions {
+    display: flex;
+    margin-block-start: 1.25rem;
+    flex-wrap: wrap;
+    gap: 10px;
   }
 }

--- a/src/openforms/scss/components/admin/_button-group.scss
+++ b/src/openforms/scss/components/admin/_button-group.scss
@@ -1,5 +1,0 @@
-.button-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}

--- a/src/openforms/scss/components/admin/_button-group.scss
+++ b/src/openforms/scss/components/admin/_button-group.scss
@@ -1,0 +1,5 @@
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -1,4 +1,5 @@
 @import './button';
+@import './button-group';
 @import './edit-panel';
 @import './datetime';
 @import './list';

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -1,5 +1,4 @@
 @import './button';
-@import './button-group';
 @import './edit-panel';
 @import './datetime';
 @import './list';


### PR DESCRIPTION
Closes #4798

**Changes**

Replacing all `window.confirm(...)` confirmations with a new custom React hook (`useConfirm`). This new hook is using our Modal component to display the confirmation message. These changes happend to keep the application UI uniform.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
