### PR TITLE
:wastebasket: [#3283] Make FormDefinitionSerializer.name read only

### DIFF
--- a/docs/installation/upgrade-300.rst
+++ b/docs/installation/upgrade-300.rst
@@ -82,6 +82,15 @@ The legacy format (from before Open Forms 2.3) for registration backend will no 
 converted to the current standard. When importing a form with this configuration,
 the form will be created without registration backends.
 
+``FormDefinition.name`` field is now read only
+----------------------------------------------
+
+The ``name`` field of a ``FormDefinition`` export is no longer written to the matching
+active locale field (``name_nl`` or ``name_en``) during imports. Instead, the
+``translations`` key is used. This affects forms that were exported before the
+``translations`` key existed.  We recommend re-creating the exports on a newer version
+of Open Forms.
+
 Removal of /api/v2/location/get-street-name-and-city endpoint
 =============================================================
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7825,7 +7825,7 @@ components:
           format: uuid
         name:
           type: string
-          maxLength: 50
+          readOnly: true
         internalName:
           type: string
           description: internal name for management purposes
@@ -7876,7 +7876,7 @@ components:
           format: uuid
         name:
           type: string
-          maxLength: 50
+          readOnly: true
         internalName:
           type: string
           description: internal name for management purposes
@@ -9383,7 +9383,7 @@ components:
           format: uuid
         name:
           type: string
-          maxLength: 50
+          readOnly: true
         internalName:
           type: string
           description: internal name for management purposes

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -111,8 +111,7 @@ class FormDefinitionSerializer(
                 "view_name": "api:formdefinition-detail",
                 "lookup_field": "uuid",
             },
-            # TODO: enable this in v3, deprecate writing this field
-            # "name": {"read_only": True},  # writing is done via the `translations` field
+            "name": {"read_only": True},  # writing is done via the `translations` field
             "slug": {
                 "required": False,
             },

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -281,6 +281,10 @@ class FormAdminImportExportTests(WebTest):
                                         }
                                     ]
                                 },
+                                "translations": {
+                                    "en": {"name": "testform"},
+                                    "nl": {"name": "testformulier"},
+                                },
                             }
                         ]
                     ).encode("utf-8")

--- a/src/openforms/forms/tests/exports/formDefinitions.json
+++ b/src/openforms/forms/tests/exports/formDefinitions.json
@@ -12,6 +12,10 @@
         "internal_name": "Test Definition Internal 1",
         "slug": "test-definition-1",
         "url": "http://testserver/api/v2/form-definitions/f0dad93b-333b-49af-868b-a6bcb94fa1b8",
-        "uuid": "f0dad93b-333b-49af-868b-a6bcb94fa1b8"
+        "uuid": "f0dad93b-333b-49af-868b-a6bcb94fa1b8",
+        "translations": {
+            "en": {"name": "Test Definition 1"},
+            "nl": {"name": "Test Definitie 1"}
+        }
     }
 ]

--- a/src/openforms/forms/tests/test_api_form_versions.py
+++ b/src/openforms/forms/tests/test_api_form_versions.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.urls import reverse
+from django.utils import translation
 
 from freezegun import freeze_time
 from rest_framework import status
@@ -191,7 +192,9 @@ class FormVersionRestoreAPITests(APITestCase):
         form_step = form_steps.get()
         restored_form_definition = form_step.form_definition
 
-        self.assertEqual("Test Definition 1", restored_form_definition.name)
+        with translation.override("en"):
+            self.assertEqual("Test Definition 1", restored_form_definition.name)
+            self.assertEqual("Test Definitie 1", restored_form_definition.name_nl)
         self.assertEqual(
             "Test Definition Internal 1", restored_form_definition.internal_name
         )

--- a/src/openforms/forms/tests/test_api_formdefinition.py
+++ b/src/openforms/forms/tests/test_api_formdefinition.py
@@ -156,6 +156,10 @@ class FormDefinitionsAPITests(APITestCase):
                     ],
                 },
                 "login_required": True,
+                "translations": {
+                    "en": {"name": "Updated name"},
+                    "nl": {"name": "Bijgewerkte naam"},
+                },
             },
         )
 
@@ -163,7 +167,8 @@ class FormDefinitionsAPITests(APITestCase):
 
         definition.refresh_from_db()
 
-        self.assertEqual("Updated name", definition.name)
+        self.assertEqual("Bijgewerkte naam", definition.name)
+        self.assertEqual("Updated name", definition.name_en)
         self.assertEqual("updated-slug", definition.slug)
         self.assertEqual(True, definition.login_required)
         self.assertIn(
@@ -217,6 +222,10 @@ class FormDefinitionsAPITests(APITestCase):
                         }
                     ],
                 },
+                "translations": {
+                    "en": {"name": "Name"},
+                    "nl": {"name": "Naam"},
+                },
             },
         )
 
@@ -224,7 +233,8 @@ class FormDefinitionsAPITests(APITestCase):
 
         definition = FormDefinition.objects.get()
 
-        self.assertEqual("Name", definition.name)
+        self.assertEqual("Naam", definition.name)
+        self.assertEqual("Name", definition.name_en)
         self.assertEqual("a-slug", definition.slug)
         self.assertEqual(
             [

--- a/src/openforms/forms/tests/test_restore_version.py
+++ b/src/openforms/forms/tests/test_restore_version.py
@@ -3,6 +3,7 @@ import datetime
 import json
 
 from django.test import TestCase
+from django.utils import translation
 from django.utils.translation import gettext as _
 
 from freezegun import freeze_time
@@ -63,7 +64,9 @@ class RestoreVersionTest(TestCase):
 
         restored_form_definition = form_steps.get().form_definition
 
-        self.assertEqual("Test Definition 1", restored_form_definition.name)
+        with translation.override("en"):
+            self.assertEqual("Test Definition 1", restored_form_definition.name)
+            self.assertEqual("Test Definitie 1", restored_form_definition.name_nl)
         self.assertEqual(
             "Test Definition Internal 1", restored_form_definition.internal_name
         )


### PR DESCRIPTION
Related to #3283

**Changes**

* Make FormDefinitionSerializer.name read only

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
