### PR TITLE
Ensure that no form variables are created for soft required errors

### DIFF
--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -60,7 +60,7 @@ class FormVariableManager(models.Manager):
         ):
             if (
                 is_layout_component(component)
-                or component["type"] == "content"
+                or component["type"] in ("content", "softRequiredErrors")
                 or component["key"] in existing_form_variables_keys
                 or component_in_editgrid(form_definition_configuration, component)
             ):

--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -60,6 +60,9 @@ const makeNewVariableFromComponent = (component, formDefinition) => {
 const shouldNotUpdateVariables = (newComponent, oldComponent, mutationType, stepConfiguration) => {
   // Issue #1695: content components are not considered layout components
   if (newComponent.type === 'content') return true;
+  // Issue #4884 - soft required errors are pretty much the same as content components,
+  // with additional special client-side behaviour
+  if (newComponent.type === 'softRequiredErrors') return true;
 
   const isLayout = FormioUtils.isLayoutComponent(newComponent);
 
@@ -84,9 +87,10 @@ const shouldNotUpdateVariables = (newComponent, oldComponent, mutationType, step
 const getFormVariables = (formDefinition, configuration) => {
   const newFormVariables = [];
 
-  FormioUtils.eachComponent(configuration.components, component =>
-    newFormVariables.push(makeNewVariableFromComponent(component, formDefinition))
-  );
+  FormioUtils.eachComponent(configuration.components, component => {
+    if (component.type === 'softRequiredErrors') return;
+    newFormVariables.push(makeNewVariableFromComponent(component, formDefinition));
+  });
   return newFormVariables;
 };
 


### PR DESCRIPTION
Closes #4884

The soft required errors component should have the same behaviour like the content component, as it holds no submission values and is purely client-side behaviour.

Formio itself excludes the content component when looping over a configuration with eachComponent, so we need to add this same logic to our own code since Formio is not aware of our custom component semantics.

In the backend, we extend the behaviour for content components to the softRequiredErrors component to ensure no variables are created in the database either.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
