### PR TITLE
Refactor ZGW options components structure

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2517,6 +2517,12 @@
       "value": "Add variable"
     }
   ],
+  "LbiXCA": [
+    {
+      "type": 0,
+      "value": "Something went wrong while retrieving the available products defined in the selected case. Please check that the services in the selected API group are configured correctly."
+    }
+  ],
   "LeVpdf": [
     {
       "type": 0,
@@ -5335,12 +5341,6 @@
     {
       "type": 0,
       "value": "Add item"
-    }
-  ],
-  "ln2iyc": [
-    {
-      "type": 0,
-      "value": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly."
     }
   ],
   "ln72CJ": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2538,6 +2538,12 @@
       "value": "Variabele toevoegen"
     }
   ],
+  "LbiXCA": [
+    {
+      "type": 0,
+      "value": "Er ging iets fout bij het ophalen van de beschikbare producten binnen het geselecteerde zaaktype. Controleer of de services in de geselecteerde API-groep goed ingesteld zijn."
+    }
+  ],
   "LeVpdf": [
     {
       "type": 0,
@@ -5109,12 +5115,6 @@
       "value": "optie 2: € 15,99"
     }
   ],
-  "jtWzSW": [
-    {
-      "type": 0,
-      "value": "optie 2: € 15,99"
-    }
-  ],
   "jy1jTd": [
     {
       "offset": 0,
@@ -5363,12 +5363,6 @@
     {
       "type": 0,
       "value": "Item toevoegen"
-    }
-  ],
-  "ln2iyc": [
-    {
-      "type": 0,
-      "value": "Er ging iets fout bij het ophalen van de beschikbare catalogi of geselecteerde zaak producten. Controleer of de services in de geselecteerde API-groep goed ingesteld zijn."
     }
   ],
   "ln72CJ": [

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/LegacyOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/LegacyOptionsFieldset.js
@@ -1,0 +1,35 @@
+import {FormattedMessage} from 'react-intl';
+
+import Fieldset from 'components/admin/forms/Fieldset';
+
+import {LegacyCaseType, LegacyDocumentType} from './fields';
+
+/**
+ * @deprecated
+ */
+const LegacyOptionsFieldset = () => (
+  <Fieldset
+    title={
+      <FormattedMessage
+        description="ZGw APIs registration: legacy configuration options fieldset title"
+        defaultMessage="Legacy configuration"
+      />
+    }
+    fieldNames={['zaaktype', 'informatieobjecttype']}
+    collapsible
+  >
+    <div className="description">
+      <FormattedMessage
+        description="ZGW APIs legacy config options informative message"
+        defaultMessage={`The configuration options here are legacy options. They
+          will continue working, but you should upgrade to the new configuration
+          options above. If a new configuration option is specified, the matching
+          legacy option will be ignored.`}
+      />
+    </div>
+    <LegacyCaseType />
+    <LegacyDocumentType />
+  </Fieldset>
+);
+
+export default LegacyOptionsFieldset;

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ObjectsAPIOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ObjectsAPIOptionsFieldset.js
@@ -1,0 +1,62 @@
+import {useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import {ContentJSON} from 'components/admin/form_design/registrations/objectsapi/LegacyConfigFields';
+import Fieldset from 'components/admin/forms/Fieldset';
+import {ObjectsAPIGroup} from 'components/admin/forms/objects_api';
+
+import {ObjectType, ObjectTypeVersion} from './fields';
+
+/**
+ * Callback to invoke when the API group changes - used to reset the dependent fields.
+ */
+const onApiGroupChange = prevValues => ({
+  ...prevValues,
+  objecttype: '',
+  objecttypeVersion: undefined,
+});
+
+/**
+ * Configuration fields related to the Objects API (template based) integration.
+ */
+const ObjectsAPIOptionsFieldset = ({objectsApiGroupChoices}) => {
+  const {
+    values: {objecttype = ''},
+  } = useFormikContext();
+  return (
+    <Fieldset
+      title={
+        <FormattedMessage
+          description="ZGW APIs registration: Objects API fieldset title"
+          defaultMessage="Objects API integration"
+        />
+      }
+      collapsible
+      fieldNames={['objecttype', 'objecttypeVersion', 'contentJson']}
+    >
+      <ObjectsAPIGroup
+        apiGroupChoices={objectsApiGroupChoices}
+        onApiGroupChange={onApiGroupChange}
+        required={!!objecttype}
+        isClearable
+      />
+      <ObjectType />
+      <ObjectTypeVersion />
+      <ContentJSON />
+    </Fieldset>
+  );
+};
+
+ObjectsAPIOptionsFieldset.propTypes = {
+  objectsApiGroupChoices: PropTypes.arrayOf(
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.number, // value
+        PropTypes.string, // label
+      ])
+    )
+  ),
+};
+
+export default ObjectsAPIOptionsFieldset;

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/OptionalOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/OptionalOptionsFieldset.js
@@ -1,16 +1,12 @@
-import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
-import {useAsync} from 'react-use';
 
 import Fieldset from 'components/admin/forms/Fieldset';
-import {getCatalogueOption} from 'components/admin/forms/zgw';
 import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {ConfidentialityLevel, MedewerkerRoltype, OrganisationRSIN, ProductSelect} from './fields';
-import {getCatalogues} from './utils';
 
-const OptionalOptionsFieldset = ({confidentialityLevelChoices}) => {
+const OptionalOptionsFieldset = ({confidentialityLevelChoices, catalogueUrl}) => {
   return (
     <Fieldset
       title={
@@ -42,38 +38,22 @@ const OptionalOptionsFieldset = ({confidentialityLevelChoices}) => {
           <FormattedMessage
             description="ZGW APIs registrations options: case product error"
             defaultMessage={`Something went wrong while retrieving the available
-            catalogues or products defined in the selected case. Please
-            check that the services in the selected API group are configured correctly.`}
+            products defined in the selected case. Please check that the services in
+            the selected API group are configured correctly.`}
           />
         }
       >
-        <CatalogiApiField />
+        <ProductSelect catalogueUrl={catalogueUrl} />
       </ErrorBoundary>
     </Fieldset>
   );
-};
-
-const CatalogiApiField = () => {
-  const {
-    values: {zgwApiGroup = null, catalogue = undefined},
-  } = useFormikContext();
-
-  // fetch available catalogues and re-use the result
-  const {value: catalogueOptionGroups = [], error: cataloguesError} = useAsync(async () => {
-    if (!zgwApiGroup) return [];
-    return await getCatalogues(zgwApiGroup);
-  }, [zgwApiGroup]);
-  if (cataloguesError) throw cataloguesError;
-
-  const catalogueValue = getCatalogueOption(catalogueOptionGroups, catalogue || {});
-  const catalogueUrl = catalogueValue?.url;
-  return <ProductSelect catalogueUrl={catalogueUrl} />;
 };
 
 OptionalOptionsFieldset.propTypes = {
   confidentialityLevelChoices: PropTypes.arrayOf(
     PropTypes.arrayOf(PropTypes.string) // value & label are both string
   ).isRequired,
+  catalogueUrl: PropTypes.string,
 };
 
 export default OptionalOptionsFieldset;

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -9,7 +9,13 @@ import {
 import {rsSelect} from 'utils/storybookTestHelpers';
 
 import ZGWFormFields from './ZGWOptionsFormFields';
-import {mockCaseTypesGet, mockCataloguesGet, mockDocumenTypesGet, mockProductsGet} from './mocks';
+import {
+  mockCaseTypesGet,
+  mockCataloguesGet,
+  mockCataloguesGetError,
+  mockDocumenTypesGet,
+  mockProductsGet,
+} from './mocks';
 
 const NAME = 'form.registrationBackends.0.options';
 
@@ -54,7 +60,12 @@ export default {
   },
   parameters: {
     msw: {
-      handlers: [mockCataloguesGet(), mockCaseTypesGet(), mockDocumenTypesGet(), mockProductsGet()],
+      handlers: {
+        catalogues: [mockCataloguesGet()],
+        caseTypes: [mockCaseTypesGet()],
+        documentTypes: [mockDocumenTypesGet()],
+        products: [mockProductsGet()],
+      },
     },
   },
 };
@@ -76,11 +87,16 @@ export const ValidationErrorsBaseTab = {
   args: {
     validationErrors: [
       [`${NAME}.zgwApiGroup`, 'Computer says no'],
+      [`${NAME}.catalogue`, 'Computer says no'],
+      [`${NAME}.caseTypeIdentification`, 'Computer says no'],
+      [`${NAME}.documentTypeDescription`, 'Computer says no'],
       [`${NAME}.zaaktype`, 'Computer says no'],
       [`${NAME}.informatieobjecttype`, 'Computer says no'],
       [`${NAME}.organisatieRsin`, 'Computer says no'],
       [`${NAME}.zaakVertrouwelijkheidaanduiding`, 'Computer says no'],
       [`${NAME}.medewerkerRoltype`, 'Computer says no'],
+      [`${NAME}.productUrl`, 'Computer says no'],
+      [`${NAME}.objectsApiGroup`, 'Computer says no'],
       [`${NAME}.objecttype`, 'Computer says no'],
       [`${NAME}.objecttypeVersion`, 'Computer says no'],
       [`${NAME}.contentJson`, 'Computer says no'],
@@ -130,5 +146,22 @@ export const SelectCaseTypeAndDocumentType = {
       selector: '#id_documentTypeDescription',
     });
     await rsSelect(documentTypeSelect, 'Attachment');
+  },
+};
+
+export const CataloguesLoadingFails = {
+  args: {
+    formData: {
+      zgwApiGroup: 1,
+      zaaktype: '',
+      propertyMappings: [],
+    },
+  },
+  parameters: {
+    msw: {
+      handlers: {
+        catalogues: [mockCataloguesGetError()],
+      },
+    },
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/mocks.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/mocks.js
@@ -29,6 +29,11 @@ export const mockCataloguesGet = () =>
     HttpResponse.json(CATALOGUES)
   );
 
+export const mockCataloguesGetError = () =>
+  http.get(`${API_BASE_URL}/api/v2/registration/plugins/zgw-api/catalogues`, () =>
+    HttpResponse.json({unexpected: 'error'}, {status: 500})
+  );
+
 const CASE_TYPES = {
   'https://example.com/catalogi/api/v1/catalogussen/1': [
     {
@@ -143,14 +148,14 @@ export const mockDocumenTypesGet = () =>
 
 const PRODUCTS = [
   {
-    uri: 'https://example.com/product/1234',
+    url: 'https://example.com/product/1234',
   },
   {
-    uri: 'https://example.com/product/4321',
+    url: 'https://example.com/product/4321',
     description: undefined,
   },
   {
-    uri: 'https://example.com/product/1423',
+    url: 'https://example.com/product/1423',
     description: 'Product 1423',
   },
 ];

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/useCatalogueOptions.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/useCatalogueOptions.js
@@ -1,0 +1,90 @@
+import {useFormikContext} from 'formik';
+import {useAsync, usePrevious, useUpdateEffect} from 'react-use';
+
+import {getCatalogueOption} from 'components/admin/forms/zgw';
+
+import {getCatalogues} from './utils';
+
+/**
+ * Hook that manages everything related to the ZGW API group available catalogues.
+ *
+ * It's responsible for retrieving the options and the derived catalogueUrl if a
+ * catalogue is selected. It also takes care of resetting dependent form state if the
+ * catalogue changes.
+ */
+const useCatalogueOptions = () => {
+  const {
+    values: {
+      zgwApiGroup = null,
+      catalogue = undefined,
+      caseTypeIdentification = '',
+      documentTypeDescription = '',
+      medewerkerRoltype = '',
+      productUrl = '',
+    },
+    setFieldValue,
+  } = useFormikContext();
+
+  const previousCatalogue = usePrevious(catalogue);
+  const previousCaseTypeIdentification = usePrevious(caseTypeIdentification);
+
+  // fetch available catalogues and re-use the result
+  const {
+    loading: loadingCatalogues,
+    value: catalogueOptionGroups = [],
+    error: cataloguesError,
+  } = useAsync(async () => {
+    if (!zgwApiGroup) return [];
+    return await getCatalogues(zgwApiGroup);
+  }, [zgwApiGroup]);
+
+  const catalogueValue = getCatalogueOption(catalogueOptionGroups, catalogue || {});
+  const catalogueUrl = catalogueValue?.url;
+
+  // Synchronize dependent fields when dependencies change.
+  // 1. Clear case type when catalogue changes.
+  useUpdateEffect(() => {
+    const catalogueChanged = catalogue !== previousCatalogue;
+    if (previousCatalogue && catalogueChanged && caseTypeIdentification) {
+      setFieldValue('caseTypeIdentification', '');
+    }
+  }, [setFieldValue, previousCatalogue, catalogue, caseTypeIdentification]);
+
+  // 2. Clear document type when case type changes
+  useUpdateEffect(() => {
+    const caseTypeChanged = caseTypeIdentification !== previousCaseTypeIdentification;
+    if (previousCaseTypeIdentification && caseTypeChanged && documentTypeDescription) {
+      setFieldValue('documentTypeDescription', '');
+    }
+  }, [
+    setFieldValue,
+    previousCaseTypeIdentification,
+    caseTypeIdentification,
+    documentTypeDescription,
+  ]);
+
+  // 3. Clear selected product when case type changes
+  useUpdateEffect(() => {
+    const caseTypeChanged = caseTypeIdentification !== previousCaseTypeIdentification;
+    if (previousCaseTypeIdentification && caseTypeChanged && productUrl) {
+      setFieldValue('productUrl', '');
+    }
+  }, [setFieldValue, previousCaseTypeIdentification, caseTypeIdentification, productUrl]);
+
+  // 4. Clear medewerker roltype when case type changes
+  useUpdateEffect(() => {
+    const caseTypeChanged = caseTypeIdentification !== previousCaseTypeIdentification;
+    if (previousCaseTypeIdentification && caseTypeChanged && medewerkerRoltype) {
+      setFieldValue('medewerkerRoltype', '');
+    }
+  }, [setFieldValue, previousCaseTypeIdentification, caseTypeIdentification, medewerkerRoltype]);
+
+  return {
+    loadingCatalogues,
+    catalogueOptionGroups,
+    cataloguesError,
+    catalogueUrl,
+  };
+};
+
+export default useCatalogueOptions;

--- a/src/openforms/js/components/admin/forms/zgw/CatalogueSelect.js
+++ b/src/openforms/js/components/admin/forms/zgw/CatalogueSelect.js
@@ -78,22 +78,24 @@ const CatalogueSelect = ({label, isDisabled = false, loading, optionGroups}) => 
   );
 };
 
+export const CatalogueSelectOptions = PropTypes.arrayOf(
+  PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        rsin: PropTypes.string.isRequired,
+        domain: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+  })
+);
+
 CatalogueSelect.propTypes = {
   label: PropTypes.node.isRequired,
   isDisabled: PropTypes.bool,
   loading: PropTypes.bool.isRequired,
-  optionGroups: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      options: PropTypes.arrayOf(
-        PropTypes.shape({
-          rsin: PropTypes.string.isRequired,
-          domain: PropTypes.string.isRequired,
-          label: PropTypes.string.isRequired,
-        })
-      ).isRequired,
-    })
-  ),
+  optionGroups: CatalogueSelectOptions,
 };
 
 export default CatalogueSelect;

--- a/src/openforms/js/components/admin/forms/zgw/index.js
+++ b/src/openforms/js/components/admin/forms/zgw/index.js
@@ -3,6 +3,7 @@
  */
 export {
   default as CatalogueSelect,
+  CatalogueSelectOptions,
   extractValue as getCatalogueOption,
   groupAndSortOptions as groupAndSortCatalogueOptions,
 } from './CatalogueSelect';

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1214,6 +1214,11 @@
     "description": "Add process variable button",
     "originalDefault": "Add variable"
   },
+  "LbiXCA": {
+    "defaultMessage": "Something went wrong while retrieving the available products defined in the selected case. Please check that the services in the selected API group are configured correctly.",
+    "description": "ZGW APIs registrations options: case product error",
+    "originalDefault": "Something went wrong while retrieving the available products defined in the selected case. Please check that the services in the selected API group are configured correctly."
+  },
   "LeVpdf": {
     "defaultMessage": "Plugin configuration: Email",
     "description": "Email registration options modal title",
@@ -2493,11 +2498,6 @@
     "defaultMessage": "Add item",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
-  },
-  "ln2iyc": {
-    "defaultMessage": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly.",
-    "description": "ZGW APIs registrations options: case product error",
-    "originalDefault": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly."
   },
   "ln72CJ": {
     "defaultMessage": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1223,6 +1223,11 @@
     "description": "Add process variable button",
     "originalDefault": "Add variable"
   },
+  "LbiXCA": {
+    "defaultMessage": "Er ging iets fout bij het ophalen van de beschikbare producten binnen het geselecteerde zaaktype. Controleer of de services in de geselecteerde API-groep goed ingesteld zijn.",
+    "description": "ZGW APIs registrations options: case product error",
+    "originalDefault": "Something went wrong while retrieving the available products defined in the selected case. Please check that the services in the selected API group are configured correctly."
+  },
   "LeVpdf": {
     "defaultMessage": "Plugin-insellingen: e-mail",
     "description": "Email registration options modal title",
@@ -2514,11 +2519,6 @@
     "defaultMessage": "Item toevoegen",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
-  },
-  "ln2iyc": {
-    "defaultMessage": "Er ging iets fout bij het ophalen van de beschikbare catalogi of geselecteerde zaak producten. Controleer of de services in de geselecteerde API-groep goed ingesteld zijn.",
-    "description": "ZGW APIs registrations options: case product error",
-    "originalDefault": "Something went wrong while retrieving the available catalogues or products defined in the selected case. Please check that the services in the selected API group are configured correctly."
   },
   "ln72CJ": {
     "defaultMessage": "Objecttyperesource-URL in de Objecttypen-API. Wanneer dit ingesteld is, dan wordt een object van dit type aangemaakt en aan de zaak gerelateerd.",


### PR DESCRIPTION
Required for #4606

Refactored the components and hooks so we can lift up the retrieval of available catalogues in a ZGW API group.

The parent component is now responsible for fetching the available catalogues and relays the loading/error state from useAsync. It also encapsulated the derived catalogueUrl when a valid value is available and selected, which other components need to look up related objects (like case types, document types, products and the future role types).

I've opted to pass down the error into a component that just throws for the existing error boundary behaviour and location, as it's important that you can still change the API group to trigger a new attempt and we want to keep the code nicely organised.

Finally, some more fieldsets were abstracted into their own components for readability reasons.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
