### PR TITLE
[#4899] Fix optional serializer fields in ZaakOptionsSerializer

### DIFF
--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -86,24 +86,27 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         default="",
     )
     product_url = serializers.URLField(
-        required=False,
         label=_("Product url"),
         help_text=_(
             "The product url will be retrieved from the specified case type "
             "and the version that is active at that moment. "
         ),
+        required=False,
+        allow_blank=True,
         default="",
     )
 
     # DeprecationWarning - deprecated, will be removed in OF 3.0 or 4.0
     zaaktype = serializers.URLField(
-        required=False,
         help_text=_("URL of the ZAAKTYPE in the Catalogi API"),
+        required=False,
+        allow_blank=True,
         default="",
     )
     informatieobjecttype = serializers.URLField(
-        required=False,
         help_text=_("URL of the INFORMATIEOBJECTTYPE in the Catalogi API"),
+        required=False,
+        allow_blank=True,
         default="",
     )
     organisatie_rsin = serializers.CharField(


### PR DESCRIPTION
Closes #4899

**Changes**

- Allow optional url fields to receive empty string values

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
