### PR TITLE
Update CHANGELOG with 2.7.10 and 2.8.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,68 @@
 Changelog
 =========
 
-Upgrade notes
--------------
+2.8.2 (2024-11-25)
+==================
 
-* [:backend:`4810`] Fixed uppercase component variable values turing lowercase.
-  There are manual actions required.
+Regular bugfix release
+
+.. warning:: Manual intervention required
+    
+    We fixed a bug that would mess with the default values of selectboxes components.
+    A script is included to fix the forms that are affected - you need to run this
+    after deploying the patch release.
+
+    .. code-block:: bash
+
+        # in the container via ``docker exec`` or ``kubectl exec``:
+        python src/manage.py /app/bin/fix_selectboxes_component_default_values.py
+
+    Alternatively, you can also manually open and save all the affected forms in the
+    admin interface.
+
+**Bugfixes**
+
+* [:backend:`4732`] Fixed CSP issues for Expoints and Govmetric analytics.
+* [:backend:`4745`] Fixed missing registration variable to the Objects API with all
+  the attachment URLs.
+* [:backend:`4810`] Fixed uppercase component variable values turing lowercase. See the
+  remark above for additional instructions.
+* [:backend:`4823`] Fixed uploaded files with leading or trailing whitespaces in the
+  filename.
+* [:backend:`4727`] Fixed crash when a user defined variable was changed to an array
+  datatype.
+* [:backend:`4320`] Fixed ambiguous langugage in the summary PDF when the submission 
+  still requires cosigning.
+
+2.7.10 (2024-11-25)
+===================
+
+Periodic bugfix release
+
+.. warning:: Manual intervention required
+    
+    We fixed a bug that would mess with the default values of selectboxes components.
+    A script is included to fix the forms that are affected - you need to run this
+    after deploying the patch release.
+
+    .. code-block:: bash
+
+        # in the container via ``docker exec`` or ``kubectl exec``:
+        python src/manage.py /app/bin/fix_selectboxes_component_default_values.py
+    
+    Alternatively, you can also manually open and save all the affected forms in the
+    admin interface.
+
+**Bugfixes**
+
+* [:backend:`4732`] Fixed CSP issues for Expoints/other analytics.
+* [:backend:`4745`] Fixed missing registration variable for the Objects API plugin.
+* [:backend:`4810`] Fixed uppercase selectboxes options being lowercased if the component is
+  in a step that's being skipped. See the instructions below on how to patch existing forms.
+* [:backend:`4823`] Fixed uploading files with leading or trailing whitespace in the
+  filename.
+* [:backend:`4727`] Fixed a crash in the form designer UI when a user defined variable was 
+  changed to an array datatype.
 
 2.8.1 (2024-10-29)
 ==================


### PR DESCRIPTION
Closes #4843 

**Changes**

- Added the patch release notes for `2.7.10` and `2.8.2`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
