### PR TITLE
:bug: [#4732] Add missing CSP directives for Expoints/other analytics

### DIFF
--- a/src/openforms/analytics_tools/contrib/expoints/csp_headers.json
+++ b/src/openforms/analytics_tools/contrib/expoints/csp_headers.json
@@ -1,34 +1,14 @@
 [
     {
-        "directive" : "connect-src",
-        "value": "https://*.expoints.nl"
-    },
-    {
-        "directive" : "frame-src",
+        "directive" : "default-src",
         "value": "https://*.expoints.nl"
     },
     {
         "directive" : "font-src",
-        "value": "https://*.expoints.nl"
-    },
-    {
-        "directive" : "font-src",
-        "value": "https://cdn.expoints.nl"
-    },
-    {
-        "directive" : "img-src",
-        "value": "https://*.expoints.nl"
+        "value": "https://*.expoints.nl https://cdn.expoints.nl"
     },
     {
         "directive" : "script-src",
-        "value": "https://*.expoints.nl"
-    },
-    {
-        "directive" : "script-src-elem",
-        "value": "https://*.expoints.nl"
-    },
-    {
-        "directive" : "style-src",
         "value": "https://*.expoints.nl"
     }
 ]

--- a/src/openforms/analytics_tools/contrib/govmetric/csp_headers.json
+++ b/src/openforms/analytics_tools/contrib/govmetric/csp_headers.json
@@ -1,15 +1,15 @@
 [
     {
+        "directive" : "default-src",
+        "value": "https://*.govmetric.com"
+    },
+    {
         "directive" : "script-src",
         "value": "https://*.govmetric.com"
     },
     {
         "directive" : "frame-src",
         "value": "https://*.govmetric.com"
-    },
-    {
-        "directive" : "connect-src",
-        "value": "'self' https://*.govmetric.com"
     },
     {
         "directive": "img-src",

--- a/src/openforms/analytics_tools/tests/test_expoints.py
+++ b/src/openforms/analytics_tools/tests/test_expoints.py
@@ -15,14 +15,12 @@ class ExpointsTests(AnalyticsMixin, TestCase):
         cls.json_cookies = []
 
         cls.json_csp = [
-            {"directive": "connect-src", "value": "https://*.expoints.nl"},
-            {"directive": "frame-src", "value": "https://*.expoints.nl"},
-            {"directive": "font-src", "value": "https://*.expoints.nl"},
-            {"directive": "font-src", "value": "https://cdn.expoints.nl"},
-            {"directive": "img-src", "value": "https://*.expoints.nl"},
+            {"directive": "default-src", "value": "https://*.expoints.nl"},
+            {
+                "directive": "font-src",
+                "value": "https://*.expoints.nl https://cdn.expoints.nl",
+            },
             {"directive": "script-src", "value": "https://*.expoints.nl"},
-            {"directive": "script-src-elem", "value": "https://*.expoints.nl"},
-            {"directive": "style-src", "value": "https://*.expoints.nl"},
         ]
 
     def test_expoints_properly_enabled(self):

--- a/src/openforms/analytics_tools/tests/test_govmetric.py
+++ b/src/openforms/analytics_tools/tests/test_govmetric.py
@@ -20,9 +20,9 @@ class GovMetricTests(AnalyticsMixin, TestCase):
         ]
 
         cls.json_csp = [
+            {"directive": "default-src", "value": "https://*.govmetric.com"},
             {"directive": "script-src", "value": "https://*.govmetric.com"},
             {"directive": "frame-src", "value": "https://*.govmetric.com"},
-            {"directive": "connect-src", "value": "'self' https://*.govmetric.com"},
             {"directive": "img-src", "value": "https://www.klantinfocus.nl"},
         ]
 

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1094,6 +1094,7 @@ CSP_OBJECT_SRC = config("CSP_OBJECT_SRC", default=["\"'none'\""], split=True)
 # of CSP_INCLUDE_NONCE_IN
 CSP_STYLE_SRC = CSP_DEFAULT_SRC
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC
+CSP_FONT_SRC = CSP_DEFAULT_SRC
 
 # firefox does not get the nonce from default-src, see
 # https://stackoverflow.com/a/63376012


### PR DESCRIPTION
some of these were missing, others caused issues because we could no longer rely on defaults

Closes #4732 

**Changes**

* Add missing CSP directives for Expoints/other analytics

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
