### PR TITLE
Removing objecttype URL to UUID import conversion

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -31,3 +31,4 @@ and expertise.
    issues/index
    upgrade-240
    upgrade-250
+   upgrade-300

--- a/docs/installation/upgrade-300.rst
+++ b/docs/installation/upgrade-300.rst
@@ -1,0 +1,19 @@
+.. _installation_upgrade_300:
+
+===================================
+Upgrade details to Open Forms 3.0.0
+===================================
+
+Backwards compatibility in form import changes
+==============================================
+
+Removal of Object API object type convertion
+--------------------------------------------
+
+With the UX changes of OF 2.8.0, the Object Api registration no longer lets you use
+hyperlinks when configuring the object type. The usage of hyperlinks for the object type
+is now also disallowed when importing a form.
+
+Previously the hyperlinks would be converted to the expected format, and saved as such.
+The convertion will no-longer take place, and the 'to be imported' form is expected to
+use the new UUID format for the object type.


### PR DESCRIPTION
Part of #3283

**Changes**

The URL to UUID convertion of the Objects API `objecttype` in the form import has been removed. The `objecttype` now has to be a UUID. Along this change, the `objects_api_group` is now again required.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
