### PR TITLE
:arrow_up: [#4788] Upgrade mozilla-django-oidc-db to 0.21.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -329,7 +329,7 @@ maykin-python3-saml==1.16.1
     # via django-digid-eherkenning
 mozilla-django-oidc==4.0.0
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db==0.21.0
+mozilla-django-oidc-db==0.21.1
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -603,7 +603,7 @@ mozilla-django-oidc==4.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.21.0
+mozilla-django-oidc-db==0.21.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -669,7 +669,7 @@ mozilla-django-oidc==4.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.21.0
+mozilla-django-oidc-db==0.21.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -551,7 +551,7 @@ mozilla-django-oidc==4.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.21.0
+mozilla-django-oidc-db==0.21.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -660,7 +660,7 @@ mozilla-django-oidc==4.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.21.0
+mozilla-django-oidc-db==0.21.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
the previous release specified oidc_op_jwks_endpoint and oidc_op_logout_endpoint outside of endpoint_config
