### PR TITLE
[#4762] Add cosign data (bsn) to the stuf-zds creerzaak bericht

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -243,6 +243,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
         zaak_options: ZaakOptions = {
             **options,
             "omschrijving": submission.form.admin_name,
+            "co_sign_data": submission.co_sign_data if submission.co_sign_data else {},
         }
 
         with get_client(options=zaak_options) as client:

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -214,6 +214,7 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "language_code": "Dothraki",  # some form widget defined by form designer
             },
             language_code="en",
+            co_sign_data={"value": "123456782"},
         )
 
         attachment = SubmissionFileAttachmentFactory.create(
@@ -292,6 +293,7 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "//zkn:isVan/zkn:gerelateerde/zkn:omschrijving": "zt-omschrijving",
                 "//zkn:heeft/zkn:gerelateerde/zkn:code": "123",
                 "//zkn:heeft/zkn:gerelateerde/zkn:omschrijving": "aaabbc",
+                "//zkn:object/zkn:heeftAlsOverigBetrokkene/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:inp.bsn": "123456782",
             },
         )
         # extraElementen

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -94,6 +94,7 @@ class ZaakOptions(TypedDict):
     ]
     # extra's
     omschrijving: str
+    co_sign_data: NotRequired[dict[str, str]]
 
 
 class NoServiceConfigured(RuntimeError):
@@ -240,6 +241,11 @@ class Client(BaseClient):
                 "zds_zaaktype_status_omschrijving"
             ),
             "zaak_omschrijving": self.zds_options["omschrijving"],
+            "co_signer": (
+                co_sign_data["value"]
+                if (co_sign_data := self.zds_options.get("co_sign_data"))
+                else {}
+            ),
             "zaak_identificatie": zaak_identificatie,
             "extra": extra_data,
             "global_config": GlobalConfiguration.get_solo(),

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -124,6 +124,17 @@
                 <StUF:tijdstipRegistratie>{{ tijdstip_registratie }}</StUF:tijdstipRegistratie>
             </ZKN:heeftAlsInitiator>
         {% endif %}
+        {% if co_signer %}
+            <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype="ZAKOBJ" StUF:verwerkingssoort="T">
+                <ZKN:gerelateerde>
+                    <ZKN:natuurlijkPersoon StUF:entiteittype="NPS" StUF:verwerkingssoort="T">
+                        <BG:inp.bsn>{{ co_signer }}</BG:inp.bsn>
+                        <BG:authentiek StUF:metagegeven="true">J</BG:authentiek>
+                    </ZKN:natuurlijkPersoon>
+                </ZKN:gerelateerde>
+                <ZKN:omschrijving>mede_initiator</ZKN:omschrijving>
+            </ZKN:heeftAlsOverigBetrokkene>
+        {% endif %}
         {% if registrator.medewerker %}
         <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype="ZAKBTROVR" StUF:verwerkingssoort="T">
             <ZKN:gerelateerde>

--- a/src/stuf/stuf_zds/tests/test_backend.py
+++ b/src/stuf/stuf_zds/tests/test_backend.py
@@ -208,6 +208,7 @@ class StufZDSClientTests(StUFZDSTestBase):
 
     def test_create_zaak(self, m):
         client = StufZDSClient(self.service, self.options)
+        self.options.update({"co_sign_data": {"value": "123456782"}})
         m.post(
             self.service.soap_service.url,
             content=load_mock("creeerZaak.xml"),
@@ -241,6 +242,7 @@ class StufZDSClientTests(StUFZDSTestBase):
                 "//zkn:object/zkn:isVan/zkn:gerelateerde/zkn:code": "zt-code",
                 "//zkn:object/zkn:isVan/zkn:gerelateerde/zkn:omschrijving": "zt-omschrijving",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:inp.bsn": "111222333",
+                "//zkn:object/zkn:heeftAlsOverigBetrokkene/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:inp.bsn": "123456782",
             },
         )
 


### PR DESCRIPTION
Closes #4762 

**Changes**

- Added the cosigner's bsn to the creerzaak bericht

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
