### PR TITLE
Refactor (accessing) the cosign state

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -14,6 +14,7 @@ include = [
     "src/openforms/pre_requests/base.py",
     "src/openforms/pre_requests/registry.py",
     "src/openforms/prefill/base.py",
+    "src/openforms/prefill/co_sign.py",
     "src/openforms/prefill/registry.py",
     "src/openforms/registrations/base.py",
     "src/openforms/registrations/registry.py",
@@ -29,6 +30,8 @@ include = [
     # Interaction with the outside world
     "src/openforms/contrib/zgw/service.py",
     "src/openforms/contrib/objects_api/",
+    # Emails
+    "src/openforms/emails/templatetags/cosign_information.py",
     # Registrations
     "src/openforms/registrations/tasks.py",
     "src/openforms/registrations/contrib/email/config.py",
@@ -38,9 +41,13 @@ include = [
     "src/openforms/registrations/contrib/stuf_zds/typing.py",
     "src/openforms/registrations/contrib/objects_api/handlers/",
     "src/openforms/registrations/contrib/objects_api/plugin.py",
+    "src/openforms/registrations/contrib/objects_api/registration_variables.py",
     "src/openforms/registrations/contrib/objects_api/submission_registration.py",
     "src/openforms/registrations/contrib/objects_api/typing.py",
     "src/openforms/registrations/contrib/zgw_apis/",
+    # core submissions app
+    "src/openforms/submissions/cosigning.py",
+    "src/openforms/submissions/report.py",
     # our own template app/package on top of Django
     "src/openforms/template",
     # generic typing helpers

--- a/src/openforms/authentication/api/serializers.py
+++ b/src/openforms/authentication/api/serializers.py
@@ -93,7 +93,7 @@ class LoginOptionSerializer(serializers.Serializer):
 
 class CosignLoginInfoSerializer(LoginOptionSerializer):
     def get_attribute(self, form):
-        if not form.cosign_component:
+        if not form.has_cosign_enabled:
             return None
 
         # cosign component but no auth backends is an invalid config that should

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -36,9 +36,12 @@ class Registry(BaseRegistry["BasePlugin"]):
         form: Form | None = None,
         is_for_cosign: bool = False,
     ) -> list[LoginInfo]:
-        options = list()
-        if is_for_cosign and (not form or not form.cosign_component):
-            return options
+        options: list[LoginInfo] = []
+
+        # return empty list for forms without cosign
+        if is_for_cosign:
+            if not form or not form.has_cosign_enabled:
+                return []
 
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:

--- a/src/openforms/emails/confirmation_emails.py
+++ b/src/openforms/emails/confirmation_emails.py
@@ -26,8 +26,9 @@ def get_confirmation_email_templates(submission: Submission) -> tuple[str, str]:
     with translation.override(submission.language_code):
         config = GlobalConfiguration.get_solo()
         custom_templates = getattr(submission.form, "confirmation_email_template", None)
+        cosign = submission.cosign_state
 
-        match (submission.requires_cosign, custom_templates):
+        match (cosign.is_required, custom_templates):
             # no cosign, definitely no custom templates exist
             case (False, None):
                 return (
@@ -72,7 +73,7 @@ def get_confirmation_email_context_data(submission: Submission) -> dict[str, Any
             **get_variables_for_context(submission),
             "public_reference": submission.public_registration_reference,
             "registration_completed": submission.is_registered,
-            "waiting_on_cosign": submission.waiting_on_cosign,
+            "waiting_on_cosign": submission.cosign_state.is_waiting,
         }
 
     # use the ``|date`` filter so that the timestamp is first localized to the correct

--- a/src/openforms/emails/templatetags/cosign_information.py
+++ b/src/openforms/emails/templatetags/cosign_information.py
@@ -1,12 +1,23 @@
+from typing import NotRequired, TypedDict
+
 from django import template
 from django.template.loader import render_to_string
+
+from openforms.submissions.models import Submission
 
 register = template.Library()
 
 
+class CosignInformationContext(TypedDict):
+    _submission: Submission
+    rendering_text: NotRequired[bool]
+
+
 @register.simple_tag(takes_context=True)
-def cosign_information(context):
+def cosign_information(context: CosignInformationContext) -> str:
     submission = context["_submission"]
+    if not (cosign := submission.cosign_state).is_required:
+        return ""
 
     if context.get("rendering_text"):
         template_name = "emails/templatetags/cosign_information.txt"
@@ -14,8 +25,8 @@ def cosign_information(context):
         template_name = "emails/templatetags/cosign_information.html"
 
     tag_context = {
-        "cosign_complete": submission.cosign_complete,
-        "waiting_on_cosign": submission.waiting_on_cosign,
-        "cosigner_email": submission.cosigner_email,
+        "cosign_complete": cosign.is_signed,
+        "waiting_on_cosign": cosign.is_waiting,
+        "cosigner_email": cosign.email,
     }
     return render_to_string(template_name, tag_context)

--- a/src/openforms/prefill/co_sign.py
+++ b/src/openforms/prefill/co_sign.py
@@ -10,6 +10,7 @@ received, see the :mod:`signals` module.
 import logging
 
 from openforms.authentication.service import AuthAttribute
+from openforms.submissions.cosigning import CosignV1Data
 from openforms.submissions.models import Submission
 
 from .models import PrefillConfig
@@ -57,10 +58,16 @@ def add_co_sign_representation(
         plugin,
     )
 
+    _cosign_data: CosignV1Data = submission.co_sign_data.copy()
+
     values, representation = plugin.get_co_sign_values(
-        submission,
-        submission.co_sign_data["identifier"],
+        submission, _cosign_data["identifier"]
     )
-    submission.co_sign_data["fields"] = values
-    submission.co_sign_data["representation"] = representation
+    _cosign_data.update(
+        {
+            "fields": values,
+            "representation": representation,
+        }
+    )
+    submission.co_sign_data.update(_cosign_data)
     submission.save(update_fields=["co_sign_data"])

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -243,7 +243,11 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
         zaak_options: ZaakOptions = {
             **options,
             "omschrijving": submission.form.admin_name,
-            "co_sign_data": submission.co_sign_data if submission.co_sign_data else {},
+            "cosigner": (
+                cosign.signing_details["value"]
+                if (cosign := submission.cosign_state).is_signed
+                else ""
+            ),
         }
 
         with get_client(options=zaak_options) as client:

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -199,6 +199,7 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 {
                     "key": "language_code",
                 },
+                {"key": "cosignerEmail", "type": "cosign"},
             ],
             form__name="my-form",
             bsn="111222333",
@@ -214,7 +215,8 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "language_code": "Dothraki",  # some form widget defined by form designer
             },
             language_code="en",
-            co_sign_data={"value": "123456782"},
+            cosigned=True,
+            co_sign_data__value="123456782",
         )
 
         attachment = SubmissionFileAttachmentFactory.create(

--- a/src/openforms/registrations/tasks.py
+++ b/src/openforms/registrations/tasks.py
@@ -189,7 +189,7 @@ def register_submission(submission_id: int, event: PostSubmissionEvents | str) -
         )
         return
 
-    if submission.waiting_on_cosign:
+    if submission.cosign_state.is_waiting:
         logger.debug(
             "Skipping registration for submission '%s' as it hasn't been co-signed yet.",
             submission,

--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -1,0 +1,183 @@
+"""
+Expose utilities for submissions that require cosigning.
+
+Cosigning is the practice where a second actor "approves" the submission. The original
+submitter specifies who needs to cosign, e.g. a partner.
+
+Currently there are two versions of cosigning, with a third in the making:
+
+* v1: a cosign component directly in the form, which starts an additional authentication
+  flow. When the submission is completed, it is already cosigned. This flow causes
+  problems if the DigiD session is remembered and the original submitter is
+  automatically logged in again.
+* v2: still a component in the form, but cosigning is now out-of-band. The original
+  submitter provides the email address of the cosigner who will receive the request
+  via email. When the submission is completed, it is not yet cosigned.
+* v3: will probably be similar to v2, but more rigid and without Formio components.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, NotRequired, TypedDict
+
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.typing import FormAuth
+from openforms.formio.typing import Component
+from openforms.typing import JSONObject
+
+if TYPE_CHECKING:
+    from .models import Submission
+
+type CosignData = CosignV1Data | CosignV2Data
+
+
+class CosignV1Data(TypedDict):
+    """
+    The shape of data stored in
+    :attr:`openforms.submissions.models.Submission.co_sign_data`.
+    """
+
+    plugin: str
+    identifier: str
+    representation: NotRequired[str]
+    co_sign_auth_attribute: AuthAttribute
+    fields: JSONObject
+
+
+class CosignV2Data(FormAuth):
+    """
+    The shape of data stored in
+    :attr:`openforms.submissions.models.Submission.co_sign_data`.
+
+    In cosign v2, the data inherits from the standard :class:`FormAuth` data, so it
+    contains the auth plugin, attribute and identifier value.
+    """
+
+    cosign_date: NotRequired[str]
+    """
+    ISO-8601 formatted datetime indicating when the cosigner confirmed the submission.
+
+    The key may be absent in legacy submissions, which is why it's marked as
+    ``NotRequired``. It was added in Open Forms 2.7.0
+
+    .. todo:: DeprecationWarning -> remove NotRequired in Open Forms 4.0.
+    """
+
+
+class CosignState:
+    """
+    Encapsulate all the cosign state of a submission.
+    """
+
+    def __init__(self, submission: Submission):
+        self.submission = submission
+
+    def __repr__(self):
+        reference = (
+            self.submission.public_registration_reference or self.submission.uuid
+        )
+        return f"<CosignState submission=<Submission reference={reference}>>"
+
+    def _find_component(self) -> Component | None:
+        """
+        Discover the Formio cosign component in the submission/form.
+        """
+        # use the complete view on the Formio component tree(s)
+        configuration_wrapper = self.submission.total_configuration_wrapper
+
+        # there should only be one cosign component, so we check our flatmap to find the
+        # component.
+        for component in configuration_wrapper.component_map.values():
+            if component["type"] == "cosign":
+                return component
+        return None
+
+    @property
+    def is_required(self) -> bool:
+        """
+        Determine if cosigning is required for the submission or not.
+
+        Cosign is considered required in either of the following conditions:
+
+        * the cosign component in the form is required (even after evaluating form logic)
+        * the cosign component in the form is optional and an email address has been
+          provided - this indicates the submitter wanted someone to cosign it given the
+          choice.
+
+        .. note:: This does not consider cosign v1, as the cosigning is required to be
+           able to complete the submission.
+        """
+        cosign_component = self._find_component()
+        if cosign_component is None:
+            return False
+
+        # if the component itself is marked as required, we know for sure cosigning is
+        # required
+        required = cosign_component.get("validate", {}).get("required", False)
+        if required:
+            return True
+
+        # otherwise, we check if there's a cosigner email specified
+        return bool(self.email)
+
+    @property
+    def is_waiting(self) -> bool:
+        """
+        Indicate if the submission is still waiting to be cosigned.
+        """
+        if self.is_signed:
+            return False
+
+        # Cosign not complete, but required or the component was filled in the form
+        if self.is_required:
+            return True
+
+        # Cosign optional or possibly not relevant at all.
+        return False
+
+    @property
+    def is_signed(self) -> bool:
+        """
+        Indicate if the submission has been cosigned.
+        """
+        return self.submission.cosign_complete
+
+    @cached_property
+    def email(self) -> str:
+        """
+        Get the email address of the cosigner.
+        """
+        cosign_component = self._find_component()
+        assert (
+            cosign_component is not None
+        ), "You can only look up the email in forms that have a cosign component"
+
+        variables_state = self.submission.load_submission_value_variables_state()
+        values = variables_state.get_data(as_formio_data=True)
+        cosigner_email = values[cosign_component["key"]]
+        assert isinstance(cosigner_email, str)
+        return cosigner_email
+
+    @property
+    def legacy_signing_details(self) -> CosignData:
+        """
+        Expose the legacy cosign data.
+
+        In the legacy format, we don't know (at the type level) whether cosign v1 or
+        v2 was used.
+        """
+        return self.submission.co_sign_data
+
+    @property
+    def signing_details(self) -> CosignV2Data:
+        """
+        Expose the cosign details.
+
+        Legacy (cosign v1) cosign details are unsupported, use
+        :attr:`legacy_signing_details` for those instead.
+        """
+        assert (
+            self.is_signed
+        ), "You may only access the signing details after validating the 'is_signed' state."
+        return self.submission.co_sign_data

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -12,6 +12,7 @@ import faker
 import magic
 from glom import PathAccessError, glom
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.forms.tests.factories import (
     FormDefinitionFactory,
     FormFactory,
@@ -151,6 +152,25 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         with_public_registration_reference = factory.Trait(
             completed=True,
             public_registration_reference=factory.LazyFunction(get_random_reference),
+        )
+        cosigned = factory.Trait(
+            completed=True,
+            cosign_request_email_sent=True,
+            cosign_privacy_policy_accepted=True,
+            cosign_statement_of_truth_accepted=True,
+            cosign_complete=True,
+            co_sign_data=factory.Dict(
+                {
+                    "plugin": "demo",
+                    "attribute": AuthAttribute.bsn,
+                    "value": "123456782",
+                    "cosign_date": factory.LazyAttribute(
+                        lambda o: (
+                            o.factory_parent.completed_on + timedelta(days=1)
+                        ).isoformat()
+                    ),
+                }
+            ),
         )
 
     @factory.post_generation

--- a/src/openforms/submissions/tests/test_cosign_state.py
+++ b/src/openforms/submissions/tests/test_cosign_state.py
@@ -1,0 +1,150 @@
+from django.test import TestCase
+
+from ..cosigning import CosignState
+from .factories import SubmissionFactory
+
+
+class CosignStateTests(TestCase):
+
+    def test_string_representation(self):
+        submission = SubmissionFactory.build(public_registration_reference="OF-123")
+        cosign = CosignState(submission=submission)
+
+        str_repr = str(cosign)
+
+        self.assertEqual(
+            str_repr, "<CosignState submission=<Submission reference=OF-123>>"
+        )
+
+    def test_cosign_required_state(self):
+        submissions = (
+            (
+                SubmissionFactory.create(cosigned=False),
+                False,
+            ),
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": False},
+                        }
+                    ],
+                    cosigned=False,
+                ),
+                False,
+            ),
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": True},
+                        }
+                    ],
+                    cosigned=True,
+                ),
+                True,
+            ),
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": False},
+                        }
+                    ],
+                    submitted_data={"cosign": "cosigner@example.com"},
+                    cosigned=False,
+                ),
+                True,
+            ),
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": False},
+                        }
+                    ],
+                    submitted_data={"cosign": "cosigner@example.com"},
+                    cosigned=True,
+                ),
+                True,
+            ),
+        )
+
+        for index, (submission, expected) in enumerate(submissions):
+            with self.subTest(f"submission at index {index}"):
+                cosign = CosignState(submission=submission)
+
+                self.assertEqual(cosign.is_required, expected)
+
+    def test_is_waiting(self):
+        submissions = (
+            # without cosign
+            (
+                SubmissionFactory.create(cosigned=False),
+                False,
+            ),
+            # not signed yet
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": True},
+                        }
+                    ],
+                    cosigned=False,
+                ),
+                True,
+            ),
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": False},
+                        }
+                    ],
+                    submitted_data={"cosign": "cosigner@example.com"},
+                    cosigned=False,
+                ),
+                True,
+            ),
+            # signed
+            (
+                SubmissionFactory.from_components(
+                    [
+                        {
+                            "type": "cosign",
+                            "key": "cosign",
+                            "hidden": False,
+                            "validate": {"required": False},
+                        }
+                    ],
+                    submitted_data={"cosign": "cosigner@example.com"},
+                    cosigned=True,
+                ),
+                False,
+            ),
+        )
+
+        for index, (submission, expected) in enumerate(submissions):
+            with self.subTest(f"submission at index {index}"):
+                cosign = CosignState(submission=submission)
+
+                self.assertEqual(cosign.is_waiting, expected)

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -568,13 +568,13 @@ class SubmissionTests(TestCase):
         )
 
         with self.subTest("simple"):
-            self.assertEqual(submission1.cosigner_email, "test@test.nl")
+            self.assertEqual(submission1.cosign_state.email, "test@test.nl")
 
         with self.subTest("in fieldset"):
-            self.assertEqual(submission2.cosigner_email, "test@test.nl")
+            self.assertEqual(submission2.cosign_state.email, "test@test.nl")
 
         with self.subTest("nested"):
-            self.assertEqual(submission3.cosigner_email, "test@test.nl")
+            self.assertEqual(submission3.cosign_state.email, "test@test.nl")
 
     def test_clear_execution_state_without_execution_state(self):
         submission = SubmissionFactory.create()

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -169,16 +169,17 @@ def send_confirmation_email(submission: Submission) -> None:
         logger.warning(
             "Could not determine the recipient e-mail address for submission %d, "
             "skipping the confirmation e-mail.",
-            submission.id,
+            submission.pk,
         )
         logevent.confirmation_email_skip(submission)
         return
 
     cc_emails = []
+    cosign = submission.cosign_state
     should_cosigner_be_in_cc = (
-        submission.cosign_complete and not submission.cosign_confirmation_email_sent
+        cosign.is_signed and not submission.cosign_confirmation_email_sent
     )
-    if should_cosigner_be_in_cc and (cosigner_email := submission.cosigner_email):
+    if should_cosigner_be_in_cc and (cosigner_email := cosign.email):
         cc_emails.append(cosigner_email)
 
     context = get_confirmation_email_context_data(submission)
@@ -237,7 +238,7 @@ def initialise_user_defined_variables(submission: Submission):
         if variable.form_variable.source == FormVariableSources.user_defined
     }
     SubmissionValueVariable.objects.bulk_create(
-        [variable for key, variable in variables.items() if not variable.pk]
+        [variable for variable in variables.values() if not variable.pk]
     )
 
 

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -94,7 +94,7 @@ class ZaakOptions(TypedDict):
     ]
     # extra's
     omschrijving: str
-    co_sign_data: NotRequired[dict[str, str]]
+    cosigner: NotRequired[str]  # identifier of the cosigner (BSN)
 
 
 class NoServiceConfigured(RuntimeError):
@@ -241,11 +241,7 @@ class Client(BaseClient):
                 "zds_zaaktype_status_omschrijving"
             ),
             "zaak_omschrijving": self.zds_options["omschrijving"],
-            "co_signer": (
-                co_sign_data["value"]
-                if (co_sign_data := self.zds_options.get("co_sign_data"))
-                else {}
-            ),
+            "co_signer": self.zds_options.get("cosigner"),
             "zaak_identificatie": zaak_identificatie,
             "extra": extra_data,
             "global_config": GlobalConfiguration.get_solo(),

--- a/src/stuf/stuf_zds/tests/test_backend.py
+++ b/src/stuf/stuf_zds/tests/test_backend.py
@@ -208,7 +208,7 @@ class StufZDSClientTests(StUFZDSTestBase):
 
     def test_create_zaak(self, m):
         client = StufZDSClient(self.service, self.options)
-        self.options.update({"co_sign_data": {"value": "123456782"}})
+        self.options.update({"cosigner": "123456782"})
         m.post(
             self.service.soap_service.url,
             content=load_mock("creeerZaak.xml"),


### PR DESCRIPTION
Closes #4320

**Changes**

This refactor sets up a dedicated interface to read the cosign state of a submission. Highlights:

* Good typing support
* Ability to deal with cosign v1 and v2 details in the proper context
* Proper factory trait to set up the necessary database state of a submission
* Prepared for cosign v3

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
