### PR TITLE
Fix unintended hashing of identifying attributes when the cosigner logs out

### DIFF
--- a/src/openforms/authentication/api/views.py
+++ b/src/openforms/authentication/api/views.py
@@ -68,11 +68,14 @@ class SubmissionLogoutView(GenericAPIView):
                 plugin = register[submission.auth_info.plugin]
                 plugin.logout(request)
 
-            if not submission.auth_info.attribute_hashed:
-                submission.auth_info.hash_identifying_attributes()
+            if submission.is_ready_to_hash_identifying_attributes:
+                if not submission.auth_info.attribute_hashed:
+                    submission.auth_info.hash_identifying_attributes()
 
-            if not submission.registrator.attribute_hashed:
-                submission.registrator.hash_identifying_attributes()
+                if (
+                    registrator := submission.registrator
+                ) and not registrator.attribute_hashed:
+                    registrator.hash_identifying_attributes()
 
         if FORM_AUTH_SESSION_KEY in request.session:
             del request.session[FORM_AUTH_SESSION_KEY]

--- a/src/openforms/authentication/api/views.py
+++ b/src/openforms/authentication/api/views.py
@@ -39,7 +39,7 @@ class PluginListView(ListMixin, APIView):
         return list(register.iter_enabled_plugins())
 
 
-class SubmissionLogoutView(GenericAPIView):
+class SubmissionLogoutView(GenericAPIView[Submission]):
     authentication_classes = (AnonCSRFSessionAuthentication,)
     permission_classes = (ActiveSubmissionPermission,)
     serializer_class = (

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -451,7 +451,7 @@ class Submission(models.Model):
         return self.form.login_required
 
     @property
-    def is_authenticated(self):
+    def is_authenticated(self) -> bool:
         return hasattr(self, "auth_info")
 
     @property

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -470,7 +470,33 @@ class Submission(models.Model):
         return bool(self.completed_on)
 
     @property
+    def is_ready_to_hash_identifying_attributes(self) -> bool:
+        """
+        Check if the submission can safely hash the identifying auth attributes.
+        """
+        # no authentication -> there's nothing to hash
+        if not self.is_authenticated:
+            return False
+        # completed, but not cosigned yet -> registration after cosigning requires
+        # unhashed attributes
+        if self.is_completed and self.waiting_on_cosign:
+            return False
+
+        # the submission has not been submitted/completed/finalized, so it will
+        # definitely not be processed yet -> okay to hash
+        if not self.is_completed:
+            return True
+
+        # fully registered, no more processing needed -> safe to hash
+        if self.is_registered:
+            return True
+
+        # otherwise assume it's not safe yet
+        return False
+
+    @property
     def is_registered(self) -> bool:
+        # success is set if it succeeded or there was no registration backend configured
         return self.registration_status == RegistrationStatuses.success
 
     @transaction.atomic()

--- a/src/openforms/submissions/tasks/cleanup.py
+++ b/src/openforms/submissions/tasks/cleanup.py
@@ -8,7 +8,6 @@ from rest_framework.request import Request
 
 from openforms.celery import app
 
-from ..constants import RegistrationStatuses
 from ..models import Submission
 from ..status import SubmissionProcessingStatus
 from ..tokens import submission_status_token_generator
@@ -74,11 +73,7 @@ def maybe_hash_identifying_attributes(submission_id: int) -> None:
     submission = Submission.objects.get(id=submission_id)
     assert submission.completed_on is not None, "Submission must be completed first"
 
-    # success is set if it succeeded or there was no registration backend configured
-    if submission.registration_status != RegistrationStatuses.success:
-        return
-
-    if not submission.is_authenticated:
+    if not submission.is_ready_to_hash_identifying_attributes:
         return
 
     if not submission.auth_info.attribute_hashed:


### PR DESCRIPTION
Closes #4862 

**Changes**

* Added regression test that reproduces the problem
* Added minimal bugfix that can be backported by considering the cosign status
* Refactored/cleaned up other parts of code to make use of the same centralized logic if hashing is possible or not

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
