### PR TITLE
:green_heart: Fix flaky msgraph test

### DIFF
--- a/src/openforms/registrations/contrib/microsoft_graph/plugin.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/plugin.py
@@ -68,7 +68,7 @@ class MSGraphRegistration(BasePlugin):
         data["__metadata__"] = {"submission_language": submission.language_code}
         uploader.upload_json(data, folder_name / "data.json")
 
-        for attachment in submission.attachments.all():
+        for attachment in submission.attachments.order_by("pk"):
             uploader.upload_django_file(
                 attachment.content,
                 folder_name / "attachments" / attachment.get_display_name(),

--- a/src/openforms/registrations/contrib/microsoft_graph/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/tests/test_backend.py
@@ -101,8 +101,9 @@ class MSGraphRegistrationBackendTests(TestCase):
 
         set_submission_reference(submission)
 
-        with patch.object(Account, "is_authenticated", True), patch.object(
-            Drive, "get_root_folder", return_value=MockFolder()
+        with (
+            patch.object(Account, "is_authenticated", True),
+            patch.object(Drive, "get_root_folder", return_value=MockFolder()),
         ):
             graph_submission = MSGraphRegistration("microsoft-graph")
             graph_submission.register_submission(submission, self.options)


### PR DESCRIPTION
The lack of deterministic ordering when processing the submission attachments can cause tests to sometimes fail in CI.

When no explicit ordering is specified, Postgres figures out an ordering which tends to correspond to how the tuples/records are stored on disk, and on particular bad alignment of the stars the later-created record can appear before earlier ones, being returned in a non-intuitive order. For this reason, you should always make ordering explicit or if ordering doesn't matter, write assertions without assuming any ordering.

In this case, making the order explicit is the simplest fix.