### PR TITLE
:boom: Remove conversion of form step URL to form step UUID

### DIFF
--- a/docs/installation/upgrade-300.rst
+++ b/docs/installation/upgrade-300.rst
@@ -91,6 +91,13 @@ active locale field (``name_nl`` or ``name_en``) during imports. Instead, the
 ``translations`` key existed.  We recommend re-creating the exports on a newer version
 of Open Forms.
 
+Removal of ``formStep`` reference in form logic
+-----------------------------------------------
+
+The ``formStep`` key was deprecated in favour of ``formStepUuid`` and the conversion
+code has been removed. This may affect form exports from before Open Forms 2.1.0. We
+recommend re-creating the exports on a newer version of Open Forms.
+
 Removal of /api/v2/location/get-street-name-and-city endpoint
 =============================================================
 

--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -24,6 +24,8 @@ include = [
     # Formio tooling
     "src/openforms/formio/typing/",
     "src/openforms/formio/formatters/",
+    # Core forms app
+    "src/openforms/forms/api/serializers/logic/action_serializers.py",
     # Payments
     "src/openforms/payments/models.py",
     # Interaction with the outside world

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8754,13 +8754,6 @@ components:
           title: Key of the target variable
           description: Sleutel van de variabele die aangepast wordt door de actie.
             Dit veld is verplicht voor de actietypes `variable` - anders is het optioneel.
-        formStep:
-          type: string
-          format: uri
-          nullable: true
-          description: De formulierstap die wordt beïnvloed door de actie. Dit veld
-            is verplicht als het actietype `step-not-applicable` is, anders optioneel.
-          deprecated: true
         formStepUuid:
           type: string
           format: uuid

--- a/src/openforms/forms/tests/e2e_tests/test_logic_tab.py
+++ b/src/openforms/forms/tests/e2e_tests/test_logic_tab.py
@@ -77,7 +77,6 @@ class LogicTabTests(E2ETestCase):
                     rule.actions[0],
                     {
                         "component": "field1",
-                        "form_step": "",
                         "action": {
                             "type": "property",
                             "property": {"value": "validate.required", "type": "bool"},

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -873,8 +873,7 @@ class ImportExportTests(TempdirMixin, TestCase):
                     "actions": [
                         {
                             "action": {"type": "step-not-applicable"},
-                            # In versions <= 2.0, we used the url of the form step, but this was replaced with the UUID
-                            "form_step": "http://127.0.0.1:8999/api/v2/forms/324cadce-a627-4e3f-b117-37ca232f16b2/steps/a54864c6-c460-48bd-a520-eced60ffb209",
+                            "form_step_uuid": "a54864c6-c460-48bd-a520-eced60ffb209",
                         }
                     ],
                     "form": "http://testserver/api/v2/forms/324cadce-a627-4e3f-b117-37ca232f16b2",


### PR DESCRIPTION
Part of #3283

Fully qualified URLs to resolve a form step have been deprecated for a while, since they're not portable across environments with different base URLs.

Now the compatibility code is removed too, which may break old exports.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
