### PR TITLE
[#4874] Add missing script to the Dockerfile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,10 @@ Check off the items that are completed or not relevant.
   - [ ] Ran `./bin/makemessages_js.sh`
   - [ ] Ran `./bin/compilemessages_js.sh`
 
+- Dockerfile/scripts
+
+  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder
+
 - Commit hygiene
 
   - [ ] Commit messages refer to the relevant Github issue

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ COPY \
     ./bin/check_celery_worker_liveness.py \
     ./bin/report_component_problems.py \
     ./bin/check_temporary_uploads.py \
+    ./bin/fix_selectboxes_component_default_values.py \
     ./bin/
 
 # prevent writing to the container layer, which would degrade performance.

--- a/docs/installation/additional_scipts.rst
+++ b/docs/installation/additional_scipts.rst
@@ -1,0 +1,23 @@
+.. _installation_additional_scripts:
+
+=========================================
+Update Open Forms with additional scripts
+=========================================
+
+Sometimes, upgrading from a specific version of Open Forms to another one requires an extra
+script which is necessary for additional operations. In case this script is missing in your
+container you can follow the instructions to copy it from the project source.
+
+1.  Visit the source code of Open Forms in github and download the raw file:
+
+.. code-block:: bash
+
+    $ wget https://github.com/open-formulieren/open-forms/blob/master/<name_of_the_file>
+
+2.  Copy the downloaded file to the `/app/bin` folder in the container
+
+.. code-block:: bash
+
+    $ docker cp <file_name> <container_id_or_name>:/app/bin
+
+3.  Run the script

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -31,6 +31,7 @@ After installation, follow the :ref:`configuration_index` instructions to enable
    self_signed
    form_hosting
    redis
+   additional_scipts
    issues/index
    upgrade-300
    upgrade-250


### PR DESCRIPTION
Closes #4874 

**Changes**

- Added `fix_selectboxes_component_default_values` scipt to the Dockerfile
- Updated issue template (reminder for such scripts)
- Added instructions for downloading and adding the script manually

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
