### PR TITLE
[#4319] Make title of document configurable in StUF-ZDS

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -405,6 +405,12 @@
       "value": "API group"
     }
   ],
+  "2mgmOj": [
+    {
+      "type": 0,
+      "value": "The title for the document that is related to the case."
+    }
+  ],
   "2nxTFx": [
     {
       "type": 0,
@@ -2939,6 +2945,12 @@
       "value": "StUF-ZDS name"
     }
   ],
+  "Qd9qN8": [
+    {
+      "type": 0,
+      "value": "Tile layer"
+    }
+  ],
   "Qjl92W": [
     {
       "type": 0,
@@ -4211,12 +4223,6 @@
       "value": "Product request type"
     }
   ],
-  "ctoEdl": [
-    {
-      "type": 0,
-      "value": "The name under which the INFORMATIEOBJECT is formally known."
-    }
-  ],
   "cuivC6": [
     {
       "type": 0,
@@ -4389,6 +4395,12 @@
     {
       "type": 0,
       "value": "Map configuration"
+    }
+  ],
+  "eAmrdi": [
+    {
+      "type": 0,
+      "value": "Loading..."
     }
   ],
   "eBk+W0": [
@@ -6401,6 +6413,12 @@
     {
       "type": 0,
       "value": "Translation enabled"
+    }
+  ],
+  "xbUkMg": [
+    {
+      "type": 0,
+      "value": "The tile layer is responsible for showing the map background. This effects the map style at particular coordinates and zoom levels."
     }
   ],
   "xcp+LU": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -405,6 +405,12 @@
       "value": "API-groep"
     }
   ],
+  "2mgmOj": [
+    {
+      "type": 0,
+      "value": "De titel voor het zaakdocument."
+    }
+  ],
   "2nxTFx": [
     {
       "type": 0,
@@ -2956,6 +2962,12 @@
       "value": "StUF-ZDS-naam"
     }
   ],
+  "Qd9qN8": [
+    {
+      "type": 0,
+      "value": "Kaartlaag"
+    }
+  ],
   "Qjl92W": [
     {
       "type": 0,
@@ -4233,12 +4245,6 @@
       "value": "Productaanvraagtype"
     }
   ],
-  "ctoEdl": [
-    {
-      "type": 0,
-      "value": "Titel voor het document in de Documenten API."
-    }
-  ],
   "cuivC6": [
     {
       "type": 0,
@@ -4411,6 +4417,12 @@
     {
       "type": 0,
       "value": "Kaartinstellingen"
+    }
+  ],
+  "eAmrdi": [
+    {
+      "type": 0,
+      "value": "Aan het laden..."
     }
   ],
   "eBk+W0": [
@@ -6423,6 +6435,12 @@
     {
       "type": 0,
       "value": "Vertalingen ingeschakeld"
+    }
+  ],
+  "xbUkMg": [
+    {
+      "type": 0,
+      "value": "De kaartlaag bepaalt de achtergrond van het kaartmateriaal voor verschillende coördinaten en zoomniveaus."
     }
   ],
   "xcp+LU": [

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -345,7 +345,7 @@
   "Vertrouwelijkheidaanduiding": "Vertrouwelijkheidaanduiding",
   "Indication of the level to which extent the INFORMATIEOBJECT is meant to be public.": "Vertrouwelijkheidaanduiding van het document in de Documenten API. Indien leeg, dan worden algemene instellingen gebruikt.",
   "Title": "Titel",
-  "The name under which the INFORMATIEOBJECT is formally known.": "Titel voor het document in de Documenten API.",
+  "The title for the document that is related to the case.": "De titel voor het zaak document.",
   "The maximum number of decimal places.": "Het maximaal aantal decimalen.",
   "Column Properties": "Kolomeigenschappen",
   "Add Column": "Kolom toevoegen",

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -374,7 +374,8 @@ class Client(BaseClient):
             doc_id=doc_id,
             document=submission_attachment,
             doc_data={
-                "titel": "bijlage",
+                "titel": submission_attachment.titel
+                or submission_attachment.get_display_name(),
                 "bestandsnaam": submission_attachment.get_display_name(),
                 "formaat": submission_attachment.content_type,
                 "beschrijving": "Bijgevoegd document",


### PR DESCRIPTION
Closes #4319

**Changes**

- [x] Add the ability to configure document's title in StUF-ZDS by the file upload component itself.
~- Needs open-formulieren/formio-builder#199~ (this will be handled by #4881)
~- Upgrade the formio-builder to the new version~ (this will be handled by #4881)
- [x] Update the translations in the backend

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
