### PR TITLE
:bug: [#4823] Allow files with leading whitespace

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -328,7 +328,7 @@ class PhoneNumber(BasePlugin):
 class FileDataSerializer(serializers.Serializer):
     url = serializers.URLField()
     form = serializers.ChoiceField(choices=[""])
-    name = serializers.CharField()
+    name = serializers.CharField(trim_whitespace=False)
     size = serializers.IntegerField(min_value=0)
     baseUrl = serializers.URLField()
     project = serializers.ChoiceField(choices=[""])
@@ -336,7 +336,7 @@ class FileDataSerializer(serializers.Serializer):
 
 class FileSerializer(serializers.Serializer):
     name = serializers.CharField()
-    originalName = serializers.CharField()
+    originalName = serializers.CharField(trim_whitespace=False)
     size = serializers.IntegerField(min_value=0)
     storage = serializers.ChoiceField(choices=["url"])
     type = serializers.CharField(


### PR DESCRIPTION
Closes #4823

**Changes**

Allows uploaded files with leading whitespaces.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
