### PR TITLE
Refactored the record-data building + post-processing in Objects API registration v2

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -26,13 +26,16 @@ include = [
     "src/openforms/formio/formatters/",
     # Payments
     "src/openforms/payments/models.py",
-    # Registrations
+    # Interaction with the outside world
     "src/openforms/contrib/zgw/service.py",
+    "src/openforms/contrib/objects_api/",
+    # Registrations
     "src/openforms/registrations/contrib/email/config.py",
     "src/openforms/registrations/contrib/email/plugin.py",
     "src/openforms/registrations/contrib/stuf_zds/options.py",
     "src/openforms/registrations/contrib/stuf_zds/plugin.py",
     "src/openforms/registrations/contrib/stuf_zds/typing.py",
+    "src/openforms/registrations/contrib/objects_api/handlers/",
     "src/openforms/registrations/contrib/objects_api/plugin.py",
     "src/openforms/registrations/contrib/objects_api/submission_registration.py",
     "src/openforms/registrations/contrib/objects_api/typing.py",
@@ -44,6 +47,8 @@ include = [
 ]
 exclude = [
     "**/__pycache__",
+    "src/openforms/contrib/objects_api/tests/",
+    "src/openforms/contrib/objects_api/json_schema.py",
     "src/openforms/formio/formatters/tests/",
     "src/openforms/registrations/contrib/zgw_apis/tests/test_backend_partial_failure.py",
     "src/openforms/registrations/contrib/zgw_apis/tests/test_utils.py",

--- a/src/openforms/contrib/objects_api/clients/objects.py
+++ b/src/openforms/contrib/objects_api/clients/objects.py
@@ -1,12 +1,14 @@
 from zgw_consumers.nlx import NLXClient
 
+from ..typing import Object, Record
+
 CRS_HEADERS = {"Content-Crs": "EPSG:4326"}
 
 
 class ObjectsClient(NLXClient):
-    def create_object(self, objecttype_url: str, record_data: dict) -> dict:
+    def create_object(self, objecttype_url: str, record_data: Record) -> dict:
 
-        json = {
+        json: Object = {
             "type": objecttype_url,
             "record": record_data,
         }
@@ -24,9 +26,9 @@ class ObjectsClient(NLXClient):
 
         return response.json()
 
-    def update_object(self, record_data: dict, object_uuid: str) -> dict:
+    def update_object(self, record_data: Record, object_uuid: str) -> dict:
         endpoint = f"objects/{object_uuid}"
-        json = {
+        json: Object = {
             "record": record_data,
         }
 

--- a/src/openforms/contrib/objects_api/helpers.py
+++ b/src/openforms/contrib/objects_api/helpers.py
@@ -1,12 +1,13 @@
-from typing import Any
-
+from openforms.typing import JSONObject
 from openforms.utils.date import get_today
+
+from .typing import Record
 
 
 def prepare_data_for_registration(
-    data: dict[str, Any],
+    data: JSONObject,
     objecttype_version: int,
-) -> dict[str, Any]:
+) -> Record:
     """Prepare the submission data for sending it to the Objects API."""
 
     return {

--- a/src/openforms/contrib/objects_api/typing.py
+++ b/src/openforms/contrib/objects_api/typing.py
@@ -1,0 +1,15 @@
+from typing import NotRequired, TypedDict
+
+from openforms.typing import JSONObject
+
+
+class Record(TypedDict):
+    typeVersion: int
+    startAt: str
+    data: JSONObject
+    geometry: NotRequired[JSONObject]  # TODO: narrow to GeoJSON
+
+
+class Object(TypedDict):
+    type: NotRequired[str]  # Required for create, optional for update
+    record: Record

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -59,6 +59,10 @@ class ObjecttypeVariableMappingSerializer(serializers.Serializer):
         required=False,
     )
     # specific options according to the variable key/type
+    # TODO: validate the shape of the options based on the component type that
+    # ``variable_key`` points to. However - we currently can't do this because the
+    # registration backend options are saved before the form definitions/steps are
+    # saved through the frontend/API.
     options = JSONFieldWithSchema(default=dict, required=False)
 
 

--- a/src/openforms/registrations/contrib/objects_api/handlers/__init__.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/__init__.py
@@ -1,0 +1,13 @@
+"""
+Versioned registration handlers.
+
+The Objects API registration options have multiple possible configuration versions:
+
+* v1 (legacy) - uses Django template strings to produce JSON
+* v2 (recommended) - uses explicit mappings of source -> target variables to produce
+  structures that can be JSON-serialized
+
+The implementation details vary quite a bit, but they must implement the same top-level
+interface called by the plugin, and there are some shared bits of functionality like
+handling the file uploads to the Documents API.
+"""

--- a/src/openforms/registrations/contrib/objects_api/handlers/v2.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v2.py
@@ -1,0 +1,120 @@
+"""
+Implementation details for the v2 registration handler.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from glom import Assign, Path, glom
+
+from openforms.api.utils import underscore_to_camel
+from openforms.formio.typing import Component
+from openforms.typing import JSONObject, JSONValue
+
+from ..typing import ObjecttypeVariableMapping
+
+
+@dataclass
+class AssignmentSpec:
+    """
+    Describes where certain values need to be assigned in a target object.
+    """
+
+    destination: Path
+    """
+    The target path where ``value`` shall be assigned.
+    """
+    value: JSONValue
+    """
+    The value to assign at ``destination``.
+    """
+
+
+@dataclass
+class OutputSpec:
+    assignments: Sequence[AssignmentSpec]
+
+    def create_output_data(self) -> JSONObject:
+        """
+        Assigns the specified assignment configurations to the output data.
+        """
+        target: JSONObject = {}
+        spec = tuple(
+            [
+                Assign(path=assignment.destination, val=assignment.value, missing=dict)
+                for assignment in self.assignments
+            ]
+        )
+        glom(target, spec)
+        return target
+
+
+def process_mapped_variable(
+    mapping: ObjecttypeVariableMapping,
+    value: (
+        JSONValue | date | datetime
+    ),  # can't narrow it down yet, as the type depends on the component type
+    component: Component | None = None,
+) -> AssignmentSpec | Sequence[AssignmentSpec]:
+    target_path = Path(*bits) if (bits := mapping.get("target_path")) else None
+
+    # normalize non-primitive date/datetime values so that they're ready for JSON
+    # serialization in the proper format
+    if isinstance(value, (date, datetime)):
+        value = value.isoformat()
+
+    # transform the value within the context of the component
+    # TODO: convert this in a proper registry in due time so we can use better type
+    # annotations
+    match component:
+        case {"type": "addressNL"}:
+            assert isinstance(value, dict)
+            value = value.copy()
+            value.pop("secretStreetCity", None)
+
+            # apply the more specific mappings rather than mapping the whole object
+            if detailed_mappings := mapping.get("options"):
+                return [
+                    AssignmentSpec(destination=Path(*target_path_bits), value=_value)
+                    for key, target_path_bits in detailed_mappings.items()
+                    if target_path_bits
+                    # TODO
+                    # We don't want to deal with snake/camel conversions, but for
+                    # that data model needs to be restructured and the frontend will
+                    # be affected too (see comment in PR #4751)
+                    if (_key := underscore_to_camel(key)) in value
+                    # TODO: I think we should not omit data that has been explicitly
+                    # mapped, even though it has falsy values - the key is present in
+                    # the submission data! So the next line should be deleted.
+                    if (_value := value[_key])
+                ]
+
+            # map the address NL values as a whole
+            else:
+                assert target_path is not None
+                return AssignmentSpec(destination=target_path, value=value)
+
+        # multiple files - return an array
+        case {"type": "file", "multiple": True}:
+            assert isinstance(value, list)
+
+        # single file - return only one element
+        case {"type": "file"}:
+            assert isinstance(value, list)
+            value = value[0] if value else ""
+
+        case {"type": "map"}:
+            # Currently we only support Point coordinates
+            assert isinstance(value, list) and len(value) == 2
+            value = {
+                "type": "Point",
+                "coordinates": [value[0], value[1]],
+            }
+
+        # not a component or standard behaviour where no transformation is necessary
+        case None | _:
+            pass
+
+    assert target_path is not None
+    return AssignmentSpec(destination=target_path, value=value)

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -1147,9 +1147,9 @@ class V2HandlerTests(TestCase):
                     "variable_key": "addressNl",
                     "options": {
                         "postcode": ["addressNL", "postcode"],
-                        "houseLetter": ["addressNL", "houseLetter"],
-                        "houseNumber": ["addressNL", "houseNumber"],
-                        "houseNumberAddition": [
+                        "house_letter": ["addressNL", "houseLetter"],
+                        "house_number": ["addressNL", "houseNumber"],
+                        "house_number_addition": [
                             "addressNL",
                             "houseNumberAddition",
                         ],
@@ -1177,7 +1177,7 @@ class V2HandlerTests(TestCase):
             },
         )
 
-    def test_addressNl_with_specific_target_paths_mapped_and_missing_submitted_data(
+    def test_addressNl_with_specific_target_paths_mapped_and_empty_submitted_data(
         self,
     ):
         submission = SubmissionFactory.from_components(
@@ -1213,9 +1213,9 @@ class V2HandlerTests(TestCase):
                     "variable_key": "addressNl",
                     "options": {
                         "postcode": ["addressNL", "postcode"],
-                        "houseLetter": ["addressNL", "houseLetter"],
-                        "houseNumber": ["addressNL", "houseNumber"],
-                        "houseNumberAddition": [
+                        "house_letter": ["addressNL", "houseLetter"],
+                        "house_number": ["addressNL", "houseNumber"],
+                        "house_number_addition": [
                             "addressNL",
                             "houseNumberAddition",
                         ],

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -51,11 +51,11 @@ class RegistrationOptionsV1(_BaseRegistrationOptions, total=False):
 
 class AddressNLObjecttypeVariableMapping(TypedDict):
     postcode: NotRequired[list[str]]
-    houseLetter: NotRequired[list[str]]
-    houseNumber: NotRequired[list[str]]
-    houseNumberAddition: NotRequired[list[str]]
+    house_letter: NotRequired[list[str]]
+    house_number: NotRequired[list[str]]
+    house_number_addition: NotRequired[list[str]]
     city: NotRequired[list[str]]
-    streetName: NotRequired[list[str]]
+    street_name: NotRequired[list[str]]
 
 
 class ObjecttypeVariableMapping(TypedDict):

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -647,7 +647,10 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
         )
 
         apply_data_mapping(
-            submission, object_mapping, REGISTRATION_ATTRIBUTE, record_data
+            submission,
+            object_mapping,
+            REGISTRATION_ATTRIBUTE,
+            record_data,  # pyright: ignore[reportArgumentType]
         )
 
         api_group = options["objects_api_group"]

--- a/src/openforms/submissions/mapping.py
+++ b/src/openforms/submissions/mapping.py
@@ -1,5 +1,6 @@
 import dataclasses
-from typing import Any, Callable, Mapping, TypeAlias
+from collections.abc import MutableMapping
+from typing import Any, Callable, Mapping
 
 from glom import Assign, glom
 
@@ -34,15 +35,17 @@ class FieldConf:
         assert self.attribute or self.form_field or self.submission_auth_info_attribute
 
 
-MappingConfig: TypeAlias = Mapping[str, str | FieldConf]
+type MappingConfig = Mapping[str, str | FieldConf]
 
 
-def apply_data_mapping(
+def apply_data_mapping[
+    T: MutableMapping[str, Any]
+](
     submission: Submission,
     mapping_config: MappingConfig,
     component_attribute: str,
-    target_dict: dict | None = None,
-) -> dict:
+    target_dict: T | None = None,
+) -> T:
     """
     apply mapping to data and build new data structure based on mapped attributes on the formio component configuration
 

--- a/src/openforms/typing.py
+++ b/src/openforms/typing.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import decimal
 import uuid
-from typing import TYPE_CHECKING, Any, NewType, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Any, NewType, Protocol
 
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
@@ -14,19 +16,19 @@ if TYPE_CHECKING:
 else:
     _StrOrPromise = str
 
-JSONPrimitive: TypeAlias = str | int | float | bool | None
+type JSONPrimitive = str | int | float | bool | None
 
-JSONValue: TypeAlias = "JSONPrimitive | JSONObject | list[JSONValue]"
+type JSONValue = JSONPrimitive | JSONObject | list[JSONValue]
 
-JSONObject: TypeAlias = dict[str, JSONValue]
+type JSONObject = dict[str, JSONValue]
 
-DataMapping: TypeAlias = dict[str, Any]  # key: value pair
+type DataMapping = dict[str, Any]  # key: value pair
 
-AnyRequest: TypeAlias = HttpRequest | Request
+type AnyRequest = HttpRequest | Request
 
 RegistrationBackendKey = NewType("RegistrationBackendKey", str)
 
-StrOrPromise: TypeAlias = _StrOrPromise
+type StrOrPromise = _StrOrPromise
 """Either ``str`` or a ``Promise`` object returned by the lazy ``gettext`` functions."""
 
 
@@ -35,8 +37,15 @@ class RequestHandler(Protocol):
 
 
 # Types that `django.core.serializers.json.DjangoJSONEncoder` can handle
-DjangoJSONEncodable: TypeAlias = (
-    "JSONValue | datetime.datetime | datetime.date | datetime.time | datetime.timedelta | decimal.Decimal | uuid.UUID | Promise"
+type DjangoJSONEncodable = (
+    JSONValue
+    | datetime.datetime
+    | datetime.date
+    | datetime.time
+    | datetime.timedelta
+    | decimal.Decimal
+    | uuid.UUID
+    | Promise
 )
 
 
@@ -44,4 +53,4 @@ class JSONSerializable(Protocol):
     def __json__(self) -> DjangoJSONEncodable: ...
 
 
-JSONEncodable: TypeAlias = "DjangoJSONEncodable | JSONSerializable"
+type JSONEncodable = DjangoJSONEncodable | JSONSerializable

--- a/src/openforms/variables/service.py
+++ b/src/openforms/variables/service.py
@@ -12,10 +12,13 @@ from .registry import register_static_variable as static_variables_registry
 __all__ = ["get_static_variables"]
 
 
+type VariablesRegistry = BaseRegistry[BaseStaticVariable]
+
+
 def get_static_variables(
     *,
     submission: Submission | None = None,
-    variables_registry: BaseRegistry[BaseStaticVariable] | None = None,
+    variables_registry: VariablesRegistry | None = None,
 ) -> list[FormVariable]:
     """
     Return the full collection of static variables registered by all apps.


### PR DESCRIPTION
Part of #4431 - builds on top of #4850

**Changes**

Refactored the Objects API v2 registration data building/transformations after the mappings were implemented by @vaszig. I was also able to add more files to the type checker and finally some type definitions / hints could also be cleaned up, hurray!

This had been on my mind for a while when we were fixing the bugs specifically to the file upload types w/r to single/multiple uploads, and now the additional options lead to more :spaghetti: code in this registration handler, so I figured it was time to put my thoughts into code.