### PR TITLE
:white_check_mark: [#4796] Added mock rx mission service to tests

### DIFF
--- a/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetProductsListViewTests/GetProductsListViewTests.test_fetch_products_by_case_type.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/files/vcr_cassettes/GetProductsListViewTests/GetProductsListViewTests.test_fetch_products_by_case_type.yaml
@@ -80,4 +80,36 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10
+  response:
+    body:
+      string: "{\n  \"code\": \"RX-10\",\n  \"description\": \"Advies vergunning met
+        instemming\",\n  \"id\": \"1234abcd-12ab-34cd-56ef-12345abcde10\",\n  \"streeftermijn\":
+        \"P0D\",\n  \"uiterlijkeTermijn\": \"P0D\",\n  \"url\": \"https://example.com/product/1234abcd-12ab-34cd-56ef-12345abcde10\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '256'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 20 Nov 2024 18:23:37 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.7
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_api_endpoints.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_api_endpoints.py
@@ -276,6 +276,12 @@ class GetProductsListViewTests(OFVCRMixin, APITestCase):
     def setUpTestData(cls):
         super().setUpTestData()
 
+        # create service for the docker-compose rx-mission instance.
+        ServiceFactory.create(
+            api_type=APITypes.orc,
+            api_root="http://localhost/product",
+            auth_type=AuthTypes.no_auth,
+        )
         cls.zgw_api_group = ZGWApiGroupConfigFactory.create(
             for_test_docker_compose=True
         )
@@ -342,7 +348,7 @@ class GetProductsListViewTests(OFVCRMixin, APITestCase):
         expected_products = [
             {
                 "url": "http://localhost/product/1234abcd-12ab-34cd-56ef-12345abcde10",
-                "description": "",
+                "description": "Advies vergunning met instemming",
             }
         ]
         self.assertEqual(results, expected_products)


### PR DESCRIPTION
Extends #4796 

**Changes**

Extending the tests to cover the using of the mock RX mission service.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
