### PR TITLE
:boom: Disable legacy OIDC endpoints by default

### DIFF
--- a/docs/configuration/authentication/oidc_digid.rst
+++ b/docs/configuration/authentication/oidc_digid.rst
@@ -45,12 +45,9 @@ omgeving van de OpenID Connect provider.
 
 **Redirect URI (vanaf Open Formulieren 2.7.0)**
 
-.. warning::
+.. versionchanged:: 3.0
 
-    Zorg dat Open Formulieren :ref:`geïnstalleerd <installation_index>` is met de
-    ``USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS=false``
-    :ref:`omgevingsvariabele<installation_environment_config>`, anders worden de legacy
-    (zie hieronder) endpoints gebruikt.
+    Open Forms no longer uses the legacy endpoints by default.
 
 Voor de **Redirect URI** vul je ``https://open-formulieren.gemeente.nl/auth/oidc/callback/`` in,
 waarbij je ``open-formulieren.gemeente.nl`` vervangt door het relevante domein.

--- a/docs/configuration/authentication/oidc_eherkenning.rst
+++ b/docs/configuration/authentication/oidc_eherkenning.rst
@@ -60,12 +60,9 @@ maken in de omgeving van de OpenID Connect provider.
 
 **Redirect URI (vanaf Open Formulieren 2.7.0)**
 
-.. warning::
+.. versionchanged:: 3.0
 
-    Zorg dat Open Formulieren :ref:`geïnstalleerd <installation_index>` is met de
-    ``USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS=false``
-    :ref:`omgevingsvariabele<installation_environment_config>`, anders worden de legacy
-    (zie hieronder) endpoints gebruikt.
+    Open Forms no longer uses the legacy endpoints by default.
 
 Voor de **Redirect URI** vul je ``https://open-formulieren.gemeente.nl/auth/oidc/callback/`` in,
 waarbij je ``open-formulieren.gemeente.nl`` vervangt door het relevante domein.

--- a/docs/configuration/general/oidc.rst
+++ b/docs/configuration/general/oidc.rst
@@ -38,12 +38,9 @@ maken in de omgeving van de OpenID Connect provider.
 
 **Redirect URI (vanaf Open Formulieren 2.7.0)**
 
-.. warning::
+.. versionchanged:: 3.0
 
-    Zorg dat Open Formulieren :ref:`geïnstalleerd <installation_index>` is met de
-    ``USE_LEGACY_OIDC_ENDPOINTS=false`` en ``USE_LEGACY_ORG_OIDC_ENDPOINTS=false``
-    :ref:`omgevingsvariabelen<installation_environment_config>`, anders worden de legacy
-    (zie hieronder) endpoints gebruikt.
+    Open Forms no longer uses the legacy endpoints by default.
 
 Voor de **Redirect URI** vul je ``https://open-formulieren.gemeente.nl/auth/oidc/callback/`` in,
 waarbij je ``open-formulieren.gemeente.nl`` vervangt door het relevante domein. Deze

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -277,23 +277,6 @@ Other settings
   enable :ref:`Organization accounts <configuration_authentication_oidc>`. Defaults
   to ``False``.
 
-* ``USE_LEGACY_OIDC_ENDPOINTS``: Defaults to ``True`` for backwards compatibility
-  reasons. New installations should opt-out. If ``False``, the OIDC callback URL is
-  ``/auth/oidc/callback/``, if ``True``, it is ``/oidc/callback/``.
-
-* ``USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS``: Defaults to ``True`` for backwards compatibility
-  reasons. New installations should opt-out. If ``False``, the OIDC callback URL is
-  ``/auth/oidc/callback/``, if ``True``, they are:
-
-      - ``/digid-oidc/callback/``
-      - ``/eherkenning-oidc/callback/``
-      - ``/digid-machtigen-oidc/callback/``
-      - ``/eherkenning-bewindvoering-oidc/callback/``
-
-* ``USE_LEGACY_ORG_OIDC_ENDPOINTS``: Defaults to ``True`` for backwards compatibility
-  reasons. New installations should opt-out. If ``False``, the OIDC callback URL is
-  ``/auth/oidc/callback/``, if ``True``, it is ``/org-oidc/callback/``.
-
 * ``SESSION_EXPIRE_AT_BROWSER_CLOSE``: Controls if sessions expire at browser close.
   This applies to both the session of end-users filling out forms and staff using the
   administrative interface. Enabling this forces users to log in every time they open

--- a/docs/installation/upgrade-300.rst
+++ b/docs/installation/upgrade-300.rst
@@ -14,6 +14,29 @@ be aware of, as they may require additional manual actions.
    :depth: 1
    :local:
 
+Legacy OpenID Connect callback endpoints are now disabled by default
+====================================================================
+
+Before Open Forms 3.0, the legacy endpoints were used by default.
+
+The following environment variables now default to ``False`` instead of ``True``:
+
+* ``USE_LEGACY_OIDC_ENDPOINTS``
+* ``USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS``
+* ``USE_LEGACY_ORG_OIDC_ENDPOINTS``
+
+To keep the old behaviour, make sure you deploy with:
+
+.. code-block:: bash
+
+    USE_LEGACY_OIDC_ENDPOINTS=True
+    USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS=True
+    USE_LEGACY_ORG_OIDC_ENDPOINTS=True
+
+To use the new behaviour, you must ensure that
+``https://open-formulieren.gemeente.nl/auth/oidc/callback/`` is listed in the allowed
+**Redirect URI** values of your identity provider.
+
 Removal of price logic
 ======================
 

--- a/src/openforms/accounts/tests/data/vcr_cassettes/OIDCFlowTests/OIDCFlowTests.test_duplicate_email_unique_constraint_violated.yaml
+++ b/src/openforms/accounts/tests/data/vcr_cassettes/OIDCFlowTests/OIDCFlowTests.test_duplicate_email_unique_constraint_violated.yaml
@@ -11,23 +11,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ukqle/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/ukqle/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"42bc6649-8efa-40ef-a229-7f9f26e02c29\",\n
-        \             \"mIGsjEG5nr4\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=mIGsjEG5nr4&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"5b3a8c2e-d6fd-4bf2-839f-76765f0aece8\",\n
+        \             \"trVwvLk7Us8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=trVwvLk7Us8&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -35,7 +35,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=gNqT7l3I9fzf0d5g5A3s0h6k8D-u5snr93EhiyO5Aoo&amp;execution=7a8c9245-126d-4109-935a-4dcabde8fa23&amp;client_id=testid&amp;tab_id=mIGsjEG5nr4\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=rGam8K8FsQd0mP6kKHJLxqBBNcdzHx3YL9ViUR0iJyI&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=trVwvLk7Us8\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -61,7 +61,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/ukqle/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -75,11 +75,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=42bc6649-8efa-40ef-a229-7f9f26e02c29; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=5b3a8c2e-d6fd-4bf2-839f-76765f0aece8; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=42bc6649-8efa-40ef-a229-7f9f26e02c29; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=5b3a8c2e-d6fd-4bf2-839f-76765f0aece8; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.f7ZABGR0O48xm61gDKLOR_LjWH9a59wtTbGXUfm78sI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.UsxD0tVSe-9hZ_8P5DlMkG_4ShlRvds8Z3EiZQ2goYc;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -110,11 +110,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=42bc6649-8efa-40ef-a229-7f9f26e02c29; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.f7ZABGR0O48xm61gDKLOR_LjWH9a59wtTbGXUfm78sI
+      - AUTH_SESSION_ID_LEGACY=5b3a8c2e-d6fd-4bf2-839f-76765f0aece8; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.UsxD0tVSe-9hZ_8P5DlMkG_4ShlRvds8Z3EiZQ2goYc
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=gNqT7l3I9fzf0d5g5A3s0h6k8D-u5snr93EhiyO5Aoo&execution=7a8c9245-126d-4109-935a-4dcabde8fa23&client_id=testid&tab_id=mIGsjEG5nr4
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=rGam8K8FsQd0mP6kKHJLxqBBNcdzHx3YL9ViUR0iJyI&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=trVwvLk7Us8
   response:
     body:
       string: ''
@@ -124,7 +124,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/oidc/callback/?state=not-a-random-string&session_state=42bc6649-8efa-40ef-a229-7f9f26e02c29&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=1070eed8-272a-4056-8cc9-b9d8633f06a4.42bc6649-8efa-40ef-a229-7f9f26e02c29.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=5b3a8c2e-d6fd-4bf2-839f-76765f0aece8&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=3ee3cb40-05c0-4b17-bd73-f703bcb8427a.5b3a8c2e-d6fd-4bf2-839f-76765f0aece8.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -134,15 +134,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE0ODksImlhdCI6MTczMjYxNTQ4OSwianRpIjoiZjAwNWEzNGUtMzM1ZS00MjNiLWFmNWMtOTcxZDBlOTk4MGVkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJzaWQiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJzdGF0ZV9jaGVja2VyIjoiclV3MTFMX2JETHpnTXNYbGc1YklLX0VlODNtMFlRejJBay1tM1l0Q3FVZyJ9.7sEzBmVgrhzW5C1xg2__xh6wglHsYNQvrtItXa088FY;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ0NjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiNmVhNGRmMjAtMWY4NC00YzJhLThjYzYtYWVhNzZmZWZjNTdhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJzaWQiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJzdGF0ZV9jaGVja2VyIjoic3V3Vm1rMmhrQXZXZGdGQk41MmdQcXRQc0EwLVlrY0liLVpmcmtjSlRxQSJ9._M7WsRPFEtPvCU-SEYBw7c-4H0GWvJGQx7LR85fvWSM;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE0ODksImlhdCI6MTczMjYxNTQ4OSwianRpIjoiZjAwNWEzNGUtMzM1ZS00MjNiLWFmNWMtOTcxZDBlOTk4MGVkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJzaWQiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJzdGF0ZV9jaGVja2VyIjoiclV3MTFMX2JETHpnTXNYbGc1YklLX0VlODNtMFlRejJBay1tM1l0Q3FVZyJ9.7sEzBmVgrhzW5C1xg2__xh6wglHsYNQvrtItXa088FY;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ0NjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiNmVhNGRmMjAtMWY4NC00YzJhLThjYzYtYWVhNzZmZWZjNTdhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJzaWQiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJzdGF0ZV9jaGVja2VyIjoic3V3Vm1rMmhrQXZXZGdGQk41MmdQcXRQc0EwLVlrY0liLVpmcmtjSlRxQSJ9._M7WsRPFEtPvCU-SEYBw7c-4H0GWvJGQx7LR85fvWSM;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/42bc6649-8efa-40ef-a229-7f9f26e02c29;
-        Version=1; Expires=Tue, 26-Nov-2024 20:04:49 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/5b3a8c2e-d6fd-4bf2-839f-76765f0aece8;
+        Version=1; Expires=Fri, 13-Dec-2024 07:21:04 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/42bc6649-8efa-40ef-a229-7f9f26e02c29;
-        Version=1; Expires=Tue, 26-Nov-2024 20:04:49 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/5b3a8c2e-d6fd-4bf2-839f-76765f0aece8;
+        Version=1; Expires=Fri, 13-Dec-2024 07:21:04 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -161,7 +161,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=1070eed8-272a-4056-8cc9-b9d8633f06a4.42bc6649-8efa-40ef-a229-7f9f26e02c29.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Foidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=3ee3cb40-05c0-4b17-bd73-f703bcb8427a.5b3a8c2e-d6fd-4bf2-839f-76765f0aece8.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -170,7 +170,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '267'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -179,7 +179,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODksImlhdCI6MTczMjYxNTQ4OSwiYXV0aF90aW1lIjoxNzMyNjE1NDg5LCJqdGkiOiIzOWRjZDFmNS1iNmFkLTRkMzEtODhjZS00MmEyZDZkMmI2NzIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjQyYmM2NjQ5LThlZmEtNDBlZi1hMjI5LTdmOWYyNmUwMmMyOSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjQyYmM2NjQ5LThlZmEtNDBlZi1hMjI5LTdmOWYyNmUwMmMyOSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.KqCuaz2sMD8Ld0zR0tYOQZ8s21Qp9NVuwjovKDYa_Cmkg3qQfiCqR9yQEoTrYVKsMhimVJb7QNE_KYSs20aJ0p54reDVPPX3kHbJe5Bj__QAmH2eNkgNHXthn77UtWoSxisd_tWq2ctS8C-_7zyxwhZC0WMhs9X8mmppoBfNoKQmIHcZm1TBRVXNc412TF_nInWDAyoRoF93pI3yiqwh1YHiScNhZ5Ndr8Si5l50q1BNwyDShMVTjlKceJuATpkBdAb7y5kM8YT91krRzj7UJ-6_MyuO3Z-ALMbBM0O9ZqJ1RaTK2iTeK9034-bj_ML1ksIC7q6BVWCb30mzw_ry9A","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTcyODksImlhdCI6MTczMjYxNTQ4OSwianRpIjoiMjFjMDYwYjEtZTJlOC00YTU3LTkyZjItYThiNDNjNzk1ZWNlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNDJiYzY2NDktOGVmYS00MGVmLWEyMjktN2Y5ZjI2ZTAyYzI5In0.O3TRMHk-99X5RrQKh6okDGdyvrJZVPdgOk972uwTvI8","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODksImlhdCI6MTczMjYxNTQ4OSwiYXV0aF90aW1lIjoxNzMyNjE1NDg5LCJqdGkiOiI2Y2VlYTk2ZC1kMjI1LTQ0ZGQtYjYyNy05MThjYTEzNzk5MGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJhdF9oYXNoIjoienFBYjVjUzRzaGU1RmlYeG5TOG9EUSIsImFjciI6IjEiLCJzaWQiOiI0MmJjNjY0OS04ZWZhLTQwZWYtYTIyOS03ZjlmMjZlMDJjMjkiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.uUdCSm0d4hSZqwywesD9ZaGxH-F7EGPd5OdY8VjGWJAPte2T_ET2Yic6rhYEqPXn-ZC5F8qv9_wQ88yYFxiLkmRHcgEmD8eFKQthqXg-RwX87-CPi5K4ruirqPEISFaZfjrDqFumCpFIRALQTgpPRhR1x_X8dSe-XMZo7Rfmb92ggx80l7Vngnncuvd1qVnBE2I7rIMe6T9tWzLCK742HP3z_eYsefQjLi4FszCAhAJ5stCSl7610IBT_oczN-noLN2GGRdcO5CpsSNM6NlXUK8WT_5kaKjlCTQy8V6K91gFszt_OwsXb_ZmPE5rKu1M__9vZvjD4q3RdFX5aYFkEQ","not-before-policy":0,"session_state":"42bc6649-8efa-40ef-a229-7f9f26e02c29","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiI5ZGIxMTkzOS0yMDIyLTQ2MGQtYjRjNy0yOTg1M2Y0MmRkMGQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjViM2E4YzJlLWQ2ZmQtNGJmMi04MzlmLTc2NzY1ZjBhZWNlOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjViM2E4YzJlLWQ2ZmQtNGJmMi04MzlmLTc2NzY1ZjBhZWNlOCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.yd0mLrP2oegS2EnU2SWxtIn5Vvn2arqqo4xhrUIC69skeCC-44DE2OF7o2qOB14284HSqeo-O25yyrrPYd2ovvh0de-xKH08oLfRXYxAwx2NHov7yTzb0RCFPr8CehAL4VV5ItJz1ghLDMdrCiGwqnTxe8LuOMtcmtVcxU27NVMbWQ_Q0TMULIcCxxK_u-5Fch7puOnOZ8mgN1si349K9jbNolBmctAvEiZNFqqMUz3qt67p1tUPoaOyZkpnpw3SOsTUxNK7-Ct6wh8RxX_-thrZsdl0eKrWaUzQxVNGkucZhSrYW1M-GsYGPzPDRs6QvdLcqFCxdzuUadQW5phj2Q","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAyNjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiOTU5YTc5ZTMtZmViNi00YjMxLThkYzktOTczMmNiODY5YjdlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNWIzYThjMmUtZDZmZC00YmYyLTgzOWYtNzY3NjVmMGFlY2U4In0.HKe3YP2hFJ9QaYMc6u5HFnJymJIA2KXnPBYIrliNOWQ","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiIzODBkMTBlOC0yMWFhLTQxZTAtYjhhYS0zMWE2MDhlNmFmODQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJhdF9oYXNoIjoiOGs1YzZhaUtGbTNoOGZtcklxcVAwQSIsImFjciI6IjEiLCJzaWQiOiI1YjNhOGMyZS1kNmZkLTRiZjItODM5Zi03Njc2NWYwYWVjZTgiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.qhQThWMqgAWPUr6k5ykHKtuFGL1IFUkrRljaxQWvbrpv_qjsXoWLrQnzrKNKfvb67jbMZcsnqve4AT8HGblKA0woSbZYPwTr2pmj_HAJNJMJgsp2EWctggEubiKZ1BWOPxeSfaYLDao0zgqk5nkuU5uRZ7AKp8icY5Uh5vNX6jqRiPEz7WUqF0xRao6rzylczzTJfK_4cjmzsNQ5M0CMxHLAU2rWKnI3rufV_mNLy_Zfv832wEIHYYVi_RCg0KZN3Pp3O0BXQUISd9ZrkLSzCvYP7Gvc7LN7jv76ENBIFLfeIJwtMBI0Cpqilr-6CG-31TXgyy2lXESesqWKn3myGg","not-before-policy":0,"session_state":"5b3a8c2e-d6fd-4bf2-839f-76765f0aece8","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -247,7 +247,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODksImlhdCI6MTczMjYxNTQ4OSwiYXV0aF90aW1lIjoxNzMyNjE1NDg5LCJqdGkiOiIzOWRjZDFmNS1iNmFkLTRkMzEtODhjZS00MmEyZDZkMmI2NzIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjQyYmM2NjQ5LThlZmEtNDBlZi1hMjI5LTdmOWYyNmUwMmMyOSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjQyYmM2NjQ5LThlZmEtNDBlZi1hMjI5LTdmOWYyNmUwMmMyOSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.KqCuaz2sMD8Ld0zR0tYOQZ8s21Qp9NVuwjovKDYa_Cmkg3qQfiCqR9yQEoTrYVKsMhimVJb7QNE_KYSs20aJ0p54reDVPPX3kHbJe5Bj__QAmH2eNkgNHXthn77UtWoSxisd_tWq2ctS8C-_7zyxwhZC0WMhs9X8mmppoBfNoKQmIHcZm1TBRVXNc412TF_nInWDAyoRoF93pI3yiqwh1YHiScNhZ5Ndr8Si5l50q1BNwyDShMVTjlKceJuATpkBdAb7y5kM8YT91krRzj7UJ-6_MyuO3Z-ALMbBM0O9ZqJ1RaTK2iTeK9034-bj_ML1ksIC7q6BVWCb30mzw_ry9A
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiI5ZGIxMTkzOS0yMDIyLTQ2MGQtYjRjNy0yOTg1M2Y0MmRkMGQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjViM2E4YzJlLWQ2ZmQtNGJmMi04MzlmLTc2NzY1ZjBhZWNlOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjViM2E4YzJlLWQ2ZmQtNGJmMi04MzlmLTc2NzY1ZjBhZWNlOCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.yd0mLrP2oegS2EnU2SWxtIn5Vvn2arqqo4xhrUIC69skeCC-44DE2OF7o2qOB14284HSqeo-O25yyrrPYd2ovvh0de-xKH08oLfRXYxAwx2NHov7yTzb0RCFPr8CehAL4VV5ItJz1ghLDMdrCiGwqnTxe8LuOMtcmtVcxU27NVMbWQ_Q0TMULIcCxxK_u-5Fch7puOnOZ8mgN1si349K9jbNolBmctAvEiZNFqqMUz3qt67p1tUPoaOyZkpnpw3SOsTUxNK7-Ct6wh8RxX_-thrZsdl0eKrWaUzQxVNGkucZhSrYW1M-GsYGPzPDRs6QvdLcqFCxdzuUadQW5phj2Q
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/accounts/tests/data/vcr_cassettes/OIDCFlowTests/OIDCFlowTests.test_happy_flow.yaml
+++ b/src/openforms/accounts/tests/data/vcr_cassettes/OIDCFlowTests/OIDCFlowTests.test_happy_flow.yaml
@@ -11,23 +11,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ukqle/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/ukqle/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"3de77b90-202e-4797-9db0-ccc1de98947b\",\n
-        \             \"Rqi7OpqzoEg\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=Rqi7OpqzoEg&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"e674b6e8-68f3-4dd9-9315-8c0629e6b9b6\",\n
+        \             \"hAev5kDJk3w\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=hAev5kDJk3w&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -35,7 +35,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=ongdr25eRzXmCU2RaqS41Beo4hicVvdqN82oeXIisEI&amp;execution=7a8c9245-126d-4109-935a-4dcabde8fa23&amp;client_id=testid&amp;tab_id=Rqi7OpqzoEg\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=aHkP3fO1IxbzTSEM9u9y_mmOSLI2fNfLcv4EwTkPNjo&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=hAev5kDJk3w\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -61,7 +61,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/ukqle/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -75,11 +75,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=3de77b90-202e-4797-9db0-ccc1de98947b; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=e674b6e8-68f3-4dd9-9315-8c0629e6b9b6; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=3de77b90-202e-4797-9db0-ccc1de98947b; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=e674b6e8-68f3-4dd9-9315-8c0629e6b9b6; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.f7ZABGR0O48xm61gDKLOR_LjWH9a59wtTbGXUfm78sI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.UsxD0tVSe-9hZ_8P5DlMkG_4ShlRvds8Z3EiZQ2goYc;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -110,11 +110,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=3de77b90-202e-4797-9db0-ccc1de98947b; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.f7ZABGR0O48xm61gDKLOR_LjWH9a59wtTbGXUfm78sI
+      - AUTH_SESSION_ID_LEGACY=e674b6e8-68f3-4dd9-9315-8c0629e6b9b6; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.UsxD0tVSe-9hZ_8P5DlMkG_4ShlRvds8Z3EiZQ2goYc
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=ongdr25eRzXmCU2RaqS41Beo4hicVvdqN82oeXIisEI&execution=7a8c9245-126d-4109-935a-4dcabde8fa23&client_id=testid&tab_id=Rqi7OpqzoEg
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=aHkP3fO1IxbzTSEM9u9y_mmOSLI2fNfLcv4EwTkPNjo&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=hAev5kDJk3w
   response:
     body:
       string: ''
@@ -124,7 +124,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/oidc/callback/?state=not-a-random-string&session_state=3de77b90-202e-4797-9db0-ccc1de98947b&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=41bd4d23-1bc8-409d-94a9-08fa7e9708f9.3de77b90-202e-4797-9db0-ccc1de98947b.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=e674b6e8-68f3-4dd9-9315-8c0629e6b9b6&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=6ad9c3ad-b0c3-4999-8775-f00bb6944494.e674b6e8-68f3-4dd9-9315-8c0629e6b9b6.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -134,15 +134,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE0ODgsImlhdCI6MTczMjYxNTQ4OCwianRpIjoiNGU2YTFlNDctZjk3OC00YjUxLWI0ZDItN2ViMWFjNTllMzZkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJzaWQiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJzdGF0ZV9jaGVja2VyIjoidElVZ2tYOVNDazFxWEgzbEhEZXh6WHM0QzFrNVJ6RFhURUxJYkhQWl8wWSJ9.ueSOeDIOzqnfJ2wt6whcko9jEY-bkfLwePQ-FjTWC7I;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ0NjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiZmI0YjBmNGYtYmQ5Yy00NTIwLWJiMzEtYWVkYzI1Yzg3MmI0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJzaWQiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJzdGF0ZV9jaGVja2VyIjoiUFlJZGdrSi13aG5ORXdaWndjUGdLRE5TMDRFYjNMOE0wcEZQeWZ3dTR1QSJ9.-zHa9btTlWg7Ac_swnKTsdeca7dWThsr3v5pOxScVBo;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE0ODgsImlhdCI6MTczMjYxNTQ4OCwianRpIjoiNGU2YTFlNDctZjk3OC00YjUxLWI0ZDItN2ViMWFjNTllMzZkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJzaWQiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJzdGF0ZV9jaGVja2VyIjoidElVZ2tYOVNDazFxWEgzbEhEZXh6WHM0QzFrNVJ6RFhURUxJYkhQWl8wWSJ9.ueSOeDIOzqnfJ2wt6whcko9jEY-bkfLwePQ-FjTWC7I;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ0NjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiZmI0YjBmNGYtYmQ5Yy00NTIwLWJiMzEtYWVkYzI1Yzg3MmI0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJzaWQiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJzdGF0ZV9jaGVja2VyIjoiUFlJZGdrSi13aG5ORXdaWndjUGdLRE5TMDRFYjNMOE0wcEZQeWZ3dTR1QSJ9.-zHa9btTlWg7Ac_swnKTsdeca7dWThsr3v5pOxScVBo;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/3de77b90-202e-4797-9db0-ccc1de98947b;
-        Version=1; Expires=Tue, 26-Nov-2024 20:04:48 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/e674b6e8-68f3-4dd9-9315-8c0629e6b9b6;
+        Version=1; Expires=Fri, 13-Dec-2024 07:21:04 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/3de77b90-202e-4797-9db0-ccc1de98947b;
-        Version=1; Expires=Tue, 26-Nov-2024 20:04:48 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/e674b6e8-68f3-4dd9-9315-8c0629e6b9b6;
+        Version=1; Expires=Fri, 13-Dec-2024 07:21:04 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -161,7 +161,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=41bd4d23-1bc8-409d-94a9-08fa7e9708f9.3de77b90-202e-4797-9db0-ccc1de98947b.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Foidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=6ad9c3ad-b0c3-4999-8775-f00bb6944494.e674b6e8-68f3-4dd9-9315-8c0629e6b9b6.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -170,7 +170,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '267'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -179,7 +179,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODgsImlhdCI6MTczMjYxNTQ4OCwiYXV0aF90aW1lIjoxNzMyNjE1NDg4LCJqdGkiOiJlMDcwODA5ZS05YjI3LTQwNjYtODQxNC04NDIwZDFmYjVmNTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjNkZTc3YjkwLTIwMmUtNDc5Ny05ZGIwLWNjYzFkZTk4OTQ3YiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjNkZTc3YjkwLTIwMmUtNDc5Ny05ZGIwLWNjYzFkZTk4OTQ3YiIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.co3ny8YX8Xus8S_JaGpEBIeWJz2xEvFcYl8aa28qx4idou0q1dWimqXfR2pTru9ZIjGwAylNc_jo6zI7eAKIB1lDY3711DfM_kgPdTx5GmnwbR9u0Tdm1tGEN14VV_sQNovR_8Y-Sp2jsOB41d-64ZqNYLHXye4tHirDKmLV5m781jqVEkKoUTIxfsfYXBN5MZlKB2vTDmQLYWc2wgKhp8lC5KVkMXDZFIZ3qaEJs5VmZxRxm22K1VX85UTDtD0zc8xj9qkmKlVa4VfPqUyYSpw-z33q5Fit2f07jONZqYR8IesHTIZsCqX71fpSCQcP8Qx2aqMKW3oblGi96PfGLQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTcyODgsImlhdCI6MTczMjYxNTQ4OCwianRpIjoiZTgyZTZlNjYtYjE4ZS00ODUzLWI5YWEtNzE1ODcxOGZjZDY1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiM2RlNzdiOTAtMjAyZS00Nzk3LTlkYjAtY2NjMWRlOTg5NDdiIn0.ogDJBIY37L_qK_HegjKsT8v4NfVpM4P5p4rbi6CLfO0","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODgsImlhdCI6MTczMjYxNTQ4OCwiYXV0aF90aW1lIjoxNzMyNjE1NDg4LCJqdGkiOiIzMTUyNGI4YS01OTNmLTRhMWYtOTA2Yi03Mzk1ZDljYjQyMjEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJhdF9oYXNoIjoiV0JzZ05OLWRzeDM1TFFQN1Q4X2FJZyIsImFjciI6IjEiLCJzaWQiOiIzZGU3N2I5MC0yMDJlLTQ3OTctOWRiMC1jY2MxZGU5ODk0N2IiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.Hxqk_Ta8SmD5Dg2RgRsTy5X8ExKcPzC0XQG5GWyxzO0HDuyINaEWU6B1Edy1LFmR5H0k_t3fpuntg4rDqJiaiU9nDhRu4YXQ9hRr2CBUTCAbA-7BUA37bgaWNnlOJSqPQJnvCOPL1TqH5P2N25S5MUeOHGQsvDnslvYF5JE8aBrU1ribihU_f4a0-SqBEgDuA0tgnorHQya3uurTuJP5YmJlZu5A8WjhTVDaWG5jrkd4RcW6ql-DSFDj-QnCqfrHRJzld5MjJfosutjAOOlQGmyAvjUXqKLLb8X0CMEoQsfMiEPa6vWKXRDse9SqwIAaa4wu_OSlzH4EVtOFvdrU1w","not-before-policy":0,"session_state":"3de77b90-202e-4797-9db0-ccc1de98947b","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiJhZDRmOTQzMi1mYWIyLTRjMzAtOTRmMS1iOWE5MjEwZGYzN2MiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImU2NzRiNmU4LTY4ZjMtNGRkOS05MzE1LThjMDYyOWU2YjliNiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImU2NzRiNmU4LTY4ZjMtNGRkOS05MzE1LThjMDYyOWU2YjliNiIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.SkVvjN2HxMxCu6eaNQo-t0lHTCIEQQjMr7l6n1eJRLlyMA08NyZIGg-dS55M7M4mj52IY0CMWICMXflsziL8SBPM5S_jjK4isZ61asZlOApugGJR6oNiAj0LLhqOZKHO1hKNRGi17zvqDHvK6pa3AcQi81dIIRAqhjWYemO1eA7CwAHjH8P5dhWPGxEECgtZ-iziykrUcdo9cdh3hoUUohKYITahmaQCE9UGC6zIPkY7HxpnI917-j4916BYku71mL6CY0DRcRKIwOvc-JLy5JXvP5HbsQ_8mQG546YzTGPBOWD5bpauSfd0DgOz3195NPW12lC1JmSJRFHz3Qj86g","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAyNjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiNzkzZWYyNDItNTU5Ni00MTkwLWI1YTMtNGFiZGE1N2RmYjVhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZTY3NGI2ZTgtNjhmMy00ZGQ5LTkzMTUtOGMwNjI5ZTZiOWI2In0.Ufkpaf77Y7fKGFTg9n_oaJBzFNUUjvXxyNM-eZt894A","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiJmMTRiNmRlNC1jOTNkLTQ4MDctYjRiOC0wMjdjNWU1YzBkNjUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJhdF9oYXNoIjoiQk44QklDZGJhWUR2aDlCb2Y2WWVndyIsImFjciI6IjEiLCJzaWQiOiJlNjc0YjZlOC02OGYzLTRkZDktOTMxNS04YzA2MjllNmI5YjYiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.H82pjhUrK4GTsiJTSLM3VP7USepS_G8KSkq7w9GZkRvd33thXa8OesWoasTitPuxKQIXtnJCtVJNtC5LCFY4LFU6zW1R-yNVYfsSSmQBtlR8afmgDAoz0wx4qTqWo2RwFNqAe-gPcqGGBHwRrDylGAYh9ev75bkjFoBg4WWzJldZm5Zfhs3FMwN1iFC-rWi52gB77CjxAanAoZxY6eXTwuDH13kruyOdE0en2s7bUX6GIwxQv3E05yn_w0W3Hxz1wxNtMjpZJlrCf-GiXxwxNbNd1Ma46J3GhPErhRx4Ta0RrhAHVzw1o5a6K9MlTiEPVWdcNTtzWSKt3QWpOqq6xA","not-before-policy":0,"session_state":"e674b6e8-68f3-4dd9-9315-8c0629e6b9b6","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -247,7 +247,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODgsImlhdCI6MTczMjYxNTQ4OCwiYXV0aF90aW1lIjoxNzMyNjE1NDg4LCJqdGkiOiJlMDcwODA5ZS05YjI3LTQwNjYtODQxNC04NDIwZDFmYjVmNTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjNkZTc3YjkwLTIwMmUtNDc5Ny05ZGIwLWNjYzFkZTk4OTQ3YiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjNkZTc3YjkwLTIwMmUtNDc5Ny05ZGIwLWNjYzFkZTk4OTQ3YiIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.co3ny8YX8Xus8S_JaGpEBIeWJz2xEvFcYl8aa28qx4idou0q1dWimqXfR2pTru9ZIjGwAylNc_jo6zI7eAKIB1lDY3711DfM_kgPdTx5GmnwbR9u0Tdm1tGEN14VV_sQNovR_8Y-Sp2jsOB41d-64ZqNYLHXye4tHirDKmLV5m781jqVEkKoUTIxfsfYXBN5MZlKB2vTDmQLYWc2wgKhp8lC5KVkMXDZFIZ3qaEJs5VmZxRxm22K1VX85UTDtD0zc8xj9qkmKlVa4VfPqUyYSpw-z33q5Fit2f07jONZqYR8IesHTIZsCqX71fpSCQcP8Qx2aqMKW3oblGi96PfGLQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiJhZDRmOTQzMi1mYWIyLTRjMzAtOTRmMS1iOWE5MjEwZGYzN2MiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImU2NzRiNmU4LTY4ZjMtNGRkOS05MzE1LThjMDYyOWU2YjliNiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImU2NzRiNmU4LTY4ZjMtNGRkOS05MzE1LThjMDYyOWU2YjliNiIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.SkVvjN2HxMxCu6eaNQo-t0lHTCIEQQjMr7l6n1eJRLlyMA08NyZIGg-dS55M7M4mj52IY0CMWICMXflsziL8SBPM5S_jjK4isZ61asZlOApugGJR6oNiAj0LLhqOZKHO1hKNRGi17zvqDHvK6pa3AcQi81dIIRAqhjWYemO1eA7CwAHjH8P5dhWPGxEECgtZ-iziykrUcdo9cdh3hoUUohKYITahmaQCE9UGC6zIPkY7HxpnI917-j4916BYku71mL6CY0DRcRKIwOvc-JLy5JXvP5HbsQ_8mQG546YzTGPBOWD5bpauSfd0DgOz3195NPW12lC1JmSJRFHz3Qj86g
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/accounts/tests/data/vcr_cassettes/OIDCFlowTests/OIDCFlowTests.test_happy_flow_existing_user.yaml
+++ b/src/openforms/accounts/tests/data/vcr_cassettes/OIDCFlowTests/OIDCFlowTests.test_happy_flow_existing_user.yaml
@@ -11,23 +11,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ukqle/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/ukqle/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/ukqle/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a\",\n
-        \             \"-s2Yzk7AEMc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=-s2Yzk7AEMc&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"fa046a41-8688-4dd4-8066-aaa2debfbdbe\",\n
+        \             \"YTrlYRT8im8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=YTrlYRT8im8&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -35,7 +35,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=EDqAFXJguuTrpiz0IGiWsfsX6fJzBw2w3gVr8zPyAcg&amp;execution=7a8c9245-126d-4109-935a-4dcabde8fa23&amp;client_id=testid&amp;tab_id=-s2Yzk7AEMc\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=Ubte4ZvVwg_eh2EvN2NXNKF-TbMyKt542NBzCtcpfxM&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=YTrlYRT8im8\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -61,7 +61,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/ukqle/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -75,11 +75,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=fa046a41-8688-4dd4-8066-aaa2debfbdbe; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=fa046a41-8688-4dd4-8066-aaa2debfbdbe; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.f7ZABGR0O48xm61gDKLOR_LjWH9a59wtTbGXUfm78sI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.UsxD0tVSe-9hZ_8P5DlMkG_4ShlRvds8Z3EiZQ2goYc;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -110,11 +110,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.f7ZABGR0O48xm61gDKLOR_LjWH9a59wtTbGXUfm78sI
+      - AUTH_SESSION_ID_LEGACY=fa046a41-8688-4dd4-8066-aaa2debfbdbe; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.UsxD0tVSe-9hZ_8P5DlMkG_4ShlRvds8Z3EiZQ2goYc
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=EDqAFXJguuTrpiz0IGiWsfsX6fJzBw2w3gVr8zPyAcg&execution=7a8c9245-126d-4109-935a-4dcabde8fa23&client_id=testid&tab_id=-s2Yzk7AEMc
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=Ubte4ZvVwg_eh2EvN2NXNKF-TbMyKt542NBzCtcpfxM&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=YTrlYRT8im8
   response:
     body:
       string: ''
@@ -124,7 +124,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/oidc/callback/?state=not-a-random-string&session_state=78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=21be08d7-5441-4f10-ad74-2d4dd63df8ab.78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=fa046a41-8688-4dd4-8066-aaa2debfbdbe&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=373c117c-5921-4436-8f26-d568b222e53d.fa046a41-8688-4dd4-8066-aaa2debfbdbe.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -134,15 +134,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE0ODgsImlhdCI6MTczMjYxNTQ4OCwianRpIjoiMTAyOWQwNzMtNDhiNS00OTRjLTg5MWYtZDYxMGQ1YmVlZjY4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJzaWQiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJzdGF0ZV9jaGVja2VyIjoiWHQxcVRQWDExMkZBYmJ6NkFZMFBDbmp5XzNKNm5jQ2ctSTNRdmtKTmFzZyJ9.qoUEjw_yjGn8KrCUVfp1n5gIXgsLJAF9SzXgKksKUjw;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ0NjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiNWI0Y2EwNjUtZTBjNS00OGZjLWFhOGQtYzEyZGY5NWVjNDYxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJzaWQiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJzdGF0ZV9jaGVja2VyIjoiX2FMWkx4T0h1UnBxYVFqV1JndG1ELWtfX3QwekdoTEluNHNzQjhWa1pDNCJ9.kyHdVZd0V0SbUIVHGStC0k20mIEDTwIxaYyuox1R5h8;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE0ODgsImlhdCI6MTczMjYxNTQ4OCwianRpIjoiMTAyOWQwNzMtNDhiNS00OTRjLTg5MWYtZDYxMGQ1YmVlZjY4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJzaWQiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJzdGF0ZV9jaGVja2VyIjoiWHQxcVRQWDExMkZBYmJ6NkFZMFBDbmp5XzNKNm5jQ2ctSTNRdmtKTmFzZyJ9.qoUEjw_yjGn8KrCUVfp1n5gIXgsLJAF9SzXgKksKUjw;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ0NjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiNWI0Y2EwNjUtZTBjNS00OGZjLWFhOGQtYzEyZGY5NWVjNDYxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJzaWQiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJzdGF0ZV9jaGVja2VyIjoiX2FMWkx4T0h1UnBxYVFqV1JndG1ELWtfX3QwekdoTEluNHNzQjhWa1pDNCJ9.kyHdVZd0V0SbUIVHGStC0k20mIEDTwIxaYyuox1R5h8;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a;
-        Version=1; Expires=Tue, 26-Nov-2024 20:04:48 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/fa046a41-8688-4dd4-8066-aaa2debfbdbe;
+        Version=1; Expires=Fri, 13-Dec-2024 07:21:04 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a;
-        Version=1; Expires=Tue, 26-Nov-2024 20:04:48 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/fa046a41-8688-4dd4-8066-aaa2debfbdbe;
+        Version=1; Expires=Fri, 13-Dec-2024 07:21:04 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -161,7 +161,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=21be08d7-5441-4f10-ad74-2d4dd63df8ab.78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Foidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=373c117c-5921-4436-8f26-d568b222e53d.fa046a41-8688-4dd4-8066-aaa2debfbdbe.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -170,7 +170,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '267'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -179,7 +179,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODgsImlhdCI6MTczMjYxNTQ4OCwiYXV0aF90aW1lIjoxNzMyNjE1NDg4LCJqdGkiOiJjNmZlMjMyNC1kYTE4LTQ2ZjQtODE2Ni1jMzI5MjhhNjJmZTciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijc4Yzc1ODViLTNjYmEtNGVjYi05ZmE1LTFhOTFlYTY1YmMxYSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijc4Yzc1ODViLTNjYmEtNGVjYi05ZmE1LTFhOTFlYTY1YmMxYSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.Dik_6Po4uNIwhZN2B7nHjOeV8CMyhA6ktAmZ8fAqEmhuHrlJf583M9Ur_7SKAlnAgXVQ597Pgc0XaPaQbAWz2xEkM2y7oji-lJXCJreDZaIIXgwftHa2pxBh81v6Grsj1Lmh4qOmWeMG5BJa5gaxAmiWYUiNtA3bAmGYpmpSvaaQeZaoXELATfo6PRf8O7hEDphhMIRv2tPc0v8KdjyL4RRXVdG6uruaQmjQmgx6MnVLhLE-J9Jt9UATwcl6ns_pmoMDNj78ozOZFMWE_HTiPfj6e7byO057nzFW0dRPqJxv2-Np-qPJauebvIYhsedz-duhsIqCcIal-krM1tHoLQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTcyODgsImlhdCI6MTczMjYxNTQ4OCwianRpIjoiMWI2ODYyOWEtOGRiZC00N2Y3LTg4MGQtMTA3MDg2M2VkZmQ0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNzhjNzU4NWItM2NiYS00ZWNiLTlmYTUtMWE5MWVhNjViYzFhIn0.rNwKB1S41DlpWneGfT7_zTDcagxfqmnd6SwL-6bLSZM","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODgsImlhdCI6MTczMjYxNTQ4OCwiYXV0aF90aW1lIjoxNzMyNjE1NDg4LCJqdGkiOiI2ZWI3ZmQ2Mi0xNzA1LTQwZGItOTliYS04MzVmNTI4YmRiZmYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJhdF9oYXNoIjoibmF0aTAwQlBlcEFNU2pvbkZ4N1lDdyIsImFjciI6IjEiLCJzaWQiOiI3OGM3NTg1Yi0zY2JhLTRlY2ItOWZhNS0xYTkxZWE2NWJjMWEiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.y2m_ROfk1q38WJMfJm3B1J-kaFeIq7jpfuTtrddovgQiLSudBnWnVy-AoYTCmS02WhM0444kM14Px6PfTVEera-mudORazPSORB5oQiT43q0ahpHISB5eH0JeMQQ8JwBcnqF-wUO-QkSqLg_xwsnGiOmPEY_JMavcp-pOYOUfqeFw6NnFvBR--2GKA-ObW6SJd-9cpftOf8GDBlVtjnm-jWVWu314CJZwZeQXpfKsG0Wg1eFLYJPLuS-LiFYaVwqEf5AOjwbMRP42z-Ao6CrfXInjNp8TkHse7bHIdYAEjh1Mpu_ZfnAUuFiQ-c-HD5wSqlspTwG8WDPvRSOUtrm-Q","not-before-policy":0,"session_state":"78c7585b-3cba-4ecb-9fa5-1a91ea65bc1a","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiI0MjRkOGI5NS05OTA1LTQyMTgtODJlYy01OTM5ODE5NTk2MzEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImZhMDQ2YTQxLTg2ODgtNGRkNC04MDY2LWFhYTJkZWJmYmRiZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImZhMDQ2YTQxLTg2ODgtNGRkNC04MDY2LWFhYTJkZWJmYmRiZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.0cPaEuTt62AANQPiotBP-yRMAs4bIz9KA3OqBQ3lUR5rl5DQjyNAdC0J2oXjclQbIkSHlK5vTYdF_9FBbfIWfxi79aMdsQYiLGlkp_Kf1VQh44bLXyV9Yqkp6IAyW7OknYTQ4yuF2Tk4NZNapTIGCzwBXKrTqZiti2bPLhrJJBaBcKl3l9uiqglxX8eQYROusY1ZS2oyN52Cjzf78iAwPWzsoeihf-KiaIkViYoJ8L5fo8K9-0BBJjMW7gn10HChdKsrNF4lVZ4TtiqLDFE8lYczB1Lc31L4ANnrM-p_xDpOeVw3oRIXe8LHJ7GWjP3CNb_q8SAqnkyodHbohkaDWg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAyNjQsImlhdCI6MTczNDAzODQ2NCwianRpIjoiNWNiYTA3NzgtNjYyOC00OTJiLWJmMDgtMGVmNGM3ODg4NzI4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZmEwNDZhNDEtODY4OC00ZGQ0LTgwNjYtYWFhMmRlYmZiZGJlIn0.lyHzbJogFRmduOPucyPUIgXfOjEbp6rIsHBg5SHpNzg","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiJkNzA0OTJjMS1kM2IzLTQwNDYtYmZiYy1lNTJhMDc4N2Y5ZmUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJhdF9oYXNoIjoidUdqZlFUS3dXZkZUVzZncWxrSVBPdyIsImFjciI6IjEiLCJzaWQiOiJmYTA0NmE0MS04Njg4LTRkZDQtODA2Ni1hYWEyZGViZmJkYmUiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.RmKlzBIkNbxPcr6P865oIJW54BBgP93SjRercGEqtRV-LS1aOaPn9wScg7OfT2H7atUUcwLjyJWakTRtHJ4nyS-857Qmmda_JJaupoyuAL_GmrLUhkPdcgBvMAq3wvE5aIa_oNnqkCpLRBQjoCEtqLP6sTDnVbZ-1VSliQ8LiZTPNVdla3-jsxwiRLPHX_AlVYHI2gHpkRyO1LJ3rrg1BQaOLt1b3adHm0rOdnrmDlkQmv6DRYYaZgQwbgwIDkYkf3h56wKZD731e-tsCgyG6krshc1ANsRVYwPTHV_w2dmlnyAfDF5VESjGyhclZHO--Gylhi1bHUp4cXoQ0tpyeg","not-before-policy":0,"session_state":"fa046a41-8688-4dd4-8066-aaa2debfbdbe","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -247,7 +247,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTU3ODgsImlhdCI6MTczMjYxNTQ4OCwiYXV0aF90aW1lIjoxNzMyNjE1NDg4LCJqdGkiOiJjNmZlMjMyNC1kYTE4LTQ2ZjQtODE2Ni1jMzI5MjhhNjJmZTciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijc4Yzc1ODViLTNjYmEtNGVjYi05ZmE1LTFhOTFlYTY1YmMxYSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijc4Yzc1ODViLTNjYmEtNGVjYi05ZmE1LTFhOTFlYTY1YmMxYSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.Dik_6Po4uNIwhZN2B7nHjOeV8CMyhA6ktAmZ8fAqEmhuHrlJf583M9Ur_7SKAlnAgXVQ597Pgc0XaPaQbAWz2xEkM2y7oji-lJXCJreDZaIIXgwftHa2pxBh81v6Grsj1Lmh4qOmWeMG5BJa5gaxAmiWYUiNtA3bAmGYpmpSvaaQeZaoXELATfo6PRf8O7hEDphhMIRv2tPc0v8KdjyL4RRXVdG6uruaQmjQmgx6MnVLhLE-J9Jt9UATwcl6ns_pmoMDNj78ozOZFMWE_HTiPfj6e7byO057nzFW0dRPqJxv2-Np-qPJauebvIYhsedz-duhsIqCcIal-krM1tHoLQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg3NjQsImlhdCI6MTczNDAzODQ2NCwiYXV0aF90aW1lIjoxNzM0MDM4NDY0LCJqdGkiOiI0MjRkOGI5NS05OTA1LTQyMTgtODJlYy01OTM5ODE5NTk2MzEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImZhMDQ2YTQxLTg2ODgtNGRkNC04MDY2LWFhYTJkZWJmYmRiZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImZhMDQ2YTQxLTg2ODgtNGRkNC04MDY2LWFhYTJkZWJmYmRiZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.0cPaEuTt62AANQPiotBP-yRMAs4bIz9KA3OqBQ3lUR5rl5DQjyNAdC0J2oXjclQbIkSHlK5vTYdF_9FBbfIWfxi79aMdsQYiLGlkp_Kf1VQh44bLXyV9Yqkp6IAyW7OknYTQ4yuF2Tk4NZNapTIGCzwBXKrTqZiti2bPLhrJJBaBcKl3l9uiqglxX8eQYROusY1ZS2oyN52Cjzf78iAwPWzsoeihf-KiaIkViYoJ8L5fo8K9-0BBJjMW7gn10HChdKsrNF4lVZ4TtiqLDFE8lYczB1Lc31L4ANnrM-p_xDpOeVw3oRIXe8LHJ7GWjP3CNb_q8SAqnkyodHbohkaDWg
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/accounts/tests/test_oidc.py
+++ b/src/openforms/accounts/tests/test_oidc.py
@@ -63,7 +63,7 @@ class OIDCLoginButtonTestCase(WebTest):
         )
 
 
-class OIDCFLowTests(OFVCRMixin, WebTest):
+class OIDCFlowTests(OFVCRMixin, WebTest):
     VCR_TEST_FILES = TEST_FILES
 
     @mock_admin_oidc_config()

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/models.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/models.py
@@ -31,7 +31,7 @@ class OFDigiDConfig(DigiDConfig):
     def oidc_authentication_callback_url(cls) -> str:  # type: ignore
         if settings.USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS:
             warnings.warn(
-                "Legacy DigiD-eHerkenning callback endpoints will be removed in 3.0",
+                "Legacy DigiD-eHerkenning callback endpoints will be removed in 4.0",
                 DeprecationWarning,
             )
             return "digid_oidc:callback"
@@ -51,7 +51,7 @@ class OFDigiDMachtigenConfig(DigiDMachtigenConfig):
     def oidc_authentication_callback_url(cls) -> str:  # type: ignore
         if settings.USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS:
             warnings.warn(
-                "Legacy DigiD-eHerkenning callback endpoints will be removed in 3.0",
+                "Legacy DigiD-eHerkenning callback endpoints will be removed in 4.0",
                 DeprecationWarning,
             )
             return "digid_machtigen_oidc:callback"
@@ -71,7 +71,7 @@ class OFEHerkenningConfig(EHerkenningConfig):
     def oidc_authentication_callback_url(cls) -> str:  # type: ignore
         if settings.USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS:
             warnings.warn(
-                "Legacy DigiD-eHerkenning callback endpoints will be removed in 3.0",
+                "Legacy DigiD-eHerkenning callback endpoints will be removed in 4.0",
                 DeprecationWarning,
             )
             return "eherkenning_oidc:callback"
@@ -91,7 +91,7 @@ class OFEHerkenningBewindvoeringConfig(EHerkenningBewindvoeringConfig):
     def oidc_authentication_callback_url(cls) -> str:  # type: ignore
         if settings.USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS:
             warnings.warn(
-                "Legacy DigiD-eHerkenning callback endpoints will be removed in 3.0",
+                "Legacy DigiD-eHerkenning callback endpoints will be removed in 4.0",
                 DeprecationWarning,
             )
             return "eherkenning_bewindvoering_oidc:callback"

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDAuthContextTests/DigiDAuthContextTests.test_record_auth_context.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDAuthContextTests/DigiDAuthContextTests.test_record_auth_context.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"39e1e4d0-7dff-4a50-96b7-d194c4d1727f\",\n
-        \             \"j3A0nOesT9s\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=j3A0nOesT9s&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"2374c25e-75e4-44af-a8b8-4e6fcd3aef43\",\n
+        \             \"Pk6S7bjfBHs\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=Pk6S7bjfBHs&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=JqMgvW5NytbrcUJSn_3rNDb48C--TujonjJsTeRwUQY&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=j3A0nOesT9s\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=4pqqcQRy4a2tQ7kTRKvPviFr__jHr8yJaLX8tyzdVBQ&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=Pk6S7bjfBHs\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=39e1e4d0-7dff-4a50-96b7-d194c4d1727f; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=2374c25e-75e4-44af-a8b8-4e6fcd3aef43; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=39e1e4d0-7dff-4a50-96b7-d194c4d1727f; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=2374c25e-75e4-44af-a8b8-4e6fcd3aef43; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMC9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.AHg6jhFUpUl03AFQGLx6uuaft43Rmw6H3TyINpSe8Iw;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=39e1e4d0-7dff-4a50-96b7-d194c4d1727f; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMC9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.AHg6jhFUpUl03AFQGLx6uuaft43Rmw6H3TyINpSe8Iw
+      - AUTH_SESSION_ID_LEGACY=2374c25e-75e4-44af-a8b8-4e6fcd3aef43; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=JqMgvW5NytbrcUJSn_3rNDb48C--TujonjJsTeRwUQY&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=j3A0nOesT9s
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=4pqqcQRy4a2tQ7kTRKvPviFr__jHr8yJaLX8tyzdVBQ&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=Pk6S7bjfBHs
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/digid-oidc/callback/?state=not-a-random-string&session_state=39e1e4d0-7dff-4a50-96b7-d194c4d1727f&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=93e8c8d7-58da-42db-8142-6c8cde24caa1.39e1e4d0-7dff-4a50-96b7-d194c4d1727f.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=2374c25e-75e4-44af-a8b8-4e6fcd3aef43&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=6134059c-2c2c-4d30-aeca-0f3ce320b698.2374c25e-75e4-44af-a8b8-4e6fcd3aef43.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODUsImlhdCI6MTczMjYxNTg4NSwianRpIjoiZDVhNDMwNDItM2QyYy00MDU1LWE2ZjctNTUzN2FiZTMzNWU0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJzaWQiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJzdGF0ZV9jaGVja2VyIjoiVFF5UlhVZzdSQXAta3cyMTZLUlhvX3Zkc0p4VGplNHJSeFNma0gybDBWQSJ9.QTw0v1v6qMSbG95jS71KkVH3C-gg7VH2J2y5zNsP0pE;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiYTQ5ODFiZDAtMjA5NS00NmQ4LTkwODgtNjI2OTQyMTk3NDgzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJzaWQiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJzdGF0ZV9jaGVja2VyIjoiNlJCUnpCcmFiT0drVUYtV3JzSW1KM09zanZSQi1NMU1oTS0zUGFURjZ2MCJ9.x8Cc5tlVmXqdXt3otzjb7phKc6fGcAfSrx65S7uI3EM;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODUsImlhdCI6MTczMjYxNTg4NSwianRpIjoiZDVhNDMwNDItM2QyYy00MDU1LWE2ZjctNTUzN2FiZTMzNWU0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJzaWQiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJzdGF0ZV9jaGVja2VyIjoiVFF5UlhVZzdSQXAta3cyMTZLUlhvX3Zkc0p4VGplNHJSeFNma0gybDBWQSJ9.QTw0v1v6qMSbG95jS71KkVH3C-gg7VH2J2y5zNsP0pE;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiYTQ5ODFiZDAtMjA5NS00NmQ4LTkwODgtNjI2OTQyMTk3NDgzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJzaWQiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJzdGF0ZV9jaGVja2VyIjoiNlJCUnpCcmFiT0drVUYtV3JzSW1KM09zanZSQi1NMU1oTS0zUGFURjZ2MCJ9.x8Cc5tlVmXqdXt3otzjb7phKc6fGcAfSrx65S7uI3EM;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/39e1e4d0-7dff-4a50-96b7-d194c4d1727f;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:25 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/2374c25e-75e4-44af-a8b8-4e6fcd3aef43;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:32 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/39e1e4d0-7dff-4a50-96b7-d194c4d1727f;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:25 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/2374c25e-75e4-44af-a8b8-4e6fcd3aef43;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:32 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=93e8c8d7-58da-42db-8142-6c8cde24caa1.39e1e4d0-7dff-4a50-96b7-d194c4d1727f.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fdigid-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=6134059c-2c2c-4d30-aeca-0f3ce320b698.2374c25e-75e4-44af-a8b8-4e6fcd3aef43.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '279'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODUsImlhdCI6MTczMjYxNTg4NSwiYXV0aF90aW1lIjoxNzMyNjE1ODg1LCJqdGkiOiIzZDIxNjE5YS1kZTJhLTQ4ZmMtYjk5MC1hZDFhYmVmNGFiZTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM5ZTFlNGQwLTdkZmYtNGE1MC05NmI3LWQxOTRjNGQxNzI3ZiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM5ZTFlNGQwLTdkZmYtNGE1MC05NmI3LWQxOTRjNGQxNzI3ZiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.rz-YUdCrwR04pF6JUz1jABwYSdEHR5IgO9AUfu-6y4UYS-1dVUVg0RuFGtd5mB-lGIRn9zl1ebaAShEeot6OfgGHyhJ1h4GGW13gFnwn3BpIAKIVMAqiyIMML61z-FnUlOe77lpvzO9sknAarq4t1ulmjHYa4DiB66NBP7EjK2BHHQOhXkiW40J19VcdsjRJNaDsLHpsxbJugbeIO6Cx1kIVx0DVkh_9yGTgMZm2wYRqOJQ_3ASL17DQUn5ewjq5h4DQX_CBf54x5gRy5o8tAmDp2msLG_YGuzN9kr2wzRB2lugErIsZCtRh827nvUuJ1wVa0G8CEkKYE55lHd8UeQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODUsImlhdCI6MTczMjYxNTg4NSwianRpIjoiNjAzZDY2NDMtNjBmZi00ZWRjLThkNGUtMzgzNDRkYTcwYjg0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMzllMWU0ZDAtN2RmZi00YTUwLTk2YjctZDE5NGM0ZDE3MjdmIn0.jJAy-aNwBRBdcbcNsZF1qHzTYnHSzvDuPDkRiCvKDPg","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODUsImlhdCI6MTczMjYxNTg4NSwiYXV0aF90aW1lIjoxNzMyNjE1ODg1LCJqdGkiOiIwZTI3NDkyOS1hN2NiLTQ2MTAtOTJlYy02OWY1YjVjMzRlNmIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJhdF9oYXNoIjoiRXo5N2VVWHI3cVh0aEtoNHFZUnJRZyIsImFjciI6IjEiLCJzaWQiOiIzOWUxZTRkMC03ZGZmLTRhNTAtOTZiNy1kMTk0YzRkMTcyN2YiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.kUHTJKMSuWNzuY4UMk12mVirVezxpHqgCV9IY9TCRm3NSShZhvL7c0kNcyQLB71frO9RbGndih-CSeQlbCpS5M00RtVR2uh7HqHI7v1xrhifWHwwPqe66OAamwQJcjg9erik-pmMg6pmeoONGxf1uGBV-aElkpQL96UPbCp35R7OJHfvwa0WEIdXiKma5AQVgTKvOW3g8iqZ-1SjO0D-R9Ml24o5k1Oytp5uX5HUGFIuHgdSmOiF-lzNDST0uowJVPALFWx2vedlRMCzYlKSrkTqUGsJT7N5Zp-RDI_h_iwGBwur4nIMPWeXe1Ge1tUYwFlu4lusrbZ29YCDZU7yjg","not-before-policy":0,"session_state":"39e1e4d0-7dff-4a50-96b7-d194c4d1727f","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiIxNDUzMjBiOS0zZTNkLTQzYWMtOTQxZS01YzgzM2UwZDk1MjgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjIzNzRjMjVlLTc1ZTQtNDRhZi1hOGI4LTRlNmZjZDNhZWY0MyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjIzNzRjMjVlLTc1ZTQtNDRhZi1hOGI4LTRlNmZjZDNhZWY0MyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.J-uS6SOM_JKC-3Khv3rmB9-EKAzaiEQYYrI6QKq4VE486g1kEE3a61EOf5zsii8Z1ixONkjrnqRc-3imVSCPpxeTJqcInU0OcbPUjvTJhr8CBvWKjLImJczr8kb6tpod-ejMFCNRLkq9Xo7C8CgiGXPVCH4pQGllrehBiE8hbj7Wm4OTAMuiC6R0cFdLTdvSOR4XAhVtUSgcFPT2a2sirEdnFzqw2NqqNIAYiKa-A4EMjrjfQWbJd5fgWFAS1acidcydJVqjTuQVVuHtLPpiBgbDeCVjCipU1br4mU31G7qVcSQbrlpJJ6xs0ibcjUaqhhfYU7W3uD4lA_rNhYLH9A","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiYWU0ZjBjZTMtMzg3Ny00M2QxLTgzZWEtMzliMTkyNDdjMjI3IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMjM3NGMyNWUtNzVlNC00NGFmLWE4YjgtNGU2ZmNkM2FlZjQzIn0.UwITd-FEt1pbjPKmYYfsTFn7b-9lEkg6yAQbft634z0","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiI3MDU4OTAzYy0yY2FiLTRiMGUtOWE5Yi1hNTRkNjg2ZDViMTIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJhdF9oYXNoIjoiRllzcTB0Y1hJNndxRWZ6TzlNMDgxdyIsImFjciI6IjEiLCJzaWQiOiIyMzc0YzI1ZS03NWU0LTQ0YWYtYThiOC00ZTZmY2QzYWVmNDMiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.niP6ZjAwdNLMQDwSfo1WvmZfpyk1iOjzzNlnNFQ3Cg1mJF_RxI0p0B_GaaQGE0IiAxYSpPNYpyFgDiOnDRddBij2tik9_r382-5J2wfUH0hhpsDvUaEbEV-aJQDcdYdk6DUbgf7P8cxHqFU0-Z-v2bXOSRN6WAjQ6kDseYnr-RseJ18k5tQAtlmLIpvpmCK034kVMi-nCt3K0ng5no13v6zVyKWGPt2P1ah0QdPtcufeNSxxm-dBlEiweVHJ3gSN2XG-t5Eyu13KocnHPQJ9ky_Zmr8F1t5mxE6UadVtY5K73XNSYW9r9E_Wz5Q5PL1h7BKdXCPpC9vMSBUleMNJbg","not-before-policy":0,"session_state":"2374c25e-75e4-44af-a8b8-4e6fcd3aef43","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODUsImlhdCI6MTczMjYxNTg4NSwiYXV0aF90aW1lIjoxNzMyNjE1ODg1LCJqdGkiOiIzZDIxNjE5YS1kZTJhLTQ4ZmMtYjk5MC1hZDFhYmVmNGFiZTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM5ZTFlNGQwLTdkZmYtNGE1MC05NmI3LWQxOTRjNGQxNzI3ZiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM5ZTFlNGQwLTdkZmYtNGE1MC05NmI3LWQxOTRjNGQxNzI3ZiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.rz-YUdCrwR04pF6JUz1jABwYSdEHR5IgO9AUfu-6y4UYS-1dVUVg0RuFGtd5mB-lGIRn9zl1ebaAShEeot6OfgGHyhJ1h4GGW13gFnwn3BpIAKIVMAqiyIMML61z-FnUlOe77lpvzO9sknAarq4t1ulmjHYa4DiB66NBP7EjK2BHHQOhXkiW40J19VcdsjRJNaDsLHpsxbJugbeIO6Cx1kIVx0DVkh_9yGTgMZm2wYRqOJQ_3ASL17DQUn5ewjq5h4DQX_CBf54x5gRy5o8tAmDp2msLG_YGuzN9kr2wzRB2lugErIsZCtRh827nvUuJ1wVa0G8CEkKYE55lHd8UeQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiIxNDUzMjBiOS0zZTNkLTQzYWMtOTQxZS01YzgzM2UwZDk1MjgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjIzNzRjMjVlLTc1ZTQtNDRhZi1hOGI4LTRlNmZjZDNhZWY0MyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjIzNzRjMjVlLTc1ZTQtNDRhZi1hOGI4LTRlNmZjZDNhZWY0MyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.J-uS6SOM_JKC-3Khv3rmB9-EKAzaiEQYYrI6QKq4VE486g1kEE3a61EOf5zsii8Z1ixONkjrnqRc-3imVSCPpxeTJqcInU0OcbPUjvTJhr8CBvWKjLImJczr8kb6tpod-ejMFCNRLkq9Xo7C8CgiGXPVCH4pQGllrehBiE8hbj7Wm4OTAMuiC6R0cFdLTdvSOR4XAhVtUSgcFPT2a2sirEdnFzqw2NqqNIAYiKa-A4EMjrjfQWbJd5fgWFAS1acidcydJVqjTuQVVuHtLPpiBgbDeCVjCipU1br4mU31G7qVcSQbrlpJJ6xs0ibcjUaqhhfYU7W3uD4lA_rNhYLH9A
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_digid_error_reported_for_cancelled_login_anon_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_digid_error_reported_for_cancelled_login_anon_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/digid-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_digid_error_reported_for_cancelled_login_with_staff_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_digid_error_reported_for_cancelled_login_with_staff_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/digid-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_failing_claim_verification.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_failing_claim_verification.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"cc69a94f-ba9a-4274-a6c9-0e92b623250b\",\n
-        \             \"VdYevpzp-50\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=VdYevpzp-50&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"95dfef2f-53c0-4380-a48c-b4710c547ea9\",\n
+        \             \"VYe4p-pZBuU\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=VYe4p-pZBuU&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=wRuM_q8vBWg0Jc5G7LYqouRN9q1URm6re-7EfbO-sVQ&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=VdYevpzp-50\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=7ga0bWBbDmWot-bFg5bMhEWq5F9J5mXfosd64trrZF8&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=VYe4p-pZBuU\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=cc69a94f-ba9a-4274-a6c9-0e92b623250b; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=95dfef2f-53c0-4380-a48c-b4710c547ea9; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=cc69a94f-ba9a-4274-a6c9-0e92b623250b; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=95dfef2f-53c0-4380-a48c-b4710c547ea9; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=cc69a94f-ba9a-4274-a6c9-0e92b623250b; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI
+      - AUTH_SESSION_ID_LEGACY=95dfef2f-53c0-4380-a48c-b4710c547ea9; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=wRuM_q8vBWg0Jc5G7LYqouRN9q1URm6re-7EfbO-sVQ&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=VdYevpzp-50
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=7ga0bWBbDmWot-bFg5bMhEWq5F9J5mXfosd64trrZF8&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=VYe4p-pZBuU
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-oidc/callback/?state=not-a-random-string&session_state=cc69a94f-ba9a-4274-a6c9-0e92b623250b&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=78ef319f-6d92-4618-b372-bbe7e8bccd03.cc69a94f-ba9a-4274-a6c9-0e92b623250b.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=95dfef2f-53c0-4380-a48c-b4710c547ea9&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=910fb6c3-35a3-4f10-997e-a554f12600c1.95dfef2f-53c0-4380-a48c-b4710c547ea9.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODksImlhdCI6MTczMjYxNTg4OSwianRpIjoiMTg1Y2I4YTktMGM5NS00ZDQwLWE2NjctMmQwNTlmOTMzNjYxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJzaWQiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJzdGF0ZV9jaGVja2VyIjoiM1RWS1ladFNydUZqWlRnYVhBSHQ4Y0lyZU43SnR3cGsyQTV4cVNUa2U5OCJ9.5LK3pSXqDgf82FHWtwOJkR4acj2viHLO5QoZWWwt2uk;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiNTdlNjlhYTEtMWEwYi00MTI0LTgwYTEtMDJmNzBiM2NkYjBlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJzaWQiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJzdGF0ZV9jaGVja2VyIjoiSmxaWHhhRGpEOXMwei01REdwMl92dFNxUGxsemRleTQ4eGhXWWRWZWRBYyJ9.lPbziuc1fqXKndMewr4TwjLN3Zmv2yAgb63jg6An6y4;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODksImlhdCI6MTczMjYxNTg4OSwianRpIjoiMTg1Y2I4YTktMGM5NS00ZDQwLWE2NjctMmQwNTlmOTMzNjYxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJzaWQiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJzdGF0ZV9jaGVja2VyIjoiM1RWS1ladFNydUZqWlRnYVhBSHQ4Y0lyZU43SnR3cGsyQTV4cVNUa2U5OCJ9.5LK3pSXqDgf82FHWtwOJkR4acj2viHLO5QoZWWwt2uk;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiNTdlNjlhYTEtMWEwYi00MTI0LTgwYTEtMDJmNzBiM2NkYjBlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJzaWQiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJzdGF0ZV9jaGVja2VyIjoiSmxaWHhhRGpEOXMwei01REdwMl92dFNxUGxsemRleTQ4eGhXWWRWZWRBYyJ9.lPbziuc1fqXKndMewr4TwjLN3Zmv2yAgb63jg6An6y4;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/cc69a94f-ba9a-4274-a6c9-0e92b623250b;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:29 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/95dfef2f-53c0-4380-a48c-b4710c547ea9;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/cc69a94f-ba9a-4274-a6c9-0e92b623250b;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:29 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/95dfef2f-53c0-4380-a48c-b4710c547ea9;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=78ef319f-6d92-4618-b372-bbe7e8bccd03.cc69a94f-ba9a-4274-a6c9-0e92b623250b.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=910fb6c3-35a3-4f10-997e-a554f12600c1.95dfef2f-53c0-4380-a48c-b4710c547ea9.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '273'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODksImlhdCI6MTczMjYxNTg4OSwiYXV0aF90aW1lIjoxNzMyNjE1ODg5LCJqdGkiOiI4MGMxOWU4Ni0xMWNlLTRjMTUtYjVhZS1jMWVmMjQ4YmY3NmEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImNjNjlhOTRmLWJhOWEtNDI3NC1hNmM5LTBlOTJiNjIzMjUwYiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImNjNjlhOTRmLWJhOWEtNDI3NC1hNmM5LTBlOTJiNjIzMjUwYiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.yoQpvfKZGBFdbMkT9C4MI2Uyg4tr_jr5H6zoYo4m6D6QxGeK96UBqL-ho9YbJFFyuIXnfJCn8jj-wTHkML9p-ZATfv1dnTDLt5snX2jyN31uZIon36yBkBhQ5geEbLp4VAF3-SbgiQUBcjCkcD0UxB8IbELMqfQyZxLBSiam89hCHHk0ZxYCFVnPB9Ik9zzJLPdMGXl3GhfG6-FXAw9cCoerCa6vbA-QF35sxwpe_6weWtDdtYHFUMdbKFerAaUQ8CfQ7JdWhz9WMY-kDrZQfxwPN18WBHDzHXkaJSZCTTSpXtqZlgOWz-fHb8sxWRnsGNDlP4aruxpHmwwkSjB-Mw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODksImlhdCI6MTczMjYxNTg4OSwianRpIjoiYTFhNzllNjQtMTk2My00YTdjLWFkNjMtNWJiNTMwM2Q1NTRiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiY2M2OWE5NGYtYmE5YS00Mjc0LWE2YzktMGU5MmI2MjMyNTBiIn0.8E5nzGg5FfFG105HEVdPMOoBYbZxCr7KF2EmgoyxQmA","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODksImlhdCI6MTczMjYxNTg4OSwiYXV0aF90aW1lIjoxNzMyNjE1ODg5LCJqdGkiOiJlMTg3ZGU5Yy05YzA1LTRjNTctODJjYS0wZGJkZDNiMDgwOTMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJhdF9oYXNoIjoiRTBIYkJmWUpfZ19RNXhiMEw1TXdoZyIsImFjciI6IjEiLCJzaWQiOiJjYzY5YTk0Zi1iYTlhLTQyNzQtYTZjOS0wZTkyYjYyMzI1MGIiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.eMNg6YHW3r5PF1HRtXSAW9W6bCqKmKPXw8jfDxEnvS3mk61PeL568N99oW1j0uZerGtUTWdvIFMn3H_XFiUM2zeUp-CtlLtJwIcJSakRKAk8cOiKm2SxRLY9BCIVz-GhZ2g-CBYHVvejN73pjerMYXTp0Mi7NMbrTrFxdEKXSoAdDQEXdeuguR-uEBoW0OLLTu97h7lFhXjDvzDv1zRodCbLZeelv5w5pUio38pINHW3APJhYsF6QuVmV58mASd9evOxvXWIVIiPfovFwGQPYarjbt0IGLladOQFcMXUUJNYfcx6A--mlvY1u_J4yEkH8_QASOpugzN74ckOoa05Iw","not-before-policy":0,"session_state":"cc69a94f-ba9a-4274-a6c9-0e92b623250b","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiI0NGQ2ZTRiZi03Y2ZiLTQwMGUtODUzOS1jYjIwYWZlZTc2ZjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk1ZGZlZjJmLTUzYzAtNDM4MC1hNDhjLWI0NzEwYzU0N2VhOSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk1ZGZlZjJmLTUzYzAtNDM4MC1hNDhjLWI0NzEwYzU0N2VhOSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.ihD_JhiEjGEifz0woSO9xJvlpZmmNfPFaZbkz9pKGQh2T8Bk3B7SjAFvFSTQfp5tCWq98wqq22F5T_4Y-QdhvGhaRTbiRdwG5ciKcEYlUnH3K19YkuwX-kBb66xf0DyANARuml1MPFr_qaQTHuQrZPK41Mv5wX8nmBZ6iIjRljzsQ8406PGWDgcupT5yIlllAPyeiT_3OkS6AEm9ROeOkMXlpCbGptP1zwFvk-a08EotMPhVFs-guE_-uQrtemsAc_SOLOD3bcsAmEkadGBmebr5c1GHhXnM7u0rXzRbEeqKSDSDXRvmpHYtfn3MjBvcDHnzEVlStyAwMOGf6FDwMA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiZDA2NTA3YjgtYjQ0Mi00ODhlLWEyYjQtODdiNmYzYWU5MGJmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOTVkZmVmMmYtNTNjMC00MzgwLWE0OGMtYjQ3MTBjNTQ3ZWE5In0.Uz4Q3ARf2QxzIdHlu3yhiYK-fVQieRQeY_GJ2zAVj9o","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiI3ZTgzNDRkMy0wNThmLTQzNmEtOTU5My0wOWI2ZDgyMDIwNjIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJhdF9oYXNoIjoicDlRVU5ZS2twelpHcHRBVWYzV3JkdyIsImFjciI6IjEiLCJzaWQiOiI5NWRmZWYyZi01M2MwLTQzODAtYTQ4Yy1iNDcxMGM1NDdlYTkiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.1sPRXART0aAbqDL-2_FKtaSxCnlW2h25wZdTgcRR4pKUbQJy2J69mGYN1q8KFpksviKHFKekYH_ET0EAXeBCPzLSsNqp8adh9ZRVYk9M6jrhsH5lcLwPrsNe5uD8vIA_5hsQ6siQL-PwpsgfvWLAyMOgUcKvpTKCfzDa1gjhCTQz-9hhUHkfUU3LUAS2rfYnvaOfBEXdtb_qztk1-FfXhFrDd6WzyIj9MMmiEu2ya4nzE7aXMj_Yn6z49KjNZgjFZ4cGdkyaNCdnLs8rsPlb6TPFUeeTjLeLY-sRL7UXJoglX9esPfdbdmqRVtoae8RPHLRBXKQqED3HY06_K1pLXw","not-before-policy":0,"session_state":"95dfef2f-53c0-4380-a48c-b4710c547ea9","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODksImlhdCI6MTczMjYxNTg4OSwiYXV0aF90aW1lIjoxNzMyNjE1ODg5LCJqdGkiOiI4MGMxOWU4Ni0xMWNlLTRjMTUtYjVhZS1jMWVmMjQ4YmY3NmEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImNjNjlhOTRmLWJhOWEtNDI3NC1hNmM5LTBlOTJiNjIzMjUwYiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImNjNjlhOTRmLWJhOWEtNDI3NC1hNmM5LTBlOTJiNjIzMjUwYiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.yoQpvfKZGBFdbMkT9C4MI2Uyg4tr_jr5H6zoYo4m6D6QxGeK96UBqL-ho9YbJFFyuIXnfJCn8jj-wTHkML9p-ZATfv1dnTDLt5snX2jyN31uZIon36yBkBhQ5geEbLp4VAF3-SbgiQUBcjCkcD0UxB8IbELMqfQyZxLBSiam89hCHHk0ZxYCFVnPB9Ik9zzJLPdMGXl3GhfG6-FXAw9cCoerCa6vbA-QF35sxwpe_6weWtDdtYHFUMdbKFerAaUQ8CfQ7JdWhz9WMY-kDrZQfxwPN18WBHDzHXkaJSZCTTSpXtqZlgOWz-fHb8sxWRnsGNDlP4aruxpHmwwkSjB-Mw
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiI0NGQ2ZTRiZi03Y2ZiLTQwMGUtODUzOS1jYjIwYWZlZTc2ZjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk1ZGZlZjJmLTUzYzAtNDM4MC1hNDhjLWI0NzEwYzU0N2VhOSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk1ZGZlZjJmLTUzYzAtNDM4MC1hNDhjLWI0NzEwYzU0N2VhOSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.ihD_JhiEjGEifz0woSO9xJvlpZmmNfPFaZbkz9pKGQh2T8Bk3B7SjAFvFSTQfp5tCWq98wqq22F5T_4Y-QdhvGhaRTbiRdwG5ciKcEYlUnH3K19YkuwX-kBb66xf0DyANARuml1MPFr_qaQTHuQrZPK41Mv5wX8nmBZ6iIjRljzsQ8406PGWDgcupT5yIlllAPyeiT_3OkS6AEm9ROeOkMXlpCbGptP1zwFvk-a08EotMPhVFs-guE_-uQrtemsAc_SOLOD3bcsAmEkadGBmebr5c1GHhXnM7u0rXzRbEeqKSDSDXRvmpHYtfn3MjBvcDHnzEVlStyAwMOGf6FDwMA
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_redirects_after_successful_auth.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDCallbackTests/DigiDCallbackTests.test_redirects_after_successful_auth.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"f05dd5d3-5825-491b-b802-a0dc8a924c52\",\n
-        \             \"pdbHDjBBcXc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=pdbHDjBBcXc&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"5fe31c63-71ea-4786-9663-7ff456fce726\",\n
+        \             \"3mhihqN6k38\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=3mhihqN6k38&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=sArW9PydWqh3aBn7z14qDoLzAGFVG5NTMvHniIeVHVU&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=pdbHDjBBcXc\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=MTxLhJ6Bzm9T0xzVqB8SfW7KnxBM7sMUvTfyY8WXEq8&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=3mhihqN6k38\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=f05dd5d3-5825-491b-b802-a0dc8a924c52; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=5fe31c63-71ea-4786-9663-7ff456fce726; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=f05dd5d3-5825-491b-b802-a0dc8a924c52; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=5fe31c63-71ea-4786-9663-7ff456fce726; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=f05dd5d3-5825-491b-b802-a0dc8a924c52; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI
+      - AUTH_SESSION_ID_LEGACY=5fe31c63-71ea-4786-9663-7ff456fce726; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=sArW9PydWqh3aBn7z14qDoLzAGFVG5NTMvHniIeVHVU&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=pdbHDjBBcXc
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=MTxLhJ6Bzm9T0xzVqB8SfW7KnxBM7sMUvTfyY8WXEq8&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=3mhihqN6k38
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-oidc/callback/?state=not-a-random-string&session_state=f05dd5d3-5825-491b-b802-a0dc8a924c52&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=fde05cd1-166f-4597-9bbb-f1b5815bb75b.f05dd5d3-5825-491b-b802-a0dc8a924c52.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=5fe31c63-71ea-4786-9663-7ff456fce726&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=5167558b-c583-49ae-b98e-7a16f1e24041.5fe31c63-71ea-4786-9663-7ff456fce726.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTAsImlhdCI6MTczMjYxNTg5MCwianRpIjoiNzU1OGQxMGEtNzk4OS00ZDJkLWI3M2YtNmU4MTk2MGIyY2Q2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJzaWQiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJzdGF0ZV9jaGVja2VyIjoiUTNTMUpUMzllS0s2SEVQYjh2MUtNaEpsaXRvMmVEelFacUdWRHpDQ3lXbyJ9.GwQJVF0wK-tA6mzNXqJBFzVKMKDqLt7wlIGg8TI-jP4;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiOTU3YTI3ZDktYzliYi00Yjc5LTg1ODItZDM5NWQ4NWMxMzFjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJzaWQiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJzdGF0ZV9jaGVja2VyIjoiMHotbEM3MnZDV1RVN1BaZjBsTnVlQjY4Tm5PcTBESldNb282cGMtM2ZZdyJ9.-Q-SEeN58VhIfMSWJ5ynVB_BC07MqJhzc3WBSObQ_Mc;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTAsImlhdCI6MTczMjYxNTg5MCwianRpIjoiNzU1OGQxMGEtNzk4OS00ZDJkLWI3M2YtNmU4MTk2MGIyY2Q2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJzaWQiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJzdGF0ZV9jaGVja2VyIjoiUTNTMUpUMzllS0s2SEVQYjh2MUtNaEpsaXRvMmVEelFacUdWRHpDQ3lXbyJ9.GwQJVF0wK-tA6mzNXqJBFzVKMKDqLt7wlIGg8TI-jP4;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiOTU3YTI3ZDktYzliYi00Yjc5LTg1ODItZDM5NWQ4NWMxMzFjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJzaWQiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJzdGF0ZV9jaGVja2VyIjoiMHotbEM3MnZDV1RVN1BaZjBsTnVlQjY4Tm5PcTBESldNb282cGMtM2ZZdyJ9.-Q-SEeN58VhIfMSWJ5ynVB_BC07MqJhzc3WBSObQ_Mc;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/f05dd5d3-5825-491b-b802-a0dc8a924c52;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:30 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/5fe31c63-71ea-4786-9663-7ff456fce726;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/f05dd5d3-5825-491b-b802-a0dc8a924c52;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:30 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/5fe31c63-71ea-4786-9663-7ff456fce726;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=fde05cd1-166f-4597-9bbb-f1b5815bb75b.f05dd5d3-5825-491b-b802-a0dc8a924c52.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=5167558b-c583-49ae-b98e-7a16f1e24041.5fe31c63-71ea-4786-9663-7ff456fce726.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '273'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTAsImlhdCI6MTczMjYxNTg5MCwiYXV0aF90aW1lIjoxNzMyNjE1ODkwLCJqdGkiOiJhMmU4N2Q0NC0zMWNlLTRiOTUtYmM0Ny1jMWRlYjA1OWJiYTMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImYwNWRkNWQzLTU4MjUtNDkxYi1iODAyLWEwZGM4YTkyNGM1MiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImYwNWRkNWQzLTU4MjUtNDkxYi1iODAyLWEwZGM4YTkyNGM1MiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.RrZjxuj0DgLngkCcKjq-KbzEHoGPtVAlKwWsL5EaDv09omSmNqS4UqBsdo-DGg4zrLCdHSdOneUA0fUekHrvEanCelsL1pMtHVBl2O73cUU0uncqQ1tFIQ3mVqwMz30sXik3RUfM0XS18-o4EZ_7nwM60sUfXplUoI9HALpf04aV4jTp66YtgwsbuZBzs7lLScwUB0V-K5y0CSDQqZIPjUSrp2GHFs7kKiMD_IaSjWoWIQBrI_-VpABfh_Dh5weCIiYfa5aGZjRrfFtBlrJq6R9PWIIOdgaKBnHwuHuMXWyOf74xkhD63BnhK7psKwT1gSsKtYwoGV90nsU1pYf7eA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTAsImlhdCI6MTczMjYxNTg5MCwianRpIjoiMzVlZjlhMzgtNTkxMC00YWViLTkwZmMtNDFkNDMzNTRiNThlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZjA1ZGQ1ZDMtNTgyNS00OTFiLWI4MDItYTBkYzhhOTI0YzUyIn0.he0IrV6XnwTaY8Qsep8DnrTJiC1C3vEhBMALJEb0QFs","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTAsImlhdCI6MTczMjYxNTg5MCwiYXV0aF90aW1lIjoxNzMyNjE1ODkwLCJqdGkiOiI0YTVhZGZkYi01ZWUzLTQ0OWEtODI4Zi04YmU2ODNhMTA0ZjEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJhdF9oYXNoIjoiQVZzaU9NeC01QXloblBsZjNUdXhUZyIsImFjciI6IjEiLCJzaWQiOiJmMDVkZDVkMy01ODI1LTQ5MWItYjgwMi1hMGRjOGE5MjRjNTIiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.vLtmlO_ly0hbvzZU2UUBHk5Kbm6gyY5f0fGgFVfwCv41JFEib1EN4lorJP84Q6pSjg3sU8LdR7nQ8Ee6C_oRS6IoFFIFmzx3WJnx_OV_3u1qzneGJH6SF6khrffUs3Ou6AoBl9FDj2dtdhwRhjPcQb_AP0nQ4FNbTsvPBtOO8fjB7SJwYn5RKXJkVDcTEM6wqoJII4Lg_OccYKnJ-kDj45uKi3vyXSMie7oiHkgjWlPd4RlwHJQyUToOIWAPpaqdrazMilUtc70_fRJJSnoSrAJkEykUc1ZYBTzhvFmEWFqHuziFbnJ6uabrXEqLNB9zbcT9pGLI9fdFFgpNjOQBzQ","not-before-policy":0,"session_state":"f05dd5d3-5825-491b-b802-a0dc8a924c52","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiJkMWI3YWFkYS00MWQxLTRiZDMtYjUyNS0yNDE5NTdjMmY5OGYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjVmZTMxYzYzLTcxZWEtNDc4Ni05NjYzLTdmZjQ1NmZjZTcyNiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjVmZTMxYzYzLTcxZWEtNDc4Ni05NjYzLTdmZjQ1NmZjZTcyNiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.GgnycZr6TukctNZ9_tTKEkZ09Y4FYIXPpGDIZsa1XCc46kfJyADyOT9lfVX4Zg_o4wS3cB9MCfwWwcGaKnaM3HKSUmvywBrsW5F_c8HNHY4yk_O6Lv0GFBRs2WSs_j7us6_GaDayYEgTMj8e_ZHab8bfoCuf63Yp-N44Rq67vBvQgDZmte33LFV9O6P2jWNvCtKyKj1aZsjGypGEg2FGGHo6TiGkwVBDImUQpC-nmK2MQePNF6C00mZpvwVMZvWRjecOlmjyLiWJTXPfvWCpRwG45qOeloWpnfWi3ZdKArdH5noNkQmuIyt0BdRzcs5q921EPRXZS2dCb_7XswpGbw","expires_in":300,"refresh_expires_in":1799,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTQsImlhdCI6MTczNDAzODMxNSwianRpIjoiYjZiMDIwYzktNDQxNC00ZDZiLWE2Y2QtZWU3YzEzZWIxYTllIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNWZlMzFjNjMtNzFlYS00Nzg2LTk2NjMtN2ZmNDU2ZmNlNzI2In0.tChq0xAz4BuP2h8XObz8KHPiUter4W4sKWQrHrfKDLM","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiI5MWI0YjAxZS1mYzYxLTQxM2UtOTc0OC1jNmM5NDlkYzE0NmYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJhdF9oYXNoIjoiWVM0ZnZLOFhXZFEwUlRIaFFGMXgxZyIsImFjciI6IjEiLCJzaWQiOiI1ZmUzMWM2My03MWVhLTQ3ODYtOTY2My03ZmY0NTZmY2U3MjYiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.MazIFj2xTyiCL-ZgeRY6pnRsHKVDInbig1Ad15msA2bZAJJ4eKoMrtdPXGIkN1iBJqK-z2JxmuP2eCPONfE9Q_dmez4mEwoOMkpKo7Q4vB0TfOd1ajjbxUKGs6aBpZs4Xrw53zz0Jh6zQCrKXNMHreJvk1Ls79j2NaZqsPLK2FA2LHhfooQi1ZmKy8WB9qXQl1e7w3qRkq9gHuLt-R1iKLssq0B5Z-pvmR7Xx4mh8zu_CFP4DAhPUS8ByCSLfbCXh49yoVYmLHHfxWJAzwXGmfy_2Aqrs04WxFt8se74pc5-L6gyjOiHGaUaQhbNCs-kYMGaPZWlJtcTj2cILEIgsw","not-before-policy":0,"session_state":"5fe31c63-71ea-4786-9663-7ff456fce726","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTAsImlhdCI6MTczMjYxNTg5MCwiYXV0aF90aW1lIjoxNzMyNjE1ODkwLCJqdGkiOiJhMmU4N2Q0NC0zMWNlLTRiOTUtYmM0Ny1jMWRlYjA1OWJiYTMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImYwNWRkNWQzLTU4MjUtNDkxYi1iODAyLWEwZGM4YTkyNGM1MiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImYwNWRkNWQzLTU4MjUtNDkxYi1iODAyLWEwZGM4YTkyNGM1MiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.RrZjxuj0DgLngkCcKjq-KbzEHoGPtVAlKwWsL5EaDv09omSmNqS4UqBsdo-DGg4zrLCdHSdOneUA0fUekHrvEanCelsL1pMtHVBl2O73cUU0uncqQ1tFIQ3mVqwMz30sXik3RUfM0XS18-o4EZ_7nwM60sUfXplUoI9HALpf04aV4jTp66YtgwsbuZBzs7lLScwUB0V-K5y0CSDQqZIPjUSrp2GHFs7kKiMD_IaSjWoWIQBrI_-VpABfh_Dh5weCIiYfa5aGZjRrfFtBlrJq6R9PWIIOdgaKBnHwuHuMXWyOf74xkhD63BnhK7psKwT1gSsKtYwoGV90nsU1pYf7eA
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiJkMWI3YWFkYS00MWQxLTRiZDMtYjUyNS0yNDE5NTdjMmY5OGYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjVmZTMxYzYzLTcxZWEtNDc4Ni05NjYzLTdmZjQ1NmZjZTcyNiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjVmZTMxYzYzLTcxZWEtNDc4Ni05NjYzLTdmZjQ1NmZjZTcyNiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.GgnycZr6TukctNZ9_tTKEkZ09Y4FYIXPpGDIZsa1XCc46kfJyADyOT9lfVX4Zg_o4wS3cB9MCfwWwcGaKnaM3HKSUmvywBrsW5F_c8HNHY4yk_O6Lv0GFBRs2WSs_j7us6_GaDayYEgTMj8e_ZHab8bfoCuf63Yp-N44Rq67vBvQgDZmte33LFV9O6P2jWNvCtKyKj1aZsjGypGEg2FGGHo6TiGkwVBDImUQpC-nmK2MQePNF6C00mZpvwVMZvWRjecOlmjyLiWJTXPfvWCpRwG45qOeloWpnfWi3ZdKArdH5noNkQmuIyt0BdRzcs5q921EPRXZS2dCb_7XswpGbw
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDInitTests/DigiDInitTests.test_keycloak_idp_hint_is_respected.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDInitTests/DigiDInitTests.test_keycloak_idp_hint_is_respected.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDInitTests/DigiDInitTests.test_start_flow_redirects_to_oidc_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDInitTests/DigiDInitTests.test_start_flow_redirects_to_oidc_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDLogoutTests/DigiDLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDLogoutTests/DigiDLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"9865d33c-12b0-4ff5-8206-5873094b9f8c\",\n
-        \             \"6hLs7ISZpC8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=6hLs7ISZpC8&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"52b6ef41-3ded-49c9-8791-710c8d52128d\",\n
+        \             \"vbxpEbEwWHc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=vbxpEbEwWHc&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=FxPcxA_n-uY-Va82OBEcBiwCoWw2SVKAOpfoT3OvSuk&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=6hLs7ISZpC8\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=xl1mz3MzCElOg4Y7Qgd7fgmw-YYkoCTldnH9tG-dFKg&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=vbxpEbEwWHc\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=9865d33c-12b0-4ff5-8206-5873094b9f8c; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=52b6ef41-3ded-49c9-8791-710c8d52128d; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=9865d33c-12b0-4ff5-8206-5873094b9f8c; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=52b6ef41-3ded-49c9-8791-710c8d52128d; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=9865d33c-12b0-4ff5-8206-5873094b9f8c; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI
+      - AUTH_SESSION_ID_LEGACY=52b6ef41-3ded-49c9-8791-710c8d52128d; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=FxPcxA_n-uY-Va82OBEcBiwCoWw2SVKAOpfoT3OvSuk&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=6hLs7ISZpC8
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=xl1mz3MzCElOg4Y7Qgd7fgmw-YYkoCTldnH9tG-dFKg&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=vbxpEbEwWHc
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-oidc/callback/?state=not-a-random-string&session_state=9865d33c-12b0-4ff5-8206-5873094b9f8c&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=3e32df5e-5b92-465b-aaab-c09c0b14edc2.9865d33c-12b0-4ff5-8206-5873094b9f8c.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=52b6ef41-3ded-49c9-8791-710c8d52128d&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=0769f69e-f39d-49e8-833c-e46113eb859b.52b6ef41-3ded-49c9-8791-710c8d52128d.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiMjNkNjhhYmEtZDhiNC00ZGEwLTk3YWUtZDIzMjBkZWQzMDJhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzdGF0ZV9jaGVja2VyIjoiWFc3XzE2WC00MUM5MDVLNTVWODE4bEV6YWpPSVd4cTdkUVVPQlBndy1TdyJ9.Vd312uLhKST-gmrt0pqEE-wQeyvTSxmaBOrvJ2RU8dQ;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiYzM4YmUyMDgtNDkzMC00Yzc4LWI5NDAtNGJkYWVmMjM1YjQ5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzdGF0ZV9jaGVja2VyIjoiUnk1ak10VjFRWDhuSnM0VjNwS1M1Z3c5eGs0UjFDdVpZU1dVdFcxaFRYRSJ9.9Xz2Q6QCAXD9QcZ499tu64757zspzevfqZIaPuPcRrs;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiMjNkNjhhYmEtZDhiNC00ZGEwLTk3YWUtZDIzMjBkZWQzMDJhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzdGF0ZV9jaGVja2VyIjoiWFc3XzE2WC00MUM5MDVLNTVWODE4bEV6YWpPSVd4cTdkUVVPQlBndy1TdyJ9.Vd312uLhKST-gmrt0pqEE-wQeyvTSxmaBOrvJ2RU8dQ;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiYzM4YmUyMDgtNDkzMC00Yzc4LWI5NDAtNGJkYWVmMjM1YjQ5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzdGF0ZV9jaGVja2VyIjoiUnk1ak10VjFRWDhuSnM0VjNwS1M1Z3c5eGs0UjFDdVpZU1dVdFcxaFRYRSJ9.9Xz2Q6QCAXD9QcZ499tu64757zspzevfqZIaPuPcRrs;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/9865d33c-12b0-4ff5-8206-5873094b9f8c;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:35 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/52b6ef41-3ded-49c9-8791-710c8d52128d;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/9865d33c-12b0-4ff5-8206-5873094b9f8c;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:35 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/52b6ef41-3ded-49c9-8791-710c8d52128d;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -236,12 +236,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -284,12 +284,12 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=9865d33c-12b0-4ff5-8206-5873094b9f8c; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiMjNkNjhhYmEtZDhiNC00ZGEwLTk3YWUtZDIzMjBkZWQzMDJhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzdGF0ZV9jaGVja2VyIjoiWFc3XzE2WC00MUM5MDVLNTVWODE4bEV6YWpPSVd4cTdkUVVPQlBndy1TdyJ9.Vd312uLhKST-gmrt0pqEE-wQeyvTSxmaBOrvJ2RU8dQ;
-        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/9865d33c-12b0-4ff5-8206-5873094b9f8c
+      - AUTH_SESSION_ID_LEGACY=52b6ef41-3ded-49c9-8791-710c8d52128d; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiYzM4YmUyMDgtNDkzMC00Yzc4LWI5NDAtNGJkYWVmMjM1YjQ5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzdGF0ZV9jaGVja2VyIjoiUnk1ak10VjFRWDhuSnM0VjNwS1M1Z3c5eGs0UjFDdVpZU1dVdFcxaFRYRSJ9.9Xz2Q6QCAXD9QcZ499tu64757zspzevfqZIaPuPcRrs;
+        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/52b6ef41-3ded-49c9-8791-710c8d52128d
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
@@ -297,11 +297,11 @@ interactions:
       Cache-Control:
       - no-store, must-revalidate, max-age=0
       Location:
-      - http://testserver/digid-oidc/callback/?state=not-a-random-string&session_state=9865d33c-12b0-4ff5-8206-5873094b9f8c&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=ddccd09b-53d5-44d6-b275-eab4cec9fce4.9865d33c-12b0-4ff5-8206-5873094b9f8c.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=52b6ef41-3ded-49c9-8791-710c8d52128d&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=5eb85afa-dcae-4c3a-9738-75ef76328387.52b6ef41-3ded-49c9-8791-710c8d52128d.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
@@ -309,15 +309,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiMmQ4ZmQ3ZTktODdiMC00NmU5LWExZTAtNDZmZmJkNThjZGYzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzdGF0ZV9jaGVja2VyIjoiWFc3XzE2WC00MUM5MDVLNTVWODE4bEV6YWpPSVd4cTdkUVVPQlBndy1TdyJ9.Z4UWZJ4Fh-vLD3zPIqyYBI4h6MqMTLfnnNPKQGIZWXM;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiNjkwY2JjZjMtMzFlZS00MzBiLTg5OGQtZTMwMTkxODI3OTllIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzdGF0ZV9jaGVja2VyIjoiUnk1ak10VjFRWDhuSnM0VjNwS1M1Z3c5eGs0UjFDdVpZU1dVdFcxaFRYRSJ9.fv7gPxBHPA5GW2hf2qNYDOOQP7kHkrDBlCBKpQpqi50;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiMmQ4ZmQ3ZTktODdiMC00NmU5LWExZTAtNDZmZmJkNThjZGYzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzdGF0ZV9jaGVja2VyIjoiWFc3XzE2WC00MUM5MDVLNTVWODE4bEV6YWpPSVd4cTdkUVVPQlBndy1TdyJ9.Z4UWZJ4Fh-vLD3zPIqyYBI4h6MqMTLfnnNPKQGIZWXM;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiNjkwY2JjZjMtMzFlZS00MzBiLTg5OGQtZTMwMTkxODI3OTllIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzdGF0ZV9jaGVja2VyIjoiUnk1ak10VjFRWDhuSnM0VjNwS1M1Z3c5eGs0UjFDdVpZU1dVdFcxaFRYRSJ9.fv7gPxBHPA5GW2hf2qNYDOOQP7kHkrDBlCBKpQpqi50;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/9865d33c-12b0-4ff5-8206-5873094b9f8c;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:35 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/52b6ef41-3ded-49c9-8791-710c8d52128d;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/9865d33c-12b0-4ff5-8206-5873094b9f8c;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:35 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/52b6ef41-3ded-49c9-8791-710c8d52128d;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=ddccd09b-53d5-44d6-b275-eab4cec9fce4.9865d33c-12b0-4ff5-8206-5873094b9f8c.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=5eb85afa-dcae-4c3a-9738-75ef76328387.52b6ef41-3ded-49c9-8791-710c8d52128d.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -341,7 +341,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '273'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -350,7 +350,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTUsImlhdCI6MTczMjYxNTg5NSwiYXV0aF90aW1lIjoxNzMyNjE1ODk1LCJqdGkiOiJlNDMwMDQ2My02NzAwLTQ0Y2QtOTdjMC00ZGRjYTg1N2E1YTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk4NjVkMzNjLTEyYjAtNGZmNS04MjA2LTU4NzMwOTRiOWY4YyIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk4NjVkMzNjLTEyYjAtNGZmNS04MjA2LTU4NzMwOTRiOWY4YyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.10VLKCGAvQBoXBWXaDgtyJOY3L1ef0x70lR_zBSWL1fNjVl1_hi1Oz7FJtxKccruPOHGOnpq0MgGrDdtmw_DZu1fEN6Ffu_UizxzSlf2uIDBYT0uS-iKSxISkEuptfL6ffEbBF3K0yO9Yfby9ESAWXYDZ5UWOBaBhhfXs5VVZM7RYofceTGTPrqF-KC_Q3E-vyjD-br7HpRiVKQGhHWxy4FpzNbS3I375G-Ja23netzudHwylg37M387OjADG3unGGkeuMfEoca-Wxvq2HoPPGEGY8MnrHHxZckutvNhInGegu00KePFeKdtdKXG0pYGcWd7sIV5hKNb5JytCw6sgg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiNzNkYjVmMmYtZDI3Ny00NjA5LWI0MjItOTFhZmFlN2NlMGI0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOTg2NWQzM2MtMTJiMC00ZmY1LTgyMDYtNTg3MzA5NGI5ZjhjIn0.fV6ymFeZF-rz7MRSP6a-71bhsD5VhlTE68ROdnkE-Hg","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTUsImlhdCI6MTczMjYxNTg5NSwiYXV0aF90aW1lIjoxNzMyNjE1ODk1LCJqdGkiOiIyOWIzMzYzZi03NDQ4LTRkZjAtOWIwZi1lMmNhM2U1NTliODIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJhdF9oYXNoIjoiOUtRVzJBUERESzNJTUVhMFRTVVdIUSIsImFjciI6IjAiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.fvfsbl6Y1_yGUQ2wcjRsmdZ3dqH-ecy6ImxHFZgh8S9OBVu0EQO5XklrlaGIT6ObWY8LppPKYOamdM83FodGAkeYfdqzdzI7LkePcd_PaqXK-LS0Xs64c_jfAwh01eE-7MyBTQTi2Qb9vJysz0x4NCfZGh4urk6Lbv7UeonBhmYdr-buG4R-6slnHB_TDqC-qrAKwfZXPkmZtVC5vOtZ40MIFMVSgdZ1lra2wMlr7WzbNn95uuzn_klObEXw09NUoPzabxzal1JxjIaMNQMvjVycYoYkqJwfL8EjlSbzGKEJsgz4mLTy3lWllMIiVSdvqy5sxMBD9FriaP7keaWrwQ","not-before-policy":0,"session_state":"9865d33c-12b0-4ff5-8206-5873094b9f8c","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiJkY2JkZGU4Yy05OGJjLTQyNmQtYmEzYy01YTc3OTQzY2MyYTUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjUyYjZlZjQxLTNkZWQtNDljOS04NzkxLTcxMGM4ZDUyMTI4ZCIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjUyYjZlZjQxLTNkZWQtNDljOS04NzkxLTcxMGM4ZDUyMTI4ZCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.oaOTnSxyzJa2Tz2jt-y38CD3LmWJpVRavusmNpqmziY0aK-osOfqjTj2MqmoK8eLRIyo3llQthGBMddKFRnL5SjgJX7IDHHS8Yk3qrlwIMcCga6SyXAb6umTFJn4OVRA5b_3V5m1Pyk4m7HFrUzaWhy4-YvNiEzHdhYHpuJ2PLauC_OrUCZcpbI02hRLumRJHZeqjM1DkqTOEXFH2zEAPUT_ieY0-gguJZ4ET_CIWc8zTlfyiXDgB4PSdfJinc7mr5No0JsA3QUPEtmWGSeoe07vODLPu4PCfNABsf8Jge4d4ZVcen4bZnuHy7OZ34GWabkWfArUNzk-mUJzTQB0TQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiOWJjYzk2YTktNjM5NC00MmU5LTg4MzEtZGRlYWE5MWU4N2ZkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNTJiNmVmNDEtM2RlZC00OWM5LTg3OTEtNzEwYzhkNTIxMjhkIn0.PQxdAaJX8uJiS0mpWPAvQar-RYELFVezHqXMRKkMb24","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiIyODdiMGNmNS0zNjAxLTRmYjYtYjc5ZC0zZDBjN2M3ZTkwMzciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJhdF9oYXNoIjoiOFZ6ZlRLNThvTTBiMHpWd3JtZVkzQSIsImFjciI6IjAiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.vYRhJLoVhmG823gkSonanR6Deh-DSs-5c-FFOyAp3kA3PWc8DbsHT82rDwNqXHfqiil-fQ8LM9q2bXUIuaBtSbQlYkMdLkkBD3tcVgLxd4gHFW26R7zyxsPki3Aurf-7_LZTn_HMH_Ih98YIvJeW0Pki19ErQvaeEZOCV8Y5QfLTML2gWYbp3QKj7LdFaJZ9tR2jDCUeAajMlM1xF8mwuc5eHUlnEk-3aVD8bU6gV6Glzl-DcyWgYBHCbgGBkoMi2ITfY7j7BriQqiD-eAk9MXXTRG3F-wSHxEuBPSZUr-qSumdYFypR2mTsZ1J90B4YNuCc6awUa-Ud8o2jN-rH_w","not-before-policy":0,"session_state":"52b6ef41-3ded-49c9-8791-710c8d52128d","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -418,7 +418,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTUsImlhdCI6MTczMjYxNTg5NSwiYXV0aF90aW1lIjoxNzMyNjE1ODk1LCJqdGkiOiJlNDMwMDQ2My02NzAwLTQ0Y2QtOTdjMC00ZGRjYTg1N2E1YTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk4NjVkMzNjLTEyYjAtNGZmNS04MjA2LTU4NzMwOTRiOWY4YyIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk4NjVkMzNjLTEyYjAtNGZmNS04MjA2LTU4NzMwOTRiOWY4YyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.10VLKCGAvQBoXBWXaDgtyJOY3L1ef0x70lR_zBSWL1fNjVl1_hi1Oz7FJtxKccruPOHGOnpq0MgGrDdtmw_DZu1fEN6Ffu_UizxzSlf2uIDBYT0uS-iKSxISkEuptfL6ffEbBF3K0yO9Yfby9ESAWXYDZ5UWOBaBhhfXs5VVZM7RYofceTGTPrqF-KC_Q3E-vyjD-br7HpRiVKQGhHWxy4FpzNbS3I375G-Ja23netzudHwylg37M387OjADG3unGGkeuMfEoca-Wxvq2HoPPGEGY8MnrHHxZckutvNhInGegu00KePFeKdtdKXG0pYGcWd7sIV5hKNb5JytCw6sgg
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiJkY2JkZGU4Yy05OGJjLTQyNmQtYmEzYy01YTc3OTQzY2MyYTUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjUyYjZlZjQxLTNkZWQtNDljOS04NzkxLTcxMGM4ZDUyMTI4ZCIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjUyYjZlZjQxLTNkZWQtNDljOS04NzkxLTcxMGM4ZDUyMTI4ZCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.oaOTnSxyzJa2Tz2jt-y38CD3LmWJpVRavusmNpqmziY0aK-osOfqjTj2MqmoK8eLRIyo3llQthGBMddKFRnL5SjgJX7IDHHS8Yk3qrlwIMcCga6SyXAb6umTFJn4OVRA5b_3V5m1Pyk4m7HFrUzaWhy4-YvNiEzHdhYHpuJ2PLauC_OrUCZcpbI02hRLumRJHZeqjM1DkqTOEXFH2zEAPUT_ieY0-gguJZ4ET_CIWc8zTlfyiXDgB4PSdfJinc7mr5No0JsA3QUPEtmWGSeoe07vODLPu4PCfNABsf8Jge4d4ZVcen4bZnuHy7OZ34GWabkWfArUNzk-mUJzTQB0TQ
       Connection:
       - keep-alive
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTUsImlhdCI6MTczMjYxNTg5NSwiYXV0aF90aW1lIjoxNzMyNjE1ODk1LCJqdGkiOiIyOWIzMzYzZi03NDQ4LTRkZjAtOWIwZi1lMmNhM2U1NTliODIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJhdF9oYXNoIjoiOUtRVzJBUERESzNJTUVhMFRTVVdIUSIsImFjciI6IjAiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.fvfsbl6Y1_yGUQ2wcjRsmdZ3dqH-ecy6ImxHFZgh8S9OBVu0EQO5XklrlaGIT6ObWY8LppPKYOamdM83FodGAkeYfdqzdzI7LkePcd_PaqXK-LS0Xs64c_jfAwh01eE-7MyBTQTi2Qb9vJysz0x4NCfZGh4urk6Lbv7UeonBhmYdr-buG4R-6slnHB_TDqC-qrAKwfZXPkmZtVC5vOtZ40MIFMVSgdZ1lra2wMlr7WzbNn95uuzn_klObEXw09NUoPzabxzal1JxjIaMNQMvjVycYoYkqJwfL8EjlSbzGKEJsgz4mLTy3lWllMIiVSdvqy5sxMBD9FriaP7keaWrwQ
+    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiIyODdiMGNmNS0zNjAxLTRmYjYtYjc5ZC0zZDBjN2M3ZTkwMzciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJhdF9oYXNoIjoiOFZ6ZlRLNThvTTBiMHpWd3JtZVkzQSIsImFjciI6IjAiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.vYRhJLoVhmG823gkSonanR6Deh-DSs-5c-FFOyAp3kA3PWc8DbsHT82rDwNqXHfqiil-fQ8LM9q2bXUIuaBtSbQlYkMdLkkBD3tcVgLxd4gHFW26R7zyxsPki3Aurf-7_LZTn_HMH_Ih98YIvJeW0Pki19ErQvaeEZOCV8Y5QfLTML2gWYbp3QKj7LdFaJZ9tR2jDCUeAajMlM1xF8mwuc5eHUlnEk-3aVD8bU6gV6Glzl-DcyWgYBHCbgGBkoMi2ITfY7j7BriQqiD-eAk9MXXTRG3F-wSHxEuBPSZUr-qSumdYFypR2mTsZ1J90B4YNuCc6awUa-Ud8o2jN-rH_w
     headers:
       Accept:
       - '*/*'
@@ -505,12 +505,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -531,9 +531,9 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=d1948dc0-4677-4187-87b0-272ca447678e; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=11d78256-11a8-42ee-a2bd-7071678fa12c; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=d1948dc0-4677-4187-87b0-272ca447678e; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=11d78256-11a8-42ee-a2bd-7071678fa12c; Version=1; Path=/realms/test/;
         HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -569,12 +569,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -617,29 +617,29 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=9865d33c-12b0-4ff5-8206-5873094b9f8c; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTUsImlhdCI6MTczMjYxNTg5NSwianRpIjoiMmQ4ZmQ3ZTktODdiMC00NmU5LWExZTAtNDZmZmJkNThjZGYzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzaWQiOiI5ODY1ZDMzYy0xMmIwLTRmZjUtODIwNi01ODczMDk0YjlmOGMiLCJzdGF0ZV9jaGVja2VyIjoiWFc3XzE2WC00MUM5MDVLNTVWODE4bEV6YWpPSVd4cTdkUVVPQlBndy1TdyJ9.Z4UWZJ4Fh-vLD3zPIqyYBI4h6MqMTLfnnNPKQGIZWXM;
-        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/9865d33c-12b0-4ff5-8206-5873094b9f8c;
-        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI
+      - AUTH_SESSION_ID_LEGACY=52b6ef41-3ded-49c9-8791-710c8d52128d; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiNjkwY2JjZjMtMzFlZS00MzBiLTg5OGQtZTMwMTkxODI3OTllIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzaWQiOiI1MmI2ZWY0MS0zZGVkLTQ5YzktODc5MS03MTBjOGQ1MjEyOGQiLCJzdGF0ZV9jaGVja2VyIjoiUnk1ak10VjFRWDhuSnM0VjNwS1M1Z3c5eGs0UjFDdVpZU1dVdFcxaFRYRSJ9.fv7gPxBHPA5GW2hf2qNYDOOQP7kHkrDBlCBKpQpqi50;
+        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/52b6ef41-3ded-49c9-8791-710c8d52128d;
+        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"204f2d5e-bc25-455f-b9b9-612d6e7c5df4\",\n
-        \             \"tODn7ORyAtY\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=tODn7ORyAtY&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"218b8b52-eb78-405b-a86d-e51524651dd8\",\n
+        \             \"yEev-SIOZ3s\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=yEev-SIOZ3s&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -647,7 +647,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=WAdfsneQ_ZBo6rXGqaHyFGRa1B2PV-GYmYV56EEN3kM&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=tODn7ORyAtY\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=uRTS3EWJ_TPvDqkE8yV4yi648L-JmemESlHwKVmezl0&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=yEev-SIOZ3s\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -673,7 +673,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -703,11 +703,11 @@ interactions:
         00:00:10 GMT; Max-Age=0; Path=/realms/test
       - KEYCLOAK_SESSION_LEGACY=; Version=1; Comment=Expiring cookie; Expires=Thu,
         01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/realms/test
-      - AUTH_SESSION_ID=204f2d5e-bc25-455f-b9b9-612d6e7c5df4; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=218b8b52-eb78-405b-a86d-e51524651dd8; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=204f2d5e-bc25-455f-b9b9-612d6e7c5df4; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=218b8b52-eb78-405b-a86d-e51524651dd8; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZGlnaWQtb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.HScBoNNJvmVcGQXpymd_ftVGkGUJBQnuwqgk59VJnYI;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenAuthContextTests/DigiDMachtigenAuthContextTests.test_new_required_claims_are_backwards_compatible.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenAuthContextTests/DigiDMachtigenAuthContextTests.test_new_required_claims_are_backwards_compatible.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"aa45337c-8311-4c3e-b317-78de12ce5571\",\n
-        \             \"uUsUZx2ehm4\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=uUsUZx2ehm4&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"f4429385-d43a-471d-aa5f-e700053d8415\",\n
+        \             \"il8IjljY02g\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=il8IjljY02g&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=RiDVyQ9_XKr-9DPAUMmo29bQWr4_v8sAlJuvFfmC8P4&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=uUsUZx2ehm4\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=pguGrYLO8O6zoEhC5xXk8VjZZt0pxPNd9UwSlDOGwCU&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=il8IjljY02g\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=aa45337c-8311-4c3e-b317-78de12ce5571; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=f4429385-d43a-471d-aa5f-e700053d8415; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=aa45337c-8311-4c3e-b317-78de12ce5571; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=f4429385-d43a-471d-aa5f-e700053d8415; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.cu-BJEBROWGEhzLxv4SEl3JCIIV6IY55UEVKK3keSQs;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=aa45337c-8311-4c3e-b317-78de12ce5571; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.cu-BJEBROWGEhzLxv4SEl3JCIIV6IY55UEVKK3keSQs
+      - AUTH_SESSION_ID_LEGACY=f4429385-d43a-471d-aa5f-e700053d8415; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=RiDVyQ9_XKr-9DPAUMmo29bQWr4_v8sAlJuvFfmC8P4&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=uUsUZx2ehm4
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=pguGrYLO8O6zoEhC5xXk8VjZZt0pxPNd9UwSlDOGwCU&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=il8IjljY02g
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=aa45337c-8311-4c3e-b317-78de12ce5571&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=4e11ed80-2474-41ab-8d7a-b9f7ef4614b4.aa45337c-8311-4c3e-b317-78de12ce5571.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=f4429385-d43a-471d-aa5f-e700053d8415&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=6559a335-8056-4ea4-96d4-6269b79ed048.f4429385-d43a-471d-aa5f-e700053d8415.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODYsImlhdCI6MTczMjYxNTg4NiwianRpIjoiZTRiMzA0OGUtMjUwOS00YTM0LWEyMGEtMGQzOTBlYmE2YzM1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJzaWQiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJzdGF0ZV9jaGVja2VyIjoiejg1MV92TU5KYWk4bllORG1GODluVjhab1MtYUFGYzZMSHB3QWZMRjJhVSJ9.YtUQ6QgI1M8UiSuuZiEVUtxrAdusLecfXRktT3UhQ_I;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiYzYyMThlZDEtMWYwNi00NjNmLThlY2MtMTAxNDdlZWI4MzUyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJzaWQiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJzdGF0ZV9jaGVja2VyIjoiSUxSTVBhQVVoTFIwWHQ4N3lNUWdIZ2xQNzY4VlFkLVhaMzZ1ODQ4OWFEOCJ9.dCzsurrCxpnwxw3RacbrT6M89fCFmAOlxt2zGkwJGtg;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODYsImlhdCI6MTczMjYxNTg4NiwianRpIjoiZTRiMzA0OGUtMjUwOS00YTM0LWEyMGEtMGQzOTBlYmE2YzM1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJzaWQiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJzdGF0ZV9jaGVja2VyIjoiejg1MV92TU5KYWk4bllORG1GODluVjhab1MtYUFGYzZMSHB3QWZMRjJhVSJ9.YtUQ6QgI1M8UiSuuZiEVUtxrAdusLecfXRktT3UhQ_I;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiYzYyMThlZDEtMWYwNi00NjNmLThlY2MtMTAxNDdlZWI4MzUyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJzaWQiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJzdGF0ZV9jaGVja2VyIjoiSUxSTVBhQVVoTFIwWHQ4N3lNUWdIZ2xQNzY4VlFkLVhaMzZ1ODQ4OWFEOCJ9.dCzsurrCxpnwxw3RacbrT6M89fCFmAOlxt2zGkwJGtg;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/aa45337c-8311-4c3e-b317-78de12ce5571;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:26 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/f4429385-d43a-471d-aa5f-e700053d8415;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:32 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/aa45337c-8311-4c3e-b317-78de12ce5571;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:26 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/f4429385-d43a-471d-aa5f-e700053d8415;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:32 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=4e11ed80-2474-41ab-8d7a-b9f7ef4614b4.aa45337c-8311-4c3e-b317-78de12ce5571.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fdigid-machtigen-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=6559a335-8056-4ea4-96d4-6269b79ed048.f4429385-d43a-471d-aa5f-e700053d8415.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '289'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODYsImlhdCI6MTczMjYxNTg4NiwiYXV0aF90aW1lIjoxNzMyNjE1ODg2LCJqdGkiOiI2NmYzMjU3MS0xOTYxLTQ5NzEtYWNjYi1mY2M4MGJiYWEwMGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImFhNDUzMzdjLTgzMTEtNGMzZS1iMzE3LTc4ZGUxMmNlNTU3MSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImFhNDUzMzdjLTgzMTEtNGMzZS1iMzE3LTc4ZGUxMmNlNTU3MSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.BigCmMBDtXzCW7E49eRQdzvH0b9almip1wuZWdeYHUH2AZiOidOcFzfol6szpJpHGB9ufuyZq0VCeKva0dqgX4bNzfJ-xW6xdt-K1dvgONuIYPx0vUx2S5ZGuI6dKk3GTnqGKKEzRCZqjmKKrPWYPOdbq80eyPLfVl2odEglhVt_gG9gI4j2V25pnZf1kMRRq75tW4yLseiEgycJ-e3pLglGSibbP98ozirN9y7xWHqmagvG0GFHOtrXWXqOI-Xa-dJQLiknnImP8AeJROCl9yXJk4Zk31CXyG0wWuqXr5XjHkqszNa4UouwrAx7NArWfKms2ACc8jKfkXvlplhSiQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODYsImlhdCI6MTczMjYxNTg4NiwianRpIjoiN2E3MTZmZWMtZTJmNy00OGI3LWFjZTYtYWZmODIxYjU0YzY5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYWE0NTMzN2MtODMxMS00YzNlLWIzMTctNzhkZTEyY2U1NTcxIn0.xt9gnrE4mwNqeTICQ_FhO9hVUlUgI_TXzyayul68Z8g","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODYsImlhdCI6MTczMjYxNTg4NiwiYXV0aF90aW1lIjoxNzMyNjE1ODg2LCJqdGkiOiIyNDQ4OThjMy00YjE2LTRmOTItOWVkZC1kNzAxMTM4MWVkYjEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJhdF9oYXNoIjoiQlpnSHRqdXNkYzRYZy04YjZVUzhGUSIsImFjciI6IjEiLCJzaWQiOiJhYTQ1MzM3Yy04MzExLTRjM2UtYjMxNy03OGRlMTJjZTU1NzEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.CaoLF0RJTR6GMcIKDtAWYh0q6tS-BZV_mZpdYcGHTciTSINVJ7GCFnPVMluUfRVajcE63axBN-Rq7BMGzRRtng7ASb2DNsNtHiPLj4Ehc3qfaF4jST5jLmkiG9k66y84FQyq0vdMehYlShHQxQE7ZfNIuqIhQgshvK5O_EuABpIitsy1Y_Id3XytCJ55HlpXsWcoIGyfXYFq2XH2jf3D_1CA4kt8BHddivOLHEwHHsR8ek-A4J3lEeD3f-wQseR20KiLDbCxcPnu2RblA_Efxe4XRZHkRkPfG7q-ikiYHNhfv_RDhi3ve5-_-Jd1FqA9E6yFVzmH2mEDg8RJBX2D_A","not-before-policy":0,"session_state":"aa45337c-8311-4c3e-b317-78de12ce5571","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiI2YmE0MjFhOC1lNGNmLTRiZjktOTBkOS02NzQ0NTAzMGI5MGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImY0NDI5Mzg1LWQ0M2EtNDcxZC1hYTVmLWU3MDAwNTNkODQxNSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImY0NDI5Mzg1LWQ0M2EtNDcxZC1hYTVmLWU3MDAwNTNkODQxNSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.IC6l3sii-ftvudbyTbsQ-6egSI5SHkx-sJfW5Fh6ymDtQcH37oi7F4Wf8a9BjSe4SSV7ZDytm-mh3meDvP2PtjARGu48CMQ2DIvIYcd7WmDcyylLj_tByQkDhKKdn3ktBqJIBMP6J3QTlopnpIKIkHMcncz8ydwsB0KxiZ37b0JFP70X8jlLuixqrw2m9ckS0qoocBZhXlc9xtsU3-LA1jDASuRiK1p0pJbBvKppMEnsfVbI6VVpaeUMifKr7V3BOVy7sxb3XBXBQc_48MpYUACAKGxMESznZLo1YiF-mtmUIIJSnCRa5mxLanXqcvQKjG3toC8H_olC9lZ35bUI8w","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiZWUxYTYyZTEtYzAwYi00YzM2LWFjMTAtODcxOWNkNGM0MGQ5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZjQ0MjkzODUtZDQzYS00NzFkLWFhNWYtZTcwMDA1M2Q4NDE1In0.JbLjQqrGYz5iWrMTJF6v1sTeDGecyM1TiRRF5i0g0mw","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiI5NDcyMjUxZC03NGFiLTQ4MmMtYTdhYi03YmNhM2Y2ZjdiNTMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJhdF9oYXNoIjoic05JODdkbklhWkpBNTZTcS1kOEgxQSIsImFjciI6IjEiLCJzaWQiOiJmNDQyOTM4NS1kNDNhLTQ3MWQtYWE1Zi1lNzAwMDUzZDg0MTUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.T8iPUMHB4j0MEoXvgS0bZn0NHjLxjRABqfXiEql9Qyqpd3reoKMZBWmpOQ5DpLWHwQGKA5r4Lt2jqeysKSvPqlOgsMLVAfr8vDjWDYe4B7Qonu2JZwD2woiNNqpTvxe6GVpsuqj2c0zkzSyYo2jrIzICWKNx3gjRz0q7oT-D0UMBY5jPJWZPa57jVaUNU_qJDswjVrzTSipY57xWx9hD1dNDPg34flB02G9AxgeAu1ARM46f1uPr7oj4t0NzpltemrQqmjYBgH7SHvnFEUIpm2YueSaKMjRUIe38_y1_UGTSxWCkCuQSObV6nAgBy_TQEEfLsEXW1rLvSfW1KA_GzA","not-before-policy":0,"session_state":"f4429385-d43a-471d-aa5f-e700053d8415","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODYsImlhdCI6MTczMjYxNTg4NiwiYXV0aF90aW1lIjoxNzMyNjE1ODg2LCJqdGkiOiI2NmYzMjU3MS0xOTYxLTQ5NzEtYWNjYi1mY2M4MGJiYWEwMGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImFhNDUzMzdjLTgzMTEtNGMzZS1iMzE3LTc4ZGUxMmNlNTU3MSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImFhNDUzMzdjLTgzMTEtNGMzZS1iMzE3LTc4ZGUxMmNlNTU3MSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.BigCmMBDtXzCW7E49eRQdzvH0b9almip1wuZWdeYHUH2AZiOidOcFzfol6szpJpHGB9ufuyZq0VCeKva0dqgX4bNzfJ-xW6xdt-K1dvgONuIYPx0vUx2S5ZGuI6dKk3GTnqGKKEzRCZqjmKKrPWYPOdbq80eyPLfVl2odEglhVt_gG9gI4j2V25pnZf1kMRRq75tW4yLseiEgycJ-e3pLglGSibbP98ozirN9y7xWHqmagvG0GFHOtrXWXqOI-Xa-dJQLiknnImP8AeJROCl9yXJk4Zk31CXyG0wWuqXr5XjHkqszNa4UouwrAx7NArWfKms2ACc8jKfkXvlplhSiQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiI2YmE0MjFhOC1lNGNmLTRiZjktOTBkOS02NzQ0NTAzMGI5MGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImY0NDI5Mzg1LWQ0M2EtNDcxZC1hYTVmLWU3MDAwNTNkODQxNSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImY0NDI5Mzg1LWQ0M2EtNDcxZC1hYTVmLWU3MDAwNTNkODQxNSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.IC6l3sii-ftvudbyTbsQ-6egSI5SHkx-sJfW5Fh6ymDtQcH37oi7F4Wf8a9BjSe4SSV7ZDytm-mh3meDvP2PtjARGu48CMQ2DIvIYcd7WmDcyylLj_tByQkDhKKdn3ktBqJIBMP6J3QTlopnpIKIkHMcncz8ydwsB0KxiZ37b0JFP70X8jlLuixqrw2m9ckS0qoocBZhXlc9xtsU3-LA1jDASuRiK1p0pJbBvKppMEnsfVbI6VVpaeUMifKr7V3BOVy7sxb3XBXBQc_48MpYUACAKGxMESznZLo1YiF-mtmUIIJSnCRa5mxLanXqcvQKjG3toC8H_olC9lZ35bUI8w
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenAuthContextTests/DigiDMachtigenAuthContextTests.test_record_auth_context.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenAuthContextTests/DigiDMachtigenAuthContextTests.test_record_auth_context.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d\",\n
-        \             \"7bM52lYWk1A\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=7bM52lYWk1A&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"5e5d8c26-b210-42a3-9d6c-e991e5c9ac12\",\n
+        \             \"X-g2Qyx-BR4\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=X-g2Qyx-BR4&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=73MiOyWQyH61VjV0-BCwqgUl0HcJc-Bk61JeoR1l3_Y&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=7bM52lYWk1A\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=El7eId3rvDRJBoh84IWTkVoseRJ0N9bf8tLsuEdXgzI&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=X-g2Qyx-BR4\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=5e5d8c26-b210-42a3-9d6c-e991e5c9ac12; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=5e5d8c26-b210-42a3-9d6c-e991e5c9ac12; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.cu-BJEBROWGEhzLxv4SEl3JCIIV6IY55UEVKK3keSQs;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZGlnaWQtbWFjaHRpZ2VuLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.cu-BJEBROWGEhzLxv4SEl3JCIIV6IY55UEVKK3keSQs
+      - AUTH_SESSION_ID_LEGACY=5e5d8c26-b210-42a3-9d6c-e991e5c9ac12; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=73MiOyWQyH61VjV0-BCwqgUl0HcJc-Bk61JeoR1l3_Y&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=7bM52lYWk1A
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=El7eId3rvDRJBoh84IWTkVoseRJ0N9bf8tLsuEdXgzI&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=X-g2Qyx-BR4
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=9ea51d1b-c2c3-4f07-bbe3-a6d1e3d98b14.38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=5e5d8c26-b210-42a3-9d6c-e991e5c9ac12&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=bd1b04a4-ff58-4f38-bf12-a1c8bce60900.5e5d8c26-b210-42a3-9d6c-e991e5c9ac12.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODYsImlhdCI6MTczMjYxNTg4NiwianRpIjoiOWIzYzYxZGUtNzhhNS00N2Y4LWI1YTEtNjFjYTJiZGExMjZjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJzaWQiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJzdGF0ZV9jaGVja2VyIjoiUDdBSFN0YmxNdGt4NWVaQ0h4RzkxV041VmZaOEh5ajczTC1jODVvbUNkbyJ9.GTP9XkbIzODUC_TGirNvMl_Y4hecqCWf_Fp_45jUqd8;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiZjAzMWM0MmYtMGFkZi00OTMwLTliZGItZDNhNjM3ZDMwMzBhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJzaWQiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJzdGF0ZV9jaGVja2VyIjoiVTJncGpUOE8yOVVNR1BPc0RnQklZX1lpeGh6TjZGblo2Q1FKX0Rod2dicyJ9.m_roHmaROZobqlnMPyPDW4Cxv2TTvbM9MoVnlTozw9M;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODYsImlhdCI6MTczMjYxNTg4NiwianRpIjoiOWIzYzYxZGUtNzhhNS00N2Y4LWI1YTEtNjFjYTJiZGExMjZjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJzaWQiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJzdGF0ZV9jaGVja2VyIjoiUDdBSFN0YmxNdGt4NWVaQ0h4RzkxV041VmZaOEh5ajczTC1jODVvbUNkbyJ9.GTP9XkbIzODUC_TGirNvMl_Y4hecqCWf_Fp_45jUqd8;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiZjAzMWM0MmYtMGFkZi00OTMwLTliZGItZDNhNjM3ZDMwMzBhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJzaWQiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJzdGF0ZV9jaGVja2VyIjoiVTJncGpUOE8yOVVNR1BPc0RnQklZX1lpeGh6TjZGblo2Q1FKX0Rod2dicyJ9.m_roHmaROZobqlnMPyPDW4Cxv2TTvbM9MoVnlTozw9M;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:26 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/5e5d8c26-b210-42a3-9d6c-e991e5c9ac12;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:32 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:26 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/5e5d8c26-b210-42a3-9d6c-e991e5c9ac12;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:32 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=9ea51d1b-c2c3-4f07-bbe3-a6d1e3d98b14.38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fdigid-machtigen-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=bd1b04a4-ff58-4f38-bf12-a1c8bce60900.5e5d8c26-b210-42a3-9d6c-e991e5c9ac12.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '289'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODYsImlhdCI6MTczMjYxNTg4NiwiYXV0aF90aW1lIjoxNzMyNjE1ODg2LCJqdGkiOiI0OTRhZjI5NS1jNDJhLTQ5ZTUtYmY2Mi01MjhmNzAxMjc3MjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM4ZDJkMWNhLTVlMmMtNGQzOS1hYzZjLTkwYmM4OTcxYTY4ZCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM4ZDJkMWNhLTVlMmMtNGQzOS1hYzZjLTkwYmM4OTcxYTY4ZCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.x7OQbp1cQ0u2PtA_IIafZ-TR3JZSPqGFFI9wjFSlGJlurr0sK5xYWOvzAzA3KCxBris4D4PbBSGl44IILaDW749_o3Jn2hg0f7VoMHVyQ9mG9MmklMZABNy3bz5AAgQ_P2uyMEZfgBWeQryOw_24kOBxgeZ0fbi737XJHebufNiXtLU5sHAS2NvqmccDL1aqi6p3HGYwEoEkI1jcapnYDPoFH9LVz8FG1G9mVz1nA4JaHnP6zPndDa4g67hagu8YWyjvznmz6vTx91VqfOitI1GjSjdZX1_5kpou8I0OLyqOV5oZrbPF01wBl4vlSX0qI3C-4b6Tfv3G6x__LfiP3Q","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODYsImlhdCI6MTczMjYxNTg4NiwianRpIjoiYjk4YWJhZTEtYjViYS00ODMyLTg3ZTktYzcxZDg2M2E4NTFjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMzhkMmQxY2EtNWUyYy00ZDM5LWFjNmMtOTBiYzg5NzFhNjhkIn0.V71aBgc9sYR14gmHC-yWJ575o3syxspFI9nqslBZ2Ps","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODYsImlhdCI6MTczMjYxNTg4NiwiYXV0aF90aW1lIjoxNzMyNjE1ODg2LCJqdGkiOiI2MDQ3NGNlZC0xMjAzLTRmMjMtOWJhOC1hN2M0Mjg1YmVlZmQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJhdF9oYXNoIjoiWlhORjM1aFpScURId25nSEZBZHN4USIsImFjciI6IjEiLCJzaWQiOiIzOGQyZDFjYS01ZTJjLTRkMzktYWM2Yy05MGJjODk3MWE2OGQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.E_aJw59hyZ8n5kSobB67G3YN4vX5lgmtpfDhq4E4ZKF5vJ6I2KfF2FTsI_TEjkSQ6qg3I0NDB8bWTUP-7wMRPVaJMmuBXPG5ellYKJaYz-r_v5Pr9Q1pmS05x6trrJQvZ0hztbK1-WslFFLxm0x63aSGEMyGUVHEHPPH0gtqCvNdJ0N2Dx6XZZQu6jV8nwqzSyZfU8wkezidShPub9jVm72SI-fW9Ng0L1124bjh7v-fLJUBHubc0wM34mANwPhLbQEikLaEaNXCYPC-MurV5jM_OgYLegyTrqihhgZ78fZ7jytLpLVgK4PabPEx_1fN3eJRgEBAsRHAVtp8yYpMFA","not-before-policy":0,"session_state":"38d2d1ca-5e2c-4d39-ac6c-90bc8971a68d","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiIyYjg1ZDk3YS01ZDFhLTRhZmEtOWFkMy1mNzk1YzJiYzhmNzciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjVlNWQ4YzI2LWIyMTAtNDJhMy05ZDZjLWU5OTFlNWM5YWMxMiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjVlNWQ4YzI2LWIyMTAtNDJhMy05ZDZjLWU5OTFlNWM5YWMxMiIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.hS_9A9TvPHKnK_ToFTYzc4yCRXvvuTWzP6khBmC1vNql3lXR4c8HNDv7W5g5Lw-N9pCh0Rn9lMHy_O88K9EBnhJpa1GTjt9OqmqCHYdjS6cX2i9VGDwut05jNrvjN7_z7ywVX3f8Y5HRg1uVRIEerFvwsuEQx-e_7Si6xdwlcTNOUGzpqZMI0RXETaJMJuQbCFrvR_BtM760d4VC6LDQww2f0syyJNRm8vQ7Gy2YEpoVzcijz_8rb72W8Eccy6CU2Fcjl2q4fZnxQmq0GXs7kAxvlDO4SaFKsjqs64i1_UC-58LMD0WeNP3jk_s9svs1U_YGDdrjyLyqPCe1ij1GAA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTIsImlhdCI6MTczNDAzODMxMiwianRpIjoiMjkwNjhkYWQtMzk5Yy00ZmM0LWI5MTAtZDg0NDg0ZmRmZjVlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNWU1ZDhjMjYtYjIxMC00MmEzLTlkNmMtZTk5MWU1YzlhYzEyIn0.ElXcgS3xppTbsTWWvfmxPGtw0z0CHEAIvkjk7V8CyBc","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiI1YTFlOGIwOC1kZDZkLTQ4ZTQtOWM5Ny1jMWM5YmFhYThkMjAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJhdF9oYXNoIjoiNjNJTkJlUlNralNLdElMdm9TSmpydyIsImFjciI6IjEiLCJzaWQiOiI1ZTVkOGMyNi1iMjEwLTQyYTMtOWQ2Yy1lOTkxZTVjOWFjMTIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.p7X9Dw2VaWPSSBY1raThKq9BqkBnBKzw1_eG78aq2VukSV8WmHksBokSjRbLi4oEJA3Z76G-kzieiWGrdWfVs69Jd7AicccD0OIm3AgZz6TLs_tTa76AjP0TGAYmw_KKmYrG1bgV33zXsYNa8Klo82eKJ-FFDlbcohOsdujqXi5GhMYUASH47mAaNYNrq_820GCRnA7GOuXC_mcOwLXgWYsfws6zekti4bmJb7bN415ZAhhpZXBkauPwl3b02920dKap6R2kK5WrleeicMSO2MhyA-ihbZ2_43JnI3N1OT7Pe6zQoWcGVbdHsRnvUvA241tXPlDneCbMWxNjj05jKg","not-before-policy":0,"session_state":"5e5d8c26-b210-42a3-9d6c-e991e5c9ac12","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODYsImlhdCI6MTczMjYxNTg4NiwiYXV0aF90aW1lIjoxNzMyNjE1ODg2LCJqdGkiOiI0OTRhZjI5NS1jNDJhLTQ5ZTUtYmY2Mi01MjhmNzAxMjc3MjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM4ZDJkMWNhLTVlMmMtNGQzOS1hYzZjLTkwYmM4OTcxYTY4ZCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM4ZDJkMWNhLTVlMmMtNGQzOS1hYzZjLTkwYmM4OTcxYTY4ZCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.x7OQbp1cQ0u2PtA_IIafZ-TR3JZSPqGFFI9wjFSlGJlurr0sK5xYWOvzAzA3KCxBris4D4PbBSGl44IILaDW749_o3Jn2hg0f7VoMHVyQ9mG9MmklMZABNy3bz5AAgQ_P2uyMEZfgBWeQryOw_24kOBxgeZ0fbi737XJHebufNiXtLU5sHAS2NvqmccDL1aqi6p3HGYwEoEkI1jcapnYDPoFH9LVz8FG1G9mVz1nA4JaHnP6zPndDa4g67hagu8YWyjvznmz6vTx91VqfOitI1GjSjdZX1_5kpou8I0OLyqOV5oZrbPF01wBl4vlSX0qI3C-4b6Tfv3G6x__LfiP3Q
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTIsImlhdCI6MTczNDAzODMxMiwiYXV0aF90aW1lIjoxNzM0MDM4MzEyLCJqdGkiOiIyYjg1ZDk3YS01ZDFhLTRhZmEtOWFkMy1mNzk1YzJiYzhmNzciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjVlNWQ4YzI2LWIyMTAtNDJhMy05ZDZjLWU5OTFlNWM5YWMxMiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjVlNWQ4YzI2LWIyMTAtNDJhMy05ZDZjLWU5OTFlNWM5YWMxMiIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.hS_9A9TvPHKnK_ToFTYzc4yCRXvvuTWzP6khBmC1vNql3lXR4c8HNDv7W5g5Lw-N9pCh0Rn9lMHy_O88K9EBnhJpa1GTjt9OqmqCHYdjS6cX2i9VGDwut05jNrvjN7_z7ywVX3f8Y5HRg1uVRIEerFvwsuEQx-e_7Si6xdwlcTNOUGzpqZMI0RXETaJMJuQbCFrvR_BtM760d4VC6LDQww2f0syyJNRm8vQ7Gy2YEpoVzcijz_8rb72W8Eccy6CU2Fcjl2q4fZnxQmq0GXs7kAxvlDO4SaFKsjqs64i1_UC-58LMD0WeNP3jk_s9svs1U_YGDdrjyLyqPCe1ij1GAA
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_digid_error_reported_for_cancelled_login_anon_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_digid_error_reported_for_cancelled_login_anon_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_digid_error_reported_for_cancelled_login_with_staff_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_digid_error_reported_for_cancelled_login_with_staff_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_failing_claim_verification.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_failing_claim_verification.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"bf77b527-a2f8-40ed-a9f9-173d71081985\",\n
-        \             \"klq0K4a7118\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=klq0K4a7118&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"04fa0f3f-f060-4869-93db-5020a0c72925\",\n
+        \             \"vraETi1Sh68\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=vraETi1Sh68&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=SCOOPNm20wpMBdVA06q1dngaIIm7IVGxF_UPZ5Xi5IE&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=klq0K4a7118\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=M2IOf72UHbuoNJpshqR5ThGbzt6WXZvIX_PXnNNA9WE&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=vraETi1Sh68\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=bf77b527-a2f8-40ed-a9f9-173d71081985; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=04fa0f3f-f060-4869-93db-5020a0c72925; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=bf77b527-a2f8-40ed-a9f9-173d71081985; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=04fa0f3f-f060-4869-93db-5020a0c72925; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=bf77b527-a2f8-40ed-a9f9-173d71081985; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k
+      - AUTH_SESSION_ID_LEGACY=04fa0f3f-f060-4869-93db-5020a0c72925; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=SCOOPNm20wpMBdVA06q1dngaIIm7IVGxF_UPZ5Xi5IE&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=klq0K4a7118
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=M2IOf72UHbuoNJpshqR5ThGbzt6WXZvIX_PXnNNA9WE&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=vraETi1Sh68
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=bf77b527-a2f8-40ed-a9f9-173d71081985&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=5af37cc1-f8f8-411b-b027-ddc4adbc2e98.bf77b527-a2f8-40ed-a9f9-173d71081985.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=04fa0f3f-f060-4869-93db-5020a0c72925&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=edca8398-2e67-4e67-bae8-83729b417f2a.04fa0f3f-f060-4869-93db-5020a0c72925.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTAsImlhdCI6MTczMjYxNTg5MCwianRpIjoiZGU1OGQxNmEtODdhYy00M2YwLTkwMGEtZDEwMTg3N2I4YWM3IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJzaWQiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJzdGF0ZV9jaGVja2VyIjoic2hUdUpXZ2NPRHVRaGZudllqaG1ack9mODRvekJTdTgwYjJNMkRDVWZCYyJ9.ns_5GG8bQKsQCHMqbMvRZoTeWSMXiRSBGgxOg8TyHpk;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiZjNmMGVhYjItOGMyYy00MmYzLTg2ZjAtNDdmMzc0NjFkNzUxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJzaWQiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJzdGF0ZV9jaGVja2VyIjoiVWRmRmZoWDJMQm0zN25wM095c2prYkVZMFZlem52d3Z4Szdta29jVlYyNCJ9.QYrfDDkrR-PJeUQ_jI86SvmYdjS1tZS0l9tDhTsW_fw;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTAsImlhdCI6MTczMjYxNTg5MCwianRpIjoiZGU1OGQxNmEtODdhYy00M2YwLTkwMGEtZDEwMTg3N2I4YWM3IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJzaWQiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJzdGF0ZV9jaGVja2VyIjoic2hUdUpXZ2NPRHVRaGZudllqaG1ack9mODRvekJTdTgwYjJNMkRDVWZCYyJ9.ns_5GG8bQKsQCHMqbMvRZoTeWSMXiRSBGgxOg8TyHpk;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiZjNmMGVhYjItOGMyYy00MmYzLTg2ZjAtNDdmMzc0NjFkNzUxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJzaWQiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJzdGF0ZV9jaGVja2VyIjoiVWRmRmZoWDJMQm0zN25wM095c2prYkVZMFZlem52d3Z4Szdta29jVlYyNCJ9.QYrfDDkrR-PJeUQ_jI86SvmYdjS1tZS0l9tDhTsW_fw;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/bf77b527-a2f8-40ed-a9f9-173d71081985;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:30 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/04fa0f3f-f060-4869-93db-5020a0c72925;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:35 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/bf77b527-a2f8-40ed-a9f9-173d71081985;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:30 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/04fa0f3f-f060-4869-93db-5020a0c72925;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:35 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=5af37cc1-f8f8-411b-b027-ddc4adbc2e98.bf77b527-a2f8-40ed-a9f9-173d71081985.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=edca8398-2e67-4e67-bae8-83729b417f2a.04fa0f3f-f060-4869-93db-5020a0c72925.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '283'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTAsImlhdCI6MTczMjYxNTg5MCwiYXV0aF90aW1lIjoxNzMyNjE1ODkwLCJqdGkiOiIwODgxMmUzZC04NTQzLTQ1NjEtYmVhMC03ZGJiZTYxMGI5ZjciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImJmNzdiNTI3LWEyZjgtNDBlZC1hOWY5LTE3M2Q3MTA4MTk4NSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImJmNzdiNTI3LWEyZjgtNDBlZC1hOWY5LTE3M2Q3MTA4MTk4NSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.1KfrIHMdsk3M-6i5vdq_C9FnP15HJkT7uaf0StVXb_hgJ5SsdoJkb_dhzNHXp6UEzkAxtf3GLToHNhMupX8_tSd2DF0A7eOmw9HdADmf-9sT5NN_sFFiz-xqlhD4dsK7f0BpUQ0HNmqbqFuc7jBdkl1h66cAeUV2eHPXIwTzOwqA1Hz13WbBea6qh52zF6cbYMmEpP5UEaZnJJKOxucggzsDFEalxCOkCqmH-ozONOZwGNvrdhJs5HZPK-z3AQdqJI8hiQTLpoiFs_9IPgHzMG4k945zc7uEBJVgDOLDjypnlFvz1RtT28jWInCbDpcME3ouJHGjQM7-vAHEjdPLvg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTAsImlhdCI6MTczMjYxNTg5MCwianRpIjoiZDkzNjJhMjAtZTRhNy00ZjA5LTkwNTgtN2QxZDBiMDQxM2FjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYmY3N2I1MjctYTJmOC00MGVkLWE5ZjktMTczZDcxMDgxOTg1In0.r7O_cy-20U10Ju32yRrQZPHGHKoCfNvubehREe031Fg","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTAsImlhdCI6MTczMjYxNTg5MCwiYXV0aF90aW1lIjoxNzMyNjE1ODkwLCJqdGkiOiI0NjViNTFjNC1iNzAwLTQxNWUtOWMyZS1lMjUxMDQ5YWI2NjkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJhdF9oYXNoIjoiMmxqSUJhcF9wQ2tVeWtfYUtaWUpuQSIsImFjciI6IjEiLCJzaWQiOiJiZjc3YjUyNy1hMmY4LTQwZWQtYTlmOS0xNzNkNzEwODE5ODUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.ahty4BDJWZ3QlZ7irp9Jit_mSUc88ed5ntR3HpmTBOPiPqHLNFUVSV8XZOGMyY2o3BAH7KVjtny5CR5jYEoMXWak9O84A68Ce8l6EBkqOlkFg6WcYailu9TqKroBph1t2NLCR1oa5LnAN63NDCUOa6RhOW6e1np0bUOhVJiab_q9QJfbxp1hEx1W86L_usou-zgasjpkmkLV44eQw-Hq3fINA57y0nRIJ_KYovQLXYJ0A2AIglQMbduWzRQIffBktMj-5BMR1Dex-YM89-Go5QBUFjKAJaZEPY1WqyzLe7DrxvsGocQcJOUZunODhP_MRZJE3UIoLEFbm8Ef731u2A","not-before-policy":0,"session_state":"bf77b527-a2f8-40ed-a9f9-173d71081985","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiJiZTI5MjE5Zi04YzJhLTQ1MDktYTc5Ny1mMDMwNmMwZTk3YmUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjA0ZmEwZjNmLWYwNjAtNDg2OS05M2RiLTUwMjBhMGM3MjkyNSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjA0ZmEwZjNmLWYwNjAtNDg2OS05M2RiLTUwMjBhMGM3MjkyNSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.EoV_yXnFUe1L7YUafdTyvG6ZevdrINQK89KhSlnfPkzi-4uD5ac8daOp_bUvV8AB35KG9DoMGozzuQojgUaofOlOGlGpChRSM72kilq9EMVZhMtyWp8y-Xme842n3UFSjOksxGDPL11du_0mq4sDYQ78o3U4VdU3wDvFVVRhxg8BHKTYtoQtLABeik4K4idbh3zTI5IaxHTGqCmRVWETVPSl078xg8LdGj93tH3RcgoyA94yj41jGtZ8xardcD5kPFv8XWdyMsDqwU3fuf-OAnNnOMY4SEplQRLVaWwd7WrbxN_4ELIv0B8vBaUIccPcPs2kqxET33Yzw_RLvuKzxA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiOTJmNTYwZjMtZmU1Yi00NDEyLWJjY2YtNjM4YTllMDkyY2M2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMDRmYTBmM2YtZjA2MC00ODY5LTkzZGItNTAyMGEwYzcyOTI1In0.IACAAGvv3E6_M81tOHCQ5N3bjDj9K9HJKquASJwAIVo","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiIzMjU4NmM2YS03ZTk5LTQ2MWItYTU1NC1iM2QxYTBiMjVlOGYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJhdF9oYXNoIjoiWEVNYWd2U1J4VDVpQVBwRmZKN0dLdyIsImFjciI6IjEiLCJzaWQiOiIwNGZhMGYzZi1mMDYwLTQ4NjktOTNkYi01MDIwYTBjNzI5MjUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.svJ6agzCMl3D7Ywjs-qK1hC03lwnYHHzgXU1zhhAWWMAvN_SeKIj6pU19U7GaFX-yQg4Hf1Gv8pES1m81CJkYf8AbUYQ4MtCIm0ZSv3xamsSHsOIEYRfTfwvFrjWRjRF8-GKW2lvGahC-PiJ5SJOjU34-Y-_Eq97BCZEEBeShFA2oNl3x_6GBCTO9zsYdgJnbljwvb2nT_KExeRUZbGwLo5Ldr4C4FOqDF4l5JzJL4SoEJXDk9Ih6fd2xeD9KYbmAG4wUWol2FUNboHOlIk2jT60e4h2BZ0bT7RFSYL584htfp4vCWaXZwk2LYfc9Vgv7z7rEuih7hJYubeY1jwsYA","not-before-policy":0,"session_state":"04fa0f3f-f060-4869-93db-5020a0c72925","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTAsImlhdCI6MTczMjYxNTg5MCwiYXV0aF90aW1lIjoxNzMyNjE1ODkwLCJqdGkiOiIwODgxMmUzZC04NTQzLTQ1NjEtYmVhMC03ZGJiZTYxMGI5ZjciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImJmNzdiNTI3LWEyZjgtNDBlZC1hOWY5LTE3M2Q3MTA4MTk4NSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImJmNzdiNTI3LWEyZjgtNDBlZC1hOWY5LTE3M2Q3MTA4MTk4NSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.1KfrIHMdsk3M-6i5vdq_C9FnP15HJkT7uaf0StVXb_hgJ5SsdoJkb_dhzNHXp6UEzkAxtf3GLToHNhMupX8_tSd2DF0A7eOmw9HdADmf-9sT5NN_sFFiz-xqlhD4dsK7f0BpUQ0HNmqbqFuc7jBdkl1h66cAeUV2eHPXIwTzOwqA1Hz13WbBea6qh52zF6cbYMmEpP5UEaZnJJKOxucggzsDFEalxCOkCqmH-ozONOZwGNvrdhJs5HZPK-z3AQdqJI8hiQTLpoiFs_9IPgHzMG4k945zc7uEBJVgDOLDjypnlFvz1RtT28jWInCbDpcME3ouJHGjQM7-vAHEjdPLvg
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiJiZTI5MjE5Zi04YzJhLTQ1MDktYTc5Ny1mMDMwNmMwZTk3YmUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjA0ZmEwZjNmLWYwNjAtNDg2OS05M2RiLTUwMjBhMGM3MjkyNSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjA0ZmEwZjNmLWYwNjAtNDg2OS05M2RiLTUwMjBhMGM3MjkyNSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.EoV_yXnFUe1L7YUafdTyvG6ZevdrINQK89KhSlnfPkzi-4uD5ac8daOp_bUvV8AB35KG9DoMGozzuQojgUaofOlOGlGpChRSM72kilq9EMVZhMtyWp8y-Xme842n3UFSjOksxGDPL11du_0mq4sDYQ78o3U4VdU3wDvFVVRhxg8BHKTYtoQtLABeik4K4idbh3zTI5IaxHTGqCmRVWETVPSl078xg8LdGj93tH3RcgoyA94yj41jGtZ8xardcD5kPFv8XWdyMsDqwU3fuf-OAnNnOMY4SEplQRLVaWwd7WrbxN_4ELIv0B8vBaUIccPcPs2kqxET33Yzw_RLvuKzxA
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_failing_claim_verification_strict_mode.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_failing_claim_verification_strict_mode.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"70e1138c-730e-448e-b419-b9a786721090\",\n
-        \             \"KO1eBHgWHQc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=KO1eBHgWHQc&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"3439ce51-d17d-4c23-a38a-99cfca82686e\",\n
+        \             \"BKJSi65xJMM\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=BKJSi65xJMM&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=5ePtneFmd-jQMVlDfDh3M8KW2VgYA_nHWTswPUn5ePk&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=KO1eBHgWHQc\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=WCTzylciYdJ2tyREgbpl_ZHz8v88jZtiTN39es4J4AY&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=BKJSi65xJMM\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=70e1138c-730e-448e-b419-b9a786721090; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=3439ce51-d17d-4c23-a38a-99cfca82686e; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=70e1138c-730e-448e-b419-b9a786721090; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=3439ce51-d17d-4c23-a38a-99cfca82686e; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=70e1138c-730e-448e-b419-b9a786721090; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k
+      - AUTH_SESSION_ID_LEGACY=3439ce51-d17d-4c23-a38a-99cfca82686e; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=5ePtneFmd-jQMVlDfDh3M8KW2VgYA_nHWTswPUn5ePk&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=KO1eBHgWHQc
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=WCTzylciYdJ2tyREgbpl_ZHz8v88jZtiTN39es4J4AY&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=BKJSi65xJMM
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=70e1138c-730e-448e-b419-b9a786721090&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=a6822795-d422-489b-b638-a40e3cb0da2b.70e1138c-730e-448e-b419-b9a786721090.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=3439ce51-d17d-4c23-a38a-99cfca82686e&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=533a6b5c-5b95-4f4e-a440-aeee5f764a41.3439ce51-d17d-4c23-a38a-99cfca82686e.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTEsImlhdCI6MTczMjYxNTg5MSwianRpIjoiYTgwMzJjMjktZDUyZi00OGQ5LTk5MTMtOTU5OTYzNGU0MTQxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJzaWQiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJzdGF0ZV9jaGVja2VyIjoiY3A5VmRLNEpsUXhjR1VGeHFwbVBSempzMUtWQUIwRFRXczVYbS1zZ0pSWSJ9.d9L8NKurAgmZnTUK8nwQwVdobS1wjrPJlSI_4ly_xco;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiNWUwZmQ4YWItNGY3Yy00ZDA3LTk3OWMtM2UwNjBjNzFiNjQxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJzaWQiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJzdGF0ZV9jaGVja2VyIjoiTUJydVNDT0h5dUJXVE43RVBnZkFWa19sNWM4UVJINDNKOHRpM19ha3lRdyJ9.ZT1K5QI77OlUW6q27Q5toyK2942xtvB7jEho2i4XU34;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTEsImlhdCI6MTczMjYxNTg5MSwianRpIjoiYTgwMzJjMjktZDUyZi00OGQ5LTk5MTMtOTU5OTYzNGU0MTQxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJzaWQiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJzdGF0ZV9jaGVja2VyIjoiY3A5VmRLNEpsUXhjR1VGeHFwbVBSempzMUtWQUIwRFRXczVYbS1zZ0pSWSJ9.d9L8NKurAgmZnTUK8nwQwVdobS1wjrPJlSI_4ly_xco;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiNWUwZmQ4YWItNGY3Yy00ZDA3LTk3OWMtM2UwNjBjNzFiNjQxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJzaWQiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJzdGF0ZV9jaGVja2VyIjoiTUJydVNDT0h5dUJXVE43RVBnZkFWa19sNWM4UVJINDNKOHRpM19ha3lRdyJ9.ZT1K5QI77OlUW6q27Q5toyK2942xtvB7jEho2i4XU34;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/70e1138c-730e-448e-b419-b9a786721090;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:31 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/3439ce51-d17d-4c23-a38a-99cfca82686e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:35 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/70e1138c-730e-448e-b419-b9a786721090;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:31 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/3439ce51-d17d-4c23-a38a-99cfca82686e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:35 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=a6822795-d422-489b-b638-a40e3cb0da2b.70e1138c-730e-448e-b419-b9a786721090.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=533a6b5c-5b95-4f4e-a440-aeee5f764a41.3439ce51-d17d-4c23-a38a-99cfca82686e.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '283'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTEsImlhdCI6MTczMjYxNTg5MSwiYXV0aF90aW1lIjoxNzMyNjE1ODkxLCJqdGkiOiJmNzQxMGNlMC05ZTFkLTRlZGEtYTNmNi1kNGY5NzlkOGI1MzQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZTExMzhjLTczMGUtNDQ4ZS1iNDE5LWI5YTc4NjcyMTA5MCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjcwZTExMzhjLTczMGUtNDQ4ZS1iNDE5LWI5YTc4NjcyMTA5MCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.WxKYORoDbaOwf04tDD4rQqn374Vh6JjwPHlRLKIoU7lMyMMZGOl5p_KEO4GJ_7hv1DxacL7h5MLJE8NL-fLz83NUbJLZQ1THC3XLVKoI6XWQ266s_iqINTtvsQK25qmsOpO6zA9feRmAq23tnFSEZ0uTMgfTSNRL4X68XuVpOD7Rr9hU0a0HnCooosBFuUQ7oTsYr9y9Azwm8-Lf8_YfkIxdfcYdSoeRwBOprSCryWtZccBhLrLxlzyGQY6xe7k9uDVsafO0JqzX_YIkIBusjNSY1pbhVSzoC4oZQ2S7ed2cZHIdFwlLsChfu0bRufdCRtPf5bifOHCoFDxGpYJP3Q","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTEsImlhdCI6MTczMjYxNTg5MSwianRpIjoiZWIwY2UxNmItYmNkOC00ZGM2LTgwMDctODk0Zjc0YmJhOGJmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNzBlMTEzOGMtNzMwZS00NDhlLWI0MTktYjlhNzg2NzIxMDkwIn0.Mea8EVqmwKjznOqXJZGK1GH7fWOJFNSRoR1qjko1z48","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTEsImlhdCI6MTczMjYxNTg5MSwiYXV0aF90aW1lIjoxNzMyNjE1ODkxLCJqdGkiOiJlZWI0ZTQyZS1jNjU4LTRmMGQtOGM4Zi1hMWM3ZDk3OWU3MWMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJhdF9oYXNoIjoiMTBGanN3M1R2ck1uYmpWRXNhV0ktQSIsImFjciI6IjEiLCJzaWQiOiI3MGUxMTM4Yy03MzBlLTQ0OGUtYjQxOS1iOWE3ODY3MjEwOTAiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.LDUd761eNBpgccLpIGsjrYW9NKyL04J09Fc3lfs4aNbQZl9fuWRn2_rdD_UPyDSKdtiuXxL4LmWWFtwMrz2b9Ii17-FtRh6w6NTQ6GqLLjlUUJ-JkAeHOXsSpt94mzqWhk0jfWyhYCwud03QZwxFiDg2DzlGyJ1ZaAWFBMnExjfJRNBrXhYL-F5yoM0t7kHeYA1X4uoq8jaHk7xuY2zL4dyhgXmmWgb_d-Vx2QGvSf0FhgnanZav1I0aV9bcjxnmBBLqvcGYAYXS52u3QF4onnDbvllMvQh0t4NxMWiE9iYuoGuS-Dq-VMkxjlDv8uRSme-2dzY0iyaZr-lYid3mFQ","not-before-policy":0,"session_state":"70e1138c-730e-448e-b419-b9a786721090","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiIzZjdkNzUyZS1iN2M3LTQxMzYtYTQ4NS1lNTA2YWRjZDk3Y2EiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM0MzljZTUxLWQxN2QtNGMyMy1hMzhhLTk5Y2ZjYTgyNjg2ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM0MzljZTUxLWQxN2QtNGMyMy1hMzhhLTk5Y2ZjYTgyNjg2ZSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.WFYgmwm-8Gc8XJ89aZedJAfByKxyhoFVlsFvN6NcK-mfzYjRxTGGHNBBl5uigHUkVeWHyHFtoPRq-HpbWYhCOmHcNq1yyJiFuhk4iFnkP2x1XEmQwEPbN27kdzQaoECsBOXj3FRBcTlJdX1G0ZmUr8TRi7Jp_-Nla6qyYsGC0H_3nVHLu0w86DhVAkJBt87GSDSKBRUkoWezMMoEK9gZ3aYQCLqQn-QQUfSSc1I3KXyzCfdUR3v5r7rC862aNOqr-Hnnv316HA9R6y8tAn4n4tLYdY-5wHPQ_MAtxFMmTKd1M4FguCyeInN_xZBGEMKylXW046rsljpake1PlmuJnw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiOWI0NTA3ZWEtMzljNy00NTA5LTk2YmQtZDNlNzQ0ZTM4YTk1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMzQzOWNlNTEtZDE3ZC00YzIzLWEzOGEtOTljZmNhODI2ODZlIn0.fLzIKoDRilVnBa7Bll4cfmpQ1vf_aVtYTgXXqMugcL4","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiJkZmMzOGRhMS05ZTVjLTQ0ODQtOGU2NS0yY2I0YjJmY2I1MWMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJhdF9oYXNoIjoiODBjOWxWb1VTbWJ1MGxRLVNzNEFNUSIsImFjciI6IjEiLCJzaWQiOiIzNDM5Y2U1MS1kMTdkLTRjMjMtYTM4YS05OWNmY2E4MjY4NmUiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.p_a2bWQkfu0duzJSvwm4g10Hik6bgSGYrgUG2gg2FEO-Ft8D3ilNdQEBUGNiE2UoWxc4lyMqX3sB0SzQ8fF-oKBFxjotoHtwGEHUhZbIpYbFb4UxoXjvQG2YFrv0z7Qdnajez6qBMpFgLGrqQNT1GrfqSOr62-wzoh0h9fkNM0ThYytNBqbuVtw7EGqcTKK3kSUknZCAH6DHdKlHi0YK54DEw9tVtfGjoJ5USyCCXnxnbRx4MQbcJlV2Kx8soOCCdM80rOHVPhD1wKPpnc6vzH4KeXwPltu0-xU3UJF-3zMWG2DgaOeah9YSizauIfJks9dwAIOoal_b_1Ged04BEQ","not-before-policy":0,"session_state":"3439ce51-d17d-4c23-a38a-99cfca82686e","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTEsImlhdCI6MTczMjYxNTg5MSwiYXV0aF90aW1lIjoxNzMyNjE1ODkxLCJqdGkiOiJmNzQxMGNlMC05ZTFkLTRlZGEtYTNmNi1kNGY5NzlkOGI1MzQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZTExMzhjLTczMGUtNDQ4ZS1iNDE5LWI5YTc4NjcyMTA5MCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjcwZTExMzhjLTczMGUtNDQ4ZS1iNDE5LWI5YTc4NjcyMTA5MCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.WxKYORoDbaOwf04tDD4rQqn374Vh6JjwPHlRLKIoU7lMyMMZGOl5p_KEO4GJ_7hv1DxacL7h5MLJE8NL-fLz83NUbJLZQ1THC3XLVKoI6XWQ266s_iqINTtvsQK25qmsOpO6zA9feRmAq23tnFSEZ0uTMgfTSNRL4X68XuVpOD7Rr9hU0a0HnCooosBFuUQ7oTsYr9y9Azwm8-Lf8_YfkIxdfcYdSoeRwBOprSCryWtZccBhLrLxlzyGQY6xe7k9uDVsafO0JqzX_YIkIBusjNSY1pbhVSzoC4oZQ2S7ed2cZHIdFwlLsChfu0bRufdCRtPf5bifOHCoFDxGpYJP3Q
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiIzZjdkNzUyZS1iN2M3LTQxMzYtYTQ4NS1lNTA2YWRjZDk3Y2EiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM0MzljZTUxLWQxN2QtNGMyMy1hMzhhLTk5Y2ZjYTgyNjg2ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM0MzljZTUxLWQxN2QtNGMyMy1hMzhhLTk5Y2ZjYTgyNjg2ZSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.WFYgmwm-8Gc8XJ89aZedJAfByKxyhoFVlsFvN6NcK-mfzYjRxTGGHNBBl5uigHUkVeWHyHFtoPRq-HpbWYhCOmHcNq1yyJiFuhk4iFnkP2x1XEmQwEPbN27kdzQaoECsBOXj3FRBcTlJdX1G0ZmUr8TRi7Jp_-Nla6qyYsGC0H_3nVHLu0w86DhVAkJBt87GSDSKBRUkoWezMMoEK9gZ3aYQCLqQn-QQUfSSc1I3KXyzCfdUR3v5r7rC862aNOqr-Hnnv316HA9R6y8tAn4n4tLYdY-5wHPQ_MAtxFMmTKd1M4FguCyeInN_xZBGEMKylXW046rsljpake1PlmuJnw
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_redirects_after_successful_auth.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenCallbackTests/DigiDMachtigenCallbackTests.test_redirects_after_successful_auth.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"1743907f-abd6-40ae-966e-7139b2ddc807\",\n
-        \             \"PjPK4RY075M\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=PjPK4RY075M&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"f61488da-9fe2-4b26-8ddb-13a64cc69e29\",\n
+        \             \"NoQAY1L9xTY\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=NoQAY1L9xTY&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=wQgU5PxnB1xXZsB2IPGimsyDHz-Hez-JSoA3zw0zbFQ&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=PjPK4RY075M\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=14rMu7BWfs0A7ns3261OIDX3RnkrDGJHNu9jgh0TuuM&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=NoQAY1L9xTY\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=1743907f-abd6-40ae-966e-7139b2ddc807; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=f61488da-9fe2-4b26-8ddb-13a64cc69e29; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=1743907f-abd6-40ae-966e-7139b2ddc807; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=f61488da-9fe2-4b26-8ddb-13a64cc69e29; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=1743907f-abd6-40ae-966e-7139b2ddc807; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k
+      - AUTH_SESSION_ID_LEGACY=f61488da-9fe2-4b26-8ddb-13a64cc69e29; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=wQgU5PxnB1xXZsB2IPGimsyDHz-Hez-JSoA3zw0zbFQ&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=PjPK4RY075M
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=14rMu7BWfs0A7ns3261OIDX3RnkrDGJHNu9jgh0TuuM&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=NoQAY1L9xTY
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=1743907f-abd6-40ae-966e-7139b2ddc807&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=27b35fc6-00c1-4eb2-9beb-1b1bb5e0a432.1743907f-abd6-40ae-966e-7139b2ddc807.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=f61488da-9fe2-4b26-8ddb-13a64cc69e29&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=0bcd5d35-9db4-4eac-882c-460042dffef0.f61488da-9fe2-4b26-8ddb-13a64cc69e29.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTEsImlhdCI6MTczMjYxNTg5MSwianRpIjoiMDJlMjc0MjMtN2EzZC00OGE3LTkzZjgtM2QxN2UyZTE2OGVhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJzaWQiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJzdGF0ZV9jaGVja2VyIjoiclNqb0g4QTMyV0otRWpxYUI2MDA1RV9udUJWZVBobDRTdi1yR2d6NmkzbyJ9.ZY9gXSYdG4dDU19YQUYj7BO8OEfukR2SQ20PqjDsHeE;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiNzc4NTFiMzMtODBlNy00ODFjLWFiZjUtOGUwZTA3YjYwNzMzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJzaWQiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJzdGF0ZV9jaGVja2VyIjoiX2NPWEVmbVMydndpZDVmUlFMdXFMWjNxVjdkY0pVbXpPTkkzcXF3djBjMCJ9.41vN8rKbkP8vmpJHAee24TFkdhyR3JDLeVUj8wfzFAk;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTEsImlhdCI6MTczMjYxNTg5MSwianRpIjoiMDJlMjc0MjMtN2EzZC00OGE3LTkzZjgtM2QxN2UyZTE2OGVhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJzaWQiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJzdGF0ZV9jaGVja2VyIjoiclNqb0g4QTMyV0otRWpxYUI2MDA1RV9udUJWZVBobDRTdi1yR2d6NmkzbyJ9.ZY9gXSYdG4dDU19YQUYj7BO8OEfukR2SQ20PqjDsHeE;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiNzc4NTFiMzMtODBlNy00ODFjLWFiZjUtOGUwZTA3YjYwNzMzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJzaWQiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJzdGF0ZV9jaGVja2VyIjoiX2NPWEVmbVMydndpZDVmUlFMdXFMWjNxVjdkY0pVbXpPTkkzcXF3djBjMCJ9.41vN8rKbkP8vmpJHAee24TFkdhyR3JDLeVUj8wfzFAk;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/1743907f-abd6-40ae-966e-7139b2ddc807;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:31 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/f61488da-9fe2-4b26-8ddb-13a64cc69e29;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:35 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/1743907f-abd6-40ae-966e-7139b2ddc807;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:31 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/f61488da-9fe2-4b26-8ddb-13a64cc69e29;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:35 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=27b35fc6-00c1-4eb2-9beb-1b1bb5e0a432.1743907f-abd6-40ae-966e-7139b2ddc807.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=0bcd5d35-9db4-4eac-882c-460042dffef0.f61488da-9fe2-4b26-8ddb-13a64cc69e29.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '283'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTEsImlhdCI6MTczMjYxNTg5MSwiYXV0aF90aW1lIjoxNzMyNjE1ODkxLCJqdGkiOiIwYTNlNTFkMi1lMWZkLTQyYzgtODk0MS0zM2NiYWE1OTNmYjQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjE3NDM5MDdmLWFiZDYtNDBhZS05NjZlLTcxMzliMmRkYzgwNyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjE3NDM5MDdmLWFiZDYtNDBhZS05NjZlLTcxMzliMmRkYzgwNyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.spybyzYkDKtMdc12mCUfh-ZTMYvn5J5MQ7726Dg4kJlS3mFzHnkRWwJvDSVlwE6Zp6CPJDRxtTGPUflwIlAMmoaKIrCuWlW328NtDiu06rLakjGjPPbyrBlS0b__ixDMKSSwNvWtlBgIuNgFaIXl_yQV_eGCqdjacDwvSJN6eVMohSoQH5DgYarW6lzYlxTY6_QpMgt_Vov2Y1wkoagPJ60vPyHJKdy4RX1iGbHiZVa1ivVKGbUqZBz9xj4D8GVSsaIEJWxEPNfZ5_djsxjw7KKCFH2_Xj02zLO72oxEQvRmzkXSXnL8HDj7JVemU4JTMOHSl-DBbVAtBs_JSETmOA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTEsImlhdCI6MTczMjYxNTg5MSwianRpIjoiYjkxZDQwNzgtYWNjZS00NWQ5LWI3MDEtY2ZmMjk2ZjNmZWZlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMTc0MzkwN2YtYWJkNi00MGFlLTk2NmUtNzEzOWIyZGRjODA3In0._WdB8UBzUa7VhWdS_LJnfdJnUQK1s6gpQiW_YQ5B4ZA","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTEsImlhdCI6MTczMjYxNTg5MSwiYXV0aF90aW1lIjoxNzMyNjE1ODkxLCJqdGkiOiJiZmFhN2QwNS02MmRjLTRkYTgtYTJkYS05MWYyMGVhZDdmNjAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJhdF9oYXNoIjoiaFdaTTc1eWY0alplR1BqNGN2bG9vdyIsImFjciI6IjEiLCJzaWQiOiIxNzQzOTA3Zi1hYmQ2LTQwYWUtOTY2ZS03MTM5YjJkZGM4MDciLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.q0Tdoi-uawsW_0wPLVW9H_1GU8qJJH1wShAPLWWa_UrxRG4EdbSPqynR2XbHKRWEaUaOzZE9ghHv-N0RVl0BGTlvBoxcwN3M-4rHnZ-W73-qlVGGmPfVIeT9szoQkCR1ccTGz2_7ZCvLHlVlyAtVI8EcsBYeuMTj8WdOaPnOPFUUn1IdnzSQAjELPuPvT-QWDqhpUYOIpVIO0vxM_B17AIdNId_c38VgSK7KXOAblHnHFdrWds3dl58SnbNxBeKSNy-7fCT5erwz2nOSgBt4J1ILtPQIQxgq4AvYb0MZNGq0FZNFCC4bqzyIZhLSmR8X2WDkYJjTKXZsAZmpbKdkQQ","not-before-policy":0,"session_state":"1743907f-abd6-40ae-966e-7139b2ddc807","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiIzZTJjODEzMy02NTQzLTQyYmItYWQ1NS0xODM2YmU1YzM5NzIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImY2MTQ4OGRhLTlmZTItNGIyNi04ZGRiLTEzYTY0Y2M2OWUyOSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImY2MTQ4OGRhLTlmZTItNGIyNi04ZGRiLTEzYTY0Y2M2OWUyOSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.AHzYLzL9_JI3jAnc90F54NZozPd0H1_aJz5sd-fll-z4KIZswy-hVfos_9fQmwezzxrJ2Bd5Zd8-qm3w9ncqsYzr_X5S4qB-bvk0KBB4Tvd1xNkcBlXxRXI-Xasdx71M7XeAL4DkBRutbvTE0kW0fmUDlZQbVy3Bs3mS3g5OGJnDYCQ3XkMKT2afvKXpSLsW5StRX9lXcODPGRsA6VVS-iF7ybVa7yyJMMO3Dfb5lbhM7H0ztmNHAYGTa-PZuOBGxO7Balpj9lJwl0DJs1WhIAZP2mdKvN54ADOpYwUTnkJ-XUW-U0YRBFJzJJLshjZd2BrMi7XX-fhqOHqxuflVcA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTUsImlhdCI6MTczNDAzODMxNSwianRpIjoiMjIwN2ExZGMtM2U3YS00ODMwLWE5Y2EtY2EwZjRlNTIxZjY4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZjYxNDg4ZGEtOWZlMi00YjI2LThkZGItMTNhNjRjYzY5ZTI5In0.JFxvl572VZXcgGk9hvVE1p-KnAxQP7LhCE0U17T58L4","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiJjNDA0MDUzNC0wN2JkLTRjNjgtYjg4Ni00YTVhMzNkZGJkOGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJhdF9oYXNoIjoiaVVHcTVjSHVEVExRYUtZeFVoX0pHQSIsImFjciI6IjEiLCJzaWQiOiJmNjE0ODhkYS05ZmUyLTRiMjYtOGRkYi0xM2E2NGNjNjllMjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.c_9GmKc4rYIZIpBAmiHo98i9lH6XC_QF4q894xSZn8WlUu-P-63kxvFqnik9UTvjuib_JkXBeZD_cm1kC43WYPxa853PEm2I71XwH6a-C4ISIxD3IZZIFvNNgzxCf3a8vI3e5aMq9nlIUTxhJzuL7w28sNwsPXdWmYOeGw2fYo4h-1K3tk781geMiat5LKupaTXSZQtJZpM0MpB0HutEawP8nTg_2qg_d0O8PEqBMs9JL6dqRFwiSKVCVYT55HsVof6w6sH_1H58ORvourkXvE-Ff-j1q3mCqGcPxqJ_8odTg4I4HqOPwUYehT7LVGaN2gmkzZq-V6Zsxheyc-bcgg","not-before-policy":0,"session_state":"f61488da-9fe2-4b26-8ddb-13a64cc69e29","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTEsImlhdCI6MTczMjYxNTg5MSwiYXV0aF90aW1lIjoxNzMyNjE1ODkxLCJqdGkiOiIwYTNlNTFkMi1lMWZkLTQyYzgtODk0MS0zM2NiYWE1OTNmYjQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjE3NDM5MDdmLWFiZDYtNDBhZS05NjZlLTcxMzliMmRkYzgwNyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjE3NDM5MDdmLWFiZDYtNDBhZS05NjZlLTcxMzliMmRkYzgwNyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.spybyzYkDKtMdc12mCUfh-ZTMYvn5J5MQ7726Dg4kJlS3mFzHnkRWwJvDSVlwE6Zp6CPJDRxtTGPUflwIlAMmoaKIrCuWlW328NtDiu06rLakjGjPPbyrBlS0b__ixDMKSSwNvWtlBgIuNgFaIXl_yQV_eGCqdjacDwvSJN6eVMohSoQH5DgYarW6lzYlxTY6_QpMgt_Vov2Y1wkoagPJ60vPyHJKdy4RX1iGbHiZVa1ivVKGbUqZBz9xj4D8GVSsaIEJWxEPNfZ5_djsxjw7KKCFH2_Xj02zLO72oxEQvRmzkXSXnL8HDj7JVemU4JTMOHSl-DBbVAtBs_JSETmOA
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTUsImlhdCI6MTczNDAzODMxNSwiYXV0aF90aW1lIjoxNzM0MDM4MzE1LCJqdGkiOiIzZTJjODEzMy02NTQzLTQyYmItYWQ1NS0xODM2YmU1YzM5NzIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImY2MTQ4OGRhLTlmZTItNGIyNi04ZGRiLTEzYTY0Y2M2OWUyOSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImY2MTQ4OGRhLTlmZTItNGIyNi04ZGRiLTEzYTY0Y2M2OWUyOSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.AHzYLzL9_JI3jAnc90F54NZozPd0H1_aJz5sd-fll-z4KIZswy-hVfos_9fQmwezzxrJ2Bd5Zd8-qm3w9ncqsYzr_X5S4qB-bvk0KBB4Tvd1xNkcBlXxRXI-Xasdx71M7XeAL4DkBRutbvTE0kW0fmUDlZQbVy3Bs3mS3g5OGJnDYCQ3XkMKT2afvKXpSLsW5StRX9lXcODPGRsA6VVS-iF7ybVa7yyJMMO3Dfb5lbhM7H0ztmNHAYGTa-PZuOBGxO7Balpj9lJwl0DJs1WhIAZP2mdKvN54ADOpYwUTnkJ-XUW-U0YRBFJzJJLshjZd2BrMi7XX-fhqOHqxuflVcA
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenInitTests/DigiDMachtigenInitTests.test_keycloak_idp_hint_is_respected.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenInitTests/DigiDMachtigenInitTests.test_keycloak_idp_hint_is_respected.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenInitTests/DigiDMachtigenInitTests.test_start_flow_redirects_to_oidc_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenInitTests/DigiDMachtigenInitTests.test_start_flow_redirects_to_oidc_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenLogoutTests/DigiDMachtigenLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/DigiDMachtigenLogoutTests/DigiDMachtigenLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"df5542f6-9152-4e00-a4d6-c764e5b0a3aa\",\n
-        \             \"6tPPR6tqRLI\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=6tPPR6tqRLI&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"91f43bfa-1c55-428a-86e5-f70835588a78\",\n
+        \             \"t8f41sksQzs\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=t8f41sksQzs&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=12TA3GnSscQllO9v1RH--It2GXIHaBFiuUcXK2f1tII&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=6tPPR6tqRLI\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=NYfwEs3QfPh8KmXw5UHkhtjZbFJV5y3RMvb8Ln-MhWg&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=t8f41sksQzs\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=df5542f6-9152-4e00-a4d6-c764e5b0a3aa; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=91f43bfa-1c55-428a-86e5-f70835588a78; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=df5542f6-9152-4e00-a4d6-c764e5b0a3aa; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=91f43bfa-1c55-428a-86e5-f70835588a78; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=df5542f6-9152-4e00-a4d6-c764e5b0a3aa; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k
+      - AUTH_SESSION_ID_LEGACY=91f43bfa-1c55-428a-86e5-f70835588a78; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=12TA3GnSscQllO9v1RH--It2GXIHaBFiuUcXK2f1tII&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=6tPPR6tqRLI
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=NYfwEs3QfPh8KmXw5UHkhtjZbFJV5y3RMvb8Ln-MhWg&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=t8f41sksQzs
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=df5542f6-9152-4e00-a4d6-c764e5b0a3aa&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=8e51ec5b-f828-44fc-9c73-7d20e5155b17.df5542f6-9152-4e00-a4d6-c764e5b0a3aa.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=91f43bfa-1c55-428a-86e5-f70835588a78&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=b9613b61-a96f-428b-8dd5-d394ce4b6b3b.91f43bfa-1c55-428a-86e5-f70835588a78.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiZDhjMDAyZTYtYjZhMi00MjFkLWFjOTYtZTZmZTNmNjg4Zjk2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzdGF0ZV9jaGVja2VyIjoiNmUxU2dtTEZ5YUdsd0xvXzBLZjNSZmhYVk8ycTBtTmFiUjh2alpZeFp1OCJ9.7PcE4xAIaCH5E0YBbBdiJds1LTl25vF_5GXVuaNn-bw;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiOWJkYTIxMDMtZWFhMS00MmYxLWJiZWMtZjJhN2NkZTQ5NDE5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzdGF0ZV9jaGVja2VyIjoiNWpiclNMdjEzV1NWa3YxYTRCajR0V0lZT0I2SHhNbmdEaXI2SlBsM3V3byJ9.acYdrZwCRUMlA9wVKoZNu8HdtsNAgBaROjAPAW2swJY;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiZDhjMDAyZTYtYjZhMi00MjFkLWFjOTYtZTZmZTNmNjg4Zjk2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzdGF0ZV9jaGVja2VyIjoiNmUxU2dtTEZ5YUdsd0xvXzBLZjNSZmhYVk8ycTBtTmFiUjh2alpZeFp1OCJ9.7PcE4xAIaCH5E0YBbBdiJds1LTl25vF_5GXVuaNn-bw;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiOWJkYTIxMDMtZWFhMS00MmYxLWJiZWMtZjJhN2NkZTQ5NDE5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzdGF0ZV9jaGVja2VyIjoiNWpiclNMdjEzV1NWa3YxYTRCajR0V0lZT0I2SHhNbmdEaXI2SlBsM3V3byJ9.acYdrZwCRUMlA9wVKoZNu8HdtsNAgBaROjAPAW2swJY;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/df5542f6-9152-4e00-a4d6-c764e5b0a3aa;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/91f43bfa-1c55-428a-86e5-f70835588a78;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/df5542f6-9152-4e00-a4d6-c764e5b0a3aa;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/91f43bfa-1c55-428a-86e5-f70835588a78;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -236,12 +236,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -284,12 +284,12 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=df5542f6-9152-4e00-a4d6-c764e5b0a3aa; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiZDhjMDAyZTYtYjZhMi00MjFkLWFjOTYtZTZmZTNmNjg4Zjk2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzdGF0ZV9jaGVja2VyIjoiNmUxU2dtTEZ5YUdsd0xvXzBLZjNSZmhYVk8ycTBtTmFiUjh2alpZeFp1OCJ9.7PcE4xAIaCH5E0YBbBdiJds1LTl25vF_5GXVuaNn-bw;
-        KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/df5542f6-9152-4e00-a4d6-c764e5b0a3aa
+      - AUTH_SESSION_ID_LEGACY=91f43bfa-1c55-428a-86e5-f70835588a78; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiOWJkYTIxMDMtZWFhMS00MmYxLWJiZWMtZjJhN2NkZTQ5NDE5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzdGF0ZV9jaGVja2VyIjoiNWpiclNMdjEzV1NWa3YxYTRCajR0V0lZT0I2SHhNbmdEaXI2SlBsM3V3byJ9.acYdrZwCRUMlA9wVKoZNu8HdtsNAgBaROjAPAW2swJY;
+        KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/91f43bfa-1c55-428a-86e5-f70835588a78
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
@@ -297,11 +297,11 @@ interactions:
       Cache-Control:
       - no-store, must-revalidate, max-age=0
       Location:
-      - http://testserver/digid-machtigen-oidc/callback/?state=not-a-random-string&session_state=df5542f6-9152-4e00-a4d6-c764e5b0a3aa&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=3585ed4a-0142-4951-876d-d5438368522a.df5542f6-9152-4e00-a4d6-c764e5b0a3aa.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=91f43bfa-1c55-428a-86e5-f70835588a78&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=df63c77b-bb4d-48a6-87cb-4d5d048dbc42.91f43bfa-1c55-428a-86e5-f70835588a78.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
@@ -309,15 +309,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiOGUwMzliODMtNWRmNS00MzAwLThmNjAtN2ZlMjFjZGQzNDJiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzdGF0ZV9jaGVja2VyIjoiNmUxU2dtTEZ5YUdsd0xvXzBLZjNSZmhYVk8ycTBtTmFiUjh2alpZeFp1OCJ9.J1G0WT0Dk1VEjoxGcLTbaTneEV7AZBJ8ih3j52VnucU;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiNTkyOTU2OWYtODE2ZC00NTlkLWE0MzYtYjlkOThhNjlmMzIwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzdGF0ZV9jaGVja2VyIjoiNWpiclNMdjEzV1NWa3YxYTRCajR0V0lZT0I2SHhNbmdEaXI2SlBsM3V3byJ9.o4x6eMPBt10gLyONrnfADgP4QxZU8ec6FeLNBQ2s_d0;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiOGUwMzliODMtNWRmNS00MzAwLThmNjAtN2ZlMjFjZGQzNDJiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzdGF0ZV9jaGVja2VyIjoiNmUxU2dtTEZ5YUdsd0xvXzBLZjNSZmhYVk8ycTBtTmFiUjh2alpZeFp1OCJ9.J1G0WT0Dk1VEjoxGcLTbaTneEV7AZBJ8ih3j52VnucU;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiNTkyOTU2OWYtODE2ZC00NTlkLWE0MzYtYjlkOThhNjlmMzIwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzdGF0ZV9jaGVja2VyIjoiNWpiclNMdjEzV1NWa3YxYTRCajR0V0lZT0I2SHhNbmdEaXI2SlBsM3V3byJ9.o4x6eMPBt10gLyONrnfADgP4QxZU8ec6FeLNBQ2s_d0;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/df5542f6-9152-4e00-a4d6-c764e5b0a3aa;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/91f43bfa-1c55-428a-86e5-f70835588a78;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/df5542f6-9152-4e00-a4d6-c764e5b0a3aa;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/91f43bfa-1c55-428a-86e5-f70835588a78;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:38 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=3585ed4a-0142-4951-876d-d5438368522a.df5542f6-9152-4e00-a4d6-c764e5b0a3aa.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=df63c77b-bb4d-48a6-87cb-4d5d048dbc42.91f43bfa-1c55-428a-86e5-f70835588a78.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -341,7 +341,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '283'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -350,7 +350,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiJjODhhZWE2ZS1mM2Y2LTQzZDAtOTIxYS1iMjRmYjBjNWJkOGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImRmNTU0MmY2LTkxNTItNGUwMC1hNGQ2LWM3NjRlNWIwYTNhYSIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImRmNTU0MmY2LTkxNTItNGUwMC1hNGQ2LWM3NjRlNWIwYTNhYSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.dnG0MF-_xr1lB-3Ur-X-D5-zQDdNiUxUoMSatZkutHT804ZbXq5OUJbajP8lAH1ivGTZIPxnyTxNV93_LSwccPRyhROWL0YuCbMchP1cYq2PQb3Qbq4aeKEWjcB0X3kba45QPxJJsyetI75CJJ9JBcqGXzFaIA3lmafDno0DEgl9KIWOVkaAEzHaWUVZcnMh1kwvLPAS3samxctI1MhbF5zkMiWYm8cPLS8hmyV4MB6B6lgNLxlahVeBuAI9YDCKhnO0j_H2jLq07kKrntYgVGjpvDwCIi5urf8BZbO999MZeh-0FABPYOtd-1zlv-MQ2NFFyvhdC2rfR6c9cfXC5g","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiY2ZkM2EzNDEtYWU5YS00NTRmLTlmZDMtMmUzMDVmMDk2YjRjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZGY1NTQyZjYtOTE1Mi00ZTAwLWE0ZDYtYzc2NGU1YjBhM2FhIn0.sfHDDUFMXOaYtLNfsLtYNnqqxKhXHBb8vxsb6rnnECQ","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiJlZDg3ZjI2Mi03ZDViLTQ4NzMtYjFiNS02MWUzYTc1NDU5ZjUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJhdF9oYXNoIjoiQVdqMmU4eEVjRVpUY09RY3BxWkxaUSIsImFjciI6IjAiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.wAeho4LuD_GfJsWA2b9Lo834Q9jCVuPC5vr-RLvM8_BQjnuojW1wFUxQrat4UsovN0QKeyp2PCgHkxSv3FP6C_2gHhWAQKxCNSd7q5Ko9-NGejpr65YHLiznFwXyN8-Xw2E5jOkxQJb2KiG15W5l1ovxEwqlk7IjMseO1qJk_Zalw6g2HTizoGGLWDIcLaQOYdZv3C7DhhA577rbCZAJTE7nBCpPZSRNZZe4Bp0n3bNl04o4ASuYTYoPh7FUTUjQIzXjU0QFcZPSHKYXJnLu6YxrKt7CPBV7DQGZvH6pRjqjFulf5Y4slxCkD6ePwmtKvs_8wFyK6BDYoTM6nzu3QA","not-before-policy":0,"session_state":"df5542f6-9152-4e00-a4d6-c764e5b0a3aa","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiI0NGIxNzdjYi00ZmFjLTRmMWItODFhYS02YTIyYmVhYTc3ODUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjkxZjQzYmZhLTFjNTUtNDI4YS04NmU1LWY3MDgzNTU4OGE3OCIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjkxZjQzYmZhLTFjNTUtNDI4YS04NmU1LWY3MDgzNTU4OGE3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.0a3T8kzk6jFgESuSNgFZTWU2kWQvx2_90aGaGOklvxiTrT6e3SPfTdmjgiqdUlOTbBhMOKH1e7LobzHM-N98AoRRj1sqKKu2Ku8GQBJ-B0ZGTS6RB2oga3Qn68KIHU8Sj1e1FPlvQy_BC3sgbMg-HzeFWBJXSvPKJMMHAcU8gYwJkl1u4uOVDyYnEwX0K0FURNjjcGssuBK-Q5wJPfb3uxb_OdWGFYUsgln1MRhPyT2o75htP6qNrnS3rZ_Wqb_wX1ZfnPDWdvdPmULbEps5J-xjcmQZoarAi5JnLhvfdh_UK3wQtZ3ZvMnr1PYVqphha5GH8kwrOFJBJqAvDDo0rA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiMjM0YWU5ZDYtMTA0My00MTVmLTkzZWMtZDRhNmFhMGI2NjcxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOTFmNDNiZmEtMWM1NS00MjhhLTg2ZTUtZjcwODM1NTg4YTc4In0.2Z7rAh10txWm5ELzorelpouG0FLFK9KUCxazJQmX0fg","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiI4ODRkODUyMi0xMmExLTQyMDEtYmVhZC03MTlmYWFiMmE3NTEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJhdF9oYXNoIjoiaDZDNjM4elMzM2xDem9OZTcyaWdnZyIsImFjciI6IjAiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.MoaAo_7GWqquF_vXlzjb0YGwSHIBFmnrT3_0uRVItIFFldBGqGAhwygMOJOl6n-RTItPPOxSj5hOVzMenYJXUTepUsJtcmFw2B1mmauSK6OjRwq0rJJZLAdbNGBk0dl4_qm3XcQFAGXXiJtflAFTW_Sawl8buf_Rgv5DTET0d1yq9-RCgvOV68NMbgVexxkOowxjVvDkQTSgC7LA_B6pOXfBBa_mPAJ9ztMU-Wy8GTMrz4dXTY4r2Nhv1_bJNsvoqUYG9HwGulO682gA9l3Izk5jpGaVghPK6pv92tEGvJF6V-tISwlvUTw9AqIU8ySvf9QejMgaVV8WBbVZvSYFxA","not-before-policy":0,"session_state":"91f43bfa-1c55-428a-86e5-f70835588a78","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -418,7 +418,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiJjODhhZWE2ZS1mM2Y2LTQzZDAtOTIxYS1iMjRmYjBjNWJkOGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImRmNTU0MmY2LTkxNTItNGUwMC1hNGQ2LWM3NjRlNWIwYTNhYSIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImRmNTU0MmY2LTkxNTItNGUwMC1hNGQ2LWM3NjRlNWIwYTNhYSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.dnG0MF-_xr1lB-3Ur-X-D5-zQDdNiUxUoMSatZkutHT804ZbXq5OUJbajP8lAH1ivGTZIPxnyTxNV93_LSwccPRyhROWL0YuCbMchP1cYq2PQb3Qbq4aeKEWjcB0X3kba45QPxJJsyetI75CJJ9JBcqGXzFaIA3lmafDno0DEgl9KIWOVkaAEzHaWUVZcnMh1kwvLPAS3samxctI1MhbF5zkMiWYm8cPLS8hmyV4MB6B6lgNLxlahVeBuAI9YDCKhnO0j_H2jLq07kKrntYgVGjpvDwCIi5urf8BZbO999MZeh-0FABPYOtd-1zlv-MQ2NFFyvhdC2rfR6c9cfXC5g
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiI0NGIxNzdjYi00ZmFjLTRmMWItODFhYS02YTIyYmVhYTc3ODUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjkxZjQzYmZhLTFjNTUtNDI4YS04NmU1LWY3MDgzNTU4OGE3OCIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjkxZjQzYmZhLTFjNTUtNDI4YS04NmU1LWY3MDgzNTU4OGE3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwic2VydmljZV9pZCI6ImIxOGRkNzNmLTNkY2EtNGI2Ny1hNGZiLTA2Y2I0ZWJiZTJlYiIsImdlbWFjaHRpZ2RlLmJzbiI6Ijk5OTk5OTk5OSIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sImFhbnZyYWdlci5ic24iOiIwMDAwMDAwMDAiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkaWdpZC1tYWNodGlnZW4ifQ.0a3T8kzk6jFgESuSNgFZTWU2kWQvx2_90aGaGOklvxiTrT6e3SPfTdmjgiqdUlOTbBhMOKH1e7LobzHM-N98AoRRj1sqKKu2Ku8GQBJ-B0ZGTS6RB2oga3Qn68KIHU8Sj1e1FPlvQy_BC3sgbMg-HzeFWBJXSvPKJMMHAcU8gYwJkl1u4uOVDyYnEwX0K0FURNjjcGssuBK-Q5wJPfb3uxb_OdWGFYUsgln1MRhPyT2o75htP6qNrnS3rZ_Wqb_wX1ZfnPDWdvdPmULbEps5J-xjcmQZoarAi5JnLhvfdh_UK3wQtZ3ZvMnr1PYVqphha5GH8kwrOFJBJqAvDDo0rA
       Connection:
       - keep-alive
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiJlZDg3ZjI2Mi03ZDViLTQ4NzMtYjFiNS02MWUzYTc1NDU5ZjUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJhdF9oYXNoIjoiQVdqMmU4eEVjRVpUY09RY3BxWkxaUSIsImFjciI6IjAiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.wAeho4LuD_GfJsWA2b9Lo834Q9jCVuPC5vr-RLvM8_BQjnuojW1wFUxQrat4UsovN0QKeyp2PCgHkxSv3FP6C_2gHhWAQKxCNSd7q5Ko9-NGejpr65YHLiznFwXyN8-Xw2E5jOkxQJb2KiG15W5l1ovxEwqlk7IjMseO1qJk_Zalw6g2HTizoGGLWDIcLaQOYdZv3C7DhhA577rbCZAJTE7nBCpPZSRNZZe4Bp0n3bNl04o4ASuYTYoPh7FUTUjQIzXjU0QFcZPSHKYXJnLu6YxrKt7CPBV7DQGZvH6pRjqjFulf5Y4slxCkD6ePwmtKvs_8wFyK6BDYoTM6nzu3QA
+    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTgsImlhdCI6MTczNDAzODMxOCwiYXV0aF90aW1lIjoxNzM0MDM4MzE4LCJqdGkiOiI4ODRkODUyMi0xMmExLTQyMDEtYmVhZC03MTlmYWFiMmE3NTEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJlYzVhMWY3MC0zZDEwLTQ4YTgtYTE4Yi0yZDEzYzkyNWNkOTIiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJhdF9oYXNoIjoiaDZDNjM4elMzM2xDem9OZTcyaWdnZyIsImFjciI6IjAiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInNlcnZpY2VfaWQiOiJiMThkZDczZi0zZGNhLTRiNjctYTRmYi0wNmNiNGViYmUyZWIiLCJnZW1hY2h0aWdkZS5ic24iOiI5OTk5OTk5OTkiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJhYW52cmFnZXIuYnNuIjoiMDAwMDAwMDAwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGlnaWQtbWFjaHRpZ2VuIn0.MoaAo_7GWqquF_vXlzjb0YGwSHIBFmnrT3_0uRVItIFFldBGqGAhwygMOJOl6n-RTItPPOxSj5hOVzMenYJXUTepUsJtcmFw2B1mmauSK6OjRwq0rJJZLAdbNGBk0dl4_qm3XcQFAGXXiJtflAFTW_Sawl8buf_Rgv5DTET0d1yq9-RCgvOV68NMbgVexxkOowxjVvDkQTSgC7LA_B6pOXfBBa_mPAJ9ztMU-Wy8GTMrz4dXTY4r2Nhv1_bJNsvoqUYG9HwGulO682gA9l3Izk5jpGaVghPK6pv92tEGvJF6V-tISwlvUTw9AqIU8ySvf9QejMgaVV8WBbVZvSYFxA
     headers:
       Accept:
       - '*/*'
@@ -505,12 +505,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -531,9 +531,9 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=f07b32d9-ad38-4b37-9d97-5bfdae8635b0; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=6d14dfb5-e85a-44c6-9416-17fb7df408d9; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=f07b32d9-ad38-4b37-9d97-5bfdae8635b0; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=6d14dfb5-e85a-44c6-9416-17fb7df408d9; Version=1; Path=/realms/test/;
         HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -569,12 +569,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -617,29 +617,29 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=df5542f6-9152-4e00-a4d6-c764e5b0a3aa; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiOGUwMzliODMtNWRmNS00MzAwLThmNjAtN2ZlMjFjZGQzNDJiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzaWQiOiJkZjU1NDJmNi05MTUyLTRlMDAtYTRkNi1jNzY0ZTViMGEzYWEiLCJzdGF0ZV9jaGVja2VyIjoiNmUxU2dtTEZ5YUdsd0xvXzBLZjNSZmhYVk8ycTBtTmFiUjh2alpZeFp1OCJ9.J1G0WT0Dk1VEjoxGcLTbaTneEV7AZBJ8ih3j52VnucU;
-        KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/df5542f6-9152-4e00-a4d6-c764e5b0a3aa;
-        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k
+      - AUTH_SESSION_ID_LEGACY=91f43bfa-1c55-428a-86e5-f70835588a78; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTgsImlhdCI6MTczNDAzODMxOCwianRpIjoiNTkyOTU2OWYtODE2ZC00NTlkLWE0MzYtYjlkOThhNjlmMzIwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiZWM1YTFmNzAtM2QxMC00OGE4LWExOGItMmQxM2M5MjVjZDkyIiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzaWQiOiI5MWY0M2JmYS0xYzU1LTQyOGEtODZlNS1mNzA4MzU1ODhhNzgiLCJzdGF0ZV9jaGVja2VyIjoiNWpiclNMdjEzV1NWa3YxYTRCajR0V0lZT0I2SHhNbmdEaXI2SlBsM3V3byJ9.o4x6eMPBt10gLyONrnfADgP4QxZU8ec6FeLNBQ2s_d0;
+        KEYCLOAK_SESSION_LEGACY=test/ec5a1f70-3d10-48a8-a18b-2d13c925cd92/91f43bfa-1c55-428a-86e5-f70835588a78;
+        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fdigid-machtigen-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"8afa20a3-96d3-4994-bc3b-3e9f1a983af6\",\n
-        \             \"iH7kN0NgyUQ\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=iH7kN0NgyUQ&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"f60af651-5ad2-4cdc-9efc-ff0d76f2342c\",\n
+        \             \"1bdUpSixEFc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=1bdUpSixEFc&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -647,7 +647,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=VWeyB1pkBCi1z6zFw2JKEClg9RoVxwOMntosgl6FE9Q&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=iH7kN0NgyUQ\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=G_yTyP0q9C2ORdDNkR8xfrtaaunIAVl7HvJIF_4gg1k&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=1bdUpSixEFc\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -673,7 +673,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -703,11 +703,11 @@ interactions:
         00:00:10 GMT; Max-Age=0; Path=/realms/test
       - KEYCLOAK_SESSION_LEGACY=; Version=1; Comment=Expiring cookie; Expires=Thu,
         01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/realms/test
-      - AUTH_SESSION_ID=8afa20a3-96d3-4994-bc3b-3e9f1a983af6; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=f60af651-5ad2-4cdc-9efc-ff0d76f2342c; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=8afa20a3-96d3-4994-bc3b-3e9f1a983af6; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=f60af651-5ad2-4cdc-9efc-ff0d76f2342c; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9kaWdpZC1tYWNodGlnZW4tb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBic24iLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly90ZXN0c2VydmVyL2RpZ2lkLW1hY2h0aWdlbi1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.CzIO8PEo0TtC0JUUGrAD0K0eHnesrWyKb05cHrA4S4k;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningAuthContextTests/EHerkenningAuthContextTests.test_record_auth_context.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningAuthContextTests/EHerkenningAuthContextTests.test_record_auth_context.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"6b7deafc-a647-4486-9d62-fefc95b20843\",\n
-        \             \"_KORQYVB3a4\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=_KORQYVB3a4&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"cacb1852-3e19-494e-997a-154bb14ff921\",\n
+        \             \"uzh-eTZHF2E\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=uzh-eTZHF2E&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=y2yUM8nfGFjkr1nWS1rNfL_LuMYWuz2UMUO45Tw5OWY&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=_KORQYVB3a4\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=nmslekefcnqlEewC5MvvAhCNNmrVC4ezaY9f1OmpYzk&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=uzh-eTZHF2E\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=6b7deafc-a647-4486-9d62-fefc95b20843; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=cacb1852-3e19-494e-997a-154bb14ff921; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=6b7deafc-a647-4486-9d62-fefc95b20843; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=cacb1852-3e19-494e-997a-154bb14ff921; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBrdmsiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMC9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.8Me56DCFR5bLdeB5ofc-CuoI9b7hc0w7Lc7eKn6tu-A;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SHAp3n0oU1RnG5eMuV5c3dJCzb09vOQGoMeKVLJtV_k;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=6b7deafc-a647-4486-9d62-fefc95b20843; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBrdmsiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMC9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.8Me56DCFR5bLdeB5ofc-CuoI9b7hc0w7Lc7eKn6tu-A
+      - AUTH_SESSION_ID_LEGACY=cacb1852-3e19-494e-997a-154bb14ff921; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SHAp3n0oU1RnG5eMuV5c3dJCzb09vOQGoMeKVLJtV_k
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=y2yUM8nfGFjkr1nWS1rNfL_LuMYWuz2UMUO45Tw5OWY&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=_KORQYVB3a4
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=nmslekefcnqlEewC5MvvAhCNNmrVC4ezaY9f1OmpYzk&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=uzh-eTZHF2E
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/eherkenning-oidc/callback/?state=not-a-random-string&session_state=6b7deafc-a647-4486-9d62-fefc95b20843&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=f74946c2-b062-4a6d-af47-26872038ac4a.6b7deafc-a647-4486-9d62-fefc95b20843.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=cacb1852-3e19-494e-997a-154bb14ff921&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=70dff67d-7f58-44ea-8f74-e8657130d3f3.cacb1852-3e19-494e-997a-154bb14ff921.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODcsImlhdCI6MTczMjYxNTg4NywianRpIjoiMzc1ZjljZWUtNGY2Yi00MjlhLTg4YmQtMGU2YzNlNmU1MzMzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJzaWQiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJzdGF0ZV9jaGVja2VyIjoidkxsM0FpS21tY2JQTGJKRXFzLWFESXRYdTZLNVZRUXd0MFpJTlppM2wxVSJ9.v0owbMGQsuSma05HSp7V7PeW8XfnzSArOJKChbcHHEA;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMmJiNDNkZjgtN2RiMC00NmE3LTkyZjgtODY5ZTlhMGM1NDQyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJzaWQiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJzdGF0ZV9jaGVja2VyIjoidlhILWE1dVZWMk5sRzZqU2ptRHhkSEJLc0F6WHRaNkdPeUFrNDJVdVVCVSJ9.7e90IupV3AujFLYaul_5UURwo4O_AV1mZ_JbHXJZJHc;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODcsImlhdCI6MTczMjYxNTg4NywianRpIjoiMzc1ZjljZWUtNGY2Yi00MjlhLTg4YmQtMGU2YzNlNmU1MzMzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJzaWQiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJzdGF0ZV9jaGVja2VyIjoidkxsM0FpS21tY2JQTGJKRXFzLWFESXRYdTZLNVZRUXd0MFpJTlppM2wxVSJ9.v0owbMGQsuSma05HSp7V7PeW8XfnzSArOJKChbcHHEA;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMmJiNDNkZjgtN2RiMC00NmE3LTkyZjgtODY5ZTlhMGM1NDQyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJzaWQiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJzdGF0ZV9jaGVja2VyIjoidlhILWE1dVZWMk5sRzZqU2ptRHhkSEJLc0F6WHRaNkdPeUFrNDJVdVVCVSJ9.7e90IupV3AujFLYaul_5UURwo4O_AV1mZ_JbHXJZJHc;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/6b7deafc-a647-4486-9d62-fefc95b20843;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:27 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/cacb1852-3e19-494e-997a-154bb14ff921;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:33 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/6b7deafc-a647-4486-9d62-fefc95b20843;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:27 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/cacb1852-3e19-494e-997a-154bb14ff921;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:33 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=f74946c2-b062-4a6d-af47-26872038ac4a.6b7deafc-a647-4486-9d62-fefc95b20843.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=70dff67d-7f58-44ea-8f74-e8657130d3f3.cacb1852-3e19-494e-997a-154bb14ff921.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '285'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODcsImlhdCI6MTczMjYxNTg4NywiYXV0aF90aW1lIjoxNzMyNjE1ODg3LCJqdGkiOiIxZTRmMDAxMy1mOTgwLTQwODQtYjEzYi0wYjQ2MTBhMDAxNjUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjZiN2RlYWZjLWE2NDctNDQ4Ni05ZDYyLWZlZmM5NWIyMDg0MyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjZiN2RlYWZjLWE2NDctNDQ4Ni05ZDYyLWZlZmM5NWIyMDg0MyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.ocC_uQEaQ7HZqThD-MOXLNKIKp3Ot7mySvf-C1DO5sbYR0ILY-LW56StytKjRdUC-zwT8UNb5UazFzPIEUri1C2qpr9EeiF6iJvDwQMUvU8MtCbpZkUutjv_ffTgEDMbdXY0LnRcbQPA6SxwYlSkRyY7mXTInzPe9hqzFrDQlMNbVQ-TqJjq99OH05U7_nGtnnIXycQXe9tBLxBOPIiTVVTQ7C05OiFqpf8Aby9fY2V3ExpxIF4sbhcU13qOW-Hg3hHfGAG1c0swVtT6QOmyMajlNOZgh93n1vhpVto7HHyCkm-IH5_4-xHftLz6qo-n0LegwKsuCCsYcf29beSJgg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODcsImlhdCI6MTczMjYxNTg4NywianRpIjoiZDQ2N2Y5NjctZDBkNi00YTZmLTg0NTItOTIzNmZlMzQyMGU2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNmI3ZGVhZmMtYTY0Ny00NDg2LTlkNjItZmVmYzk1YjIwODQzIn0.4B0j5MYWvxxamoTUekEn6gZ_sXKmfP3NO6GKiTrYwtQ","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODcsImlhdCI6MTczMjYxNTg4NywiYXV0aF90aW1lIjoxNzMyNjE1ODg3LCJqdGkiOiI5MmU1NDdiMy0yNmM1LTQ2ZDEtYmZmZi1hNWI3YjExNzdiNjIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJhdF9oYXNoIjoiWG9FdUtaR2tLdUpZMkdobHBjY3gwQSIsImFjciI6IjEiLCJzaWQiOiI2YjdkZWFmYy1hNjQ3LTQ0ODYtOWQ2Mi1mZWZjOTViMjA4NDMiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.KG8SsmYeq_nqgLiW3nHum0s5akqXlpFH2KNLaSwgMTJyLeWHBKnrXKDD9xIG3n13endxiU2pDQKcKa5bvV7LAD7YdXJ4aXwm0HebU9BUJ4Q83XPp7HOJ9fFiJiNjHKDm68TW-f5NArdimc8cgHDzpFbwZy-PqaqBzPlYMkl3E_4_lFuPVgM4kub8NmLrFSlB66TxOvYDrzn5vnTP2hI__8HuueiXanfxpagfLB3M-ePDOOA5cru9yvD_jYzI42As6VAlPcUs0uVp4Qsj5ekJLlxtU-ywce6Bx-Q3fDxcJ56UC2MMQayIJqSFeOrvTXX6Pu0-I0ybz06YPOtAVS2DUQ","not-before-policy":0,"session_state":"6b7deafc-a647-4486-9d62-fefc95b20843","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiJjZDY0YjkzMi00NDM3LTQwMDItYmQxNS1hNjlmYjUzYzJhNTQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImNhY2IxODUyLTNlMTktNDk0ZS05OTdhLTE1NGJiMTRmZjkyMSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImNhY2IxODUyLTNlMTktNDk0ZS05OTdhLTE1NGJiMTRmZjkyMSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.PPk-XSvjSYAN0nJnQPDPNqux3dEyqXliScmYrqRuSiFNfSoG-9rdya3a0XRTs7OFKXJTTuYFB69Xo5r3qjCzUG2CBFZFLkoCzftuelq3NOIs_yCWWTjljcB7ghPREQjEBWqLs_4xq20FDW_XKZyBRA_Q6d9Sd-Z0yM-CO24UzE3gbAS7yxt6NmAQt4O8c80HqNv524sho-iYlBwCNuFfOM7yUqjeNA8rHoL-LqB6W6Ld_tFGivfDZAm9-7iYSmqPWHSVL53JCRxxeqW1NC52SQpEO6dSJU_Qy2oJ-seiZRG9F6RfDiLZzCqQ_GhI3GSJBkCNGny43AYRfEOXuYMDDQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiM2JjNDYwOTUtNjM1ZS00Mzg0LWI2MTQtYmNhNzY1MDU3ZjQzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiY2FjYjE4NTItM2UxOS00OTRlLTk5N2EtMTU0YmIxNGZmOTIxIn0.5W4lbaM1I1TOhgrooEBinY4CSez7vqNoo0LLnLeph9U","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiJmYTFhMTdmNi0wMjVkLTRjOWEtYmYxNC03MzI5MmFlMTc0ZWYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJhdF9oYXNoIjoiSDFoT3R5WkM2QjBMWGtIX1FkQTAyUSIsImFjciI6IjEiLCJzaWQiOiJjYWNiMTg1Mi0zZTE5LTQ5NGUtOTk3YS0xNTRiYjE0ZmY5MjEiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.NLBXEipLVwkdWEjYAdQyp6obIMcZseK2eydgcpnKnYRe9SsRP1QsrjHUvRpYANdMfKESHfPou7GQQLNg0ljs9wzY_By84DFEhAuSnMIiz5u9GMFEYjoU-vlUeses5-yW78WRAxT8Av0lMsga3kyRf50SvVZmMw5xjcUhoJ2iRS5TK-6Q3jg1vxy_8flpRaz_uAkBfFSrYee0lFVEcEwi7vgtLLPlMrQ0g_lZovbc9ixUEHlXek7UEx8oo-fLPUQGq6yYHHUixc10Du4bHwxM-CL_QOxdmvwno2I509c0E_N7z9Sjv3FQUhdvA0Hmz6-u335r5V78yzDST0Vjm2XDyg","not-before-policy":0,"session_state":"cacb1852-3e19-494e-997a-154bb14ff921","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODcsImlhdCI6MTczMjYxNTg4NywiYXV0aF90aW1lIjoxNzMyNjE1ODg3LCJqdGkiOiIxZTRmMDAxMy1mOTgwLTQwODQtYjEzYi0wYjQ2MTBhMDAxNjUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjZiN2RlYWZjLWE2NDctNDQ4Ni05ZDYyLWZlZmM5NWIyMDg0MyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjZiN2RlYWZjLWE2NDctNDQ4Ni05ZDYyLWZlZmM5NWIyMDg0MyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.ocC_uQEaQ7HZqThD-MOXLNKIKp3Ot7mySvf-C1DO5sbYR0ILY-LW56StytKjRdUC-zwT8UNb5UazFzPIEUri1C2qpr9EeiF6iJvDwQMUvU8MtCbpZkUutjv_ffTgEDMbdXY0LnRcbQPA6SxwYlSkRyY7mXTInzPe9hqzFrDQlMNbVQ-TqJjq99OH05U7_nGtnnIXycQXe9tBLxBOPIiTVVTQ7C05OiFqpf8Aby9fY2V3ExpxIF4sbhcU13qOW-Hg3hHfGAG1c0swVtT6QOmyMajlNOZgh93n1vhpVto7HHyCkm-IH5_4-xHftLz6qo-n0LegwKsuCCsYcf29beSJgg
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiJjZDY0YjkzMi00NDM3LTQwMDItYmQxNS1hNjlmYjUzYzJhNTQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImNhY2IxODUyLTNlMTktNDk0ZS05OTdhLTE1NGJiMTRmZjkyMSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImNhY2IxODUyLTNlMTktNDk0ZS05OTdhLTE1NGJiMTRmZjkyMSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.PPk-XSvjSYAN0nJnQPDPNqux3dEyqXliScmYrqRuSiFNfSoG-9rdya3a0XRTs7OFKXJTTuYFB69Xo5r3qjCzUG2CBFZFLkoCzftuelq3NOIs_yCWWTjljcB7ghPREQjEBWqLs_4xq20FDW_XKZyBRA_Q6d9Sd-Z0yM-CO24UzE3gbAS7yxt6NmAQt4O8c80HqNv524sho-iYlBwCNuFfOM7yUqjeNA8rHoL-LqB6W6Ld_tFGivfDZAm9-7iYSmqPWHSVL53JCRxxeqW1NC52SQpEO6dSJU_Qy2oJ-seiZRG9F6RfDiLZzCqQ_GhI3GSJBkCNGny43AYRfEOXuYMDDQ
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningAuthContextTests/EHerkenningAuthContextTests.test_record_vestiging_restriction.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningAuthContextTests/EHerkenningAuthContextTests.test_record_vestiging_restriction.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"9a0be825-6014-4c23-a578-daab6e933dff\",\n
-        \             \"ZUnKHjeUs0w\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=ZUnKHjeUs0w&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"3695a30e-d90d-4f4d-b215-9cab8b6375c1\",\n
+        \             \"v_T0EORcCGA\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=v_T0EORcCGA&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=kZ9g1Cqe3FR8EXjlqa-AxhidcmiKPvscsqoKBZycOtg&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=ZUnKHjeUs0w\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=wngShT-8a119wF3oiJ_umd3lw9Y71t5EjaPDnY86rLs&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=v_T0EORcCGA\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=9a0be825-6014-4c23-a578-daab6e933dff; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=3695a30e-d90d-4f4d-b215-9cab8b6375c1; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=9a0be825-6014-4c23-a578-daab6e933dff; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=3695a30e-d90d-4f4d-b215-9cab8b6375c1; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBrdmsiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMC9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.8Me56DCFR5bLdeB5ofc-CuoI9b7hc0w7Lc7eKn6tu-A;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SHAp3n0oU1RnG5eMuV5c3dJCzb09vOQGoMeKVLJtV_k;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=9a0be825-6014-4c23-a578-daab6e933dff; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBrdmsiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMC9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.8Me56DCFR5bLdeB5ofc-CuoI9b7hc0w7Lc7eKn6tu-A
+      - AUTH_SESSION_ID_LEGACY=3695a30e-d90d-4f4d-b215-9cab8b6375c1; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SHAp3n0oU1RnG5eMuV5c3dJCzb09vOQGoMeKVLJtV_k
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=kZ9g1Cqe3FR8EXjlqa-AxhidcmiKPvscsqoKBZycOtg&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=ZUnKHjeUs0w
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=wngShT-8a119wF3oiJ_umd3lw9Y71t5EjaPDnY86rLs&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=v_T0EORcCGA
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/eherkenning-oidc/callback/?state=not-a-random-string&session_state=9a0be825-6014-4c23-a578-daab6e933dff&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=42c43554-afaa-4c05-8723-2d712181ee28.9a0be825-6014-4c23-a578-daab6e933dff.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=3695a30e-d90d-4f4d-b215-9cab8b6375c1&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=50174a77-5fc7-4744-8fe5-f2b3407cd493.3695a30e-d90d-4f4d-b215-9cab8b6375c1.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODcsImlhdCI6MTczMjYxNTg4NywianRpIjoiMDU0OGQyNzUtZTU5YS00YmZhLThiNzAtOGZkNTVmODE5ZmVhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJzaWQiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJzdGF0ZV9jaGVja2VyIjoiNlBHRTRGYVdEM0Y1eDNfbDExYzRjeVdhbmRRd05CMFdINS1pQXo2dHhVRSJ9.0H9aQtY4ogo4dhsGv8FyIvIw1t5ZtR7n-TtNXjPAmGk;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMWU4MTk4MzQtNWZlMC00N2E4LTg5MjEtYTdkNjliMTcyZDFiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJzaWQiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJzdGF0ZV9jaGVja2VyIjoia2RwTmZOYzV1OVB1SVNuVjhENFBTWVZBbXhZMXRzdlcxNGNNMHp5S19fbyJ9.fnrX_T5svtPA10CEGS7q8mPr8cjaqjPkoX7HNDRw8Nc;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODcsImlhdCI6MTczMjYxNTg4NywianRpIjoiMDU0OGQyNzUtZTU5YS00YmZhLThiNzAtOGZkNTVmODE5ZmVhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJzaWQiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJzdGF0ZV9jaGVja2VyIjoiNlBHRTRGYVdEM0Y1eDNfbDExYzRjeVdhbmRRd05CMFdINS1pQXo2dHhVRSJ9.0H9aQtY4ogo4dhsGv8FyIvIw1t5ZtR7n-TtNXjPAmGk;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMWU4MTk4MzQtNWZlMC00N2E4LTg5MjEtYTdkNjliMTcyZDFiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJzaWQiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJzdGF0ZV9jaGVja2VyIjoia2RwTmZOYzV1OVB1SVNuVjhENFBTWVZBbXhZMXRzdlcxNGNNMHp5S19fbyJ9.fnrX_T5svtPA10CEGS7q8mPr8cjaqjPkoX7HNDRw8Nc;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/9a0be825-6014-4c23-a578-daab6e933dff;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:27 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/3695a30e-d90d-4f4d-b215-9cab8b6375c1;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:33 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/9a0be825-6014-4c23-a578-daab6e933dff;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:27 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/3695a30e-d90d-4f4d-b215-9cab8b6375c1;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:33 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=42c43554-afaa-4c05-8723-2d712181ee28.9a0be825-6014-4c23-a578-daab6e933dff.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=50174a77-5fc7-4744-8fe5-f2b3407cd493.3695a30e-d90d-4f4d-b215-9cab8b6375c1.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '285'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODcsImlhdCI6MTczMjYxNTg4NywiYXV0aF90aW1lIjoxNzMyNjE1ODg3LCJqdGkiOiIyOWM3MjNhOS1jNDEyLTQxMzctYWI2MC0xMzI5MzgxYjljOTQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjlhMGJlODI1LTYwMTQtNGMyMy1hNTc4LWRhYWI2ZTkzM2RmZiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjlhMGJlODI1LTYwMTQtNGMyMy1hNTc4LWRhYWI2ZTkzM2RmZiIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.yK6cjE9GGbgXKBKdQNmOBmQtORjPEiVcewt2a_cM709BEgbZaEdtYmc2k-TyQ5FdFnvbe3aamnDnE8DvrnkeR_NOTuC0QQJ2vuQ_2TPiWpv5dmfp_7vyCTKExCQrxyDEnHJnut1vwDosCHRdEyDJ6fqqqOIgOiZK8xA1w9OYYtarEEagDgsNELVFVJR1kR-NSXb-XAtysYz4LRwwUJ6jTIPX0crj7agFOf-cBPjMs82-QPycyQ7pgyKclxd0bn_xQV59i61uNTYzhXygbY2vNv6gubi9Beg9d1dcPqezCo25cbox01xjcGVhKQPocHJSnM1D4f6JM7kGBt_qShwiNA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODcsImlhdCI6MTczMjYxNTg4NywianRpIjoiNmQwZWUyNzQtMjlhYi00MjYyLTkxMzItYzQzODJmMGY0OGJkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOWEwYmU4MjUtNjAxNC00YzIzLWE1NzgtZGFhYjZlOTMzZGZmIn0.YYSiHWVfBFcbj_wSsCCGLWEZm37I7QuNX1j69fbAiF4","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODcsImlhdCI6MTczMjYxNTg4NywiYXV0aF90aW1lIjoxNzMyNjE1ODg3LCJqdGkiOiIyMjU1MGQ1Yy05OTBhLTQyOWQtODk3My1jNmNhMTMxNGFlZjUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI0NGJlNDVmNi1hN2FlLTQyYzItOTQ4Ni0zMGYwNzhjZjViMzkiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJhdF9oYXNoIjoia2dSTktZay14Q1RWd1BUQlZGcmVSUSIsImFjciI6IjEiLCJzaWQiOiI5YTBiZTgyNS02MDE0LTRjMjMtYTU3OC1kYWFiNmU5MzNkZmYiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy12ZXN0aWdpbmciLCJ2ZXN0aWdpbmciOiIxMjM0NTY3ODkwMTIifQ.K0A3Dxo-d4rrol8OWIxJy0cyut-iHaEW2q_r4EFQkkNRnW4LB5ooRSwG3Wv9iXMadxZPaOOxWsfQvwbf5joTbl4V2sycY9aXULXUzjtav1f59Pt6NGO453k23bHK8aObqaktahhnTNFSjo-olgg3-1u7AxpdFphIkaW9l1Qj4kQ27FerucAIAAckel3ArOmQAB2n5K1kKNef8VwSyAEuZHPQAdx68FOZ2S8G1WCkv9ukcnO6UKURF9PKuy7SRxlr5jEh0qOTxvXO4wJf6tyUSSwGnEyZGg9js9Y0pj9rg4P380l7v_O8rskghTJNOMURWupvxpSPrluD5apb7kgcOw","not-before-policy":0,"session_state":"9a0be825-6014-4c23-a578-daab6e933dff","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiI5NGYzMGMxOS0yMzgxLTQ5MDUtYmU0Mi0wMWY4ZWQ4ZTEwYzUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM2OTVhMzBlLWQ5MGQtNGY0ZC1iMjE1LTljYWI4YjYzNzVjMSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM2OTVhMzBlLWQ5MGQtNGY0ZC1iMjE1LTljYWI4YjYzNzVjMSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.yavbbh7Z26rAm_sMlTMIi_71IYPOsKrf8amKhWymar_8qkb5mbZQs6JomY3cl8VJmY3i38IIr0KGlbQhiOpfaVi7SWAQHeH73gFxcx2U0OFruBIZcWVZnfvdTTc66G7lCFTVyJIJyriRA8k28Nzj0UjnXBOZxJOvsVT-uoX023tfMt_BFTP5cqiv3hM4QE9Hb1LP5gyAnaxzTr57Gyb2erQf-3EXsMyKX0TLuAmifrugO5UGcxlC8jQ8JWK3MByFnL40VhweiAT5Mhu82OywRCiIrS2eByHFa1cA17kEJTqPquUbT7JKr5nkGAYYbTnFjyd0sDayIoZi-sLcX_yphw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMWUxNTdmNWUtY2ZlOC00MTljLWE0YTMtM2RkZjU5ZDdjODU0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMzY5NWEzMGUtZDkwZC00ZjRkLWIyMTUtOWNhYjhiNjM3NWMxIn0.AlrX98JPm84RMqg05B6WuPNLykYmxrIjTD1P_QtyRbs","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiJjZmJkNzQ3NC01ODcyLTQzMWItYmRkMC0zNzNmMDE5YmJkZjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI0NGJlNDVmNi1hN2FlLTQyYzItOTQ4Ni0zMGYwNzhjZjViMzkiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJhdF9oYXNoIjoibnlmN0lzYnFXOTVHSzV1dGQ4ZjRhZyIsImFjciI6IjEiLCJzaWQiOiIzNjk1YTMwZS1kOTBkLTRmNGQtYjIxNS05Y2FiOGI2Mzc1YzEiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy12ZXN0aWdpbmciLCJ2ZXN0aWdpbmciOiIxMjM0NTY3ODkwMTIifQ.Hm7Tfakd_iQ-S_v3tZ5kpIIx9cA3ZV29AJXA6i_joII5IiUmBbPRF54kKPjF8KkdlAUeF6UMCAY0Oafz3kBnKx1gl16NyX6njN3FTPMfE8-580P8qOI9b9vDhsfjrON7hnNCJv7Eni67ksDPxtTl7q7Fq2RPr35pQ853vSBBOCIiRn4QbTr-zBxT3sT8sCkYkWbpj59ovKd1x4Y1fcKPDeY5sYhSgIzAaVGScbqChxONkPqDnT99oUF3YBE38peYcpwrh1vhArP2D5VIEIV-Nls629zH8HVzjmBbQPdgk7h85RuRpxnzIsKAOmluCzt4fXYQHqpb7QwCsasqMuMQsQ","not-before-policy":0,"session_state":"3695a30e-d90d-4f4d-b215-9cab8b6375c1","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODcsImlhdCI6MTczMjYxNTg4NywiYXV0aF90aW1lIjoxNzMyNjE1ODg3LCJqdGkiOiIyOWM3MjNhOS1jNDEyLTQxMzctYWI2MC0xMzI5MzgxYjljOTQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjlhMGJlODI1LTYwMTQtNGMyMy1hNTc4LWRhYWI2ZTkzM2RmZiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjlhMGJlODI1LTYwMTQtNGMyMy1hNTc4LWRhYWI2ZTkzM2RmZiIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.yK6cjE9GGbgXKBKdQNmOBmQtORjPEiVcewt2a_cM709BEgbZaEdtYmc2k-TyQ5FdFnvbe3aamnDnE8DvrnkeR_NOTuC0QQJ2vuQ_2TPiWpv5dmfp_7vyCTKExCQrxyDEnHJnut1vwDosCHRdEyDJ6fqqqOIgOiZK8xA1w9OYYtarEEagDgsNELVFVJR1kR-NSXb-XAtysYz4LRwwUJ6jTIPX0crj7agFOf-cBPjMs82-QPycyQ7pgyKclxd0bn_xQV59i61uNTYzhXygbY2vNv6gubi9Beg9d1dcPqezCo25cbox01xjcGVhKQPocHJSnM1D4f6JM7kGBt_qShwiNA
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiI5NGYzMGMxOS0yMzgxLTQ5MDUtYmU0Mi0wMWY4ZWQ4ZTEwYzUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjM2OTVhMzBlLWQ5MGQtNGY0ZC1iMjE1LTljYWI4YjYzNzVjMSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjM2OTVhMzBlLWQ5MGQtNGY0ZC1iMjE1LTljYWI4YjYzNzVjMSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.yavbbh7Z26rAm_sMlTMIi_71IYPOsKrf8amKhWymar_8qkb5mbZQs6JomY3cl8VJmY3i38IIr0KGlbQhiOpfaVi7SWAQHeH73gFxcx2U0OFruBIZcWVZnfvdTTc66G7lCFTVyJIJyriRA8k28Nzj0UjnXBOZxJOvsVT-uoX023tfMt_BFTP5cqiv3hM4QE9Hb1LP5gyAnaxzTr57Gyb2erQf-3EXsMyKX0TLuAmifrugO5UGcxlC8jQ8JWK3MByFnL40VhweiAT5Mhu82OywRCiIrS2eByHFa1cA17kEJTqPquUbT7JKr5nkGAYYbTnFjyd0sDayIoZi-sLcX_yphw
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringAuthContextTests/EHerkenningBewindvoeringAuthContextTests.test_new_required_claims_are_backwards_compatible.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringAuthContextTests/EHerkenningBewindvoeringAuthContextTests.test_new_required_claims_are_backwards_compatible.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3\",\n
-        \             \"Cuql436XxQA\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=Cuql436XxQA&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"31662c6c-e523-4cec-a542-be4c75966379\",\n
+        \             \"R9YgPpPC2bU\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=R9YgPpPC2bU&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=XmYOYK18P_njhOQmCEwwo6hguU6nvWTfDi5LDqkx-KQ&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=Cuql436XxQA\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=91Z0kKH0bhRc-fZs3nr2s9COBPMdDYVYB0IWUOTZunk&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=R9YgPpPC2bU\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=31662c6c-e523-4cec-a542-be4c75966379; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=31662c6c-e523-4cec-a542-be4c75966379; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctYmV3aW5kdm9lcmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2VoZXJrZW5uaW5nLWJld2luZHZvZXJpbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.u5Tk3HYN6nuiTuyL-i5bvA4Pp-HF5ocM6alXi12axeg;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctYmV3aW5kdm9lcmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2VoZXJrZW5uaW5nLWJld2luZHZvZXJpbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.u5Tk3HYN6nuiTuyL-i5bvA4Pp-HF5ocM6alXi12axeg
+      - AUTH_SESSION_ID_LEGACY=31662c6c-e523-4cec-a542-be4c75966379; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=XmYOYK18P_njhOQmCEwwo6hguU6nvWTfDi5LDqkx-KQ&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=Cuql436XxQA
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=91Z0kKH0bhRc-fZs3nr2s9COBPMdDYVYB0IWUOTZunk&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=R9YgPpPC2bU
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=31303dad-64a1-411e-ba37-05af64b74699.11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=31662c6c-e523-4cec-a542-be4c75966379&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=ca7ecfb7-9220-4a50-80cb-05f40dda4d56.31662c6c-e523-4cec-a542-be4c75966379.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiMDU3YzAzMGYtY2YzZC00YTU5LWFiOWMtMjMyZGQ2YzU5Yzk1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJzaWQiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJzdGF0ZV9jaGVja2VyIjoiRFh0YjJEOGQ5dlllLUVQOXNIX0VrUEF5c1djRHhKWkkzSmtOeXRZN2JORSJ9.GsHy8cchXjipE65JeTcx_FBEzEpmfwSMKK9ThLoNKxQ;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMzlhZjcwODctMGUxMy00Y2M3LTk4NDMtYTJhZTRlZGUwMmY5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJzaWQiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJzdGF0ZV9jaGVja2VyIjoicHJRc1VuVlpvUjRhMVBOZUs0QWEzZGtqT3c1WnoxVFJVUEtaS0lmUjZ0USJ9.qZ7UvG5SHdiAT_SjULpn0oNOW8mI9ghE0Z2KDOowlV4;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiMDU3YzAzMGYtY2YzZC00YTU5LWFiOWMtMjMyZGQ2YzU5Yzk1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJzaWQiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJzdGF0ZV9jaGVja2VyIjoiRFh0YjJEOGQ5dlllLUVQOXNIX0VrUEF5c1djRHhKWkkzSmtOeXRZN2JORSJ9.GsHy8cchXjipE65JeTcx_FBEzEpmfwSMKK9ThLoNKxQ;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiMzlhZjcwODctMGUxMy00Y2M3LTk4NDMtYTJhZTRlZGUwMmY5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJzaWQiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJzdGF0ZV9jaGVja2VyIjoicHJRc1VuVlpvUjRhMVBOZUs0QWEzZGtqT3c1WnoxVFJVUEtaS0lmUjZ0USJ9.qZ7UvG5SHdiAT_SjULpn0oNOW8mI9ghE0Z2KDOowlV4;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:28 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/31662c6c-e523-4cec-a542-be4c75966379;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:33 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:28 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/31662c6c-e523-4cec-a542-be4c75966379;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:33 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=31303dad-64a1-411e-ba37-05af64b74699.11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-bewindvoering-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=ca7ecfb7-9220-4a50-80cb-05f40dda4d56.31662c6c-e523-4cec-a542-be4c75966379.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '299'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiJjYzQwM2JjMC1kZjNjLTQxNGYtYmFjMC1hYTFhZjAyNmQ2ZmEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjExYjZmNjkyLTVlNGItNGNkNi1hNGNlLTRmMWUxMDdiOWZjMyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjExYjZmNjkyLTVlNGItNGNkNi1hNGNlLTRmMWUxMDdiOWZjMyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.lPtG_jHvRCbSayXZeGHRTNXU9r9-EiPV2ebgB9j3bltgowXCiC2wJsT93rYYiEoVieueKaISrRj3XyhVboDfatSEB5BP-Nww-nTdE7CvhSZz2lVYQfz8yXs68pqJ232fR5UCR34jVGnksTRlEUsLvSbiBYfgTQ9lK26RioHFkMUonR4IcCIo2EZskpZ3Pa5kchzK28aZX1IrMdlwsspVYoOBMRQlfkfVTxnJbKSMZ7A0kFzWIcYqFcG0RL5_CeoUxfRpRflgrsIovDX_9uYk8Kcc-K6DlIqW0Jw9smOE0Ykiin53tOjCWrWHCA09i_8OaR_kxRP3OEx8gfkrdI0l4g","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiNGYwZjRiMGMtN2JlNy00NmRiLTg4NTItNjE1N2QzNDQ4NjRmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMTFiNmY2OTItNWU0Yi00Y2Q2LWE0Y2UtNGYxZTEwN2I5ZmMzIn0.NRKalgIXW86t3izy0bb4DWxNEaym25aZc8YAG7gjAuk","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiI2NGYxNWYwYS03NTMzLTRkNDItYjY5MC04NjI4MDQyMmRmYjMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJhdF9oYXNoIjoid2VnRXZaM0t3dUVuYXFSdzRaal96QSIsImFjciI6IjEiLCJzaWQiOiIxMWI2ZjY5Mi01ZTRiLTRjZDYtYTRjZS00ZjFlMTA3YjlmYzMiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.KvICKmWt_CWjsaG4sPaXf0jACgqr6T3VY9WMgZYpg88kvsb-hDENtEbwVnX-GXvJlqH3UHH_94tkRq2eW1ud9acCh0JXypjHoMmPXBCRRSq6YSDA7dbxaInZY9hDCr7l4-AnsrG0o-vUlk41S6J-zwkpR2h5fbrXmqQsWmElzEbaUwe0NVTIS_JKQOczyLIaoxzXRzSyU7ugr0HmpDc2ypbax4zZldUqBI8JACpkluMVIauSzsTk2zi819J8XlTsph9fjvyHkXZtuqo5peLzzqQcT8l_kqqPIsRmHIfhDxF8vKhIytu24Y89_VsDFe888oNChOF01SAjYJyUyHyLrw","not-before-policy":0,"session_state":"11b6f692-5e4b-4cd6-a4ce-4f1e107b9fc3","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiI4NWQ1NjFiNS04YTJkLTQ0YWUtYTMxNS1kYzA4YTNlZWQxZTkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjMxNjYyYzZjLWU1MjMtNGNlYy1hNTQyLWJlNGM3NTk2NjM3OSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjMxNjYyYzZjLWU1MjMtNGNlYy1hNTQyLWJlNGM3NTk2NjM3OSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.LjAqJ3dGRDMo0AC66vebo-rwJZHGNSnq6EHG2yHyN_MypRih3pdH9s7zwbMbaNb4CsJAIcXL3q0dZ9YRP-vdDBeF9T4Az-408RSxkLnECcy1yx0-nYdU96llokGxxHr2Vo56MPTCTWaC4EJt3Zzyz3J6n7vBoduggQ1lUxLSWwLSS3hEq8f5GC4HkutPdvXaiJYz2JvMovWgZ7jJhtaou3xr2qKdnDWTOzcUeJcDaKmPjocpd6VyeHBoCcALeKaJ468IKoOm_hyNn_yZZSy8ugvKPDcoiMcFBQMDjfxIlxegJkP9086OrYKV12KoDkeJCe2KVx5euRo0mgYQIcs95w","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTMsImlhdCI6MTczNDAzODMxMywianRpIjoiZGZmMDEzMDMtNTU4MS00ZjEwLWFlNmItOTgzM2FjODcxNjUxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMzE2NjJjNmMtZTUyMy00Y2VjLWE1NDItYmU0Yzc1OTY2Mzc5In0._lxSVodjlpKDq5QrMMtQ0Fp3RoF0x9tB9Ek_0MqmBhY","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiI5OGJmN2QyNy1hYmU5LTRiYzctODA1Yi04M2FiMmU4ZTNkYjQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJhdF9oYXNoIjoiRlU2WVZvUnFsRVN4T1lzQk5vVkh5USIsImFjciI6IjEiLCJzaWQiOiIzMTY2MmM2Yy1lNTIzLTRjZWMtYTU0Mi1iZTRjNzU5NjYzNzkiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.0V6cQGA15f15xm0MAht2Cp8dkKNZxEe88OrGk1Oe5zSZOkHUpzSN404kZP7HD3O2TnOOU-v8ms8b6tt7UiRGbyofowpHiG9DOHZTBwLNo2JEEVbt3QDR5pfbyqj4zd_fRUSeW3UmWzoKp2tTD5i_UHeNwLhTsZBwGsIGSFXZVjnq8uKxltRzEVUw342YpxoDE3lv415PYzuA6u_RBjjW6gSA13zDL2mN0OKRWra9gJmDLNpuIXyxl1IRfta9yMGAweiQxJJAE5BgdByVcxffs1UGdYn3wc25_oMsnPZs1lkMZFtsgxoXB_Z5MbxBkFI11tYyaulbJgqwtH4hzq-xUw","not-before-policy":0,"session_state":"31662c6c-e523-4cec-a542-be4c75966379","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiJjYzQwM2JjMC1kZjNjLTQxNGYtYmFjMC1hYTFhZjAyNmQ2ZmEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjExYjZmNjkyLTVlNGItNGNkNi1hNGNlLTRmMWUxMDdiOWZjMyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjExYjZmNjkyLTVlNGItNGNkNi1hNGNlLTRmMWUxMDdiOWZjMyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.lPtG_jHvRCbSayXZeGHRTNXU9r9-EiPV2ebgB9j3bltgowXCiC2wJsT93rYYiEoVieueKaISrRj3XyhVboDfatSEB5BP-Nww-nTdE7CvhSZz2lVYQfz8yXs68pqJ232fR5UCR34jVGnksTRlEUsLvSbiBYfgTQ9lK26RioHFkMUonR4IcCIo2EZskpZ3Pa5kchzK28aZX1IrMdlwsspVYoOBMRQlfkfVTxnJbKSMZ7A0kFzWIcYqFcG0RL5_CeoUxfRpRflgrsIovDX_9uYk8Kcc-K6DlIqW0Jw9smOE0Ykiin53tOjCWrWHCA09i_8OaR_kxRP3OEx8gfkrdI0l4g
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTMsImlhdCI6MTczNDAzODMxMywiYXV0aF90aW1lIjoxNzM0MDM4MzEzLCJqdGkiOiI4NWQ1NjFiNS04YTJkLTQ0YWUtYTMxNS1kYzA4YTNlZWQxZTkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjMxNjYyYzZjLWU1MjMtNGNlYy1hNTQyLWJlNGM3NTk2NjM3OSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjMxNjYyYzZjLWU1MjMtNGNlYy1hNTQyLWJlNGM3NTk2NjM3OSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.LjAqJ3dGRDMo0AC66vebo-rwJZHGNSnq6EHG2yHyN_MypRih3pdH9s7zwbMbaNb4CsJAIcXL3q0dZ9YRP-vdDBeF9T4Az-408RSxkLnECcy1yx0-nYdU96llokGxxHr2Vo56MPTCTWaC4EJt3Zzyz3J6n7vBoduggQ1lUxLSWwLSS3hEq8f5GC4HkutPdvXaiJYz2JvMovWgZ7jJhtaou3xr2qKdnDWTOzcUeJcDaKmPjocpd6VyeHBoCcALeKaJ468IKoOm_hyNn_yZZSy8ugvKPDcoiMcFBQMDjfxIlxegJkP9086OrYKV12KoDkeJCe2KVx5euRo0mgYQIcs95w
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringAuthContextTests/EHerkenningBewindvoeringAuthContextTests.test_record_auth_context.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringAuthContextTests/EHerkenningBewindvoeringAuthContextTests.test_record_auth_context.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"2125298b-ff65-47d1-a21c-b2a36f296967\",\n
-        \             \"g8vHRvTwOAA\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=g8vHRvTwOAA&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"b638a8d8-398d-46c9-a5f7-83f5d3c51df5\",\n
+        \             \"pihGKa9M0MI\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=pihGKa9M0MI&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=wWpR1TLMDj9EHkTUdBTf0qgMX-q7YBo4KxaEwnQ5vjo&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=g8vHRvTwOAA\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=0Ma6DBbqWS_fUDKAEZlkhmzl8IDmhHBQczUa67eRwQY&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=pihGKa9M0MI\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=2125298b-ff65-47d1-a21c-b2a36f296967; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=b638a8d8-398d-46c9-a5f7-83f5d3c51df5; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=2125298b-ff65-47d1-a21c-b2a36f296967; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=b638a8d8-398d-46c9-a5f7-83f5d3c51df5; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctYmV3aW5kdm9lcmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2VoZXJrZW5uaW5nLWJld2luZHZvZXJpbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.u5Tk3HYN6nuiTuyL-i5bvA4Pp-HF5ocM6alXi12axeg;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=2125298b-ff65-47d1-a21c-b2a36f296967; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctYmV3aW5kdm9lcmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2VoZXJrZW5uaW5nLWJld2luZHZvZXJpbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.u5Tk3HYN6nuiTuyL-i5bvA4Pp-HF5ocM6alXi12axeg
+      - AUTH_SESSION_ID_LEGACY=b638a8d8-398d-46c9-a5f7-83f5d3c51df5; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=wWpR1TLMDj9EHkTUdBTf0qgMX-q7YBo4KxaEwnQ5vjo&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=g8vHRvTwOAA
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=0Ma6DBbqWS_fUDKAEZlkhmzl8IDmhHBQczUa67eRwQY&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=pihGKa9M0MI
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=2125298b-ff65-47d1-a21c-b2a36f296967&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=df0cb286-0b46-4d97-85ba-f0953ec86278.2125298b-ff65-47d1-a21c-b2a36f296967.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=b638a8d8-398d-46c9-a5f7-83f5d3c51df5&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=e050b90f-d7b8-4d75-b2ab-abff66ddb0e9.b638a8d8-398d-46c9-a5f7-83f5d3c51df5.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiYjljNmNiOGUtNGIyYS00M2YzLTk3NWYtYjc1MzFhNGMzZjFhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJzaWQiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJzdGF0ZV9jaGVja2VyIjoiS29FbWVBajJySVA3RUg2QVdEQTRBSTdNLWlOSmFFX0NpZzJLMGFRbHlKOCJ9.tfgDluuE7SVz85rWLmQ5jGcTd680jGt15siszRJham0;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiNDA2MDg3MTUtZmUxYS00ODk1LWJmYWQtNmI2OTdiZDc2ZDcyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJzaWQiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJzdGF0ZV9jaGVja2VyIjoiUlBoSjZxa2lMSkFWbjc5MEpyRm9CTGVUWXRjVWlqNWFDXzVrS09vM291WSJ9.BCWjz2jkwj5gkIYKW33Wyy71wDiZNV6QVCxEHeebPnQ;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiYjljNmNiOGUtNGIyYS00M2YzLTk3NWYtYjc1MzFhNGMzZjFhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJzaWQiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJzdGF0ZV9jaGVja2VyIjoiS29FbWVBajJySVA3RUg2QVdEQTRBSTdNLWlOSmFFX0NpZzJLMGFRbHlKOCJ9.tfgDluuE7SVz85rWLmQ5jGcTd680jGt15siszRJham0;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiNDA2MDg3MTUtZmUxYS00ODk1LWJmYWQtNmI2OTdiZDc2ZDcyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJzaWQiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJzdGF0ZV9jaGVja2VyIjoiUlBoSjZxa2lMSkFWbjc5MEpyRm9CTGVUWXRjVWlqNWFDXzVrS09vM291WSJ9.BCWjz2jkwj5gkIYKW33Wyy71wDiZNV6QVCxEHeebPnQ;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/2125298b-ff65-47d1-a21c-b2a36f296967;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:28 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/b638a8d8-398d-46c9-a5f7-83f5d3c51df5;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/2125298b-ff65-47d1-a21c-b2a36f296967;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:28 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/b638a8d8-398d-46c9-a5f7-83f5d3c51df5;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=df0cb286-0b46-4d97-85ba-f0953ec86278.2125298b-ff65-47d1-a21c-b2a36f296967.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-bewindvoering-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=e050b90f-d7b8-4d75-b2ab-abff66ddb0e9.b638a8d8-398d-46c9-a5f7-83f5d3c51df5.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '299'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiI1ZmRjMjAzZS0xZTY0LTRhNTEtYTA5Yy0yNGFmOGM0MzVlZGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjIxMjUyOThiLWZmNjUtNDdkMS1hMjFjLWIyYTM2ZjI5Njk2NyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjIxMjUyOThiLWZmNjUtNDdkMS1hMjFjLWIyYTM2ZjI5Njk2NyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.hEhNBxFd7paGiSPW2zkelrVPiLHagafwTKjU7a0dCdBPQIIOjl8YPrUGFHxktFFfN3Gj7e75ymRKj6WshlRwga1zMYc0TcXVXsRbIxXBYegOtN8V3bOoyxSodf2GLmbD9cYolZ5CwSR_jueyOXXmfppgdsNy1VA5YHKzWds-IkqJOFd9JbvvLjthbspEHOEWnxnt3ixov1cdR3S5suMGqvqyaZ7v2y7tuzbiLNhs6R6hBBqU_yw9DGBQvTIYmoYeJsC-dqLWKNXOkfKD92b_iQZR2XfEOovwtguR9RASklNCLWorkyJVYem7SPAwZ15TYa5zbB6so1txvsw0PlP-SQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiYzc5MDJmMzMtYjA3Yi00MDQ0LTg1MTAtOGYzZjIxMTE1YjUxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMjEyNTI5OGItZmY2NS00N2QxLWEyMWMtYjJhMzZmMjk2OTY3In0.YYkYX5vwLLgutWxht0LLcoqh1xbjLMlT70gTtPnDXpo","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiI1ODJjZWUyZC1iZjFiLTQxYTYtOTY5Ny0zMWM1MTFhZjJiOWUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJhdF9oYXNoIjoiQzcxU0o3X1VTTzlVbkhBLUJtSks5ZyIsImFjciI6IjEiLCJzaWQiOiIyMTI1Mjk4Yi1mZjY1LTQ3ZDEtYTIxYy1iMmEzNmYyOTY5NjciLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.qV6ByCFUCsyKAnp2MZ4lf9rlCM0E7Kq_WcB8294iZPqI3WJ3aBpyDaHpouIl8A6yBWAc1oO4Do5YXVFZob8SR5ElUoyXd91dAaS6jA-KDBejv_2TtvAsgp7G8ruPjHmGUeeTZdPtu6tOoIcAzQ8uDrvyC_Vqzc8m3iKqEYQcPojHxhlGh_zoZyROlkD2JdShDs4rC8TR7RpP7WiG8FsonlQT9ycclqxontQq5wddBGlCNfIz7IEMJ83Nzd2sWT0G4adu6SxKphQU_98S_D8_8JHPPm1GqkaRil8v1Vi657SbKyl5zsVSmGPS8sxB3SltAKO8TEYdNfMuzWACgwPU7g","not-before-policy":0,"session_state":"2125298b-ff65-47d1-a21c-b2a36f296967","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiJmNmFjNmY1YS1hNmVlLTQ1MjctODFjYi00YmE5MGE2MTFkMjAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImI2MzhhOGQ4LTM5OGQtNDZjOS1hNWY3LTgzZjVkM2M1MWRmNSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImI2MzhhOGQ4LTM5OGQtNDZjOS1hNWY3LTgzZjVkM2M1MWRmNSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.B0ILbndv9nyJNLEOP8hl2ATfi6gS9IT_WN01t55CUPCH4aJcCLqaEJ6c53oqSNPSUJ7zUTxPkKaXa1152lZoXbblYCzk5QsmECOOKeOjkq7UDeJKfyjGk7xwQQ7d2xG-2688wn-hqk44Cr-fTyYXpJeAcVdgHg3p9i7biZQ_X7lQJY-QHj_COdkcevBIWfDCu5unuUWuGAEVcZPLZYkIEFKkIcVcNaHNl-3ygOsA5nUKlTnsgLJPqnIEf36BraKpQpvdBdiWadFVwaaxyy94Fw-vCWC4ftkfuxS5UiiZTtkNX39mclVmYT8JeYmCcIWz7THwg4RlWZ4NptRktith0Q","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiNDRmMzY1NzgtYWRjOC00NDkzLWFkOWMtMDFlNGYwNDVmZDk4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYjYzOGE4ZDgtMzk4ZC00NmM5LWE1ZjctODNmNWQzYzUxZGY1In0.2rasDtBYvnSRBFZRXN3zeGEEvEaM3NUZJNsrFraifIw","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiJkZGYyZjYyYi1lODk1LTQ2OTgtYTJhMi03MGQ4ZmExMDVkYWUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJhdF9oYXNoIjoiN3dVM0YtaVBMeEdpY2NVNHRCVENTdyIsImFjciI6IjEiLCJzaWQiOiJiNjM4YThkOC0zOThkLTQ2YzktYTVmNy04M2Y1ZDNjNTFkZjUiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.ZZg5aETxLza5D1UKIR4gSqsKsrsaKlTsWs9LPN-_K6W1ax-MOZB83samWSxdHVrrPCFpg8Pa_AD6IfGyG5_2JX0d1_OrP7ig1T3lDxdIobAXOJtAsERvuQ8D2LiwnjcpTxaX7ad9AfUSJgARLaxux-IqXM3mgKzjhTli-Jd4JK-QwAfbuxjuUREoIldfRUpub-nSdcTDIWXTJ6S1wXNx78YVrL2NegJfPXOPbWVpMcQyBYpET3p6Vs9bm6Rd7gUi50W38rPF0yDfGaAxGIMyzWSHCmfJx0SUSsvnDnD7-sl_h63pCTbF9UVAJEjoXrwglKsCDQu_CHNDiKHxAhiNLw","not-before-policy":0,"session_state":"b638a8d8-398d-46c9-a5f7-83f5d3c51df5","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiI1ZmRjMjAzZS0xZTY0LTRhNTEtYTA5Yy0yNGFmOGM0MzVlZGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjIxMjUyOThiLWZmNjUtNDdkMS1hMjFjLWIyYTM2ZjI5Njk2NyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjIxMjUyOThiLWZmNjUtNDdkMS1hMjFjLWIyYTM2ZjI5Njk2NyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.hEhNBxFd7paGiSPW2zkelrVPiLHagafwTKjU7a0dCdBPQIIOjl8YPrUGFHxktFFfN3Gj7e75ymRKj6WshlRwga1zMYc0TcXVXsRbIxXBYegOtN8V3bOoyxSodf2GLmbD9cYolZ5CwSR_jueyOXXmfppgdsNy1VA5YHKzWds-IkqJOFd9JbvvLjthbspEHOEWnxnt3ixov1cdR3S5suMGqvqyaZ7v2y7tuzbiLNhs6R6hBBqU_yw9DGBQvTIYmoYeJsC-dqLWKNXOkfKD92b_iQZR2XfEOovwtguR9RASklNCLWorkyJVYem7SPAwZ15TYa5zbB6so1txvsw0PlP-SQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiJmNmFjNmY1YS1hNmVlLTQ1MjctODFjYi00YmE5MGE2MTFkMjAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImI2MzhhOGQ4LTM5OGQtNDZjOS1hNWY3LTgzZjVkM2M1MWRmNSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImI2MzhhOGQ4LTM5OGQtNDZjOS1hNWY3LTgzZjVkM2M1MWRmNSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.B0ILbndv9nyJNLEOP8hl2ATfi6gS9IT_WN01t55CUPCH4aJcCLqaEJ6c53oqSNPSUJ7zUTxPkKaXa1152lZoXbblYCzk5QsmECOOKeOjkq7UDeJKfyjGk7xwQQ7d2xG-2688wn-hqk44Cr-fTyYXpJeAcVdgHg3p9i7biZQ_X7lQJY-QHj_COdkcevBIWfDCu5unuUWuGAEVcZPLZYkIEFKkIcVcNaHNl-3ygOsA5nUKlTnsgLJPqnIEf36BraKpQpvdBdiWadFVwaaxyy94Fw-vCWC4ftkfuxS5UiiZTtkNX39mclVmYT8JeYmCcIWz7THwg4RlWZ4NptRktith0Q
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringAuthContextTests/EHerkenningBewindvoeringAuthContextTests.test_record_vestiging_restriction.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringAuthContextTests/EHerkenningBewindvoeringAuthContextTests.test_record_vestiging_restriction.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"c1482102-af60-4e9b-b58f-f72311e5da9c\",\n
-        \             \"UIHcQZqchiw\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=UIHcQZqchiw&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"92c78e2d-1e48-4a0b-8179-ff6a7f04c54a\",\n
+        \             \"E9pC3l4YIEs\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=E9pC3l4YIEs&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=x_5lxl53jBr9G5LthUzqNjECycwcXuci0facCh4m6e4&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=UIHcQZqchiw\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=S8vuATBKHa3IvhtJ1Ul-VY7jGPCXqWjPBr5Rnb75EPE&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=E9pC3l4YIEs\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=c1482102-af60-4e9b-b58f-f72311e5da9c; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=92c78e2d-1e48-4a0b-8179-ff6a7f04c54a; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=c1482102-af60-4e9b-b58f-f72311e5da9c; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=92c78e2d-1e48-4a0b-8179-ff6a7f04c54a; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctYmV3aW5kdm9lcmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2VoZXJrZW5uaW5nLWJld2luZHZvZXJpbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.u5Tk3HYN6nuiTuyL-i5bvA4Pp-HF5ocM6alXi12axeg;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=c1482102-af60-4e9b-b58f-f72311e5da9c; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvZWhlcmtlbm5pbmctYmV3aW5kdm9lcmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2VoZXJrZW5uaW5nLWJld2luZHZvZXJpbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.u5Tk3HYN6nuiTuyL-i5bvA4Pp-HF5ocM6alXi12axeg
+      - AUTH_SESSION_ID_LEGACY=92c78e2d-1e48-4a0b-8179-ff6a7f04c54a; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGJzbiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwL2F1dGgvb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.OYXY1p3ggO1AOEAPHI0QAaLoOozQg8I7q4iivB0xF6A
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=x_5lxl53jBr9G5LthUzqNjECycwcXuci0facCh4m6e4&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=UIHcQZqchiw
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=S8vuATBKHa3IvhtJ1Ul-VY7jGPCXqWjPBr5Rnb75EPE&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=E9pC3l4YIEs
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://localhost:8000/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=c1482102-af60-4e9b-b58f-f72311e5da9c&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=db595192-adf0-4b87-b0a9-c3774eeeaf42.c1482102-af60-4e9b-b58f-f72311e5da9c.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://localhost:8000/auth/oidc/callback/?state=not-a-random-string&session_state=92c78e2d-1e48-4a0b-8179-ff6a7f04c54a&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=610a0e42-d567-4db7-a6d0-3611f5e9f14b.92c78e2d-1e48-4a0b-8179-ff6a7f04c54a.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiNWI3NTM0NWItZmVkNy00MWU2LTg1YzgtMjc2ZGZjYmIzMmQ0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJzaWQiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJzdGF0ZV9jaGVja2VyIjoiSG1zMUtnUGNoakE0ZnFGTGQwMzNvNXFTa25rTEJhZS1FWHAzT2hwcFFFTSJ9.nbAQB3okAov7uueEFNWrnf8BP4J6uX3aDqVJXjUB9pc;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiN2NjZTIxZWItMWI3My00MDA2LWJkZjktZWIzYjE4NTI0MTk2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJzaWQiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJzdGF0ZV9jaGVja2VyIjoiUzM5Wmg5dU5iQ2ZNalA2QUlaRHpFVlJOeEd4dDZqYmdyTTZhTXE1T3JONCJ9.kN6xGOepzDcpCLACx_w9vctoydodZ2WRmXHF78TcgdE;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiNWI3NTM0NWItZmVkNy00MWU2LTg1YzgtMjc2ZGZjYmIzMmQ0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJzaWQiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJzdGF0ZV9jaGVja2VyIjoiSG1zMUtnUGNoakE0ZnFGTGQwMzNvNXFTa25rTEJhZS1FWHAzT2hwcFFFTSJ9.nbAQB3okAov7uueEFNWrnf8BP4J6uX3aDqVJXjUB9pc;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiN2NjZTIxZWItMWI3My00MDA2LWJkZjktZWIzYjE4NTI0MTk2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJzaWQiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJzdGF0ZV9jaGVja2VyIjoiUzM5Wmg5dU5iQ2ZNalA2QUlaRHpFVlJOeEd4dDZqYmdyTTZhTXE1T3JONCJ9.kN6xGOepzDcpCLACx_w9vctoydodZ2WRmXHF78TcgdE;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/c1482102-af60-4e9b-b58f-f72311e5da9c;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:28 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/92c78e2d-1e48-4a0b-8179-ff6a7f04c54a;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/c1482102-af60-4e9b-b58f-f72311e5da9c;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:28 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/44be45f6-a7ae-42c2-9486-30f078cf5b39/92c78e2d-1e48-4a0b-8179-ff6a7f04c54a;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:34 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=db595192-adf0-4b87-b0a9-c3774eeeaf42.c1482102-af60-4e9b-b58f-f72311e5da9c.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Feherkenning-bewindvoering-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=610a0e42-d567-4db7-a6d0-3611f5e9f14b.92c78e2d-1e48-4a0b-8179-ff6a7f04c54a.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '299'
+      - '280'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiI4MGRmZDdiZC1iZGJjLTQzNzItYmU3Ni03OTI4NGZkMjc5ZWUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMxNDgyMTAyLWFmNjAtNGU5Yi1iNThmLWY3MjMxMWU1ZGE5YyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMxNDgyMTAyLWFmNjAtNGU5Yi1iNThmLWY3MjMxMWU1ZGE5YyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.yi7ytVoilOflKkBd_qzL1jvyucjUjLYImCKzBocv0TSsjsVJz9v5tnFe9yE1Q_9E1FVQDliLGKVTycwuMS6b011Y3yGUO3QwgBsy7Eu3XadEKK1vG4qwRZKwmkcGAJFWNBFTkQAChUrrPP0ZQTSWwW3-YdASyK6vTGzS9UnQ8LWIHIjhNPdzYunVBiETX1ARlFUFKKwTXeJdi9PQKp8r0WhQmZ7q0IXpFlSyxpnFAaVKH1gh_27bGXn47kT6jtazZ35OGh-d-CNfc-tHQj-Ho_VsltoEWzgK7KMq-rkpUoO_63pAQZ6K2Y2l32rn8piwKMMi6Do3XVhoVzGAgA7BAw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2ODgsImlhdCI6MTczMjYxNTg4OCwianRpIjoiN2Y2NmQzMjUtNTdkNS00ZGZkLTg2NmQtMmJjYTc0YWIwNTQyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYzE0ODIxMDItYWY2MC00ZTliLWI1OGYtZjcyMzExZTVkYTljIn0.UxmTXgSEnPxZCPK0cZ6HQeoJJhQzvuXJ9DhEMH88d4k","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiJkMDY0ZmNhMy0wMjJkLTRmZTgtYTRhYy1mY2YxOWFkN2ZjNTUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI0NGJlNDVmNi1hN2FlLTQyYzItOTQ4Ni0zMGYwNzhjZjViMzkiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJhdF9oYXNoIjoiazhmR3NURG9MNFJOZjJwMkU4Qm53ZyIsImFjciI6IjEiLCJzaWQiOiJjMTQ4MjEwMi1hZjYwLTRlOWItYjU4Zi1mNzIzMTFlNWRhOWMiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy12ZXN0aWdpbmciLCJ2ZXN0aWdpbmciOiIxMjM0NTY3ODkwMTIifQ.PzOXvPuVp0wddpDuWkdxspAefYkWPOaW61DZtDCI9KsW4c5XfMCnoeaM_WXC-_6V_csb2pOozz8az8VuWi6CaWghXDQI-P-eBguuaLojrGLR4zbwROYzrfc850618oPmobG-nbH43tLkGik7jqmC9cpwg7twHImemZOFhW555vUIp3LY0ZSjemzc7Km3q47iAATQO7ozxI-fmmcwypK5KYgkfvoshgUGLf3KotxQpbpHKHvKVQU3MuY7ha2oLXkGFHch2b0574E5FwNGzcJZT-nFi9fA0tRSRN3h95xe1UL7o2FltAGEXYSelgGD81BszYn9PtxYEv2R8K6EXgZY2A","not-before-policy":0,"session_state":"c1482102-af60-4e9b-b58f-f72311e5da9c","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiI2ZTI4MGJmMy0zZjEwLTQwYTItOWY2My0yNWY1OWYzYjllODQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjkyYzc4ZTJkLTFlNDgtNGEwYi04MTc5LWZmNmE3ZjA0YzU0YSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjkyYzc4ZTJkLTFlNDgtNGEwYi04MTc5LWZmNmE3ZjA0YzU0YSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.Mn4zGABh_rHHwIMQdb5y77IBRZqUj9XYLDLArAp9qiOFAZjx870y0gFiu0lL7qPaChSPZatEsbL4KgmPrwBLB2natuuNO51dhu3JalVY2IgbJDJT7RHPzZ058O_YTgPUDYudht5kH2JE7ruHD0GxYO-tcZkEFFETdpLaiPn43FvC7tDlQitpaXFRZqkWepEpe93d7-BYQa_MsiMpoSEuEO5O4NyxzyCSM-UG9Rl5xTfLrRAbbmO_zVQYYR9VD2sYUUooGnVw1sd0rZbecDF_gt4Z7eMMIQ3Qr28-1qUE9Gg6N3HvWKFCYwX8PdTO22yCJn92Qz8NjvN0xdY5u1-18A","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTQsImlhdCI6MTczNDAzODMxNCwianRpIjoiZGQ4OTE3ZGMtYWM4My00MGJkLWFlNTgtMWNlOGJjZmM2Yjg0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOTJjNzhlMmQtMWU0OC00YTBiLTgxNzktZmY2YTdmMDRjNTRhIn0.pTu3E3GcfKfvHJeDPd5fFHGURrL0C-VmuV6fvkiCdc0","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiIyOGMzMzA2ZC0zNzRjLTQ5ZGQtOGZiOS04OTE1ZThiNmQ1NDIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI0NGJlNDVmNi1hN2FlLTQyYzItOTQ4Ni0zMGYwNzhjZjViMzkiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJhdF9oYXNoIjoiTk9PNEVPOWdYNkZHNlEzdVFRa1djZyIsImFjciI6IjEiLCJzaWQiOiI5MmM3OGUyZC0xZTQ4LTRhMGItODE3OS1mZjZhN2YwNGM1NGEiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy12ZXN0aWdpbmciLCJ2ZXN0aWdpbmciOiIxMjM0NTY3ODkwMTIifQ.0S-MLcHkFRcccM6TSHrfN4xHxbpynTyAFWrgcA8FvZG6y4LwMMuWBPw6L1vpH1pmvUAA_08y7EV-MGTZ1d2K020wSU6nhybmD_kiwC8nkEj2dqwWy6L3IN1TTPUzNUjmWk8y5G22UDiuOe7LMRRCjQVGiMhHGYJrHJo4KsTISSdJoWuZ1D9tR6Z8QL_aEIp3ay2x51H76oxNgHuxDaUxowiCmWsYowDZEQUkcXY5OLNSTx7nNLMlDhlYvgEEEV0UDe4Kt-LKr_OrntPi5-nlqTx3mdUWMRqEqDfygClns2y1y669GqNgNOHAyICFNqkGGsHdVhNc21LiEmFAMZhPeA","not-before-policy":0,"session_state":"92c78e2d-1e48-4a0b-8179-ff6a7f04c54a","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxODgsImlhdCI6MTczMjYxNTg4OCwiYXV0aF90aW1lIjoxNzMyNjE1ODg4LCJqdGkiOiI4MGRmZDdiZC1iZGJjLTQzNzItYmU3Ni03OTI4NGZkMjc5ZWUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMxNDgyMTAyLWFmNjAtNGU5Yi1iNThmLWY3MjMxMWU1ZGE5YyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMxNDgyMTAyLWFmNjAtNGU5Yi1iNThmLWY3MjMxMWU1ZGE5YyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.yi7ytVoilOflKkBd_qzL1jvyucjUjLYImCKzBocv0TSsjsVJz9v5tnFe9yE1Q_9E1FVQDliLGKVTycwuMS6b011Y3yGUO3QwgBsy7Eu3XadEKK1vG4qwRZKwmkcGAJFWNBFTkQAChUrrPP0ZQTSWwW3-YdASyK6vTGzS9UnQ8LWIHIjhNPdzYunVBiETX1ARlFUFKKwTXeJdi9PQKp8r0WhQmZ7q0IXpFlSyxpnFAaVKH1gh_27bGXn47kT6jtazZ35OGh-d-CNfc-tHQj-Ho_VsltoEWzgK7KMq-rkpUoO_63pAQZ6K2Y2l32rn8piwKMMi6Do3XVhoVzGAgA7BAw
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTQsImlhdCI6MTczNDAzODMxNCwiYXV0aF90aW1lIjoxNzM0MDM4MzE0LCJqdGkiOiI2ZTI4MGJmMy0zZjEwLTQwYTItOWY2My0yNWY1OWYzYjllODQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNDRiZTQ1ZjYtYTdhZS00MmMyLTk0ODYtMzBmMDc4Y2Y1YjM5IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjkyYzc4ZTJkLTFlNDgtNGEwYi04MTc5LWZmNmE3ZjA0YzU0YSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjkyYzc4ZTJkLTFlNDgtNGEwYi04MTc5LWZmNmE3ZjA0YzU0YSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLXZlc3RpZ2luZyIsInZlc3RpZ2luZyI6IjEyMzQ1Njc4OTAxMiJ9.Mn4zGABh_rHHwIMQdb5y77IBRZqUj9XYLDLArAp9qiOFAZjx870y0gFiu0lL7qPaChSPZatEsbL4KgmPrwBLB2natuuNO51dhu3JalVY2IgbJDJT7RHPzZ058O_YTgPUDYudht5kH2JE7ruHD0GxYO-tcZkEFFETdpLaiPn43FvC7tDlQitpaXFRZqkWepEpe93d7-BYQa_MsiMpoSEuEO5O4NyxzyCSM-UG9Rl5xTfLrRAbbmO_zVQYYR9VD2sYUUooGnVw1sd0rZbecDF_gt4Z7eMMIQ3Qr28-1qUE9Gg6N3HvWKFCYwX8PdTO22yCJn92Qz8NjvN0xdY5u1-18A
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_eherkenning_error_reported_for_cancelled_login_anon_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_eherkenning_error_reported_for_cancelled_login_anon_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/eherkenning-bewindvoering-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_eherkenning_error_reported_for_cancelled_login_with_staff_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_eherkenning_error_reported_for_cancelled_login_with_staff_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/eherkenning-bewindvoering-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_failing_claim_verification.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_failing_claim_verification.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"c67f5c14-026c-4c76-ab37-fbb4a662a3f3\",\n
-        \             \"FgtOtyhttU8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=FgtOtyhttU8&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"43212618-3886-4881-9471-c35116a77868\",\n
+        \             \"KY-qZCJKJ1Q\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=KY-qZCJKJ1Q&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=tmmOhq7XsOwMLqLKjYX2UEguHoE866mwXY6rTcd7Llk&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=FgtOtyhttU8\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=xVxWzb3XCc1y4VebgsyQ3uMyQKfNGBaOsuMBvrSZ8vc&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=KY-qZCJKJ1Q\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=c67f5c14-026c-4c76-ab37-fbb4a662a3f3; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=43212618-3886-4881-9471-c35116a77868; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=c67f5c14-026c-4c76-ab37-fbb4a662a3f3; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=43212618-3886-4881-9471-c35116a77868; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=c67f5c14-026c-4c76-ab37-fbb4a662a3f3; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro
+      - AUTH_SESSION_ID_LEGACY=43212618-3886-4881-9471-c35116a77868; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=tmmOhq7XsOwMLqLKjYX2UEguHoE866mwXY6rTcd7Llk&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=FgtOtyhttU8
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=xVxWzb3XCc1y4VebgsyQ3uMyQKfNGBaOsuMBvrSZ8vc&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=KY-qZCJKJ1Q
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=c67f5c14-026c-4c76-ab37-fbb4a662a3f3&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=8797d666-2a27-44aa-8917-0067d3990ee0.c67f5c14-026c-4c76-ab37-fbb4a662a3f3.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=43212618-3886-4881-9471-c35116a77868&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=4c635ad4-5a63-4cf8-a87b-93e01ab69bcb.43212618-3886-4881-9471-c35116a77868.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTIsImlhdCI6MTczMjYxNTg5MiwianRpIjoiYTliZmUyZmEtNzRkZC00NjUxLWFlYWMtZjJkZWNlZTdhNDdkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJzaWQiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJzdGF0ZV9jaGVja2VyIjoiWm5KS080c2RMek9uX3FRdVVLMFZzbjlVNWdZYTBFVXJ3OXNBMGZpQ2s1ZyJ9.BpssHfzxRknhm8c7ssBvmMQn7vHxPhzougRogp2leLM;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiNTdmNTJjNGMtNWM0ZC00N2U0LThkNWMtYzVlZmQ4NjYwOGU1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJzaWQiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJzdGF0ZV9jaGVja2VyIjoiVUhPendEcXNzNm95YVVoWlJUNERWUGE2WWJpQzlQM0VERkYwa2hTTkt0VSJ9.ZzkKs68iDcfkbVp_kDl4N3x3489fOBY18-_4at6-3TA;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTIsImlhdCI6MTczMjYxNTg5MiwianRpIjoiYTliZmUyZmEtNzRkZC00NjUxLWFlYWMtZjJkZWNlZTdhNDdkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJzaWQiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJzdGF0ZV9jaGVja2VyIjoiWm5KS080c2RMek9uX3FRdVVLMFZzbjlVNWdZYTBFVXJ3OXNBMGZpQ2s1ZyJ9.BpssHfzxRknhm8c7ssBvmMQn7vHxPhzougRogp2leLM;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiNTdmNTJjNGMtNWM0ZC00N2U0LThkNWMtYzVlZmQ4NjYwOGU1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJzaWQiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJzdGF0ZV9jaGVja2VyIjoiVUhPendEcXNzNm95YVVoWlJUNERWUGE2WWJpQzlQM0VERkYwa2hTTkt0VSJ9.ZzkKs68iDcfkbVp_kDl4N3x3489fOBY18-_4at6-3TA;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/c67f5c14-026c-4c76-ab37-fbb4a662a3f3;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:32 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/43212618-3886-4881-9471-c35116a77868;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:36 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/c67f5c14-026c-4c76-ab37-fbb4a662a3f3;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:32 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/43212618-3886-4881-9471-c35116a77868;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:36 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=8797d666-2a27-44aa-8917-0067d3990ee0.c67f5c14-026c-4c76-ab37-fbb4a662a3f3.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=4c635ad4-5a63-4cf8-a87b-93e01ab69bcb.43212618-3886-4881-9471-c35116a77868.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '293'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTIsImlhdCI6MTczMjYxNTg5MiwiYXV0aF90aW1lIjoxNzMyNjE1ODkyLCJqdGkiOiI0NmI4MDljMi0zZDU3LTQ0NjgtYjVkYS1lZjViNDU4NzFhYjQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImM2N2Y1YzE0LTAyNmMtNGM3Ni1hYjM3LWZiYjRhNjYyYTNmMyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImM2N2Y1YzE0LTAyNmMtNGM3Ni1hYjM3LWZiYjRhNjYyYTNmMyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.Y4UuV7B8F2rdyJVF71GWlOFU7ix9lwHuEG_B7uMqJLfmT3AedJCF-YAj29QqkSKlp4iDgcl5gkFn8vfqpnyzAxHQfNbiYR7rh29kTvP_Bpys0Mpe0pwOVALbRZaDVHgQq-I79x7UM86d_27XXqz8B_9V5Y_fNABLtt4ICPqs7R20lZkkhBpBP_1JveExPeMKQH32j2zlBRPTLPMrq2ZJlG5-8zWhXiAFMfDS8DIAxZ3L2-CEJx7upTrvyJRf2JUNwoJWlIOepRJnkuGOMYe2YYfl-GYF6jMssJZ-tvXPTtjM3ywBBFISkK7wIVc7WjVnGpdy3RGNl-j8e9Y8VyVrqA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTIsImlhdCI6MTczMjYxNTg5MiwianRpIjoiZGNhNGY5NjQtMTMzYS00YTI4LWE0MjEtODEyZDFkNzgyODI2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYzY3ZjVjMTQtMDI2Yy00Yzc2LWFiMzctZmJiNGE2NjJhM2YzIn0.lVjTmG_4NDxoevlsm5gWaH4Od-YmRMngn__t6QN0Euw","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTIsImlhdCI6MTczMjYxNTg5MiwiYXV0aF90aW1lIjoxNzMyNjE1ODkyLCJqdGkiOiI2Njg5NGQyZS1mYjUzLTRiOTYtYjMzNy1lYTE3ZjA5ZmI2ZGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJhdF9oYXNoIjoiZ3BuUGVWd1ZOUC1sbHRUbEczWlA2ZyIsImFjciI6IjEiLCJzaWQiOiJjNjdmNWMxNC0wMjZjLTRjNzYtYWIzNy1mYmI0YTY2MmEzZjMiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.wMKuchKMwpmpouOk65qjrd1wAds3QLgqYqwAtJ2xlW6NRJikIkx7kzx2BRX0mFaMVTYfUrTL9AG5h8W7gQTaW4fOHiliq7C1_IAHgC7VcU3hh0s6m-W1Ue1_bn7KbJm9ePnME6ZpVfbolPoWpICMANSUJazOdu3WQtKdr4CT5wgRKy2baxJ02Vxoiv8Mtg3HVfRT6FpFKgYolPY6UxfBjVOvk1jZEmlgqLiyN1Ewv2Jbm1j396-w14E5nSjw5Ea_haCQsgxtjxDhTuxHgNk83n9EtQxicC7llDJ-Q6EWCuh1xJg_BjfXeAa5ii9ZecNY1reyy0udnSVpnvWS1KQWig","not-before-policy":0,"session_state":"c67f5c14-026c-4c76-ab37-fbb4a662a3f3","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiI4YjgwZGRiZi01NjI2LTQ2NTAtOGM2NC1kYTdhYjI2YTMzMzEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjQzMjEyNjE4LTM4ODYtNDg4MS05NDcxLWMzNTExNmE3Nzg2OCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjQzMjEyNjE4LTM4ODYtNDg4MS05NDcxLWMzNTExNmE3Nzg2OCIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.Sr9frotshCTdC6mfCK1tRVYm-BCSFTd45VUqiVnPN-iXRQaxR2slNy5TyWHRzXORwEm99H2BcxvAsHYnnQa6Wix6yyt5icSfZ0UhNiDKLLbKcy05izx_NcIVmL5CQypbOIrL8mLd4ozjB77F4TQejbc6JpeYRjWDqBnE-ahPHQof0cxMse_HOkQTeLqb8NecJzDPOUVugm_EHuqnBmSqZG6rQR4VPuObWYmX6Rkr-FZ4DOV67T7CYPOhJm-u5Sa4hjTpMdUJdaWcA3o26FRdl1kecLg9irDju_hc4zxsnq0FQbjLN8j4GHUzOzzur7tkHw5cv8Xc6B7OPOtcCCclgg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiMzA1NDA3MGMtNmEzNy00NmNjLWFmNGUtMTgyZGY2NTMyMzUyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNDMyMTI2MTgtMzg4Ni00ODgxLTk0NzEtYzM1MTE2YTc3ODY4In0.jMLOJsEcDjw32-UKGoTQhTe3qvx-ucgjCqPpknitFAQ","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiI2OGI0MjU5Ny03NjVjLTQyY2UtYTM3My1iNWYwMDk5M2M4MTYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJhdF9oYXNoIjoiRWprNERZOXdZZGdYbFlZanlxZ1pKdyIsImFjciI6IjEiLCJzaWQiOiI0MzIxMjYxOC0zODg2LTQ4ODEtOTQ3MS1jMzUxMTZhNzc4NjgiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.1OZSOq3gkBEbgW615ePy43OZj4EQWXuy7-n0F-9xvMSvteXwKcOGtofurBGVXcuvcwizf-v4_0j6P44zBHR8-p9Qp3fI435WtCypkD_XCA1y38v0x9n2V8_kkFX_qNQwWhckU65Au-kx8LhSDxvz_5UN4OvAOSVR4pTR3KKSm1QJ_SPHF_N8WkjOFkRsKL3QOK7NFMmNR6-TI0ZpHH7oQukazrjx7HHiICLEEBl_0UkOiRC6P7833A4W8BvzI9Ieu38X2bN7tRr6HhEaAbDCDC3rs_UjIgcWLyxPwvJwrfImilSq--fbPrJWioeLTi_dfaaJt7KmmQ7t7hDP-unxNg","not-before-policy":0,"session_state":"43212618-3886-4881-9471-c35116a77868","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTIsImlhdCI6MTczMjYxNTg5MiwiYXV0aF90aW1lIjoxNzMyNjE1ODkyLCJqdGkiOiI0NmI4MDljMi0zZDU3LTQ0NjgtYjVkYS1lZjViNDU4NzFhYjQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImM2N2Y1YzE0LTAyNmMtNGM3Ni1hYjM3LWZiYjRhNjYyYTNmMyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImM2N2Y1YzE0LTAyNmMtNGM3Ni1hYjM3LWZiYjRhNjYyYTNmMyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.Y4UuV7B8F2rdyJVF71GWlOFU7ix9lwHuEG_B7uMqJLfmT3AedJCF-YAj29QqkSKlp4iDgcl5gkFn8vfqpnyzAxHQfNbiYR7rh29kTvP_Bpys0Mpe0pwOVALbRZaDVHgQq-I79x7UM86d_27XXqz8B_9V5Y_fNABLtt4ICPqs7R20lZkkhBpBP_1JveExPeMKQH32j2zlBRPTLPMrq2ZJlG5-8zWhXiAFMfDS8DIAxZ3L2-CEJx7upTrvyJRf2JUNwoJWlIOepRJnkuGOMYe2YYfl-GYF6jMssJZ-tvXPTtjM3ywBBFISkK7wIVc7WjVnGpdy3RGNl-j8e9Y8VyVrqA
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiI4YjgwZGRiZi01NjI2LTQ2NTAtOGM2NC1kYTdhYjI2YTMzMzEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjQzMjEyNjE4LTM4ODYtNDg4MS05NDcxLWMzNTExNmE3Nzg2OCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjQzMjEyNjE4LTM4ODYtNDg4MS05NDcxLWMzNTExNmE3Nzg2OCIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.Sr9frotshCTdC6mfCK1tRVYm-BCSFTd45VUqiVnPN-iXRQaxR2slNy5TyWHRzXORwEm99H2BcxvAsHYnnQa6Wix6yyt5icSfZ0UhNiDKLLbKcy05izx_NcIVmL5CQypbOIrL8mLd4ozjB77F4TQejbc6JpeYRjWDqBnE-ahPHQof0cxMse_HOkQTeLqb8NecJzDPOUVugm_EHuqnBmSqZG6rQR4VPuObWYmX6Rkr-FZ4DOV67T7CYPOhJm-u5Sa4hjTpMdUJdaWcA3o26FRdl1kecLg9irDju_hc4zxsnq0FQbjLN8j4GHUzOzzur7tkHw5cv8Xc6B7OPOtcCCclgg
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_redirects_after_successful_auth.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringCallbackTests/EHerkenningBewindvoeringCallbackTests.test_redirects_after_successful_auth.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"ef5e1854-5e13-43e3-8858-34d27c09fbb0\",\n
-        \             \"fpyC-giG8iw\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=fpyC-giG8iw&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"da287aff-d3a0-492b-9064-05e29d603e1e\",\n
+        \             \"X4ooCD-J0p8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=X4ooCD-J0p8&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=xnoNhmWkd6uWiCGJlXHV-XD4PBXgc-2lO66D6nLMX0k&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=fpyC-giG8iw\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=09tGZ7vD9NY_P-ZZQRV_IQVMawl9w-x37AbKqgXqx3k&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=X4ooCD-J0p8\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=ef5e1854-5e13-43e3-8858-34d27c09fbb0; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=da287aff-d3a0-492b-9064-05e29d603e1e; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=ef5e1854-5e13-43e3-8858-34d27c09fbb0; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=da287aff-d3a0-492b-9064-05e29d603e1e; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=ef5e1854-5e13-43e3-8858-34d27c09fbb0; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro
+      - AUTH_SESSION_ID_LEGACY=da287aff-d3a0-492b-9064-05e29d603e1e; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=xnoNhmWkd6uWiCGJlXHV-XD4PBXgc-2lO66D6nLMX0k&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=fpyC-giG8iw
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=09tGZ7vD9NY_P-ZZQRV_IQVMawl9w-x37AbKqgXqx3k&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=X4ooCD-J0p8
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=ef5e1854-5e13-43e3-8858-34d27c09fbb0&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=9d5eb69c-697d-4d25-a095-1d1b27349651.ef5e1854-5e13-43e3-8858-34d27c09fbb0.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=da287aff-d3a0-492b-9064-05e29d603e1e&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=1cc16376-58af-4163-9562-b24a540786f9.da287aff-d3a0-492b-9064-05e29d603e1e.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTIsImlhdCI6MTczMjYxNTg5MiwianRpIjoiNzk1OGVmNzQtOTNmNC00MWEwLTg1MTQtOGEzYjQ3YjlmMGIwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJzaWQiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJzdGF0ZV9jaGVja2VyIjoiZS1hajNaVGRRVUpHSGtUb0piWVo2NS1NYUpBdjB4R1RZb1B4WVQxNXJRdyJ9.Wfc7nOgBoYZJBpvE2WJbzTOBFzEhblrNgL6JfdsUJqQ;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiZDgxNjE3YjItMzJjOC00YzM1LWFjNTAtNmZjNTI5N2ZkNDlmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJzaWQiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJzdGF0ZV9jaGVja2VyIjoiRjBabVNtZHhBUXhzNGUzVTdfelg1ZmwwZUhLblNuM3AwUkVPOGNfN2IzYyJ9.bKP14IixSkoJcaO28a_KDfkmd4Y0EZ7PiP-SUBKkWzI;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTIsImlhdCI6MTczMjYxNTg5MiwianRpIjoiNzk1OGVmNzQtOTNmNC00MWEwLTg1MTQtOGEzYjQ3YjlmMGIwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJzaWQiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJzdGF0ZV9jaGVja2VyIjoiZS1hajNaVGRRVUpHSGtUb0piWVo2NS1NYUpBdjB4R1RZb1B4WVQxNXJRdyJ9.Wfc7nOgBoYZJBpvE2WJbzTOBFzEhblrNgL6JfdsUJqQ;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiZDgxNjE3YjItMzJjOC00YzM1LWFjNTAtNmZjNTI5N2ZkNDlmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJzaWQiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJzdGF0ZV9jaGVja2VyIjoiRjBabVNtZHhBUXhzNGUzVTdfelg1ZmwwZUhLblNuM3AwUkVPOGNfN2IzYyJ9.bKP14IixSkoJcaO28a_KDfkmd4Y0EZ7PiP-SUBKkWzI;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/ef5e1854-5e13-43e3-8858-34d27c09fbb0;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:32 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/da287aff-d3a0-492b-9064-05e29d603e1e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:36 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/ef5e1854-5e13-43e3-8858-34d27c09fbb0;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:32 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/da287aff-d3a0-492b-9064-05e29d603e1e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:36 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=9d5eb69c-697d-4d25-a095-1d1b27349651.ef5e1854-5e13-43e3-8858-34d27c09fbb0.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=1cc16376-58af-4163-9562-b24a540786f9.da287aff-d3a0-492b-9064-05e29d603e1e.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '293'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTIsImlhdCI6MTczMjYxNTg5MiwiYXV0aF90aW1lIjoxNzMyNjE1ODkyLCJqdGkiOiJmNmY3NzYzOS0yODM0LTQ0MDctYWYyYy0yYTRiNzgzYTUxYzAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImVmNWUxODU0LTVlMTMtNDNlMy04ODU4LTM0ZDI3YzA5ZmJiMCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImVmNWUxODU0LTVlMTMtNDNlMy04ODU4LTM0ZDI3YzA5ZmJiMCIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.QRAe7gTX6aVxxWFS7kEeMZ9oF3kQYzuOtkKi9_ShOUapI35yuGkG0bQLa8BDiunWstfVbaOTJqgK5bl7UnyJoqpiPsK2BZccYFSV7MI4bmf5Gza61jVdz6Kx7PUXdYacTSq8TqCxt8u3aTKe4WdnuC56G4JvtK9BZ82spJWVooOq-CS0355IicnaWeb_2hQJ5qyLEXb6IkrdIQUmyJs7WNtaBJLGxMLOwKoflBVqqlKe0hNxIo0_mwjxZdsWyxVLNKgBAdqeQMgmEr65HGr3ip1-REDAyxGA3eSc7GGDl8TAzbr3N_YIspm-_KMRZprUqv8oxBAry0tiqrkuMq4tjg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTIsImlhdCI6MTczMjYxNTg5MiwianRpIjoiODY4MzMzOWEtMWEyNS00MjEyLThiZmYtNzFjMmY1NmE0YjYyIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZWY1ZTE4NTQtNWUxMy00M2UzLTg4NTgtMzRkMjdjMDlmYmIwIn0.qudk0mq_rCe0gZbEQXpT4S63UdrtJa08z47QFzWfR-Q","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTIsImlhdCI6MTczMjYxNTg5MiwiYXV0aF90aW1lIjoxNzMyNjE1ODkyLCJqdGkiOiJiOWQwN2NkMy0zZjVlLTQ0YTUtYTAwYi04MTU0NmM4NGIyZTAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJhdF9oYXNoIjoiXzd0Y1U1LWYtYW55dkx6ZGlJcDcxdyIsImFjciI6IjEiLCJzaWQiOiJlZjVlMTg1NC01ZTEzLTQzZTMtODg1OC0zNGQyN2MwOWZiYjAiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.Vt8uBj4hEAf4E9gVRdmLTWJIk2xQpXe34yQ6Dgw2uGOS1--AFZX4eaOV_Rw8xptIpkKJ5_Br64nEePkDGFY4caYTZDhrFNyW1XBXfkptUXodJ3mh-rpkD_ap2HiLezDQWEq7IGxVgxVF4zLPGplNKrcUrG4XpSLH8_wYHl2wc3BrnI3Q_ekXsXaQr0FiAwHjfRB7R3kNuM17lch-E22FR2gqfs26psvop5dp3Yk7O9RxpKCWN2AdZH8VfJe91qsUagvWjpXvvwki2GO4t_PNOxIxOz37glI8CGOtoJGrfZAmuinfSODn4zd0E8haVXgB11oDw7hYRbdhHBjZaaIMSg","not-before-policy":0,"session_state":"ef5e1854-5e13-43e3-8858-34d27c09fbb0","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiJlNmY0YTkyZi1lOTg2LTQwY2ItODZjOC1kOTJmZDJmYWNkOGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImRhMjg3YWZmLWQzYTAtNDkyYi05MDY0LTA1ZTI5ZDYwM2UxZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImRhMjg3YWZmLWQzYTAtNDkyYi05MDY0LTA1ZTI5ZDYwM2UxZSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.itwqYaVenjO81H7s6oICUMhbYtMWwnPGI3wXk9wAZz-V4jX36ipfIK5MaxVPICFaYFvjtCUB_U6PDenTmctXl4p7OFCYtjtjMh_9muUf9Z80zwkDizxjFB8TnaTGeUbwtk56hmPFt3DD1ZnswjiQf7MymDDK3mXdi_g1ws36MsQu3-uNwC7YOehkMGtZGnGS3q_UvtideD5jN4wmRIdYN1qs9yZU8mdG5qPvs-Ilfnv-OPZWF6HXXfa9G5V-DFiPoPgX8YwNg5Q54Rmz_QSW54F7QEdTvsKyOl4eZvYlNXdIG3FLEb0gwZmg_Tf4_WuEUnUfdsuFfdr4u5PPoG4SQA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiZjhkNjE2OGUtMzA1NC00YzkzLWI0NzUtNzk3OWEwNTBlZGY3IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZGEyODdhZmYtZDNhMC00OTJiLTkwNjQtMDVlMjlkNjAzZTFlIn0.A5wULecVLH_cnHmz3V8oMIvvYiKpFlSgSOGSbFzm2jI","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiIyNTZhNzlkNy01Yjg2LTQwZmItYTFiMS05Mjg5MzAxZWQ5NzkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJhdF9oYXNoIjoiSHRqUzVrZUhRN3BEdU5taUV2MjNKUSIsImFjciI6IjEiLCJzaWQiOiJkYTI4N2FmZi1kM2EwLTQ5MmItOTA2NC0wNWUyOWQ2MDNlMWUiLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.atqs_YUiKuNxWaO8qT7tPCpfECOuttlclrsTGahrGmLoddtAkjk6WIWRB18CmiSUuK6uU539l7eFDwaG4BaZQHDOxT6sUG2P5b63vZ7eH9tRO5NK-851chqb1Lju_QIK8cHvNaJuRXV_FXHyreaFtwvDQMU-TDgnCw8L75TxIkkk98hiCBk8gpo0dcClf4_GDJFR2cm2UroaL_RwgltiPTgpuEVgsGlqAOeGfcoqjvS_jhGdywERKmGfYS18FgSPuk29bLUI_3On6Occb76i0yd38gxoz2FXiU7Ns3I63g9FCvwO__UoE0gpmenjbYcirk-zu08aiGdptyFtvPWB5A","not-before-policy":0,"session_state":"da287aff-d3a0-492b-9064-05e29d603e1e","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTIsImlhdCI6MTczMjYxNTg5MiwiYXV0aF90aW1lIjoxNzMyNjE1ODkyLCJqdGkiOiJmNmY3NzYzOS0yODM0LTQ0MDctYWYyYy0yYTRiNzgzYTUxYzAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImVmNWUxODU0LTVlMTMtNDNlMy04ODU4LTM0ZDI3YzA5ZmJiMCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImVmNWUxODU0LTVlMTMtNDNlMy04ODU4LTM0ZDI3YzA5ZmJiMCIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.QRAe7gTX6aVxxWFS7kEeMZ9oF3kQYzuOtkKi9_ShOUapI35yuGkG0bQLa8BDiunWstfVbaOTJqgK5bl7UnyJoqpiPsK2BZccYFSV7MI4bmf5Gza61jVdz6Kx7PUXdYacTSq8TqCxt8u3aTKe4WdnuC56G4JvtK9BZ82spJWVooOq-CS0355IicnaWeb_2hQJ5qyLEXb6IkrdIQUmyJs7WNtaBJLGxMLOwKoflBVqqlKe0hNxIo0_mwjxZdsWyxVLNKgBAdqeQMgmEr65HGr3ip1-REDAyxGA3eSc7GGDl8TAzbr3N_YIspm-_KMRZprUqv8oxBAry0tiqrkuMq4tjg
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiJlNmY0YTkyZi1lOTg2LTQwY2ItODZjOC1kOTJmZDJmYWNkOGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImRhMjg3YWZmLWQzYTAtNDkyYi05MDY0LTA1ZTI5ZDYwM2UxZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImRhMjg3YWZmLWQzYTAtNDkyYi05MDY0LTA1ZTI5ZDYwM2UxZSIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.itwqYaVenjO81H7s6oICUMhbYtMWwnPGI3wXk9wAZz-V4jX36ipfIK5MaxVPICFaYFvjtCUB_U6PDenTmctXl4p7OFCYtjtjMh_9muUf9Z80zwkDizxjFB8TnaTGeUbwtk56hmPFt3DD1ZnswjiQf7MymDDK3mXdi_g1ws36MsQu3-uNwC7YOehkMGtZGnGS3q_UvtideD5jN4wmRIdYN1qs9yZU8mdG5qPvs-Ilfnv-OPZWF6HXXfa9G5V-DFiPoPgX8YwNg5Q54Rmz_QSW54F7QEdTvsKyOl4eZvYlNXdIG3FLEb0gwZmg_Tf4_WuEUnUfdsuFfdr4u5PPoG4SQA
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringInitTests/EHerkenningBewindvoeringInitTests.test_keycloak_idp_hint_is_respected.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringInitTests/EHerkenningBewindvoeringInitTests.test_keycloak_idp_hint_is_respected.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringInitTests/EHerkenningBewindvoeringInitTests.test_start_flow_redirects_to_oidc_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringInitTests/EHerkenningBewindvoeringInitTests.test_start_flow_redirects_to_oidc_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringLogoutTests/EHerkenningBewindvoeringLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningBewindvoeringLogoutTests/EHerkenningBewindvoeringLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"4d58560b-a0a1-4b42-a583-f22a948d34d7\",\n
-        \             \"smZCX_nxtwc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=smZCX_nxtwc&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"a71e9731-2106-469f-ab4f-1f84ee792d97\",\n
+        \             \"6FYLQMbpTNc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=6FYLQMbpTNc&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=_5xltBMTtZnv-VnV4BQZTBFJ2NNa5pgBDwY9vE7Jc9w&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=smZCX_nxtwc\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=WP35yNnBaPjTgsHyNdW0J6mldDuEbdrpPAU0J4JPodQ&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=6FYLQMbpTNc\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=4d58560b-a0a1-4b42-a583-f22a948d34d7; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=a71e9731-2106-469f-ab4f-1f84ee792d97; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=4d58560b-a0a1-4b42-a583-f22a948d34d7; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=a71e9731-2106-469f-ab4f-1f84ee792d97; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=4d58560b-a0a1-4b42-a583-f22a948d34d7; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro
+      - AUTH_SESSION_ID_LEGACY=a71e9731-2106-469f-ab4f-1f84ee792d97; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=_5xltBMTtZnv-VnV4BQZTBFJ2NNa5pgBDwY9vE7Jc9w&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=smZCX_nxtwc
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=WP35yNnBaPjTgsHyNdW0J6mldDuEbdrpPAU0J4JPodQ&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=6FYLQMbpTNc
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=4d58560b-a0a1-4b42-a583-f22a948d34d7&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=6427f143-8843-43f2-9490-dde7c861f609.4d58560b-a0a1-4b42-a583-f22a948d34d7.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=a71e9731-2106-469f-ab4f-1f84ee792d97&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=09f90bcd-f873-4483-9e00-34373c7ea13a.a71e9731-2106-469f-ab4f-1f84ee792d97.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiNTVhZjliOTItNDcxYi00MjQ3LTljMzUtMDRjZDQwODUxZWE2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzdGF0ZV9jaGVja2VyIjoiY0h1ak9zQTNJUUVZNVpZenpObFlESUx4VHBxdHVsT3dYTHN1SDRYMTVoayJ9.lxLkef5ylZ289m_rjQcb1psy0MjS_8o9WkP3GRmzs6Q;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiMTljZTA2MjYtOTY1OS00NGEwLWFiMjMtNzdlOWJlMTkzZmRkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzdGF0ZV9jaGVja2VyIjoiYUNxOU0zbXU0MHVkMHZMVHFoZ3VFdWVfYmJnTFZCeE91NEU0TU95b3ByWSJ9.iuSrv2C4H7bqiJ5IDuaOKIWoihafb1W6BUER0BnPXWI;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiNTVhZjliOTItNDcxYi00MjQ3LTljMzUtMDRjZDQwODUxZWE2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzdGF0ZV9jaGVja2VyIjoiY0h1ak9zQTNJUUVZNVpZenpObFlESUx4VHBxdHVsT3dYTHN1SDRYMTVoayJ9.lxLkef5ylZ289m_rjQcb1psy0MjS_8o9WkP3GRmzs6Q;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiMTljZTA2MjYtOTY1OS00NGEwLWFiMjMtNzdlOWJlMTkzZmRkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzdGF0ZV9jaGVja2VyIjoiYUNxOU0zbXU0MHVkMHZMVHFoZ3VFdWVfYmJnTFZCeE91NEU0TU95b3ByWSJ9.iuSrv2C4H7bqiJ5IDuaOKIWoihafb1W6BUER0BnPXWI;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/4d58560b-a0a1-4b42-a583-f22a948d34d7;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/a71e9731-2106-469f-ab4f-1f84ee792d97;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/4d58560b-a0a1-4b42-a583-f22a948d34d7;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/a71e9731-2106-469f-ab4f-1f84ee792d97;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -236,12 +236,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -284,12 +284,12 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=4d58560b-a0a1-4b42-a583-f22a948d34d7; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiNTVhZjliOTItNDcxYi00MjQ3LTljMzUtMDRjZDQwODUxZWE2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzdGF0ZV9jaGVja2VyIjoiY0h1ak9zQTNJUUVZNVpZenpObFlESUx4VHBxdHVsT3dYTHN1SDRYMTVoayJ9.lxLkef5ylZ289m_rjQcb1psy0MjS_8o9WkP3GRmzs6Q;
-        KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/4d58560b-a0a1-4b42-a583-f22a948d34d7
+      - AUTH_SESSION_ID_LEGACY=a71e9731-2106-469f-ab4f-1f84ee792d97; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiMTljZTA2MjYtOTY1OS00NGEwLWFiMjMtNzdlOWJlMTkzZmRkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzdGF0ZV9jaGVja2VyIjoiYUNxOU0zbXU0MHVkMHZMVHFoZ3VFdWVfYmJnTFZCeE91NEU0TU95b3ByWSJ9.iuSrv2C4H7bqiJ5IDuaOKIWoihafb1W6BUER0BnPXWI;
+        KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/a71e9731-2106-469f-ab4f-1f84ee792d97
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
@@ -297,11 +297,11 @@ interactions:
       Cache-Control:
       - no-store, must-revalidate, max-age=0
       Location:
-      - http://testserver/eherkenning-bewindvoering-oidc/callback/?state=not-a-random-string&session_state=4d58560b-a0a1-4b42-a583-f22a948d34d7&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=734c5550-19de-4e98-8963-cbc555ec380b.4d58560b-a0a1-4b42-a583-f22a948d34d7.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=a71e9731-2106-469f-ab4f-1f84ee792d97&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=30167a67-8715-4bbc-96dd-9e9ceed4cfaa.a71e9731-2106-469f-ab4f-1f84ee792d97.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
@@ -309,15 +309,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiMTJkYzY4MDUtOTRjNC00MGFmLWE5ZTEtNjgwZmE0ZGQ1YWRmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzdGF0ZV9jaGVja2VyIjoiY0h1ak9zQTNJUUVZNVpZenpObFlESUx4VHBxdHVsT3dYTHN1SDRYMTVoayJ9.85qsbjSDMKiNxbb22mmqgd_CvJSfiD6v7OjtqE0ewC4;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiNzEzYjQ2MTItZTc2Mi00YWY0LWJiODItYWNjN2NmOGI3NzI4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzdGF0ZV9jaGVja2VyIjoiYUNxOU0zbXU0MHVkMHZMVHFoZ3VFdWVfYmJnTFZCeE91NEU0TU95b3ByWSJ9.TkooEIiaxcdrd-bEpqNxgLUG1mW-2p1zlgpaYOw07pQ;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiMTJkYzY4MDUtOTRjNC00MGFmLWE5ZTEtNjgwZmE0ZGQ1YWRmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzdGF0ZV9jaGVja2VyIjoiY0h1ak9zQTNJUUVZNVpZenpObFlESUx4VHBxdHVsT3dYTHN1SDRYMTVoayJ9.85qsbjSDMKiNxbb22mmqgd_CvJSfiD6v7OjtqE0ewC4;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiNzEzYjQ2MTItZTc2Mi00YWY0LWJiODItYWNjN2NmOGI3NzI4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzdGF0ZV9jaGVja2VyIjoiYUNxOU0zbXU0MHVkMHZMVHFoZ3VFdWVfYmJnTFZCeE91NEU0TU95b3ByWSJ9.TkooEIiaxcdrd-bEpqNxgLUG1mW-2p1zlgpaYOw07pQ;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/4d58560b-a0a1-4b42-a583-f22a948d34d7;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/a71e9731-2106-469f-ab4f-1f84ee792d97;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/4d58560b-a0a1-4b42-a583-f22a948d34d7;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:36 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/a71e9731-2106-469f-ab4f-1f84ee792d97;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=734c5550-19de-4e98-8963-cbc555ec380b.4d58560b-a0a1-4b42-a583-f22a948d34d7.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=30167a67-8715-4bbc-96dd-9e9ceed4cfaa.a71e9731-2106-469f-ab4f-1f84ee792d97.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -341,7 +341,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '293'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -350,7 +350,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiI0Zjc4NzRlYy1jOTk1LTQzNDctYWNlYS0xYjhhZTk3ODMwODAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjRkNTg1NjBiLWEwYTEtNGI0Mi1hNTgzLWYyMmE5NDhkMzRkNyIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjRkNTg1NjBiLWEwYTEtNGI0Mi1hNTgzLWYyMmE5NDhkMzRkNyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.V00dy8yb-0ogC2qC5ZuDQybx6r2KbWSMBOkGFmmPUyhIHXeVHaTA_hS-ZRyxLE3BKg1n8hHDhMZl82d8vJ9YmGedJVXnQCE37WyAWBjGx3ATTphj-lopXzYRfKD-S0DMx0fxhZGrnxVicqjwXEghMXtpFOQ95VRWscSeWt-ApE2FuFeSh-jJwp1bChdqtLv_hmt-pXok3WEuQQ7Wvjy-aLz8sWD1sOG5_8VF9EEagmz_kPr2Vov735IlO45jrc2K56skCgm-DRzmyJcAViM0Fa_f_De1J9N5mqx92hNC9Cz4uBaqpoNrmt4M0ACn5y-unfnTFx8t1a6aroAsF5Ubiw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiZTk4YzVhZTktZWM3Mi00OGNjLWJmOTUtMmMwMTA5NDY0ZGEzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNGQ1ODU2MGItYTBhMS00YjQyLWE1ODMtZjIyYTk0OGQzNGQ3In0.OnHoxSHbUcIL--ga9sT00z0Ke7z1sENRqC9FJhl4-7g","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiI0OGJhZDJjMi04YTJkLTQ3MzctYTE4MS0xYWU0YmFmZDUzMzMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJhdF9oYXNoIjoiUG9BbVJxT0pUQkp4bVhWVmRqSkd0USIsImFjciI6IjAiLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.c8ROTq3Yfna5ZwbokpCUj8PMEbe5UHWBDlTiU9Toa2BRaBTmHkuGoT05Z89DrE7yjBslX66wEYMLaWuieACZuJUuAXvQgjtl1E16Mv8W0Pi8Zm50cLeeWMmVlGRUTNn2c1a5xPqdQjSy4CCUvZtc-j5VGmLdDLCwn-2-AOzPIOsU-1OxZ3uFnzNE5biC_XlU-i9jWJAIZb8Dm5pgkbYM4MWmCSesoIGIC5ut7NbkPTv8gMb4CpywJsb9m7egvhjQD3xWSdgjbI_Tgd-UOApWSGhsw5Z3HzMcnR_PEtD_NVHGqaxRA9k5mZDvksylS_Ok-oZEfrqOC4gwvcGj-_AqnA","not-before-policy":0,"session_state":"4d58560b-a0a1-4b42-a583-f22a948d34d7","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIyYzAwZWE3Mi1mM2I1LTQ4NzQtYjhmZC1mMTBmNjQwNWZhODQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImE3MWU5NzMxLTIxMDYtNDY5Zi1hYjRmLTFmODRlZTc5MmQ5NyIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImE3MWU5NzMxLTIxMDYtNDY5Zi1hYjRmLTFmODRlZTc5MmQ5NyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.C5fqPX2o3wCY3E4pann9gctQYaDu0pDtL3nAOKrwL2IEkUh_xm2lmjdw88oBV4trFKIC3deu074ePB8dV9I0d3dX_ukVBXAcdpTpieC5f_ZKdTe29HXekMN76OQH2zl3nkNDZgXa05xFoPBJdjc8FCCdPDLKiIJBo7khWPsd3_JLoxlRj7Zvto3OHlZ_UB__YhJB5SppfUYXAjeq737gL8CtKsQ3OZcMufhl62d_WPLucN0PcBJTT8E4l6_ibGNoQWyGevhvq7b6mGaQxf527PHWfTftUswQCpdoRFlgx5aPk4uEMk88eSim0qaHAhUels57BVfYmm3uFdFz1eZ-6Q","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiMDE3ZDRiNDEtMTFlYi00YmY1LThkNWItODQ0ZTIwZjQ2MTcwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYTcxZTk3MzEtMjEwNi00NjlmLWFiNGYtMWY4NGVlNzkyZDk3In0.6GpUyTqSPokSukfeDzPd3zEdT6O16I9t5drpKgFbubA","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIxYjQ2MjQ2MC02YTEwLTQ1MTktOTk1OC05OWEwNjFiYjNmNGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJhdF9oYXNoIjoiUFdRRVRXRmU3OGZKZk1DYXdnR3ZLQSIsImFjciI6IjAiLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.e1dws1MiXyJmbckHTwaADY5GusdMe4HLUg2QNHNdrRkpskPnAaHYFiCXVQJLNqJb613lQElMSmQRWSef13GUeI003YyFUr98Y5Tx5E9jypA_m8OsMYDvgd3lkkxd6j_EZSDVNSUbvj-YZYIEKY9pOm6WAbKb_KQ8VAhQKqAkm1h5DhCHGRkxUtG_e2eixFe7yrMy4tst38CECposFJRhifuIXT7QL7mGfT1EP4vvPmnbJuWVgfSELDrbvdQXCtOGdNUFq7md5VbPhVGvNbZJyRX-PyuOX99MD3umCkKhYoZgdXvsdfi71crYgS-WwSBTd2oS6AdgKf24-nHuUKZDfQ","not-before-policy":0,"session_state":"a71e9731-2106-469f-ab4f-1f84ee792d97","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -418,7 +418,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiI0Zjc4NzRlYy1jOTk1LTQzNDctYWNlYS0xYjhhZTk3ODMwODAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjRkNTg1NjBiLWEwYTEtNGI0Mi1hNTgzLWYyMmE5NDhkMzRkNyIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjRkNTg1NjBiLWEwYTEtNGI0Mi1hNTgzLWYyMmE5NDhkMzRkNyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.V00dy8yb-0ogC2qC5ZuDQybx6r2KbWSMBOkGFmmPUyhIHXeVHaTA_hS-ZRyxLE3BKg1n8hHDhMZl82d8vJ9YmGedJVXnQCE37WyAWBjGx3ATTphj-lopXzYRfKD-S0DMx0fxhZGrnxVicqjwXEghMXtpFOQ95VRWscSeWt-ApE2FuFeSh-jJwp1bChdqtLv_hmt-pXok3WEuQQ7Wvjy-aLz8sWD1sOG5_8VF9EEagmz_kPr2Vov735IlO45jrc2K56skCgm-DRzmyJcAViM0Fa_f_De1J9N5mqx92hNC9Cz4uBaqpoNrmt4M0ACn5y-unfnTFx8t1a6aroAsF5Ubiw
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIyYzAwZWE3Mi1mM2I1LTQ4NzQtYjhmZC1mMTBmNjQwNWZhODQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImE3MWU5NzMxLTIxMDYtNDY5Zi1hYjRmLTFmODRlZTc5MmQ5NyIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImE3MWU5NzMxLTIxMDYtNDY5Zi1hYjRmLTFmODRlZTc5MmQ5NyIsInNlcnZpY2VfdXVpZCI6IjgxMjE2ZmE0LTgwYTEtNDY4Ni1hOGFjLTVjOGU1YzAzMGM5MyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicmVwcmVzZW50ZWVCU04iOiIwMDAwMDAwMDAiLCJsZWdhbFN1YmplY3RJRCI6IjEyMzQ1Njc4IiwiYWN0aW5nU3ViamVjdElEIjoiNEI3NUEwRUExMDdCM0QzNiIsInNlcnZpY2VfaWQiOiJ1cm46ZXRvZWdhbmc6RFY6MDAwMDAwMDEwMDIzMDg4MzYwMDA6c2VydmljZXM6OTExMyIsImFhbnZyYWdlci5rdmsiOiIxMjM0NTY3OCIsIm5hbWVfcXVhbGlmaWVyIjoidXJuOmV0b2VnYW5nOjEuOTpFbnRpdHlDb25jZXJuZWRJRDpLdktuciIsImdyb3VwcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImVoZXJrZW5uaW5nLWJld2luZHZvZXJpbmciLCJnZW1hY2h0aWdkZS5wc2V1ZG9JRCI6IjRCNzVBMEVBMTA3QjNEMzYifQ.C5fqPX2o3wCY3E4pann9gctQYaDu0pDtL3nAOKrwL2IEkUh_xm2lmjdw88oBV4trFKIC3deu074ePB8dV9I0d3dX_ukVBXAcdpTpieC5f_ZKdTe29HXekMN76OQH2zl3nkNDZgXa05xFoPBJdjc8FCCdPDLKiIJBo7khWPsd3_JLoxlRj7Zvto3OHlZ_UB__YhJB5SppfUYXAjeq737gL8CtKsQ3OZcMufhl62d_WPLucN0PcBJTT8E4l6_ibGNoQWyGevhvq7b6mGaQxf527PHWfTftUswQCpdoRFlgx5aPk4uEMk88eSim0qaHAhUels57BVfYmm3uFdFz1eZ-6Q
       Connection:
       - keep-alive
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTYsImlhdCI6MTczMjYxNTg5NiwiYXV0aF90aW1lIjoxNzMyNjE1ODk2LCJqdGkiOiI0OGJhZDJjMi04YTJkLTQ3MzctYTE4MS0xYWU0YmFmZDUzMzMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJhdF9oYXNoIjoiUG9BbVJxT0pUQkp4bVhWVmRqSkd0USIsImFjciI6IjAiLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.c8ROTq3Yfna5ZwbokpCUj8PMEbe5UHWBDlTiU9Toa2BRaBTmHkuGoT05Z89DrE7yjBslX66wEYMLaWuieACZuJUuAXvQgjtl1E16Mv8W0Pi8Zm50cLeeWMmVlGRUTNn2c1a5xPqdQjSy4CCUvZtc-j5VGmLdDLCwn-2-AOzPIOsU-1OxZ3uFnzNE5biC_XlU-i9jWJAIZb8Dm5pgkbYM4MWmCSesoIGIC5ut7NbkPTv8gMb4CpywJsb9m7egvhjQD3xWSdgjbI_Tgd-UOApWSGhsw5Z3HzMcnR_PEtD_NVHGqaxRA9k5mZDvksylS_Ok-oZEfrqOC4gwvcGj-_AqnA
+    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIxYjQ2MjQ2MC02YTEwLTQ1MTktOTk1OC05OWEwNjFiYjNmNGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2NDZlMjdjNi0xYjQyLTRlMTEtYTVjNi1kOWZhZTRjM2NlYTYiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJhdF9oYXNoIjoiUFdRRVRXRmU3OGZKZk1DYXdnR3ZLQSIsImFjciI6IjAiLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzZXJ2aWNlX3V1aWQiOiI4MTIxNmZhNC04MGExLTQ2ODYtYThhYy01YzhlNWMwMzBjOTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInJlcHJlc2VudGVlQlNOIjoiMDAwMDAwMDAwIiwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJzZXJ2aWNlX2lkIjoidXJuOmV0b2VnYW5nOkRWOjAwMDAwMDAxMDAyMzA4ODM2MDAwOnNlcnZpY2VzOjkxMTMiLCJhYW52cmFnZXIua3ZrIjoiMTIzNDU2NzgiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJlaGVya2VubmluZy1iZXdpbmR2b2VyaW5nIiwiZ2VtYWNodGlnZGUucHNldWRvSUQiOiI0Qjc1QTBFQTEwN0IzRDM2In0.e1dws1MiXyJmbckHTwaADY5GusdMe4HLUg2QNHNdrRkpskPnAaHYFiCXVQJLNqJb613lQElMSmQRWSef13GUeI003YyFUr98Y5Tx5E9jypA_m8OsMYDvgd3lkkxd6j_EZSDVNSUbvj-YZYIEKY9pOm6WAbKb_KQ8VAhQKqAkm1h5DhCHGRkxUtG_e2eixFe7yrMy4tst38CECposFJRhifuIXT7QL7mGfT1EP4vvPmnbJuWVgfSELDrbvdQXCtOGdNUFq7md5VbPhVGvNbZJyRX-PyuOX99MD3umCkKhYoZgdXvsdfi71crYgS-WwSBTd2oS6AdgKf24-nHuUKZDfQ
     headers:
       Accept:
       - '*/*'
@@ -505,12 +505,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -531,9 +531,9 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=baff0801-a324-48e9-8181-08864354f189; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=999dd5a8-f60d-4d63-8e97-0d61a61d53a7; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=baff0801-a324-48e9-8181-08864354f189; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=999dd5a8-f60d-4d63-8e97-0d61a61d53a7; Version=1; Path=/realms/test/;
         HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -569,12 +569,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -617,29 +617,29 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=4d58560b-a0a1-4b42-a583-f22a948d34d7; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTYsImlhdCI6MTczMjYxNTg5NiwianRpIjoiMTJkYzY4MDUtOTRjNC00MGFmLWE5ZTEtNjgwZmE0ZGQ1YWRmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzaWQiOiI0ZDU4NTYwYi1hMGExLTRiNDItYTU4My1mMjJhOTQ4ZDM0ZDciLCJzdGF0ZV9jaGVja2VyIjoiY0h1ak9zQTNJUUVZNVpZenpObFlESUx4VHBxdHVsT3dYTHN1SDRYMTVoayJ9.85qsbjSDMKiNxbb22mmqgd_CvJSfiD6v7OjtqE0ewC4;
-        KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/4d58560b-a0a1-4b42-a583-f22a948d34d7;
-        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro
+      - AUTH_SESSION_ID_LEGACY=a71e9731-2106-469f-ab4f-1f84ee792d97; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiNzEzYjQ2MTItZTc2Mi00YWY0LWJiODItYWNjN2NmOGI3NzI4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNjQ2ZTI3YzYtMWI0Mi00ZTExLWE1YzYtZDlmYWU0YzNjZWE2IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzaWQiOiJhNzFlOTczMS0yMTA2LTQ2OWYtYWI0Zi0xZjg0ZWU3OTJkOTciLCJzdGF0ZV9jaGVja2VyIjoiYUNxOU0zbXU0MHVkMHZMVHFoZ3VFdWVfYmJnTFZCeE91NEU0TU95b3ByWSJ9.TkooEIiaxcdrd-bEpqNxgLUG1mW-2p1zlgpaYOw07pQ;
+        KEYCLOAK_SESSION_LEGACY=test/646e27c6-1b42-4e11-a5c6-d9fae4c3cea6/a71e9731-2106-469f-ab4f-1f84ee792d97;
+        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-bewindvoering-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+bsn&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"8e7b9d2c-f73c-4859-b326-f3c0d5e7cec1\",\n
-        \             \"g_iFPWMzY0Q\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=g_iFPWMzY0Q&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"ca767c09-7182-4799-a878-fcb8e210dc93\",\n
+        \             \"elGyZW8qcMA\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=elGyZW8qcMA&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -647,7 +647,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=vj4dJe-wtVSMyCgTqbiJUaf5yIzviF_5w8MUuSsnE8A&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=g_iFPWMzY0Q\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=9mj9cxQTm0LFhOHGvexo3r1Jo8BW6FhuiwLZuYh3I0g&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=elGyZW8qcMA\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -673,7 +673,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -703,11 +703,11 @@ interactions:
         00:00:10 GMT; Max-Age=0; Path=/realms/test
       - KEYCLOAK_SESSION_LEGACY=; Version=1; Comment=Expiring cookie; Expires=Thu,
         01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/realms/test
-      - AUTH_SESSION_ID=8e7b9d2c-f73c-4859-b326-f3c0d5e7cec1; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=ca767c09-7182-4799-a878-fcb8e210dc93; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=8e7b9d2c-f73c-4859-b326-f3c0d5e7cec1; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=ca767c09-7182-4799-a878-fcb8e210dc93; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1iZXdpbmR2b2VyaW5nLW9pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ohW_ibsZCPn53GegGr49538xdqveI5gt43AvtPXb9ro;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgYnNuIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.V3UsBe8rRt-LQ646Js47AdHhzJHO_B07JwYNO7znkns;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_eherkenning_error_reported_for_cancelled_login_anon_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_eherkenning_error_reported_for_cancelled_login_anon_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/eherkenning-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_eherkenning_error_reported_for_cancelled_login_with_staff_django_user.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_eherkenning_error_reported_for_cancelled_login_with_staff_django_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,13 +68,13 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
     headers:
       Location:
-      - http://testserver/eherkenning-oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_failing_claim_verification.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_failing_claim_verification.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8\",\n
-        \             \"SIei6qQBZN8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=SIei6qQBZN8&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"c1f65f60-3534-4064-af6b-5b112982654e\",\n
+        \             \"L7hMv4ZMunI\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=L7hMv4ZMunI&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=zRX8ujfbHTwxTrkBtIoUHvDYhFWjq-Mm9cZxGT8_AvA&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=SIei6qQBZN8\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=Og0Pl-erIOlT8s1oM0Ox6wSjFmPZLjlYoUzFKXZt6SU&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=L7hMv4ZMunI\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=c1f65f60-3534-4064-af6b-5b112982654e; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=c1f65f60-3534-4064-af6b-5b112982654e; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo
+      - AUTH_SESSION_ID_LEGACY=c1f65f60-3534-4064-af6b-5b112982654e; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=zRX8ujfbHTwxTrkBtIoUHvDYhFWjq-Mm9cZxGT8_AvA&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=SIei6qQBZN8
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=Og0Pl-erIOlT8s1oM0Ox6wSjFmPZLjlYoUzFKXZt6SU&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=L7hMv4ZMunI
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-oidc/callback/?state=not-a-random-string&session_state=61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=86c34e65-1334-4f2f-b16b-97bd14a3fc07.61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=c1f65f60-3534-4064-af6b-5b112982654e&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=f9b00ca9-3a42-4202-9046-a99b8ec02abc.c1f65f60-3534-4064-af6b-5b112982654e.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTMsImlhdCI6MTczMjYxNTg5MywianRpIjoiNjA1MDE5Y2UtNDY5Mi00ODExLWEzOTAtODNlMDgzM2QwZjMwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJzaWQiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJzdGF0ZV9jaGVja2VyIjoiX3JQSWxUTHFDRUVFRWYwcFRBeUMxQkVXVzROSlZaREViZ0IwemtiNnRtWSJ9.gWKuPTHuC4dF34BmGgTW2WlzNeShDppwHUAyweeVRxY;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiMjY1NzMxMWMtOGJmMi00NGQzLWE2MDUtZDllYmIyNTMyMTFjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJzaWQiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJzdGF0ZV9jaGVja2VyIjoiOTdhRnFjUUJaRk0wSFplNEhVUmxvLWdSRkVyaUcyVlh1WFJZeXp0anRXayJ9.gUzBe1bz7UaSVNbKhpQ03wQvzelQ7eCA1x7tymjwHyo;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTMsImlhdCI6MTczMjYxNTg5MywianRpIjoiNjA1MDE5Y2UtNDY5Mi00ODExLWEzOTAtODNlMDgzM2QwZjMwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJzaWQiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJzdGF0ZV9jaGVja2VyIjoiX3JQSWxUTHFDRUVFRWYwcFRBeUMxQkVXVzROSlZaREViZ0IwemtiNnRtWSJ9.gWKuPTHuC4dF34BmGgTW2WlzNeShDppwHUAyweeVRxY;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiMjY1NzMxMWMtOGJmMi00NGQzLWE2MDUtZDllYmIyNTMyMTFjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJzaWQiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJzdGF0ZV9jaGVja2VyIjoiOTdhRnFjUUJaRk0wSFplNEhVUmxvLWdSRkVyaUcyVlh1WFJZeXp0anRXayJ9.gUzBe1bz7UaSVNbKhpQ03wQvzelQ7eCA1x7tymjwHyo;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:33 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c1f65f60-3534-4064-af6b-5b112982654e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:36 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:33 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c1f65f60-3534-4064-af6b-5b112982654e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:36 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=86c34e65-1334-4f2f-b16b-97bd14a3fc07.61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=f9b00ca9-3a42-4202-9046-a99b8ec02abc.c1f65f60-3534-4064-af6b-5b112982654e.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '279'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTMsImlhdCI6MTczMjYxNTg5MywiYXV0aF90aW1lIjoxNzMyNjE1ODkzLCJqdGkiOiJiZTUxNWUwZC0zNmY4LTRmNjItOTdhNy1lMTYxYTg2ZjQ1OWUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjYxZmZiMmFjLTVjNjctNGMwZS1hZmM4LTRlYjY5MzViYjZjOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjYxZmZiMmFjLTVjNjctNGMwZS1hZmM4LTRlYjY5MzViYjZjOCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.fQInnZqmYcKpuJ2mMO2BOulvLBrKn0gFFgxDuN7uW0KPuW-esAQKMvCdn-6_HjNEQ-hPiiHMK044SzEE5CUuQEnv2wbnL66Bj3cp5r5D7nzjfeSidYKMIiBM5QmgibSX1j6ZNWblueJm0r5IhmYl9k8RB3iTDqRZR_IU8ov-BNL-mvHKwJj_BVj4HQ3Dmm-iII8hMPRufhlhqsvo8BGSxcBtYlvk8gSqpiZpIQ-AliAv-j84iSj7o9_8o-6ft-gnI_GK1JqueqWtIfyI_4Tn9N5yVqrNbRnADnYlevbjshQhSDh5Kt4OLiC1yYy-13bpe1SGLxTKWiUYBeivQYF9hQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTMsImlhdCI6MTczMjYxNTg5MywianRpIjoiOTliYjY3YTMtZjNiMy00NzJkLTgyMGYtYWNjMWE1MGM4NjMxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNjFmZmIyYWMtNWM2Ny00YzBlLWFmYzgtNGViNjkzNWJiNmM4In0.Crml0kNcAA3NmErb2akooJbRVYt_ARoGveekGyinQEs","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTMsImlhdCI6MTczMjYxNTg5MywiYXV0aF90aW1lIjoxNzMyNjE1ODkzLCJqdGkiOiIzY2JhOTljNy1jYzk2LTRkNjktYTY5Ni00YTYxYTFhZmY2ZjQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJhdF9oYXNoIjoiSUdjcGNwQzZEd0UxdDBoWjd0U2hqZyIsImFjciI6IjEiLCJzaWQiOiI2MWZmYjJhYy01YzY3LTRjMGUtYWZjOC00ZWI2OTM1YmI2YzgiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.B62w0r5WS_K9umI00-N64u_75pWZBCTh613Daaoqjs9no0YuOzjUl9lxtqFVu3odq4wJoC1uEc5uuNbp0NbFEAnUTvCSseCnkk4-09-UK7crSkWeVq4AagilBDXQksrcle3VX0GdDsj761N1TwdgQypAmkQrD-wKPAhKAhAfgxsoVMgJcSzbhrVXoU6WhOawYsj6y-wemtV3op1obOuQ5_mSsAzq7k5WHQv4YA1CQyLzlma5_Bqf8krggwrEdNs-NVuQKYioL3DH8rBjAL_vZSMmESlHYszk8EA2sNWHfWKJqv9XD7VyitcfMk6z8IxpUCdGx3Q_IvEJxscrkgwpSg","not-before-policy":0,"session_state":"61ffb2ac-5c67-4c0e-afc8-4eb6935bb6c8","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiIzN2NiYjQwMS04N2VjLTRlNTUtYjE5Mi04NDc2MTA3MmJjYzgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMxZjY1ZjYwLTM1MzQtNDA2NC1hZjZiLTViMTEyOTgyNjU0ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMxZjY1ZjYwLTM1MzQtNDA2NC1hZjZiLTViMTEyOTgyNjU0ZSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.MUzUQgc3cGE9PWaK_BD6zenowQvtrn7e4HOItvLiZ690-Rt5KBfwpUuUuwh5erVfeujGEhKesdUAZwqg47dFuANpQk-F8k2B7ozpMLjuLgiNgY3c0BmEa-246tJA1p28OqzkGh7szI90Y2mvWCXHaXnez-HpObh4Qf8H8TECgKMr7O2cAulXCcmULoWyXYjH5v_Ptah0HSlrt26gzVH3RdK89vLrPfEUw-rc0Hv4OiyloMdNSzeT3nFbZbgNlRs9TdNJpGCVt4l2xEGDhjZtJZu_u8nb6TDPHLwAy88Z-jPC8mHdFRYlVJIcGFDwd1SFhRJ1Nbt3iuYoVDO9YcFOZw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTYsImlhdCI6MTczNDAzODMxNiwianRpIjoiNjA2MmI0MzMtMmI5YS00ZTUzLTgyOTEtOTZjMDA3MTQ2OTM2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYzFmNjVmNjAtMzUzNC00MDY0LWFmNmItNWIxMTI5ODI2NTRlIn0.c5aLUgrtyw9m4RQo8JfZGQCKoEiEY5grkDKc-hki3sI","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiI4YjY2ZGI0Yy03NWI4LTQyNzctYWY0ZS0zNWFkOTA5NTFhNTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJhdF9oYXNoIjoidExYdFloQTBWRVZLeXBYQ2M1SVJxZyIsImFjciI6IjEiLCJzaWQiOiJjMWY2NWY2MC0zNTM0LTQwNjQtYWY2Yi01YjExMjk4MjY1NGUiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.Ksu0JskQYgdZPD97eL5ahl1f--rkMiz-53CQFDoA6w5VBDmmRWHTH0PfEg4Upuec7GFkhmIeBu7WMDW7NlK6z8Bbx5yFmk_5zHwTMB8m8d8u1bzScTveKn7lyCLi5zAh2ULxC6c2GdTh6qBATVnvYMuV1KoDXwH0XRgOdhylUbaf_JO_ihQr4VG1Sai0Grya-pA5EG0owb0LjhUhcgiJrxpFoQxvZ2qtA19R3SkxeUwnmjOhedHdHIVT05lEYFAZPxgmrBN1aR574ZqmSYG_Mm-cXbSKb1jrvvJN9yV4GwnSuY1sipptGGzhvibz5rhyd6VTtKUknEwtOapdLdCqqA","not-before-policy":0,"session_state":"c1f65f60-3534-4064-af6b-5b112982654e","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTMsImlhdCI6MTczMjYxNTg5MywiYXV0aF90aW1lIjoxNzMyNjE1ODkzLCJqdGkiOiJiZTUxNWUwZC0zNmY4LTRmNjItOTdhNy1lMTYxYTg2ZjQ1OWUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjYxZmZiMmFjLTVjNjctNGMwZS1hZmM4LTRlYjY5MzViYjZjOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjYxZmZiMmFjLTVjNjctNGMwZS1hZmM4LTRlYjY5MzViYjZjOCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.fQInnZqmYcKpuJ2mMO2BOulvLBrKn0gFFgxDuN7uW0KPuW-esAQKMvCdn-6_HjNEQ-hPiiHMK044SzEE5CUuQEnv2wbnL66Bj3cp5r5D7nzjfeSidYKMIiBM5QmgibSX1j6ZNWblueJm0r5IhmYl9k8RB3iTDqRZR_IU8ov-BNL-mvHKwJj_BVj4HQ3Dmm-iII8hMPRufhlhqsvo8BGSxcBtYlvk8gSqpiZpIQ-AliAv-j84iSj7o9_8o-6ft-gnI_GK1JqueqWtIfyI_4Tn9N5yVqrNbRnADnYlevbjshQhSDh5Kt4OLiC1yYy-13bpe1SGLxTKWiUYBeivQYF9hQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTYsImlhdCI6MTczNDAzODMxNiwiYXV0aF90aW1lIjoxNzM0MDM4MzE2LCJqdGkiOiIzN2NiYjQwMS04N2VjLTRlNTUtYjE5Mi04NDc2MTA3MmJjYzgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMxZjY1ZjYwLTM1MzQtNDA2NC1hZjZiLTViMTEyOTgyNjU0ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMxZjY1ZjYwLTM1MzQtNDA2NC1hZjZiLTViMTEyOTgyNjU0ZSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.MUzUQgc3cGE9PWaK_BD6zenowQvtrn7e4HOItvLiZ690-Rt5KBfwpUuUuwh5erVfeujGEhKesdUAZwqg47dFuANpQk-F8k2B7ozpMLjuLgiNgY3c0BmEa-246tJA1p28OqzkGh7szI90Y2mvWCXHaXnez-HpObh4Qf8H8TECgKMr7O2cAulXCcmULoWyXYjH5v_Ptah0HSlrt26gzVH3RdK89vLrPfEUw-rc0Hv4OiyloMdNSzeT3nFbZbgNlRs9TdNJpGCVt4l2xEGDhjZtJZu_u8nb6TDPHLwAy88Z-jPC8mHdFRYlVJIcGFDwd1SFhRJ1Nbt3iuYoVDO9YcFOZw
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_failure_with_missing_acting_subject_claim.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_failure_with_missing_acting_subject_claim.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"975c5f1e-c082-4036-a5da-62d519dcba8f\",\n
-        \             \"RAsGykJPEtY\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=RAsGykJPEtY&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec\",\n
+        \             \"QrRlxw-GqW8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=QrRlxw-GqW8&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=6v5ug5cdEx4eUYyhCkILlbi332rM2Qi1Yz8q6zg5f1s&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=RAsGykJPEtY\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=lSgdPV77R5HGzXnxIqVdqIjQndMRRUtJzji1eGBcI5s&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=QrRlxw-GqW8\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=975c5f1e-c082-4036-a5da-62d519dcba8f; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=975c5f1e-c082-4036-a5da-62d519dcba8f; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=975c5f1e-c082-4036-a5da-62d519dcba8f; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo
+      - AUTH_SESSION_ID_LEGACY=c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=6v5ug5cdEx4eUYyhCkILlbi332rM2Qi1Yz8q6zg5f1s&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=RAsGykJPEtY
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=lSgdPV77R5HGzXnxIqVdqIjQndMRRUtJzji1eGBcI5s&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=QrRlxw-GqW8
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-oidc/callback/?state=not-a-random-string&session_state=975c5f1e-c082-4036-a5da-62d519dcba8f&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=cfae6f6e-8699-4975-9dba-0c6d2b78370c.975c5f1e-c082-4036-a5da-62d519dcba8f.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=960db606-4b16-4aa6-8565-e4faeff6032a.c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTMsImlhdCI6MTczMjYxNTg5MywianRpIjoiNGNjZDkyNjEtZDIzMS00NWVkLThlOTctNTRhMWU3OTAwNzQ2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJzaWQiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJzdGF0ZV9jaGVja2VyIjoia1Z5aWViejY3T05DakhfYkFiOTZzSlVBSlhfSXFlTDE4S1JoOE0yZERhWSJ9.t835_aFmeMG9jMmAYs2ov5AUoib7Yup5vQWnMVVZQ5U;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiMTgzMGFmZGQtMjc5NS00ZmIzLThlN2YtYWNkYThkNTQzNWUxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJzaWQiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJzdGF0ZV9jaGVja2VyIjoiZFZMS1BJSFRGVlBPbkpxTXFtZmJxZjlfZDBRaEdROER5aXA1S1Y3YWpwbyJ9.ZDaMKRtASh6Yy6oUtnJk78o2mCk2-Kicv9Su7X1dyqU;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTMsImlhdCI6MTczMjYxNTg5MywianRpIjoiNGNjZDkyNjEtZDIzMS00NWVkLThlOTctNTRhMWU3OTAwNzQ2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJzaWQiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJzdGF0ZV9jaGVja2VyIjoia1Z5aWViejY3T05DakhfYkFiOTZzSlVBSlhfSXFlTDE4S1JoOE0yZERhWSJ9.t835_aFmeMG9jMmAYs2ov5AUoib7Yup5vQWnMVVZQ5U;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiMTgzMGFmZGQtMjc5NS00ZmIzLThlN2YtYWNkYThkNTQzNWUxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJzaWQiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJzdGF0ZV9jaGVja2VyIjoiZFZMS1BJSFRGVlBPbkpxTXFtZmJxZjlfZDBRaEdROER5aXA1S1Y3YWpwbyJ9.ZDaMKRtASh6Yy6oUtnJk78o2mCk2-Kicv9Su7X1dyqU;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/975c5f1e-c082-4036-a5da-62d519dcba8f;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:33 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:37 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/975c5f1e-c082-4036-a5da-62d519dcba8f;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:33 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:37 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=cfae6f6e-8699-4975-9dba-0c6d2b78370c.975c5f1e-c082-4036-a5da-62d519dcba8f.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=960db606-4b16-4aa6-8565-e4faeff6032a.c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '279'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTMsImlhdCI6MTczMjYxNTg5MywiYXV0aF90aW1lIjoxNzMyNjE1ODkzLCJqdGkiOiIwYmE5ZjMwYS0yMmYzLTQ1ZjgtODdmNC03NjY1YmNjM2Q1NzEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk3NWM1ZjFlLWMwODItNDAzNi1hNWRhLTYyZDUxOWRjYmE4ZiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk3NWM1ZjFlLWMwODItNDAzNi1hNWRhLTYyZDUxOWRjYmE4ZiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.uMT1VLbYtmInRxN3R4uMNgPoE3aqukZrjOi8k8Sd6le3h8n7r90k_pwUlTjUOwYSVwy_tfdpl8EyoYfpQScKyLqjUjKa-MVDy29Sk0LHjuP5kFVajTbc1esSBV2k0cdWLKRpo5WDF_Lr-UFSoAbvuGKK73JJcdJQJ6iBNCD_Uf-8_l3oFA9k5af9FTIG67knbYnecDpsKfZ_UWvCnw8Y3o6_nrUfSH__DdaM2JeueJKIusWjWRBqobYuxc-uJQVJ6zuUDx25pp4J1aF5CONkLlLkGlkJT9ZKXUy8N1Kr7QIJFVyIeLq5JIS7o3Ia2GpzErQuWBvMoOH2dy3IzTvi8Q","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTMsImlhdCI6MTczMjYxNTg5MywianRpIjoiZjVhMGU4N2MtNDgxYi00NzhlLThkNzAtMjE2NzJlY2U4NDlhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOTc1YzVmMWUtYzA4Mi00MDM2LWE1ZGEtNjJkNTE5ZGNiYThmIn0.1rLr6ddv_3CNCzIhM4cC95t1eghGBuezaGEl2fadTMk","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTMsImlhdCI6MTczMjYxNTg5MywiYXV0aF90aW1lIjoxNzMyNjE1ODkzLCJqdGkiOiI2M2Y3M2UxMy0yMjk5LTRmNDktOWExOS1jOTIzNjIxNjU5MWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJhdF9oYXNoIjoiMHBxc3FUdXQtOUZzb0Z3SlZZQ3cyUSIsImFjciI6IjEiLCJzaWQiOiI5NzVjNWYxZS1jMDgyLTQwMzYtYTVkYS02MmQ1MTlkY2JhOGYiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.JZgWxMb_rRCC5qKnrX6iJRg5FCylzsNRVdXhy6KbcR7QWAvjwilZuXBY4eAE51_u80Gx_50YsB0h3wDZ_PY4OMRFB5iIxggRom8JU2I3btEvjdSuDBCYvbGADFCJtaCYPi_LYSmBa2fBtG3Z69nLr3ARHsVJjefmRfJb2XQVt6XyvV4zmgZKNJhyTYOtlpKreOYu3NqDe9mBtlB3W5htta9Ho1WnrZGDCTZo9RUF1HlqY3nfOEEwb5_N7Ekb1VgNLSWUp1Dbm6eT8pievUbwVofDdAtXY4-7d599Exz94vO5xqAnMTlb7crWK1sTjIHMCQ-JU8fCgMa_0zhBq-wDGg","not-before-policy":0,"session_state":"975c5f1e-c082-4036-a5da-62d519dcba8f","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiI3MWVlYjZmMC01YjIzLTRmMDMtOTg2Yi0wNWU0MjJlNzYxZWIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMxNWE4NmIyLWRkZDAtNDk4MC05NmY1LTZjMmM0MWQxZjFlYyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMxNWE4NmIyLWRkZDAtNDk4MC05NmY1LTZjMmM0MWQxZjFlYyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.jN_qWdgl_t-ARjZk1AFO_cA_B3lcTDoywH4_oxP4Z4jgIx5U9S-nETV2OQSjr7NnubAtZ6dt3QhfgVSnYLrvkJBkE4SoFaHxmiR2fcvvPro13FMYTH-45jiW9h9zg0Msiv0VfwzkMpIGLl8l7qM4bPIXn_m8WkN1QtukBVhMEDM7JqVNvpIbpVxxRQ-JOh-92e8TsNaDWTrksRCyCIHD_jddPnC9a_9d_n0rHv_lAmvAde5WIeruO6Vk-9Z-Nm4KthUbji58st2dg1I7FR1qwVIqAQsIIQ_VMxlqKjru4YSY_L82SWRXN6E6XOg4ygwokYSKLZrq54Dp721ZW1WybQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiOTE1NDA4Y2UtZmQ1MC00Yzk5LThkNTItNGVlYjUzMDZkZjE5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYzE1YTg2YjItZGRkMC00OTgwLTk2ZjUtNmMyYzQxZDFmMWVjIn0.VWHUnPzoEc8-whAvZObqIUehQcCYjPgrwYdKct4i084","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiJmMDY5ODVmNy1hMmNiLTRlYzYtYThkYS02YWU1ZGRhMjE0YzkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJhdF9oYXNoIjoiQkVmaUx4YmNXa0hPT3lvTGhVSnBYQSIsImFjciI6IjEiLCJzaWQiOiJjMTVhODZiMi1kZGQwLTQ5ODAtOTZmNS02YzJjNDFkMWYxZWMiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.NLO8kM5Kz0Rms69RX0RKM8N3jp-uF3xW0pe26e3H33xcCDm437Qf3YU0y9F1O4LpTCDe01KejAv_4_DPytAH8BQGrdpfqaBkqTdpneGmHbDi9R6SpdX2_-1Wxp66Wvp2iGfQZOOenFslcFIEFFYly5DK19YF5HNLaj_CzYrsvPXIRQhDj6NMisqvN4TIY1Nzc5xO7Iq-AffW0Bc177HZaRp875LwON7cnl1Zio_THQIz1LSxDv2Yd2-I7PzIz2JR5CTvVkkqailWGrcoGq6D-1wov082HcVYu8m9yWnYGpQy858hXxFO3BN3rQ1UxHmbfDfUqlFC3luCRvCZRKV13A","not-before-policy":0,"session_state":"c15a86b2-ddd0-4980-96f5-6c2c41d1f1ec","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTMsImlhdCI6MTczMjYxNTg5MywiYXV0aF90aW1lIjoxNzMyNjE1ODkzLCJqdGkiOiIwYmE5ZjMwYS0yMmYzLTQ1ZjgtODdmNC03NjY1YmNjM2Q1NzEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk3NWM1ZjFlLWMwODItNDAzNi1hNWRhLTYyZDUxOWRjYmE4ZiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk3NWM1ZjFlLWMwODItNDAzNi1hNWRhLTYyZDUxOWRjYmE4ZiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.uMT1VLbYtmInRxN3R4uMNgPoE3aqukZrjOi8k8Sd6le3h8n7r90k_pwUlTjUOwYSVwy_tfdpl8EyoYfpQScKyLqjUjKa-MVDy29Sk0LHjuP5kFVajTbc1esSBV2k0cdWLKRpo5WDF_Lr-UFSoAbvuGKK73JJcdJQJ6iBNCD_Uf-8_l3oFA9k5af9FTIG67knbYnecDpsKfZ_UWvCnw8Y3o6_nrUfSH__DdaM2JeueJKIusWjWRBqobYuxc-uJQVJ6zuUDx25pp4J1aF5CONkLlLkGlkJT9ZKXUy8N1Kr7QIJFVyIeLq5JIS7o3Ia2GpzErQuWBvMoOH2dy3IzTvi8Q
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiI3MWVlYjZmMC01YjIzLTRmMDMtOTg2Yi0wNWU0MjJlNzYxZWIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMxNWE4NmIyLWRkZDAtNDk4MC05NmY1LTZjMmM0MWQxZjFlYyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMxNWE4NmIyLWRkZDAtNDk4MC05NmY1LTZjMmM0MWQxZjFlYyIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.jN_qWdgl_t-ARjZk1AFO_cA_B3lcTDoywH4_oxP4Z4jgIx5U9S-nETV2OQSjr7NnubAtZ6dt3QhfgVSnYLrvkJBkE4SoFaHxmiR2fcvvPro13FMYTH-45jiW9h9zg0Msiv0VfwzkMpIGLl8l7qM4bPIXn_m8WkN1QtukBVhMEDM7JqVNvpIbpVxxRQ-JOh-92e8TsNaDWTrksRCyCIHD_jddPnC9a_9d_n0rHv_lAmvAde5WIeruO6Vk-9Z-Nm4KthUbji58st2dg1I7FR1qwVIqAQsIIQ_VMxlqKjru4YSY_L82SWRXN6E6XOg4ygwokYSKLZrq54Dp721ZW1WybQ
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_failure_with_missing_acting_subject_claim_strict_mode.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_failure_with_missing_acting_subject_claim_strict_mode.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"c064a49a-5d87-45fa-8d55-a4282da1067a\",\n
-        \             \"eLt1AUOXUF8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=eLt1AUOXUF8&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"12e815f9-46a7-4704-b8e9-cffba8eb8ba0\",\n
+        \             \"tSg-7fmpFSw\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=tSg-7fmpFSw&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=8qXvLEn2UB7-EYdmkqlzIUkMzWVK2UJTWiFdZmDdM-Y&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=eLt1AUOXUF8\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=vhpTep2JI6MpUyfSvEuWcPr3Jr6KY8MC2V5oZn2ubjU&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=tSg-7fmpFSw\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=c064a49a-5d87-45fa-8d55-a4282da1067a; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=12e815f9-46a7-4704-b8e9-cffba8eb8ba0; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=c064a49a-5d87-45fa-8d55-a4282da1067a; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=12e815f9-46a7-4704-b8e9-cffba8eb8ba0; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=c064a49a-5d87-45fa-8d55-a4282da1067a; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo
+      - AUTH_SESSION_ID_LEGACY=12e815f9-46a7-4704-b8e9-cffba8eb8ba0; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=8qXvLEn2UB7-EYdmkqlzIUkMzWVK2UJTWiFdZmDdM-Y&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=eLt1AUOXUF8
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=vhpTep2JI6MpUyfSvEuWcPr3Jr6KY8MC2V5oZn2ubjU&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=tSg-7fmpFSw
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-oidc/callback/?state=not-a-random-string&session_state=c064a49a-5d87-45fa-8d55-a4282da1067a&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=e78c478b-5f96-49ba-b651-3a7cc4e340ae.c064a49a-5d87-45fa-8d55-a4282da1067a.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=12e815f9-46a7-4704-b8e9-cffba8eb8ba0&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=af4b9fa8-a485-4ff9-8a6c-95f258035b06.12e815f9-46a7-4704-b8e9-cffba8eb8ba0.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTQsImlhdCI6MTczMjYxNTg5NCwianRpIjoiZTdhYTBmZDktMTJkOC00YjlmLWFhYjItNTM0MTM0MTg3MDRmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJzaWQiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJzdGF0ZV9jaGVja2VyIjoiRF9mVFd4WGxZdGVvZW9sd0pLSFFsWFZGNXZUQld3bjdyYlpER1FYWnR1NCJ9.JNPbKGswMDxVRlR4DGptR93GeR55wTeypkj2lZyj8qY;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiZWY4OGQ1NTYtNDIyZi00Mjk0LTlhZTAtOGE5ZDY3NjcwNDVlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJzaWQiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJzdGF0ZV9jaGVja2VyIjoiV1VXbG91VHVPeVhfVlY5RXo4MlprRE56NUhYa1p3ZHRmNFE4dlFHbkxLdyJ9.aeRWx1nZP68NuslmWQsfOc-pQZc4RsG4WfsxzUmjuK0;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTQsImlhdCI6MTczMjYxNTg5NCwianRpIjoiZTdhYTBmZDktMTJkOC00YjlmLWFhYjItNTM0MTM0MTg3MDRmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJzaWQiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJzdGF0ZV9jaGVja2VyIjoiRF9mVFd4WGxZdGVvZW9sd0pLSFFsWFZGNXZUQld3bjdyYlpER1FYWnR1NCJ9.JNPbKGswMDxVRlR4DGptR93GeR55wTeypkj2lZyj8qY;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiZWY4OGQ1NTYtNDIyZi00Mjk0LTlhZTAtOGE5ZDY3NjcwNDVlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJzaWQiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJzdGF0ZV9jaGVja2VyIjoiV1VXbG91VHVPeVhfVlY5RXo4MlprRE56NUhYa1p3ZHRmNFE4dlFHbkxLdyJ9.aeRWx1nZP68NuslmWQsfOc-pQZc4RsG4WfsxzUmjuK0;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c064a49a-5d87-45fa-8d55-a4282da1067a;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:34 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/12e815f9-46a7-4704-b8e9-cffba8eb8ba0;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:37 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c064a49a-5d87-45fa-8d55-a4282da1067a;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:34 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/12e815f9-46a7-4704-b8e9-cffba8eb8ba0;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:37 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=e78c478b-5f96-49ba-b651-3a7cc4e340ae.c064a49a-5d87-45fa-8d55-a4282da1067a.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=af4b9fa8-a485-4ff9-8a6c-95f258035b06.12e815f9-46a7-4704-b8e9-cffba8eb8ba0.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '279'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTQsImlhdCI6MTczMjYxNTg5NCwiYXV0aF90aW1lIjoxNzMyNjE1ODk0LCJqdGkiOiJjZjVkMGY1MS00M2MwLTQyYzctOTZmMC1lMTBmYjA5MTk2YzMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMwNjRhNDlhLTVkODctNDVmYS04ZDU1LWE0MjgyZGExMDY3YSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMwNjRhNDlhLTVkODctNDVmYS04ZDU1LWE0MjgyZGExMDY3YSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.VR0BQkvERcPl-zt10ttKW6YDUr97bcTyHnX3qnqnFcL7Ewuu9KWqGGK8ZQCUf0BuGQPn_2Y_ZSrOK-ipKXit3bpNaw0_9gDELeOGB6mtT-cfXROwS_nkH2LpxCf5yHkknwoxvPtFjGFRpgrQrc3icOieGBV8loag8RALAn6BIqFAiBRzmZUs5bu_ZmaLE5c97Ol9sId0f5KZ34L5tVbXkMOFKtEj3GNDahqFx_LhwaO3d2Fpd_ZAdNecCpmgvRacZMePYiP6RRKqJK9cscz07e-_heJrsEQqfEdyNu_z_iUILh4FCaWuuxgm_1MMcXLPrcY66iVcK5h56jxHeR1UeA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTQsImlhdCI6MTczMjYxNTg5NCwianRpIjoiY2I3NzdlNDQtNzFmYy00NDFjLWIwNzMtMGRlYmZlN2U3ZjFjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYzA2NGE0OWEtNWQ4Ny00NWZhLThkNTUtYTQyODJkYTEwNjdhIn0.IP_ZCCJ63h90SigAvHBiAvRHGQJK7tIAEYwCvvqCxqQ","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTQsImlhdCI6MTczMjYxNTg5NCwiYXV0aF90aW1lIjoxNzMyNjE1ODk0LCJqdGkiOiI1N2ZjMDQ1Yi1lNDY0LTQ1MDQtOWVkNC04YjZhZjA0NzBjZjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJhdF9oYXNoIjoiZERpUlNMWkp1RGpoOGV2UVc3S2hmZyIsImFjciI6IjEiLCJzaWQiOiJjMDY0YTQ5YS01ZDg3LTQ1ZmEtOGQ1NS1hNDI4MmRhMTA2N2EiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.RLDmbNX43ZlUktqdkmx65wA2nw1fqn_2liefpVpw_RCiGx0S_KT-504PYdF_-dS9OmER5nvvYzy6FqW9F9ZWcy5FYS6c1inTFj6zLYzX6ew0rFZ9RDZUSMlxzpu5vlRWs8OV8DqV8dFYfDTya_TVgDrf0a8zq5ZO-U-Zjlk5gbtfZHz7jLz9ZJuAYZnWyA8dfHVY5q01wBDyiEza6O5_OJEUmy6lzn-4NV3fMrIfe6Dgo4BTWhB7CtkvI2LHWOqEpPxQhM2y4jDZcdSRWL3-UKrGo55ipLrsGUaUdZghXumwFtIl92ArNS13M9HiRed-9TdSMSGEoeS0Z_Jv3DwguQ","not-before-policy":0,"session_state":"c064a49a-5d87-45fa-8d55-a4282da1067a","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiIxZGJhYjFmNC0zNmM1LTRkZmEtYWZmYS00NTJmZjRmOTQ2ZjkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjEyZTgxNWY5LTQ2YTctNDcwNC1iOGU5LWNmZmJhOGViOGJhMCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjEyZTgxNWY5LTQ2YTctNDcwNC1iOGU5LWNmZmJhOGViOGJhMCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.GizoXfT4gwIk2xZZXroNhp8aVDYqlUsodR5GuJGhdBvbp2DHN8CINvQSxspblHH_2DZ_SoeTZHIo9C35JueAzLkAf3pKo7CiciQigN0C2tvT3a-Uiv9YzGqqwtP40r6eokl_qP1kPfph9XdnTx3Q5Y5OSRnpYG25sFTm2_odYRNQAm5GkN4VjafmXIxFmXgiArt_xRgqkVRPJ9DLc7rBNMknCKs-EqG0KhLDc-VncaDs_ZVTnxFsvFcWCrepkXP-_Biq9zhgamFRzfH12hfdLSzkVobUhQGnRGnVlynAgzmPeP48ayYLs8dEBF2PGI3_7x0Vi94EYABgko7Hu8APzg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiZWM2YzM3MWUtNGM2Ni00ZTZkLTg2NGEtNGE2OTY1Zjk2OTQ4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMTJlODE1ZjktNDZhNy00NzA0LWI4ZTktY2ZmYmE4ZWI4YmEwIn0.2bvAMZcQslcB0m9MB8zuqEYOTO3kEciyWByX0PpZ-Ag","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiJiNzdiMTlmZS04YjQyLTQ0MTUtOTQ3NC1kZmViODA3ZTM2NmIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJhdF9oYXNoIjoiM3c2R0R6MDBnR2FKQ1dpdDdnOGtqdyIsImFjciI6IjEiLCJzaWQiOiIxMmU4MTVmOS00NmE3LTQ3MDQtYjhlOS1jZmZiYThlYjhiYTAiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.kC7UjDtwMReG518LfBIZvMhCkq6jpF5TqtwKcQCbC9rG-L51qvEwcZSj0eie7FGG6E_NSQ7yZz2blu6rCqDjbx6hiLKyNu-v4YokiUWN4zqAAOcsAR8Hh3C3Reo2m-vfdsAf9QuwVT224cxPYvJbBxKy96knhDKln3A0c_1c7wM3ngN-8IVlA2igpLn3tl0IQi0fGSDvLWYq4IT0HfZra-Wcl34tfV65PasWJBTagOik1Gns0HGSMdPHtR0avbxWNWSOEvcra6imj5z6gK2N1gjWPdCOofnjzfzFdEKIx2ce-5fAD_RtP922vTmAAdLeqcCgBC9N7oZ2obflQ7WpMg","not-before-policy":0,"session_state":"12e815f9-46a7-4704-b8e9-cffba8eb8ba0","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTQsImlhdCI6MTczMjYxNTg5NCwiYXV0aF90aW1lIjoxNzMyNjE1ODk0LCJqdGkiOiJjZjVkMGY1MS00M2MwLTQyYzctOTZmMC1lMTBmYjA5MTk2YzMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImMwNjRhNDlhLTVkODctNDVmYS04ZDU1LWE0MjgyZGExMDY3YSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImMwNjRhNDlhLTVkODctNDVmYS04ZDU1LWE0MjgyZGExMDY3YSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.VR0BQkvERcPl-zt10ttKW6YDUr97bcTyHnX3qnqnFcL7Ewuu9KWqGGK8ZQCUf0BuGQPn_2Y_ZSrOK-ipKXit3bpNaw0_9gDELeOGB6mtT-cfXROwS_nkH2LpxCf5yHkknwoxvPtFjGFRpgrQrc3icOieGBV8loag8RALAn6BIqFAiBRzmZUs5bu_ZmaLE5c97Ol9sId0f5KZ34L5tVbXkMOFKtEj3GNDahqFx_LhwaO3d2Fpd_ZAdNecCpmgvRacZMePYiP6RRKqJK9cscz07e-_heJrsEQqfEdyNu_z_iUILh4FCaWuuxgm_1MMcXLPrcY66iVcK5h56jxHeR1UeA
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiIxZGJhYjFmNC0zNmM1LTRkZmEtYWZmYS00NTJmZjRmOTQ2ZjkiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjEyZTgxNWY5LTQ2YTctNDcwNC1iOGU5LWNmZmJhOGViOGJhMCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjEyZTgxNWY5LTQ2YTctNDcwNC1iOGU5LWNmZmJhOGViOGJhMCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.GizoXfT4gwIk2xZZXroNhp8aVDYqlUsodR5GuJGhdBvbp2DHN8CINvQSxspblHH_2DZ_SoeTZHIo9C35JueAzLkAf3pKo7CiciQigN0C2tvT3a-Uiv9YzGqqwtP40r6eokl_qP1kPfph9XdnTx3Q5Y5OSRnpYG25sFTm2_odYRNQAm5GkN4VjafmXIxFmXgiArt_xRgqkVRPJ9DLc7rBNMknCKs-EqG0KhLDc-VncaDs_ZVTnxFsvFcWCrepkXP-_Biq9zhgamFRzfH12hfdLSzkVobUhQGnRGnVlynAgzmPeP48ayYLs8dEBF2PGI3_7x0Vi94EYABgko7Hu8APzg
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_redirects_after_successful_auth.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningCallbackTests/EHerkenningCallbackTests.test_redirects_after_successful_auth.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"74af7741-2371-42d0-ab34-85ea5ee73802\",\n
-        \             \"ZfzWgyNVmJo\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=ZfzWgyNVmJo&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"43056d32-aff6-412d-99ee-52bbe7bf048d\",\n
+        \             \"FUa74BbMkjI\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=FUa74BbMkjI&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=P4sPTBWP3lUSVXLS6l1LSRjo4pDtklA7hCt_ouWnh70&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=ZfzWgyNVmJo\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=Sh_xgJQfroCxzDuMHhgmuswol1THAESdYLvvJkDkzsk&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=FUa74BbMkjI\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=74af7741-2371-42d0-ab34-85ea5ee73802; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=43056d32-aff6-412d-99ee-52bbe7bf048d; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=74af7741-2371-42d0-ab34-85ea5ee73802; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=43056d32-aff6-412d-99ee-52bbe7bf048d; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=74af7741-2371-42d0-ab34-85ea5ee73802; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo
+      - AUTH_SESSION_ID_LEGACY=43056d32-aff6-412d-99ee-52bbe7bf048d; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=P4sPTBWP3lUSVXLS6l1LSRjo4pDtklA7hCt_ouWnh70&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=ZfzWgyNVmJo
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=Sh_xgJQfroCxzDuMHhgmuswol1THAESdYLvvJkDkzsk&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=FUa74BbMkjI
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-oidc/callback/?state=not-a-random-string&session_state=74af7741-2371-42d0-ab34-85ea5ee73802&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=6035c200-1c64-4ccf-a706-9c8c65a2e0d3.74af7741-2371-42d0-ab34-85ea5ee73802.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=43056d32-aff6-412d-99ee-52bbe7bf048d&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=bdc3ed46-00c8-4945-8ffb-8a5cd6853000.43056d32-aff6-412d-99ee-52bbe7bf048d.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTQsImlhdCI6MTczMjYxNTg5NCwianRpIjoiOGEzMzY2MGMtMDNlYy00NjZmLTgxZTYtN2MyZjc5ZWVjYzU0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJzaWQiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJzdGF0ZV9jaGVja2VyIjoiTzJxVExpRVI1U2tjM1MyeG9GWGxEWW05c2Fod0gtT1ZqSUNqcG83Z0NxWSJ9.nyNpa0emdv4VFrYhD9_yeay2hBCfPiWng85PHAmJuUM;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiZjhjMjBhNzktYmRmNi00NThlLTg0YTEtZWYxOWE3ZDA3YTdiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJzaWQiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJzdGF0ZV9jaGVja2VyIjoiOU9WYWdCS2pzWnh3alc3WmRDUHZEdy1CSVNodUZsdUtRWUwyc2otczVNWSJ9.3Mu2TNyVWw_f_aV1E4mrEoP2uYYdIA1ipQUl0GdWv1M;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTQsImlhdCI6MTczMjYxNTg5NCwianRpIjoiOGEzMzY2MGMtMDNlYy00NjZmLTgxZTYtN2MyZjc5ZWVjYzU0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJzaWQiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJzdGF0ZV9jaGVja2VyIjoiTzJxVExpRVI1U2tjM1MyeG9GWGxEWW05c2Fod0gtT1ZqSUNqcG83Z0NxWSJ9.nyNpa0emdv4VFrYhD9_yeay2hBCfPiWng85PHAmJuUM;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiZjhjMjBhNzktYmRmNi00NThlLTg0YTEtZWYxOWE3ZDA3YTdiIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJzaWQiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJzdGF0ZV9jaGVja2VyIjoiOU9WYWdCS2pzWnh3alc3WmRDUHZEdy1CSVNodUZsdUtRWUwyc2otczVNWSJ9.3Mu2TNyVWw_f_aV1E4mrEoP2uYYdIA1ipQUl0GdWv1M;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/74af7741-2371-42d0-ab34-85ea5ee73802;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:34 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/43056d32-aff6-412d-99ee-52bbe7bf048d;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:37 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/74af7741-2371-42d0-ab34-85ea5ee73802;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:34 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/43056d32-aff6-412d-99ee-52bbe7bf048d;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:37 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=6035c200-1c64-4ccf-a706-9c8c65a2e0d3.74af7741-2371-42d0-ab34-85ea5ee73802.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=bdc3ed46-00c8-4945-8ffb-8a5cd6853000.43056d32-aff6-412d-99ee-52bbe7bf048d.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '279'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTQsImlhdCI6MTczMjYxNTg5NCwiYXV0aF90aW1lIjoxNzMyNjE1ODk0LCJqdGkiOiI4MzA2MDY4YS0yNWMyLTRjZjctYWM3Zi1iNTljNTU1ZWUxYzUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijc0YWY3NzQxLTIzNzEtNDJkMC1hYjM0LTg1ZWE1ZWU3MzgwMiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijc0YWY3NzQxLTIzNzEtNDJkMC1hYjM0LTg1ZWE1ZWU3MzgwMiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.r6OzWaexhOcTAXSlSRurBvTFwU052zXxFgHJFOFAyVCYfpEmZf8vGXFpJFJqIba0Hm73GeptyeoKmbTQRVlr4HJfqMPvOvT-_1HzCKjQIYuiydBJkxRLk9OR1dDBMjwFHNU9KZNv-q44F-tWHlkHewLhymUSs1bL9fIiLqeAN4q-TUpi23Kvj_7Hi21it2Xy-nuOJ2iQbgyGfstGeYgR8h4jWATwZ-H6EW5RASalfoZigrJ_4Wf450P7qZP1SGGPqRMQR6jNj-u7kWRlSikfjfJ5bxpKygvl9a4ZwqQoPMrUfSrzfBl0DTQlFInzaPHa__s4qHPNJR2h7-PFOcLX5g","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTQsImlhdCI6MTczMjYxNTg5NCwianRpIjoiY2I1YmM0ZjgtNWM0OS00MjRjLWJiNTktNDBhMTA3MjRiZTgxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNzRhZjc3NDEtMjM3MS00MmQwLWFiMzQtODVlYTVlZTczODAyIn0.GdZebTv_CwPZbERBG7F7zCWWv7ajme2NIX1i7dAnIBs","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTQsImlhdCI6MTczMjYxNTg5NCwiYXV0aF90aW1lIjoxNzMyNjE1ODk0LCJqdGkiOiJjZGRlZGQyYS02ZDA3LTQ0MzAtYTFlNy0wZWNkYzg5YTVlNzUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJhdF9oYXNoIjoieVhzMHp2VVhKZjUyYVkyZlQwMVhIdyIsImFjciI6IjEiLCJzaWQiOiI3NGFmNzc0MS0yMzcxLTQyZDAtYWIzNC04NWVhNWVlNzM4MDIiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.xKTMfiONVZ-Pz0zLHkisNTYkWBIzPiAH1KB8n_jZ8c-GdnmOh6Q4qj7xHbePwar28Ju2kTb3oHjkYKh7BzoQleBhICyeTa8WLoYEOBHZ310AUt2e-cVJC9oBRsfgAac0nsDo-7w0Sf4LooJr3DUg_UMf3n4h1bSEpsNSwNXmK9eKxTonL-YS8BjAjTsFM8AI_vu4LDmdoMovlCCFnRZGktV_nN5uzWDe1pSKvVeQDIw0BrOHk5jXAecpN1-ymb0y10Pdwn_hLsaDO_tvUb3HexYuTWbXE3C4guA5o-Xtq2s5UkUkO5pg33_0X5HuksnySrf5vpP1TjRkjNTFELleVA","not-before-policy":0,"session_state":"74af7741-2371-42d0-ab34-85ea5ee73802","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiI2ZDdiMDU5MC01N2QxLTQxYTYtOTU2OC02MTkxOThhOWUxYjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjQzMDU2ZDMyLWFmZjYtNDEyZC05OWVlLTUyYmJlN2JmMDQ4ZCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjQzMDU2ZDMyLWFmZjYtNDEyZC05OWVlLTUyYmJlN2JmMDQ4ZCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.RHEavzKcgMVon1dTQ9szkAhcbUVJAoj0QCwlqFegjwMqc2n7wN82Z_lyvwb7WVOiMJweHYMPPvoOTN6il3YKLzjeecYyhFPAXgheWMUOxkMoDgdo_Dn-aDWGzGM6KZoG2gKXoZuxVcRbBl2XSlLyhxxpdoDeLDNwDS6idxumWg_J_wgxoZPpnRT6KvzmIMst7tMroneLFQqWeVqn-UQuHTHt8eThM5ATuE240F28CwkYh72PzjuwRMfsqH-bPf6rpESQOy51iu5-J83VR8jQTYPR22ClDDzag3PC0I9PKxwfopFCKJgiNbeGtz9mBpQ0geMuXZgxSpZxRpI49D2_Ow","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTcsImlhdCI6MTczNDAzODMxNywianRpIjoiMTMwNzM2MTEtZWUxOC00MjdhLWI2M2QtZjNjOWVlZmQwOWNjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNDMwNTZkMzItYWZmNi00MTJkLTk5ZWUtNTJiYmU3YmYwNDhkIn0.yn0m4jdp3aeZpAoSeX3QYQGm_ZbZRC2CbVXY9AebvzA","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiJhZGY2NmEwYi04OGRjLTQxYTAtYmRjZC1iMzg3ZjFmMGQzNTIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJhdF9oYXNoIjoiR0JlZ1lfcFR5eU8ya29wU21mTTNQUSIsImFjciI6IjEiLCJzaWQiOiI0MzA1NmQzMi1hZmY2LTQxMmQtOTllZS01MmJiZTdiZjA0OGQiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.OBTGUaKVdMs7mHlrfPIlf1wqSDRcIMBq3fNd-OJiO5TN1sHO1GiNbwTGeRMVeX2wmdlEJYNyMQMuznKz2wqwIFLfA5pKxbgi1CNpR8CD3eyuI474yx8CcU4iy_xcCBfNfmM5jseOXzvoXYTUdFz4OTiq87hMv0Gh4nbKMnDj-nUete0HA56KBr0k-uxt_RDo7B5Z07ZuW20QDJ7xGR3omMW3LXrZUxBCwNiArGBr8G03RXDZYkn_7pDh69x4SjeJ6ncLf8FmdMgdvkOn5SOe1gTBHaJ8NE2WUI9p57N9OYKpYKEHGH5wpHw7AhttYsZ5ystOKPx3sjQCY8ecSFWA2A","not-before-policy":0,"session_state":"43056d32-aff6-412d-99ee-52bbe7bf048d","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTQsImlhdCI6MTczMjYxNTg5NCwiYXV0aF90aW1lIjoxNzMyNjE1ODk0LCJqdGkiOiI4MzA2MDY4YS0yNWMyLTRjZjctYWM3Zi1iNTljNTU1ZWUxYzUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijc0YWY3NzQxLTIzNzEtNDJkMC1hYjM0LTg1ZWE1ZWU3MzgwMiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijc0YWY3NzQxLTIzNzEtNDJkMC1hYjM0LTg1ZWE1ZWU3MzgwMiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.r6OzWaexhOcTAXSlSRurBvTFwU052zXxFgHJFOFAyVCYfpEmZf8vGXFpJFJqIba0Hm73GeptyeoKmbTQRVlr4HJfqMPvOvT-_1HzCKjQIYuiydBJkxRLk9OR1dDBMjwFHNU9KZNv-q44F-tWHlkHewLhymUSs1bL9fIiLqeAN4q-TUpi23Kvj_7Hi21it2Xy-nuOJ2iQbgyGfstGeYgR8h4jWATwZ-H6EW5RASalfoZigrJ_4Wf450P7qZP1SGGPqRMQR6jNj-u7kWRlSikfjfJ5bxpKygvl9a4ZwqQoPMrUfSrzfBl0DTQlFInzaPHa__s4qHPNJR2h7-PFOcLX5g
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTcsImlhdCI6MTczNDAzODMxNywiYXV0aF90aW1lIjoxNzM0MDM4MzE3LCJqdGkiOiI2ZDdiMDU5MC01N2QxLTQxYTYtOTU2OC02MTkxOThhOWUxYjYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjQzMDU2ZDMyLWFmZjYtNDEyZC05OWVlLTUyYmJlN2JmMDQ4ZCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjQzMDU2ZDMyLWFmZjYtNDEyZC05OWVlLTUyYmJlN2JmMDQ4ZCIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.RHEavzKcgMVon1dTQ9szkAhcbUVJAoj0QCwlqFegjwMqc2n7wN82Z_lyvwb7WVOiMJweHYMPPvoOTN6il3YKLzjeecYyhFPAXgheWMUOxkMoDgdo_Dn-aDWGzGM6KZoG2gKXoZuxVcRbBl2XSlLyhxxpdoDeLDNwDS6idxumWg_J_wgxoZPpnRT6KvzmIMst7tMroneLFQqWeVqn-UQuHTHt8eThM5ATuE240F28CwkYh72PzjuwRMfsqH-bPf6rpESQOy51iu5-J83VR8jQTYPR22ClDDzag3PC0I9PKxwfopFCKJgiNbeGtz9mBpQ0geMuXZgxSpZxRpI49D2_Ow
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningInitTests/EHerkenningInitTests.test_keycloak_idp_hint_is_respected.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningInitTests/EHerkenningInitTests.test_keycloak_idp_hint_is_respected.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningInitTests/EHerkenningInitTests.test_start_flow_redirects_to_oidc_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningInitTests/EHerkenningInitTests.test_start_flow_redirects_to_oidc_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningLogoutTests/EHerkenningLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/data/vcr_cassettes/EHerkenningLogoutTests/EHerkenningLogoutTests.test_logout_also_logs_out_user_in_openid_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"c888c0ad-203c-4f67-be70-3ed30fb8fec2\",\n
-        \             \"OCTw3lvBVsA\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=OCTw3lvBVsA&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"4d67bdbc-f5d4-4130-bd6d-285e74e00301\",\n
+        \             \"eJepcoNXvJk\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=eJepcoNXvJk&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=zGCZFCQy1JXIGHLkmcwi3DDLberrNpYkI1UaVYmMVuc&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=OCTw3lvBVsA\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=t_nDxfKf9KFCYzD7yZWWdFtdJDRC05TJINwv0ChNs9s&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=eJepcoNXvJk\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=c888c0ad-203c-4f67-be70-3ed30fb8fec2; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=4d67bdbc-f5d4-4130-bd6d-285e74e00301; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=c888c0ad-203c-4f67-be70-3ed30fb8fec2; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=4d67bdbc-f5d4-4130-bd6d-285e74e00301; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=c888c0ad-203c-4f67-be70-3ed30fb8fec2; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo
+      - AUTH_SESSION_ID_LEGACY=4d67bdbc-f5d4-4130-bd6d-285e74e00301; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=zGCZFCQy1JXIGHLkmcwi3DDLberrNpYkI1UaVYmMVuc&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=OCTw3lvBVsA
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=t_nDxfKf9KFCYzD7yZWWdFtdJDRC05TJINwv0ChNs9s&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=eJepcoNXvJk
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/eherkenning-oidc/callback/?state=not-a-random-string&session_state=c888c0ad-203c-4f67-be70-3ed30fb8fec2&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=d92dd23b-88d0-4184-8090-54b0107b2e8a.c888c0ad-203c-4f67-be70-3ed30fb8fec2.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=4d67bdbc-f5d4-4130-bd6d-285e74e00301&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=db4cc979-b426-48ad-8563-56e2938a0184.4d67bdbc-f5d4-4130-bd6d-285e74e00301.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiMzQ2YmQ3MDktNDViNS00ZDZlLWE4YWQtOGQ5M2Y2NTUxNTVlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzdGF0ZV9jaGVja2VyIjoiV2pvSFp4UXJaWld4QmJUdUdBRzlRckNueS05cjFXck9tT19lSlk1UWU1VSJ9.eG7V_Dg_GzLJ0WmSu0sp4gQhEe2QCY6jvjh-irOaghs;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiOTkyYjU0ZmItOGQxMC00OTg0LTk3ZWQtNmQ3ZTNmMDY4NjJjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzdGF0ZV9jaGVja2VyIjoiS3BFX2ZpQUFnaHZndzBrY1lhS1B6U0swdHJRZVQ5dk1JTFJreW1DZ1luRSJ9.ESuKZIkJdpZz6CH-39tfzFyRxlzEyKb0RwIr5w1GOJc;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiMzQ2YmQ3MDktNDViNS00ZDZlLWE4YWQtOGQ5M2Y2NTUxNTVlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzdGF0ZV9jaGVja2VyIjoiV2pvSFp4UXJaWld4QmJUdUdBRzlRckNueS05cjFXck9tT19lSlk1UWU1VSJ9.eG7V_Dg_GzLJ0WmSu0sp4gQhEe2QCY6jvjh-irOaghs;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiOTkyYjU0ZmItOGQxMC00OTg0LTk3ZWQtNmQ3ZTNmMDY4NjJjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzdGF0ZV9jaGVja2VyIjoiS3BFX2ZpQUFnaHZndzBrY1lhS1B6U0swdHJRZVQ5dk1JTFJreW1DZ1luRSJ9.ESuKZIkJdpZz6CH-39tfzFyRxlzEyKb0RwIr5w1GOJc;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c888c0ad-203c-4f67-be70-3ed30fb8fec2;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:37 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/4d67bdbc-f5d4-4130-bd6d-285e74e00301;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c888c0ad-203c-4f67-be70-3ed30fb8fec2;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:37 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/4d67bdbc-f5d4-4130-bd6d-285e74e00301;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -236,12 +236,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -284,12 +284,12 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=c888c0ad-203c-4f67-be70-3ed30fb8fec2; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiMzQ2YmQ3MDktNDViNS00ZDZlLWE4YWQtOGQ5M2Y2NTUxNTVlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzdGF0ZV9jaGVja2VyIjoiV2pvSFp4UXJaWld4QmJUdUdBRzlRckNueS05cjFXck9tT19lSlk1UWU1VSJ9.eG7V_Dg_GzLJ0WmSu0sp4gQhEe2QCY6jvjh-irOaghs;
-        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c888c0ad-203c-4f67-be70-3ed30fb8fec2
+      - AUTH_SESSION_ID_LEGACY=4d67bdbc-f5d4-4130-bd6d-285e74e00301; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiOTkyYjU0ZmItOGQxMC00OTg0LTk3ZWQtNmQ3ZTNmMDY4NjJjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzdGF0ZV9jaGVja2VyIjoiS3BFX2ZpQUFnaHZndzBrY1lhS1B6U0swdHJRZVQ5dk1JTFJreW1DZ1luRSJ9.ESuKZIkJdpZz6CH-39tfzFyRxlzEyKb0RwIr5w1GOJc;
+        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/4d67bdbc-f5d4-4130-bd6d-285e74e00301
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: ''
@@ -297,11 +297,11 @@ interactions:
       Cache-Control:
       - no-store, must-revalidate, max-age=0
       Location:
-      - http://testserver/eherkenning-oidc/callback/?state=not-a-random-string&session_state=c888c0ad-203c-4f67-be70-3ed30fb8fec2&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=40e5e0e2-11d0-40c7-be9c-37d86f169a00.c888c0ad-203c-4f67-be70-3ed30fb8fec2.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=4d67bdbc-f5d4-4130-bd6d-285e74e00301&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=996957a3-b953-43fe-b4aa-03b6a26f528b.4d67bdbc-f5d4-4130-bd6d-285e74e00301.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
@@ -309,15 +309,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiZGQzYjAwY2ItYmNhNy00NTMzLTlhNDMtNzdhN2IxMDZlYTEwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzdGF0ZV9jaGVja2VyIjoiV2pvSFp4UXJaWld4QmJUdUdBRzlRckNueS05cjFXck9tT19lSlk1UWU1VSJ9.did2Yds1MNeoI2xnb2ngAaDcmIvVIqmneLsh62UzngQ;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiYTQyMmIyN2QtNjA4MS00MDA3LWFjODAtZmYwOWY3YmY4MDMwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzdGF0ZV9jaGVja2VyIjoiS3BFX2ZpQUFnaHZndzBrY1lhS1B6U0swdHJRZVQ5dk1JTFJreW1DZ1luRSJ9.iMzpnPSolD-uNs8dIkpuPBib3LUgcz5GeXctDcHRYos;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiZGQzYjAwY2ItYmNhNy00NTMzLTlhNDMtNzdhN2IxMDZlYTEwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzdGF0ZV9jaGVja2VyIjoiV2pvSFp4UXJaWld4QmJUdUdBRzlRckNueS05cjFXck9tT19lSlk1UWU1VSJ9.did2Yds1MNeoI2xnb2ngAaDcmIvVIqmneLsh62UzngQ;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiYTQyMmIyN2QtNjA4MS00MDA3LWFjODAtZmYwOWY3YmY4MDMwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzdGF0ZV9jaGVja2VyIjoiS3BFX2ZpQUFnaHZndzBrY1lhS1B6U0swdHJRZVQ5dk1JTFJreW1DZ1luRSJ9.iMzpnPSolD-uNs8dIkpuPBib3LUgcz5GeXctDcHRYos;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c888c0ad-203c-4f67-be70-3ed30fb8fec2;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:37 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/4d67bdbc-f5d4-4130-bd6d-285e74e00301;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c888c0ad-203c-4f67-be70-3ed30fb8fec2;
-        Version=1; Expires=Tue, 26-Nov-2024 20:11:37 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/4d67bdbc-f5d4-4130-bd6d-285e74e00301;
+        Version=1; Expires=Fri, 13-Dec-2024 07:18:39 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=40e5e0e2-11d0-40c7-be9c-37d86f169a00.c888c0ad-203c-4f67-be70-3ed30fb8fec2.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=996957a3-b953-43fe-b4aa-03b6a26f528b.4d67bdbc-f5d4-4130-bd6d-285e74e00301.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -341,7 +341,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '279'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -350,7 +350,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTcsImlhdCI6MTczMjYxNTg5NywiYXV0aF90aW1lIjoxNzMyNjE1ODk3LCJqdGkiOiIwNTYzN2YxMC1iMzBmLTRkMjktYjEzNS1hOWUyM2FmMDRmOTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImM4ODhjMGFkLTIwM2MtNGY2Ny1iZTcwLTNlZDMwZmI4ZmVjMiIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImM4ODhjMGFkLTIwM2MtNGY2Ny1iZTcwLTNlZDMwZmI4ZmVjMiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.MUDbhbWlfAp3aS4papxAI2dmbhCij4iUDhRdjzkUcPXQ5KaThshdhnsE7db7v-Opn0IBBbIB8pLUdkRm6PBiUehro-yKlwAAx0pBR9QpE67Sk5R2JtFCARfXLgqTQr_u9o5QD1h5WAYX0ZO8t5aB1SehzzR5QyiDeiiLNTgv7P4K-04fsc8gj8CwgxvKRNZ9mXN9pXEoLSzJfgPXGx9FYUbFUmdVHKZXeGWAbh0_zj29zDDomFn73AxqA7oLxLl5ZpstbsbJdEEIac1ahz72Sm4iPtPLL1FNRdurHkVNbPWggZLKtBV7slEISklctRTOzSRKDqfD36cA14--aGz1Ew","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc2OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiNjkyMjRiZTctMTY0Ni00MTI2LThmZDItYTFiMWIzYjZhNTVhIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYzg4OGMwYWQtMjAzYy00ZjY3LWJlNzAtM2VkMzBmYjhmZWMyIn0.2BL5MLhEar3Egd0Yal40I0vVHOOa7LUkFl2_eHrzsho","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTcsImlhdCI6MTczMjYxNTg5NywiYXV0aF90aW1lIjoxNzMyNjE1ODk3LCJqdGkiOiI0ZWVjMjM1OC1mNTgxLTRmNDItOTU0OS1hOTkxNTlmYWZmNGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJhdF9oYXNoIjoia0FxazVtdFdKdjZiT3V2T0VlbWFfQSIsImFjciI6IjAiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.y2vMqHCp7bKicWxXZJPZT7jZlruuy8AGcoavaWCb0iIdCPff0FOGf4Q7k_YYJEHKFC7TczuxLGJRZt2rMOgRkNnoz05DE1U-QChlkLKoD78bHdUSfyUFtaLCy2pDvc2RhEceEFj9PhabLBvnYUZD8Pe8AFBYZGHPq6w-W_U5wNZsftcmHy9xgueVJOV8fSuFDTKStdhIZRHoHNTjkfxv6PSCha6o46DImo9DR-CnM0FEyaO-DQuPFlz3YRX58LePDD-pnbUCAiGkXAjABlYPkgH9XMHucWbuMgG3G_upftUIA3_yT7eS1PWuU2w3m4G_g_5PgPONg1vEfV70q3--Xw","not-before-policy":0,"session_state":"c888c0ad-203c-4f67-be70-3ed30fb8fec2","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIzODM2ZTZjOC0xZDg4LTQyNTctODUwZS00NzBiZDhkMjU5MTciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjRkNjdiZGJjLWY1ZDQtNDEzMC1iZDZkLTI4NWU3NGUwMDMwMSIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjRkNjdiZGJjLWY1ZDQtNDEzMC1iZDZkLTI4NWU3NGUwMDMwMSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.d8VG5dLM8shaY-VtnWNk7HyCAOu7tO6U6V_BG3gBQrOE2ovzgqQtxwbKxTftFUVuQoXF5NGaJ_qlWIy7lklbbg4GP4GiAKhtVvdIZtqiWh-KJmPMM7pf_viPGB7ce2yrNvd3keQrxy4PKODKxqHuvYI0iKJUb8WnWAQhujQ3iKOtzZ7NzUR3xmLWdrzb43X1zndnva_FxtLxfYfHAddwM9JWtq4Fhaxvb69vOz6AkYp-W-1oOvXLzXWtzEbm1LzSj82QzBxuRRFg9Gf2H_wlkv7BwSqCjISJUagdzlqYUHq5Q9yNwV2fbabjtlaH-VxueeSCH4iWMOrTgKR6R8n6bA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDAxMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiNTYwZDE1YmItY2YzZS00ZjUwLWIxNGEtOTA0Mzk5YmFjYTY1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNGQ2N2JkYmMtZjVkNC00MTMwLWJkNmQtMjg1ZTc0ZTAwMzAxIn0.D1BUP38dP0uCGkVgRYLJWvxgkDgyGlypUYBH5GzbEJY","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIxMGRhOTIwNC1mYzNkLTRmZGEtOTdkYi1lZjRiOWQ1YTc4NmIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJhdF9oYXNoIjoiQjNfcU9kc2RyeDU3ZUhRa2U0Zl9tQSIsImFjciI6IjAiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.VYW_EtAlVvvvnjvbE1XUCKvHzHBcUe7JDnhdktNWpzcvb8rsvhQ2nOa2G3xagAxGQpGejX4ALikGj9lC1j-ctd3VVuji3sWQSgNiilxz8_F2Gay_1Acfa4VHCe2sN4zbBS65a7BB9L4syI4ejCafiXZFxX6TqXKDdvU5sU8ma9btLaJ3SX91Ow3lN9kQBfnPsxqEG91uwzxrUCLBv91B5TJZ1wQM4BDLwiSzeJiatimYn8g5TTX9ERNbhu5Egmgk-SkwKcl73CXmu0pjTSinek7_7HuRFrQf-NbdXiHcyVc-WT0XRorqXnXDbhIi0f_NsAbuJjaJocOnIwx_6mXDKA","not-before-policy":0,"session_state":"4d67bdbc-f5d4-4130-bd6d-285e74e00301","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -418,7 +418,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTcsImlhdCI6MTczMjYxNTg5NywiYXV0aF90aW1lIjoxNzMyNjE1ODk3LCJqdGkiOiIwNTYzN2YxMC1iMzBmLTRkMjktYjEzNS1hOWUyM2FmMDRmOTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImM4ODhjMGFkLTIwM2MtNGY2Ny1iZTcwLTNlZDMwZmI4ZmVjMiIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImM4ODhjMGFkLTIwM2MtNGY2Ny1iZTcwLTNlZDMwZmI4ZmVjMiIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.MUDbhbWlfAp3aS4papxAI2dmbhCij4iUDhRdjzkUcPXQ5KaThshdhnsE7db7v-Opn0IBBbIB8pLUdkRm6PBiUehro-yKlwAAx0pBR9QpE67Sk5R2JtFCARfXLgqTQr_u9o5QD1h5WAYX0ZO8t5aB1SehzzR5QyiDeiiLNTgv7P4K-04fsc8gj8CwgxvKRNZ9mXN9pXEoLSzJfgPXGx9FYUbFUmdVHKZXeGWAbh0_zj29zDDomFn73AxqA7oLxLl5ZpstbsbJdEEIac1ahz72Sm4iPtPLL1FNRdurHkVNbPWggZLKtBV7slEISklctRTOzSRKDqfD36cA14--aGz1Ew
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIzODM2ZTZjOC0xZDg4LTQyNTctODUwZS00NzBiZDhkMjU5MTciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjRkNjdiZGJjLWY1ZDQtNDEzMC1iZDZkLTI4NWU3NGUwMDMwMSIsImFjciI6IjAiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjRkNjdiZGJjLWY1ZDQtNDEzMC1iZDZkLTI4NWU3NGUwMDMwMSIsImt2ayI6IjAxMjM0NTY3OCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwibGVnYWxTdWJqZWN0SUQiOiIxMjM0NTY3OCIsImFjdGluZ1N1YmplY3RJRCI6IjRCNzVBMEVBMTA3QjNEMzYiLCJuYW1lX3F1YWxpZmllciI6InVybjpldG9lZ2FuZzoxLjk6RW50aXR5Q29uY2VybmVkSUQ6S3ZLbnIiLCJncm91cHMiOlsiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciIsImJzbiI6IjAwMDAwMDAwMCJ9.d8VG5dLM8shaY-VtnWNk7HyCAOu7tO6U6V_BG3gBQrOE2ovzgqQtxwbKxTftFUVuQoXF5NGaJ_qlWIy7lklbbg4GP4GiAKhtVvdIZtqiWh-KJmPMM7pf_viPGB7ce2yrNvd3keQrxy4PKODKxqHuvYI0iKJUb8WnWAQhujQ3iKOtzZ7NzUR3xmLWdrzb43X1zndnva_FxtLxfYfHAddwM9JWtq4Fhaxvb69vOz6AkYp-W-1oOvXLzXWtzEbm1LzSj82QzBxuRRFg9Gf2H_wlkv7BwSqCjISJUagdzlqYUHq5Q9yNwV2fbabjtlaH-VxueeSCH4iWMOrTgKR6R8n6bA
       Connection:
       - keep-alive
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYxOTcsImlhdCI6MTczMjYxNTg5NywiYXV0aF90aW1lIjoxNzMyNjE1ODk3LCJqdGkiOiI0ZWVjMjM1OC1mNTgxLTRmNDItOTU0OS1hOTkxNTlmYWZmNGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJhdF9oYXNoIjoia0FxazVtdFdKdjZiT3V2T0VlbWFfQSIsImFjciI6IjAiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.y2vMqHCp7bKicWxXZJPZT7jZlruuy8AGcoavaWCb0iIdCPff0FOGf4Q7k_YYJEHKFC7TczuxLGJRZt2rMOgRkNnoz05DE1U-QChlkLKoD78bHdUSfyUFtaLCy2pDvc2RhEceEFj9PhabLBvnYUZD8Pe8AFBYZGHPq6w-W_U5wNZsftcmHy9xgueVJOV8fSuFDTKStdhIZRHoHNTjkfxv6PSCha6o46DImo9DR-CnM0FEyaO-DQuPFlz3YRX58LePDD-pnbUCAiGkXAjABlYPkgH9XMHucWbuMgG3G_upftUIA3_yT7eS1PWuU2w3m4G_g_5PgPONg1vEfV70q3--Xw
+    body: id_token_hint=eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg2MTksImlhdCI6MTczNDAzODMxOSwiYXV0aF90aW1lIjoxNzM0MDM4MzE5LCJqdGkiOiIxMGRhOTIwNC1mYzNkLTRmZGEtOTdkYi1lZjRiOWQ1YTc4NmIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiJhYTEwY2ZjNy0yYzRkLTQxZjYtOGZhYy03YmY0MDVjNTcyYzQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJhdF9oYXNoIjoiQjNfcU9kc2RyeDU3ZUhRa2U0Zl9tQSIsImFjciI6IjAiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJrdmsiOiIwMTIzNDU2NzgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImxlZ2FsU3ViamVjdElEIjoiMTIzNDU2NzgiLCJhY3RpbmdTdWJqZWN0SUQiOiI0Qjc1QTBFQTEwN0IzRDM2IiwibmFtZV9xdWFsaWZpZXIiOiJ1cm46ZXRvZWdhbmc6MS45OkVudGl0eUNvbmNlcm5lZElEOkt2S25yIiwiZ3JvdXBzIjpbImRlZmF1bHQtcm9sZXMtdGVzdCIsIm9mZmxpbmVfYWNjZXNzIiwidW1hX2F1dGhvcml6YXRpb24iXSwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJic24iOiIwMDAwMDAwMDAifQ.VYW_EtAlVvvvnjvbE1XUCKvHzHBcUe7JDnhdktNWpzcvb8rsvhQ2nOa2G3xagAxGQpGejX4ALikGj9lC1j-ctd3VVuji3sWQSgNiilxz8_F2Gay_1Acfa4VHCe2sN4zbBS65a7BB9L4syI4ejCafiXZFxX6TqXKDdvU5sU8ma9btLaJ3SX91Ow3lN9kQBfnPsxqEG91uwzxrUCLBv91B5TJZ1wQM4BDLwiSzeJiatimYn8g5TTX9ERNbhu5Egmgk-SkwKcl73CXmu0pjTSinek7_7HuRFrQf-NbdXiHcyVc-WT0XRorqXnXDbhIi0f_NsAbuJjaJocOnIwx_6mXDKA
     headers:
       Accept:
       - '*/*'
@@ -505,12 +505,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -531,9 +531,9 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=d9de2ebe-f550-464e-b433-27d8fcb37ed4; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=dd494d11-e339-495a-a41d-18401e15af04; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=d9de2ebe-f550-464e-b433-27d8fcb37ed4; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=dd494d11-e339-495a-a41d-18401e15af04; Version=1; Path=/realms/test/;
         HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -569,12 +569,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -617,29 +617,29 @@ interactions:
       Connection:
       - keep-alive
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=c888c0ad-203c-4f67-be70-3ed30fb8fec2; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE4OTcsImlhdCI6MTczMjYxNTg5NywianRpIjoiZGQzYjAwY2ItYmNhNy00NTMzLTlhNDMtNzdhN2IxMDZlYTEwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzaWQiOiJjODg4YzBhZC0yMDNjLTRmNjctYmU3MC0zZWQzMGZiOGZlYzIiLCJzdGF0ZV9jaGVja2VyIjoiV2pvSFp4UXJaWld4QmJUdUdBRzlRckNueS05cjFXck9tT19lSlk1UWU1VSJ9.did2Yds1MNeoI2xnb2ngAaDcmIvVIqmneLsh62UzngQ;
-        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/c888c0ad-203c-4f67-be70-3ed30fb8fec2;
-        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo
+      - AUTH_SESSION_ID_LEGACY=4d67bdbc-f5d4-4130-bd6d-285e74e00301; KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQzMTksImlhdCI6MTczNDAzODMxOSwianRpIjoiYTQyMmIyN2QtNjA4MS00MDA3LWFjODAtZmYwOWY3YmY4MDMwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiYWExMGNmYzctMmM0ZC00MWY2LThmYWMtN2JmNDA1YzU3MmM0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzaWQiOiI0ZDY3YmRiYy1mNWQ0LTQxMzAtYmQ2ZC0yODVlNzRlMDAzMDEiLCJzdGF0ZV9jaGVja2VyIjoiS3BFX2ZpQUFnaHZndzBrY1lhS1B6U0swdHJRZVQ5dk1JTFJreW1DZ1luRSJ9.iMzpnPSolD-uNs8dIkpuPBib3LUgcz5GeXctDcHRYos;
+        KEYCLOAK_SESSION_LEGACY=test/aa10cfc7-2c4d-41f6-8fac-7bf405c572c4/4d67bdbc-f5d4-4130-bd6d-285e74e00301;
+        KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Feherkenning-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+kvk&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"5dcb3bd6-3001-4374-acde-b278efbff640\",\n
-        \             \"R9l7MrX8kpw\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=R9l7MrX8kpw&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"46f20f55-2b48-4d96-81e4-4333fa7c5952\",\n
+        \             \"2hp2rlCHFJc\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=2hp2rlCHFJc&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -647,7 +647,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=24uu4bnXO7meDb0VxFjEYTkp1xW2ZPviYEfLQmKbCt4&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=R9l7MrX8kpw\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=sPcTXGsp36Ppe7ywrlH1KdBEhvl8I9b7YciTNhCE-_s&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=2hp2rlCHFJc\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -673,7 +673,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -703,11 +703,11 @@ interactions:
         00:00:10 GMT; Max-Age=0; Path=/realms/test
       - KEYCLOAK_SESSION_LEGACY=; Version=1; Comment=Expiring cookie; Expires=Thu,
         01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/realms/test
-      - AUTH_SESSION_ID=5dcb3bd6-3001-4374-acde-b278efbff640; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=46f20f55-2b48-4d96-81e4-4333fa7c5952; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=5dcb3bd6-3001-4374-acde-b278efbff640; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=46f20f55-2b48-4d96-81e4-4333fa7c5952; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9laGVya2VubmluZy1vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGt2ayIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvZWhlcmtlbm5pbmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.SpI7JvuDjU8Dn4CR3RD56sJAxNizNRciRym82v57Ylo;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQga3ZrIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.ej_DYEIcUpDIzAmMkg-eN-m6-OhL_4l71sMGxwXnkcA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/test_auth_flow_init.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/test_auth_flow_init.py
@@ -33,7 +33,7 @@ class DigiDInitTests(IntegrationTestsBase):
     Test the outbound part of OIDC-based DigiD authentication.
     """
 
-    CALLBACK_URL = f"http://testserver{reverse_lazy('digid_oidc:callback')}"
+    CALLBACK_URL = f"http://testserver{reverse_lazy('oidc_authentication_callback')}"
 
     @mock_digid_config()
     def test_start_flow_redirects_to_oidc_provider(self):
@@ -90,7 +90,7 @@ class EHerkenningInitTests(IntegrationTestsBase):
     Test the outbound part of OIDC-based eHerkenning authentication.
     """
 
-    CALLBACK_URL = f"http://testserver{reverse_lazy('eherkenning_oidc:callback')}"
+    CALLBACK_URL = f"http://testserver{reverse_lazy('oidc_authentication_callback')}"
 
     @mock_eherkenning_config()
     def test_start_flow_redirects_to_oidc_provider(self):
@@ -149,7 +149,7 @@ class DigiDMachtigenInitTests(IntegrationTestsBase):
     Test the outbound part of OIDC-based DigiD machtigen authentication.
     """
 
-    CALLBACK_URL = f"http://testserver{reverse_lazy('digid_machtigen_oidc:callback')}"
+    CALLBACK_URL = f"http://testserver{reverse_lazy('oidc_authentication_callback')}"
 
     @mock_digid_machtigen_config()
     def test_start_flow_redirects_to_oidc_provider(self):
@@ -210,9 +210,7 @@ class EHerkenningBewindvoeringInitTests(IntegrationTestsBase):
     Test the outbound part of OIDC-based eHerkenning_bewindvoering authentication.
     """
 
-    CALLBACK_URL = (
-        f"http://testserver{reverse_lazy('eherkenning_bewindvoering_oidc:callback')}"
-    )
+    CALLBACK_URL = f"http://testserver{reverse_lazy('oidc_authentication_callback')}"
 
     @mock_eherkenning_bewindvoering_config()
     def test_start_flow_redirects_to_oidc_provider(self):

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/test_configuration.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/test_configuration.py
@@ -24,7 +24,8 @@ class CallbackURLConfigurationTests(TestCase):
         self.addCleanup(OFDigiDMachtigenConfig.clear_cache)
         self.addCleanup(OFEHerkenningBewindvoeringConfig.clear_cache)
 
-    def test_default_settings_backwards_compatible(self):
+    @override_settings(USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS=True)
+    def test_legacy_settings(self):
         cases = (
             (OFDigiDConfig, "/digid-oidc/callback/"),
             (OFEHerkenningConfig, "/eherkenning-oidc/callback/"),
@@ -45,8 +46,7 @@ class CallbackURLConfigurationTests(TestCase):
 
                 self.assertEqual(url, expected_url)
 
-    @override_settings(USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS=False)
-    def test_new_behaviour(self):
+    def test_default_settings_behaviour(self):
         cases = (
             OFDigiDConfig,
             OFEHerkenningConfig,

--- a/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCCallbackTests/OrgOIDCCallbackTests.test_failing_claim_verification.yaml
+++ b/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCCallbackTests/OrgOIDCCallbackTests.test_failing_claim_verification.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Forg-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"f1f19398-3aa3-4b52-9a63-9db59593b9ac\",\n
-        \             \"vCBtDUe-TN8\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=vCBtDUe-TN8&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"6c5ac55c-3cae-4c83-bfd0-93365f2abd7e\",\n
+        \             \"BQh3Q48mBOM\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=BQh3Q48mBOM&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=J2NLFhbDarxWHsKhgrdpOTp0WD7bMFnOQ4diLoLCwWE&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=vCBtDUe-TN8\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=A9V-TztJfNc2qVDZc1kBtapIJ9AFim4yIxD57ZRDnVQ&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=BQh3Q48mBOM\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=f1f19398-3aa3-4b52-9a63-9db59593b9ac; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=6c5ac55c-3cae-4c83-bfd0-93365f2abd7e; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=f1f19398-3aa3-4b52-9a63-9db59593b9ac; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=6c5ac55c-3cae-4c83-bfd0-93365f2abd7e; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.PVsoxNQ0-_nJN1HEGMJ6H1byID8wg96CZXFzWiaCgQk;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXV0aC9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.tdn77ODcL5bmyBYytPxHY-3fZ3w4A-EJkQxB_f9AMC8;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=f1f19398-3aa3-4b52-9a63-9db59593b9ac; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.PVsoxNQ0-_nJN1HEGMJ6H1byID8wg96CZXFzWiaCgQk
+      - AUTH_SESSION_ID_LEGACY=6c5ac55c-3cae-4c83-bfd0-93365f2abd7e; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXV0aC9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.tdn77ODcL5bmyBYytPxHY-3fZ3w4A-EJkQxB_f9AMC8
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=J2NLFhbDarxWHsKhgrdpOTp0WD7bMFnOQ4diLoLCwWE&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=vCBtDUe-TN8
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=A9V-TztJfNc2qVDZc1kBtapIJ9AFim4yIxD57ZRDnVQ&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=BQh3Q48mBOM
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/org-oidc/callback/?state=not-a-random-string&session_state=f1f19398-3aa3-4b52-9a63-9db59593b9ac&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=a6b1ad23-fb52-4c6c-8c5f-010e0cdb3ce7.f1f19398-3aa3-4b52-9a63-9db59593b9ac.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=6c5ac55c-3cae-4c83-bfd0-93365f2abd7e&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=8cfec6ec-3fe4-42f3-a00f-12fd29cbb31c.6c5ac55c-3cae-4c83-bfd0-93365f2abd7e.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE5ODYsImlhdCI6MTczMjYxNTk4NiwianRpIjoiZDU4M2VjYzItZjJmMC00MTBkLTg1MmEtYzBlNWQ4OTZjMWUwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJzaWQiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJzdGF0ZV9jaGVja2VyIjoiaGZVTlRhYWJhODNmM3ZsaXljbTdnNVU0a2dPajBvUWRlVUI5V0NmQ3FfSSJ9._bvTS4-4L89mkI37EAsrhJ9wKx8VWe9v1ovxJ0OCvog;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQwNTEsImlhdCI6MTczNDAzODA1MSwianRpIjoiNmVjODRlZGYtMmNlNS00YTg0LTgzNTYtY2IxNjFlMGIyNWNmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJzaWQiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJzdGF0ZV9jaGVja2VyIjoiWVU5V3VoUTgta0hGYm0zMU9hYThrMjBFMkdubUJhUVh5cWg0RDdwMFJ3dyJ9.3iryAV_4PAuP9yz00i53ysl_XJXgdCl_wz063DtBHWI;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE5ODYsImlhdCI6MTczMjYxNTk4NiwianRpIjoiZDU4M2VjYzItZjJmMC00MTBkLTg1MmEtYzBlNWQ4OTZjMWUwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJzaWQiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJzdGF0ZV9jaGVja2VyIjoiaGZVTlRhYWJhODNmM3ZsaXljbTdnNVU0a2dPajBvUWRlVUI5V0NmQ3FfSSJ9._bvTS4-4L89mkI37EAsrhJ9wKx8VWe9v1ovxJ0OCvog;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQwNTEsImlhdCI6MTczNDAzODA1MSwianRpIjoiNmVjODRlZGYtMmNlNS00YTg0LTgzNTYtY2IxNjFlMGIyNWNmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJzaWQiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJzdGF0ZV9jaGVja2VyIjoiWVU5V3VoUTgta0hGYm0zMU9hYThrMjBFMkdubUJhUVh5cWg0RDdwMFJ3dyJ9.3iryAV_4PAuP9yz00i53ysl_XJXgdCl_wz063DtBHWI;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/f1f19398-3aa3-4b52-9a63-9db59593b9ac;
-        Version=1; Expires=Tue, 26-Nov-2024 20:13:06 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/6c5ac55c-3cae-4c83-bfd0-93365f2abd7e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:14:11 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/f1f19398-3aa3-4b52-9a63-9db59593b9ac;
-        Version=1; Expires=Tue, 26-Nov-2024 20:13:06 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/6c5ac55c-3cae-4c83-bfd0-93365f2abd7e;
+        Version=1; Expires=Fri, 13-Dec-2024 07:14:11 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=a6b1ad23-fb52-4c6c-8c5f-010e0cdb3ce7.f1f19398-3aa3-4b52-9a63-9db59593b9ac.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Forg-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=8cfec6ec-3fe4-42f3-a00f-12fd29cbb31c.6c5ac55c-3cae-4c83-bfd0-93365f2abd7e.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '271'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODYsImlhdCI6MTczMjYxNTk4NiwiYXV0aF90aW1lIjoxNzMyNjE1OTg2LCJqdGkiOiIzZjJhN2NlOC1hZTlkLTQ5M2UtODk3Yi0yMDZmYTQ0OTk1YWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImYxZjE5Mzk4LTNhYTMtNGI1Mi05YTYzLTlkYjU5NTkzYjlhYyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImYxZjE5Mzk4LTNhYTMtNGI1Mi05YTYzLTlkYjU5NTkzYjlhYyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.JsvEoO1GzRfqj2xzSeTjFuWIC-GAM3V7il3oNRSVGvhF6gYI2VBn6fCt90NCXuFNueTyL4WC1UbqoSd60R5qFY6Qdtsd7fkEfmz_3kWVG-wSjBwSDA1rD7lxX-wMCOoFPo9mh8o9qbR2Sx_xFxWEHX7B-uHJLdnFjRqwiuBEKpI851mexaK-MDv1NWMwt90WmOBJ7iNzf-N2xfOzBVqcLFBHzGsepROA2seF74sqGBHdHUb_yX0VOtJxy0-hDA7fdb3-3h9m9V-Jb1ywRab3lH409CulnJezx6yTCqkOE0DCqHLkU_YgDFEsSeWI0VMRgehRnYcc_BQ0KpYiJe58mQ","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc3ODYsImlhdCI6MTczMjYxNTk4NiwianRpIjoiYWQzMGU1MWYtNjM4OC00NGU4LTkxZjctZjRmNDM3OGZkNTg4IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZjFmMTkzOTgtM2FhMy00YjUyLTlhNjMtOWRiNTk1OTNiOWFjIn0.aLpwefSiWCRf58snHfNBf6bWEKtPP7d5nr48ZbzUXIw","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODYsImlhdCI6MTczMjYxNTk4NiwiYXV0aF90aW1lIjoxNzMyNjE1OTg2LCJqdGkiOiI4YzY5OGNhYS01MjEwLTRmODYtOGE3MC1jNDQwZDQzYzkzMWIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJhdF9oYXNoIjoiakZ0WW02NUZkYjB4Wm5CV0VFUXlHZyIsImFjciI6IjEiLCJzaWQiOiJmMWYxOTM5OC0zYWEzLTRiNTItOWE2My05ZGI1OTU5M2I5YWMiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.xgRSdDKzXZIqs01yklNqOcGJfvMR9-7LqLwRPAi6Mq2qC6LEhwARwYGXD74NbfCH0J81MsuJP9_32dViNY5Yn7GS3POQWWSm4wS6ruo6iHsrcNx_uZmMe1jEZBmdK0_XbfVtjjwLRp5lzoImvV61Ss2voshuslpb4Sl8-6UfXx8j_nSgPpCqxa8GrlGvUoOAko1qLMyNl5OuJ53W8T3KisaYmvtNLkAcEhzC3mf0k5OJYRo7dSy7rtmoSQdTtIpcKfCs-93daBThItEqWBbjNeBa81wA8hs_8PLxMUGYZUc5yZi9M0rcjw247139rOeFAjahsYwu14Z2XoAdiuCwVg","not-before-policy":0,"session_state":"f1f19398-3aa3-4b52-9a63-9db59593b9ac","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTEsImlhdCI6MTczNDAzODA1MSwiYXV0aF90aW1lIjoxNzM0MDM4MDUxLCJqdGkiOiI5YmQ1NjlkMC02MmU1LTRiMDQtODlmZS1jN2JjYWNkMmMxNDUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjZjNWFjNTVjLTNjYWUtNGM4My1iZmQwLTkzMzY1ZjJhYmQ3ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjZjNWFjNTVjLTNjYWUtNGM4My1iZmQwLTkzMzY1ZjJhYmQ3ZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.MoYMnxVkIf39tE4wpGTUi15nkOeeQe8y5FHbow4BUh_YXSDNgWtEyHpHiaAKhBHneDoEwFpqQ_Qe1CpYuTGiow3SAUvEedPuHwpOjdvL5Brwnx16W87C3a1i1sIIxQpNbHQDJELHhYkZk-lWRxmbQTew3yhQvoTqIV_1gnB1Caemu8MhytjVmVq3LafXH-sTAK3po9_9-B2008w-No3taYRkGyalNgHD4sGDbuypTFRRKlI5iSSgaMytw2jZjhFO4eI6PStvNObeq7YxqSaeeGWc2QP1FTYby4Q99M2_-4lcuMe2jBT4lp-lZFNGhhuKfbptqGATlfWeiVsf7YH9xw","expires_in":299,"refresh_expires_in":1799,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwMzk4NTEsImlhdCI6MTczNDAzODA1MiwianRpIjoiYzAyNDg5ZGQtZGJjYy00ODI3LWJhYzgtZGNhODI0MjQ0ZGFlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNmM1YWM1NWMtM2NhZS00YzgzLWJmZDAtOTMzNjVmMmFiZDdlIn0.AXlFbu3EMkizIaxftrdzJjaEB_nmCFq9YEbgaTbV2lo","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTEsImlhdCI6MTczNDAzODA1MiwiYXV0aF90aW1lIjoxNzM0MDM4MDUxLCJqdGkiOiI2ZTdmNjFkMS1lZTRlLTQ0OWYtYmEwMC1kYmM2NmY4NmIzN2MiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJhdF9oYXNoIjoiZTdKVHNLdm1ock1memhOUUdxQ1JQUSIsImFjciI6IjEiLCJzaWQiOiI2YzVhYzU1Yy0zY2FlLTRjODMtYmZkMC05MzM2NWYyYWJkN2UiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.OIs1g792KTVtJ8kqnjuagJci7_Zcp0FkhRq1JX2ywrzYqnLIsx9cC5TRDmrT3IUY8cWmhw6og1YRXUqwqwfv8wF5rBBkQZRwu789zzeEWaC2hFvllNw4u341pcxEKhP155CSGGuICjQfZLA7XlD64t6u4zvG-kWlLLmUiVhGWmKscJsS1AEfMpCZ3WiYemnC7lFlI71SMZwep9SphwtcJmJopKEDuNHi2mebbfgM9Y41Ad-t4k6Wk1HP01xrCZAc9H7aKC0B3XWf0Lwxl0BAdQH--IAZ5WIHXcTnfulgUWQDPQ12idFpA1oBvGr3qMH38dKhgRGigip5dekN_eef0Q","not-before-policy":0,"session_state":"6c5ac55c-3cae-4c83-bfd0-93365f2abd7e","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODYsImlhdCI6MTczMjYxNTk4NiwiYXV0aF90aW1lIjoxNzMyNjE1OTg2LCJqdGkiOiIzZjJhN2NlOC1hZTlkLTQ5M2UtODk3Yi0yMDZmYTQ0OTk1YWQiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImYxZjE5Mzk4LTNhYTMtNGI1Mi05YTYzLTlkYjU5NTkzYjlhYyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImYxZjE5Mzk4LTNhYTMtNGI1Mi05YTYzLTlkYjU5NTkzYjlhYyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.JsvEoO1GzRfqj2xzSeTjFuWIC-GAM3V7il3oNRSVGvhF6gYI2VBn6fCt90NCXuFNueTyL4WC1UbqoSd60R5qFY6Qdtsd7fkEfmz_3kWVG-wSjBwSDA1rD7lxX-wMCOoFPo9mh8o9qbR2Sx_xFxWEHX7B-uHJLdnFjRqwiuBEKpI851mexaK-MDv1NWMwt90WmOBJ7iNzf-N2xfOzBVqcLFBHzGsepROA2seF74sqGBHdHUb_yX0VOtJxy0-hDA7fdb3-3h9m9V-Jb1ywRab3lH409CulnJezx6yTCqkOE0DCqHLkU_YgDFEsSeWI0VMRgehRnYcc_BQ0KpYiJe58mQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTEsImlhdCI6MTczNDAzODA1MSwiYXV0aF90aW1lIjoxNzM0MDM4MDUxLCJqdGkiOiI5YmQ1NjlkMC02MmU1LTRiMDQtODlmZS1jN2JjYWNkMmMxNDUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjZjNWFjNTVjLTNjYWUtNGM4My1iZmQwLTkzMzY1ZjJhYmQ3ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjZjNWFjNTVjLTNjYWUtNGM4My1iZmQwLTkzMzY1ZjJhYmQ3ZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.MoYMnxVkIf39tE4wpGTUi15nkOeeQe8y5FHbow4BUh_YXSDNgWtEyHpHiaAKhBHneDoEwFpqQ_Qe1CpYuTGiow3SAUvEedPuHwpOjdvL5Brwnx16W87C3a1i1sIIxQpNbHQDJELHhYkZk-lWRxmbQTew3yhQvoTqIV_1gnB1Caemu8MhytjVmVq3LafXH-sTAK3po9_9-B2008w-No3taYRkGyalNgHD4sGDbuypTFRRKlI5iSSgaMytw2jZjhFO4eI6PStvNObeq7YxqSaeeGWc2QP1FTYby4Q99M2_-4lcuMe2jBT4lp-lZFNGhhuKfbptqGATlfWeiVsf7YH9xw
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCCallbackTests/OrgOIDCCallbackTests.test_logout_clears_session.yaml
+++ b/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCCallbackTests/OrgOIDCCallbackTests.test_logout_clears_session.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Forg-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"0c6e4d4b-a444-4ce0-8247-7bea071c9f08\",\n
-        \             \"w5494th21Ro\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=w5494th21Ro&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"d64ba44c-0a98-44dc-b431-91040f2a570c\",\n
+        \             \"VVGxpnYQiAY\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=VVGxpnYQiAY&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=Wo3OLUFPuoWlDNcIet-XiFRwJOHREJ8Qe86tmWarwr8&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=w5494th21Ro\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=sUGKL1q9wiDTUfdvinBXB5-ZR_kiltIdbr4jvSha0Pw&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=VVGxpnYQiAY\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=0c6e4d4b-a444-4ce0-8247-7bea071c9f08; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=d64ba44c-0a98-44dc-b431-91040f2a570c; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=0c6e4d4b-a444-4ce0-8247-7bea071c9f08; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=d64ba44c-0a98-44dc-b431-91040f2a570c; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.PVsoxNQ0-_nJN1HEGMJ6H1byID8wg96CZXFzWiaCgQk;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXV0aC9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.tdn77ODcL5bmyBYytPxHY-3fZ3w4A-EJkQxB_f9AMC8;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=0c6e4d4b-a444-4ce0-8247-7bea071c9f08; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.PVsoxNQ0-_nJN1HEGMJ6H1byID8wg96CZXFzWiaCgQk
+      - AUTH_SESSION_ID_LEGACY=d64ba44c-0a98-44dc-b431-91040f2a570c; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXV0aC9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.tdn77ODcL5bmyBYytPxHY-3fZ3w4A-EJkQxB_f9AMC8
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=Wo3OLUFPuoWlDNcIet-XiFRwJOHREJ8Qe86tmWarwr8&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=w5494th21Ro
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=sUGKL1q9wiDTUfdvinBXB5-ZR_kiltIdbr4jvSha0Pw&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=VVGxpnYQiAY
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/org-oidc/callback/?state=not-a-random-string&session_state=0c6e4d4b-a444-4ce0-8247-7bea071c9f08&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=414a0a3a-a49b-4904-9fed-1b415f3f88c0.0c6e4d4b-a444-4ce0-8247-7bea071c9f08.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=d64ba44c-0a98-44dc-b431-91040f2a570c&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=acbdd977-525d-45fc-89d1-4ddd8a673a72.d64ba44c-0a98-44dc-b431-91040f2a570c.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE5ODcsImlhdCI6MTczMjYxNTk4NywianRpIjoiM2QxZmVjMGQtOWYxZC00ZmNkLTkxMjQtMDg1Y2JkNzliMDBlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJzaWQiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJzdGF0ZV9jaGVja2VyIjoiSkZlWlRZLW9mTzZDeTU4SWFsUFI4T1ppUGhyMXZySHR6VFV1U3dXS1VfOCJ9.LbXI9491GLi1zCMMNyXI5oc8PmK8fXm26utxngiUaik;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQwNTIsImlhdCI6MTczNDAzODA1MiwianRpIjoiOWMxYzBiNTktZjhiYy00ZWRkLTk0OTQtZmY0ODU0YzU1M2I1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJzaWQiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJzdGF0ZV9jaGVja2VyIjoiY2c4a1VwR1NkeXQtaUdSQXRyUkd1VGdyUmlhRHlZNGNLeG5SUTFJZDl5TSJ9.Q366FP-qD2HvUNZ0go5fS-ebL0I0mI6SJz62nS4r3hw;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE5ODcsImlhdCI6MTczMjYxNTk4NywianRpIjoiM2QxZmVjMGQtOWYxZC00ZmNkLTkxMjQtMDg1Y2JkNzliMDBlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJzaWQiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJzdGF0ZV9jaGVja2VyIjoiSkZlWlRZLW9mTzZDeTU4SWFsUFI4T1ppUGhyMXZySHR6VFV1U3dXS1VfOCJ9.LbXI9491GLi1zCMMNyXI5oc8PmK8fXm26utxngiUaik;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQwNTIsImlhdCI6MTczNDAzODA1MiwianRpIjoiOWMxYzBiNTktZjhiYy00ZWRkLTk0OTQtZmY0ODU0YzU1M2I1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJzaWQiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJzdGF0ZV9jaGVja2VyIjoiY2c4a1VwR1NkeXQtaUdSQXRyUkd1VGdyUmlhRHlZNGNLeG5SUTFJZDl5TSJ9.Q366FP-qD2HvUNZ0go5fS-ebL0I0mI6SJz62nS4r3hw;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/0c6e4d4b-a444-4ce0-8247-7bea071c9f08;
-        Version=1; Expires=Tue, 26-Nov-2024 20:13:07 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/d64ba44c-0a98-44dc-b431-91040f2a570c;
+        Version=1; Expires=Fri, 13-Dec-2024 07:14:12 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/0c6e4d4b-a444-4ce0-8247-7bea071c9f08;
-        Version=1; Expires=Tue, 26-Nov-2024 20:13:07 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/d64ba44c-0a98-44dc-b431-91040f2a570c;
+        Version=1; Expires=Fri, 13-Dec-2024 07:14:12 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=414a0a3a-a49b-4904-9fed-1b415f3f88c0.0c6e4d4b-a444-4ce0-8247-7bea071c9f08.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Forg-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=acbdd977-525d-45fc-89d1-4ddd8a673a72.d64ba44c-0a98-44dc-b431-91040f2a570c.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '271'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODcsImlhdCI6MTczMjYxNTk4NywiYXV0aF90aW1lIjoxNzMyNjE1OTg3LCJqdGkiOiIwOTBjOWY5Zi1jYTY0LTRjZDUtODcwNy05MDk2ZDkxYjFlNTYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjBjNmU0ZDRiLWE0NDQtNGNlMC04MjQ3LTdiZWEwNzFjOWYwOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjBjNmU0ZDRiLWE0NDQtNGNlMC04MjQ3LTdiZWEwNzFjOWYwOCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.aGCSPq3XAkgEcwKy84fn8jLsfrdPYD9fuys_6ugxFNR-bgP3YfyqTw9puXDcLmU6477Zopff7QXbi13KQenmbAi13dHKDPui0bYhBUmxCd6-DTmeB4BOlKQEq3mnBfIOYnHHnk_MPBCdlgZ0vWo4x2ZcCuH2vRSHuhv2BnzureBtMO_0ljRqe4P0SDUz4gW5aUro2dXgeEyhyi2QORaNgoaI3M_F4x-0vUefo6MH7p5GrdNxVVJmetIvIpagVC4TDBva8AM0qN1yDZmwOsfamys0QDR6-3KAmHiJnhIQic7-Q_2WVCJJWsjaW90Uf8HEovmGbVp8QZHR5s9uMj7I-g","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc3ODcsImlhdCI6MTczMjYxNTk4NywianRpIjoiYzVjMTUxMWUtMDg2MC00MmUyLTgxMDgtZGY5ZWY2M2E4NDY3IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiMGM2ZTRkNGItYTQ0NC00Y2UwLTgyNDctN2JlYTA3MWM5ZjA4In0.4qkDDYuIjSeZGJ-LEGPn6HGdVA4nVxTZzI-PdQ5JCRw","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODcsImlhdCI6MTczMjYxNTk4NywiYXV0aF90aW1lIjoxNzMyNjE1OTg3LCJqdGkiOiJmZTg5NmMxZC0zMGEyLTQwZWMtYmIzOC00M2Y1ZWNmOWMwNjMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJhdF9oYXNoIjoiWjBOMTh6ZWliV0RaM0VNa2dSZ2Y1dyIsImFjciI6IjEiLCJzaWQiOiIwYzZlNGQ0Yi1hNDQ0LTRjZTAtODI0Ny03YmVhMDcxYzlmMDgiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.Kq0O9JCz0UQt6WZUmIREpG6x_4vmk6ZYUDD6nWI4atgtxlDjdGmNDyA6aK3GOifFuCwmelG4sUsBMDz9SsZ9a3TY34kcG_w4U868OLI6XEv0o3LiMu_iB-WkgcMvaSEapro36YfyxqdKKwHPy7hkL3gDp95aijWbvb1RNxK_C7F4JxuzqRavxz3CZrP32Mt6EamCCyp9heEmRKEumsICoEpLsmpVB0bk4tPQ-IXx3LeXolB5EFDTo82YFEmiISr5iGZDUWQrhsEKPaDg-3RwFlyFI7yEepx2vgNJMgIc8T5SQJyhaI6TU0-X3ZznzFvqPV9Cj8tkiclbkv-fpQtinA","not-before-policy":0,"session_state":"0c6e4d4b-a444-4ce0-8247-7bea071c9f08","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTMsImlhdCI6MTczNDAzODA1MywiYXV0aF90aW1lIjoxNzM0MDM4MDUyLCJqdGkiOiIxYzAxZjhmNS03Yzg2LTQ5OGMtYmY0Yy01M2Y0NjQ2ZDdlNDIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImQ2NGJhNDRjLTBhOTgtNDRkYy1iNDMxLTkxMDQwZjJhNTcwYyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImQ2NGJhNDRjLTBhOTgtNDRkYy1iNDMxLTkxMDQwZjJhNTcwYyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.cFsuSv7-8BfqQo_N380DRmROVyVtV9ttYJhglOSE8k26N8XTzzdaVU3awrdyZcx98VBp2pKmp2-j4jmRXKxTjgORrgk7nt4-P-Iawm66xcv5oRtSZEp1GJPfO4SSOZ4YtJVD6odUPwdaDJuQKAthpOUfDgwA2Gi-K9oZ9ARXzk-0v8FD-lRisG8J3e0tiX5N8fs9xVlNXD9488dM96rKrToIFkv4s0HgLsNNIowt2j4U3O5Gh6hDIFRRCD3M9wlYvdaEhHYcfeZai7fQRFV5YrmNBU_Qwa1yBOridLWJTYktqkRskEDKYtG0w5VQwogPyBz5XV4KARcqV8yi4Quoog","expires_in":300,"refresh_expires_in":1799,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwMzk4NTIsImlhdCI6MTczNDAzODA1MywianRpIjoiNmZmMmIzOGMtNWUyOS00YTg5LWIxNzYtYmU2YTYxZDg4ZWI2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiZDY0YmE0NGMtMGE5OC00NGRjLWI0MzEtOTEwNDBmMmE1NzBjIn0.La8rZBRKg6W5nMHkkt5J9Lc5hBznoflL0f1857LqvfI","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTMsImlhdCI6MTczNDAzODA1MywiYXV0aF90aW1lIjoxNzM0MDM4MDUyLCJqdGkiOiJhODg5NWMzZS1hZjZhLTQ2Y2YtODU0YS00MWU3Y2ZhMmQxNWYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJhdF9oYXNoIjoiWHZtSGQzd0x2Qk11d19FeUlEbUhvdyIsImFjciI6IjEiLCJzaWQiOiJkNjRiYTQ0Yy0wYTk4LTQ0ZGMtYjQzMS05MTA0MGYyYTU3MGMiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.FPl6irf_rPS-HgZL9W0v6Yky5OZoG_tEcVEJutqRTRWtBQ8L840LZDSeGaT-0dqHAuBr82ADHEnyj69CYLWmRcnv6wTECFWqPK6bZdU8rPdgsJNDphAMXPxek9rbogXV2FVXO-QrfILi7zj5b780RNCWp2Gk4qRGgH_qrojWZ9aY_i-6E4llQpnRG9ThJgs2l6iUQxegeqOqshbQrHM3YsXkt6KjpQziXPuU30XZnP6q1t82zvSIa2hLYsEsAAo89DV41nZSrypQ-gu80Wr0waJRWDTAFRXHYXNTYPXVnfjjIlnyKmURQjc7hmnTz-xD26VpkEJIegLjt_8XlddygQ","not-before-policy":0,"session_state":"d64ba44c-0a98-44dc-b431-91040f2a570c","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODcsImlhdCI6MTczMjYxNTk4NywiYXV0aF90aW1lIjoxNzMyNjE1OTg3LCJqdGkiOiIwOTBjOWY5Zi1jYTY0LTRjZDUtODcwNy05MDk2ZDkxYjFlNTYiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjBjNmU0ZDRiLWE0NDQtNGNlMC04MjQ3LTdiZWEwNzFjOWYwOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjBjNmU0ZDRiLWE0NDQtNGNlMC04MjQ3LTdiZWEwNzFjOWYwOCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.aGCSPq3XAkgEcwKy84fn8jLsfrdPYD9fuys_6ugxFNR-bgP3YfyqTw9puXDcLmU6477Zopff7QXbi13KQenmbAi13dHKDPui0bYhBUmxCd6-DTmeB4BOlKQEq3mnBfIOYnHHnk_MPBCdlgZ0vWo4x2ZcCuH2vRSHuhv2BnzureBtMO_0ljRqe4P0SDUz4gW5aUro2dXgeEyhyi2QORaNgoaI3M_F4x-0vUefo6MH7p5GrdNxVVJmetIvIpagVC4TDBva8AM0qN1yDZmwOsfamys0QDR6-3KAmHiJnhIQic7-Q_2WVCJJWsjaW90Uf8HEovmGbVp8QZHR5s9uMj7I-g
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTMsImlhdCI6MTczNDAzODA1MywiYXV0aF90aW1lIjoxNzM0MDM4MDUyLCJqdGkiOiIxYzAxZjhmNS03Yzg2LTQ5OGMtYmY0Yy01M2Y0NjQ2ZDdlNDIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImQ2NGJhNDRjLTBhOTgtNDRkYy1iNDMxLTkxMDQwZjJhNTcwYyIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImQ2NGJhNDRjLTBhOTgtNDRkYy1iNDMxLTkxMDQwZjJhNTcwYyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.cFsuSv7-8BfqQo_N380DRmROVyVtV9ttYJhglOSE8k26N8XTzzdaVU3awrdyZcx98VBp2pKmp2-j4jmRXKxTjgORrgk7nt4-P-Iawm66xcv5oRtSZEp1GJPfO4SSOZ4YtJVD6odUPwdaDJuQKAthpOUfDgwA2Gi-K9oZ9ARXzk-0v8FD-lRisG8J3e0tiX5N8fs9xVlNXD9488dM96rKrToIFkv4s0HgLsNNIowt2j4U3O5Gh6hDIFRRCD3M9wlYvdaEhHYcfeZai7fQRFV5YrmNBU_Qwa1yBOridLWJTYktqkRskEDKYtG0w5VQwogPyBz5XV4KARcqV8yi4Quoog
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCCallbackTests/OrgOIDCCallbackTests.test_redirects_after_successful_auth.yaml
+++ b/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCCallbackTests/OrgOIDCCallbackTests.test_redirects_after_successful_auth.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Forg-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51\",\n
-        \             \"3dK9OqTxTrU\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=3dK9OqTxTrU&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"5c7a0929-1248-4327-af5e-8fb6b8c616a0\",\n
+        \             \"WRc34EAz8Fw\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=WRc34EAz8Fw&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=97TQJmBUVr48wnnQXqd9Hm37u_B_SQgleGh2v-h1SuQ&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=3dK9OqTxTrU\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=GIsEto0EWHZoiJyJlkJ2j7Cxmy56cfA5JRu7sybASgY&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=WRc34EAz8Fw\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=5c7a0929-1248-4327-af5e-8fb6b8c616a0; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=5c7a0929-1248-4327-af5e-8fb6b8c616a0; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.PVsoxNQ0-_nJN1HEGMJ6H1byID8wg96CZXFzWiaCgQk;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXV0aC9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.tdn77ODcL5bmyBYytPxHY-3fZ3w4A-EJkQxB_f9AMC8;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJhY3QiOiJBVVRIRU5USUNBVEUiLCJub3RlcyI6eyJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJyZWRpcmVjdF91cmkiOiJodHRwOi8vdGVzdHNlcnZlci9vcmctb2lkYy9jYWxsYmFjay8iLCJzdGF0ZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmciLCJub25jZSI6Im5vdC1hLXJhbmRvbS1zdHJpbmcifX0.PVsoxNQ0-_nJN1HEGMJ6H1byID8wg96CZXFzWiaCgQk
+      - AUTH_SESSION_ID_LEGACY=5c7a0929-1248-4327-af5e-8fb6b8c616a0; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vdGVzdHNlcnZlci9hdXRoL29pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL3Rlc3RzZXJ2ZXIvYXV0aC9vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.tdn77ODcL5bmyBYytPxHY-3fZ3w4A-EJkQxB_f9AMC8
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=97TQJmBUVr48wnnQXqd9Hm37u_B_SQgleGh2v-h1SuQ&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=3dK9OqTxTrU
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=GIsEto0EWHZoiJyJlkJ2j7Cxmy56cfA5JRu7sybASgY&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=WRc34EAz8Fw
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://testserver/org-oidc/callback/?state=not-a-random-string&session_state=cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=45b3e75e-e228-4216-8f56-a728b238db40.cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://testserver/auth/oidc/callback/?state=not-a-random-string&session_state=5c7a0929-1248-4327-af5e-8fb6b8c616a0&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=66332c98-2164-4086-bb75-a5e1673e9a8e.5c7a0929-1248-4327-af5e-8fb6b8c616a0.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE5ODYsImlhdCI6MTczMjYxNTk4NiwianRpIjoiNmIyY2M0NTEtYTUxMC00MDAzLWFmMmEtZWI5M2ZhYWI0Yzg2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJzaWQiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJzdGF0ZV9jaGVja2VyIjoiUmhhRFdfVDE0cmdabzlhdHVQbnk5SGVjcWZYVmE4N0lSYjl1SmN3cnlDWSJ9.GoyFreL9q4W6ispLzsdt3zJ4Nfoc5R8MAhKB68K_IhA;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQwNTIsImlhdCI6MTczNDAzODA1MiwianRpIjoiZjE0OTYwYTUtZGU5NC00OTRiLWFiNzMtZTg4MmFlMzQ1NzhkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJzaWQiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJzdGF0ZV9jaGVja2VyIjoidTA4WkNQX2U0YXJDczhqNi1zZ2hITzNyN0dlRGFweXlOREhvSDNFNU9DdyJ9.DmWCLx4w3Z4sVesPIerkb-x1G04ZdeazJY4rVT25z20;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTE5ODYsImlhdCI6MTczMjYxNTk4NiwianRpIjoiNmIyY2M0NTEtYTUxMC00MDAzLWFmMmEtZWI5M2ZhYWI0Yzg2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJzaWQiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJzdGF0ZV9jaGVja2VyIjoiUmhhRFdfVDE0cmdabzlhdHVQbnk5SGVjcWZYVmE4N0lSYjl1SmN3cnlDWSJ9.GoyFreL9q4W6ispLzsdt3zJ4Nfoc5R8MAhKB68K_IhA;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQwNTIsImlhdCI6MTczNDAzODA1MiwianRpIjoiZjE0OTYwYTUtZGU5NC00OTRiLWFiNzMtZTg4MmFlMzQ1NzhkIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJzaWQiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJzdGF0ZV9jaGVja2VyIjoidTA4WkNQX2U0YXJDczhqNi1zZ2hITzNyN0dlRGFweXlOREhvSDNFNU9DdyJ9.DmWCLx4w3Z4sVesPIerkb-x1G04ZdeazJY4rVT25z20;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51;
-        Version=1; Expires=Tue, 26-Nov-2024 20:13:06 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/5c7a0929-1248-4327-af5e-8fb6b8c616a0;
+        Version=1; Expires=Fri, 13-Dec-2024 07:14:12 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51;
-        Version=1; Expires=Tue, 26-Nov-2024 20:13:06 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/5c7a0929-1248-4327-af5e-8fb6b8c616a0;
+        Version=1; Expires=Fri, 13-Dec-2024 07:14:12 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=45b3e75e-e228-4216-8f56-a728b238db40.cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Forg-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=66332c98-2164-4086-bb75-a5e1673e9a8e.5c7a0929-1248-4327-af5e-8fb6b8c616a0.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '271'
+      - '274'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODYsImlhdCI6MTczMjYxNTk4NiwiYXV0aF90aW1lIjoxNzMyNjE1OTg2LCJqdGkiOiJkYmEyNjFhZi00NWYzLTQxZTktYTQ4YS1lMmFiOGUxZGI3NTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImNkNmJiM2Q4LTNlYzMtNDVlNC1hOGJiLTI1YmNiN2JiOGU1MSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImNkNmJiM2Q4LTNlYzMtNDVlNC1hOGJiLTI1YmNiN2JiOGU1MSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.ixez4wuZdgLtJVQqhray_IGQLGKcyp4nSzri4NIuMwwgWLy1OA6O1vz1KNdMnx0FLxjhNgRNuj_0Z3lGJYn_3cWfFE3JdZiY0bfZ5DPXcdNT-jlVh8bvTxwTCJ1nWNMhMfVo6MadG59tg_VEbpNHLRaodYoCJy5FHCvrCYwy3UYJBJkmmlN20TJXeEOgs8vsBvAOsSHLrZM9_-izsk1tX_dKTSnCAr_QXkuYG19gEqucssZ6ql_4rM1qMIf9xp32bhpCy_zf51ouYJdMl1ETUSZ8TEsqCFAmLROFEJ6KJ8c8oIYtU4RfMIoiA971O1bY6LrxxkNhguDhqPKfqBtjfg","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc3ODYsImlhdCI6MTczMjYxNTk4NiwianRpIjoiMzgxYzFiODktOWJiZC00NjFhLWJmOGQtYmI1ZGI0OGUyYjFmIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiY2Q2YmIzZDgtM2VjMy00NWU0LWE4YmItMjViY2I3YmI4ZTUxIn0.LbM7A8w_vUEa3_Xc0D9gpJMwVM9pK4xgqrddGuCf2Zw","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODYsImlhdCI6MTczMjYxNTk4NiwiYXV0aF90aW1lIjoxNzMyNjE1OTg2LCJqdGkiOiIwMGRiNjRjMC1mNWM4LTQxOTAtYmI3Zi03ZjZkN2RhYzA4OWMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJhdF9oYXNoIjoiLTE4Vmpma1RNTzFkMTltSmhYQ0xHQSIsImFjciI6IjEiLCJzaWQiOiJjZDZiYjNkOC0zZWMzLTQ1ZTQtYThiYi0yNWJjYjdiYjhlNTEiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.XLs_e12NTybHVzGYqBdbkvmeJuI0oDfKD7gPc9GntCjfygZqEWrmyPzq8VSaPK6L6XNbCjGlfqR_ygiJW_7J-BJvT-1wBx8uq9zu8Dps1-F_3gPw0BVlWJGuCNJoeh28K588yyiaFnounjZK62hE30PzhfgNKkrZSyYdehRGpj63QTxksETFAwvvDE7qggr7yxb9qqy9c19LED6AcgK547w_JDsaoq61oYj_4k7gyEFGNxTxo-6Lpxl9BzOhvPJ2D1pNwXPNgIwVkHnqJiYa6YodqUB0zcZzRKp8P3WwGvrAO3xo6ckiqqTcV9hEvNbfBWeyOzjEEKrDh9IG6Ek1iQ","not-before-policy":0,"session_state":"cd6bb3d8-3ec3-45e4-a8bb-25bcb7bb8e51","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTIsImlhdCI6MTczNDAzODA1MiwiYXV0aF90aW1lIjoxNzM0MDM4MDUyLCJqdGkiOiI1MmQ1YmIzNC1mMTBiLTRmNTAtOWRiOS02ZjgwZWM3YTA1YWIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2EwOTI5LTEyNDgtNDMyNy1hZjVlLThmYjZiOGM2MTZhMCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjVjN2EwOTI5LTEyNDgtNDMyNy1hZjVlLThmYjZiOGM2MTZhMCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.PEmhqcPuD5Wg0NFrjho-v81xAVDA8_LNvMUp5BcTDQm0xJaWtZM7bVhtQ6qtbthpRQvFH12nT5qfHpk44PKfZ51ndTlQq4sqT62-tHF8iSFt8EHIoX9Ds3TK5G9GpVGvPc45G5Rl7Sn0easX0VRfVkwO3lLqAWkVkSeGoLzU-mCdu7_FkWodIij7371Gfr_LpcDNUBdRl8PC-ekPckJM5Cv22WUD90enH00nbmQop-ZdbWvnaDlwAO_ZNAqgFMu6hZQxd8ScXrB1QbS7Lv8ERvpGapb7GNgxGgWqEOEgu_YKhM_O43MT6xE1RMnFFu9QyPyHKTV7A5J19DP6aR7PUA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwMzk4NTIsImlhdCI6MTczNDAzODA1MiwianRpIjoiYjZmYTg2ODQtZjRmOS00M2ZlLWFkOTQtOGJjNDAzYzQzMDc5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiNWM3YTA5MjktMTI0OC00MzI3LWFmNWUtOGZiNmI4YzYxNmEwIn0.JbgnxVyjEklb35VPiVq1LWb53b7uUiWIFqK1dmKXPaA","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTIsImlhdCI6MTczNDAzODA1MiwiYXV0aF90aW1lIjoxNzM0MDM4MDUyLCJqdGkiOiI2MWI0NzFkYi1hMzgwLTQwN2EtYTJjNi1hMGYyMGVmMjk2ZjciLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJhdF9oYXNoIjoiWW9TSTlNbld4NTJTNkRXRkV4SXV4ZyIsImFjciI6IjEiLCJzaWQiOiI1YzdhMDkyOS0xMjQ4LTQzMjctYWY1ZS04ZmI2YjhjNjE2YTAiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.HNxNOnMDZqxWMeFTexHu5e7nVX6MSVw0Cp7QPHtXNt5_80YgpaGfvyTFLiOAYvah4gEFzsT1FjWcbjtxmYJ84-Qvq6CSSYc5zUnRAn0ny8_l4Jxna7l_w7hrsHrt0ZFYZPf3Tw6KJSa43rpo_H4GPV9pANChcGUFZ-_sqyzQLNx3oi6zX-sPhF15qCNZI4kIsrYPMDoLfd5N3CU9Cw3xSs14FyB-CT8tOwvSf8U5LEDPe8MJ6Pi9_O0u7pJg20h1UQrPaIXmOHH6-RZWIXESrpph0rj0P_q6FUTt3sKra083qyrA6vFZ6yLQS_tIg8MSBXjeX-NNn6TWoqil81eGLw","not-before-policy":0,"session_state":"5c7a0929-1248-4327-af5e-8fb6b8c616a0","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYyODYsImlhdCI6MTczMjYxNTk4NiwiYXV0aF90aW1lIjoxNzMyNjE1OTg2LCJqdGkiOiJkYmEyNjFhZi00NWYzLTQxZTktYTQ4YS1lMmFiOGUxZGI3NTgiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImNkNmJiM2Q4LTNlYzMtNDVlNC1hOGJiLTI1YmNiN2JiOGU1MSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImNkNmJiM2Q4LTNlYzMtNDVlNC1hOGJiLTI1YmNiN2JiOGU1MSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.ixez4wuZdgLtJVQqhray_IGQLGKcyp4nSzri4NIuMwwgWLy1OA6O1vz1KNdMnx0FLxjhNgRNuj_0Z3lGJYn_3cWfFE3JdZiY0bfZ5DPXcdNT-jlVh8bvTxwTCJ1nWNMhMfVo6MadG59tg_VEbpNHLRaodYoCJy5FHCvrCYwy3UYJBJkmmlN20TJXeEOgs8vsBvAOsSHLrZM9_-izsk1tX_dKTSnCAr_QXkuYG19gEqucssZ6ql_4rM1qMIf9xp32bhpCy_zf51ouYJdMl1ETUSZ8TEsqCFAmLROFEJ6KJ8c8oIYtU4RfMIoiA971O1bY6LrxxkNhguDhqPKfqBtjfg
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzgzNTIsImlhdCI6MTczNDAzODA1MiwiYXV0aF90aW1lIjoxNzM0MDM4MDUyLCJqdGkiOiI1MmQ1YmIzNC1mMTBiLTRmNTAtOWRiOS02ZjgwZWM3YTA1YWIiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2EwOTI5LTEyNDgtNDMyNy1hZjVlLThmYjZiOGM2MTZhMCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6IjVjN2EwOTI5LTEyNDgtNDMyNy1hZjVlLThmYjZiOGM2MTZhMCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.PEmhqcPuD5Wg0NFrjho-v81xAVDA8_LNvMUp5BcTDQm0xJaWtZM7bVhtQ6qtbthpRQvFH12nT5qfHpk44PKfZ51ndTlQq4sqT62-tHF8iSFt8EHIoX9Ds3TK5G9GpVGvPc45G5Rl7Sn0easX0VRfVkwO3lLqAWkVkSeGoLzU-mCdu7_FkWodIij7371Gfr_LpcDNUBdRl8PC-ekPckJM5Cv22WUD90enH00nbmQop-ZdbWvnaDlwAO_ZNAqgFMu6hZQxd8ScXrB1QbS7Lv8ERvpGapb7GNgxGgWqEOEgu_YKhM_O43MT6xE1RMnFFu9QyPyHKTV7A5J19DP6aR7PUA
       Connection:
       - keep-alive
       User-Agent:

--- a/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCInitTests/OrgOIDCInitTests.test_start_flow_logs_out_existing_user.yaml
+++ b/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCInitTests/OrgOIDCInitTests.test_start_flow_logs_out_existing_user.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCInitTests/OrgOIDCInitTests.test_start_flow_redirects_to_oidc_provider.yaml
+++ b/src/openforms/authentication/contrib/org_oidc/tests/data/vcr_cassettes/OrgOIDCInitTests/OrgOIDCInitTests.test_start_flow_redirects_to_oidc_provider.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n

--- a/src/openforms/authentication/contrib/org_oidc/tests/test_auth_flow_init.py
+++ b/src/openforms/authentication/contrib/org_oidc/tests/test_auth_flow_init.py
@@ -29,7 +29,7 @@ class OrgOIDCInitTests(IntegrationTestsBase):
     Test the outbound part of OIDC-based organisation user authentication.
     """
 
-    CALLBACK_URL = f"http://testserver{reverse_lazy('org-oidc-callback')}"
+    CALLBACK_URL = f"http://testserver{reverse_lazy('oidc_authentication_callback')}"
 
     @mock_org_oidc_config()
     def test_start_flow_redirects_to_oidc_provider(self):

--- a/src/openforms/authentication/contrib/org_oidc/tests/test_configuration.py
+++ b/src/openforms/authentication/contrib/org_oidc/tests/test_configuration.py
@@ -16,7 +16,8 @@ class CallbackURLConfigurationTests(TestCase):
 
         self.addCleanup(OrgOpenIDConnectConfig.clear_cache)
 
-    def test_default_settings_backwards_compatible(self):
+    @override_settings(USE_LEGACY_ORG_OIDC_ENDPOINTS=True)
+    def test_legacy_settings(self):
         # use an init view to decouple the implementation details from the
         # desired behaviour.
         view = OIDCInit(config_class=OrgOpenIDConnectConfig)
@@ -25,8 +26,7 @@ class CallbackURLConfigurationTests(TestCase):
 
         self.assertEqual(url, "/org-oidc/callback/")
 
-    @override_settings(USE_LEGACY_ORG_OIDC_ENDPOINTS=False)
-    def test_new_behaviour(self):
+    def test_default_settings_behaviour(self):
         # use an init view to decouple the implementation details from the
         # desired behaviour.
         view = OIDCInit(config_class=OrgOpenIDConnectConfig)

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -631,11 +631,11 @@ ESCAPE_REGISTRATION_OUTPUT = config("ESCAPE_REGISTRATION_OUTPUT", default=False)
 # while staying backwards compatible for existing instances
 USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS = config(
     "USE_LEGACY_DIGID_EH_OIDC_ENDPOINTS",
-    default=True,
+    default=False,
 )
 USE_LEGACY_ORG_OIDC_ENDPOINTS = config(
     "USE_LEGACY_ORG_OIDC_ENDPOINTS",
-    default=True,
+    default=False,
 )
 
 ##############################
@@ -1030,7 +1030,7 @@ COOKIE_CONSENT_NAME = "cookie_consent"
 OIDC_AUTHENTICATE_CLASS = "mozilla_django_oidc_db.views.OIDCAuthenticationRequestView"
 # DeprecationWarning
 # XXX: remove in Open Forms 3.0
-_USE_LEGACY_OIDC_ENDPOINTS = config("USE_LEGACY_OIDC_ENDPOINTS", default=True)
+_USE_LEGACY_OIDC_ENDPOINTS = config("USE_LEGACY_OIDC_ENDPOINTS", default=False)
 OIDC_AUTHENTICATION_CALLBACK_URL = (
     "legacy_oidc:oidc_authentication_callback"
     if _USE_LEGACY_OIDC_ENDPOINTS

--- a/src/openforms/tests/data/vcr_cassettes/OIDCRegistratorSubjectHaalCentraalPrefillIntegrationTest/OIDCRegistratorSubjectHaalCentraalPrefillIntegrationTest.test_flow.yaml
+++ b/src/openforms/tests/data/vcr_cassettes/OIDCRegistratorSubjectHaalCentraalPrefillIntegrationTest/OIDCRegistratorSubjectHaalCentraalPrefillIntegrationTest.test_flow.yaml
@@ -18,12 +18,12 @@ interactions:
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -68,23 +68,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Fexample.com%2Forg-oidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=openid+email+profile&client_id=testid&redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
   response:
     body:
       string: "<!DOCTYPE html>\n<html class=\"login-pf\">\n\n<head>\n    <meta charset=\"utf-8\">\n
         \   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
         />\n    <meta name=\"robots\" content=\"noindex, nofollow\">\n\n            <meta
         name=\"viewport\" content=\"width=device-width,initial-scale=1\"/>\n    <title>Sign
-        in to test</title>\n    <link rel=\"icon\" href=\"/resources/2px5l/login/keycloak/img/favicon.ico\"
-        />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/common/keycloak/lib/pficon/pficon.css\"
-        rel=\"stylesheet\" />\n            <link href=\"/resources/2px5l/login/keycloak/css/login.css\"
+        in to test</title>\n    <link rel=\"icon\" href=\"/resources/ghaym/login/keycloak/img/favicon.ico\"
+        />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/@patternfly/patternfly/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/common/keycloak/lib/pficon/pficon.css\"
+        rel=\"stylesheet\" />\n            <link href=\"/resources/ghaym/login/keycloak/css/login.css\"
         rel=\"stylesheet\" />\n        <script type=\"module\">\n            import
-        { checkCookiesAndSetTimer } from \"/resources/2px5l/login/keycloak/js/authChecker.js\";\n\n
-        \           checkCookiesAndSetTimer(\n              \"a99cdc8c-0559-4255-852c-fe559a4df828\",\n
-        \             \"NE07L3LUO24\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=NE07L3LUO24&skip_logout=true\"\n
+        { checkCookiesAndSetTimer } from \"/resources/ghaym/login/keycloak/js/authChecker.js\";\n\n
+        \           checkCookiesAndSetTimer(\n              \"9555f64e-d7a9-439d-82fc-987f3ca7d268\",\n
+        \             \"N23K0q-wVVY\",\n              \"/realms/test/login-actions/restart?client_id=testid&tab_id=N23K0q-wVVY&skip_logout=true\"\n
         \           );\n        </script>\n</head>\n\n<body class=\"\">\n<div class=\"login-pf-page\">\n
         \   <div id=\"kc-header\" class=\"login-pf-page-header\">\n        <div id=\"kc-header-wrapper\"\n
         \            class=\"\">test</div>\n    </div>\n    <div class=\"card-pf\">\n
@@ -92,7 +92,7 @@ interactions:
         \       Sign in to your account\n\n</h1>\n      </header>\n      <div id=\"kc-content\">\n
         \       <div id=\"kc-content-wrapper\">\n\n\n        <div id=\"kc-form\">\n
         \         <div id=\"kc-form-wrapper\">\n                <form id=\"kc-form-login\"
-        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=w1J2289ez32ZeBivhaVZQeOxA63El8HdQt2isfP9Plk&amp;execution=2f7726ff-4b94-4587-be31-b509cccb7e18&amp;client_id=testid&amp;tab_id=NE07L3LUO24\"
+        onsubmit=\"login.disabled = true; return true;\" action=\"http://localhost:8080/realms/test/login-actions/authenticate?session_code=J-JSyP1uxuxo-qUTbW44gbujvIwNjvkvtBoGg5t7Ykw&amp;execution=257fa8d9-e016-4306-9122-85f5032a978f&amp;client_id=testid&amp;tab_id=N23K0q-wVVY\"
         method=\"post\">\n                        <div class=\"form-group\">\n                            <label
         for=\"username\" class=\"pf-c-form__label pf-c-form__label-text\">Username
         or email</label>\n\n                            <input tabindex=\"1\" id=\"username\"
@@ -118,7 +118,7 @@ interactions:
         tabindex=\"4\" class=\"pf-c-button pf-m-primary pf-m-block btn-lg\" name=\"login\"
         id=\"kc-login\" type=\"submit\" value=\"Sign In\"/>\n                      </div>\n
         \               </form>\n            </div>\n        </div>\n        <script
-        type=\"module\" src=\"/resources/2px5l/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
+        type=\"module\" src=\"/resources/ghaym/login/keycloak/js/passwordVisibility.js\"></script>\n\n\n\n\n\n
         \       </div>\n      </div>\n\n    </div>\n  </div>\n</body>\n</html>\n"
     headers:
       Cache-Control:
@@ -132,11 +132,11 @@ interactions:
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
-      - AUTH_SESSION_ID=a99cdc8c-0559-4255-852c-fe559a4df828; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID=9555f64e-d7a9-439d-82fc-987f3ca7d268; Version=1; Path=/realms/test/;
         SameSite=None; Secure; HttpOnly
-      - AUTH_SESSION_ID_LEGACY=a99cdc8c-0559-4255-852c-fe559a4df828; Version=1; Path=/realms/test/;
+      - AUTH_SESSION_ID_LEGACY=9555f64e-d7a9-439d-82fc-987f3ca7d268; Version=1; Path=/realms/test/;
         HttpOnly
-      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vZXhhbXBsZS5jb20vb3JnLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2V4YW1wbGUuY29tL29yZy1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.Gh5tsot6g5xFfd-CPdrSdfVuce-rrmiou1HGFbYFSEY;
+      - KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vZXhhbXBsZS5jb20vYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.L2EJo7T3HYUHZeCLvrxj7O2LNrsYgc6-jYKmYF6-svA;
         Version=1; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
@@ -167,11 +167,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - AUTH_SESSION_ID_LEGACY=a99cdc8c-0559-4255-852c-fe559a4df828; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vZXhhbXBsZS5jb20vb3JnLW9pZGMvY2FsbGJhY2svIiwiYWN0IjoiQVVUSEVOVElDQVRFIiwibm90ZXMiOnsic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9yZWFsbXMvdGVzdCIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2V4YW1wbGUuY29tL29yZy1vaWRjL2NhbGxiYWNrLyIsInN0YXRlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyJ9fQ.Gh5tsot6g5xFfd-CPdrSdfVuce-rrmiou1HGFbYFSEY
+      - AUTH_SESSION_ID_LEGACY=9555f64e-d7a9-439d-82fc-987f3ca7d268; KC_RESTART=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJjaWQiOiJ0ZXN0aWQiLCJwdHkiOiJvcGVuaWQtY29ubmVjdCIsInJ1cmkiOiJodHRwOi8vZXhhbXBsZS5jb20vYXV0aC9vaWRjL2NhbGxiYWNrLyIsImFjdCI6IkFVVEhFTlRJQ0FURSIsIm5vdGVzIjp7InNjb3BlIjoib3BlbmlkIGVtYWlsIHByb2ZpbGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hdXRoL29pZGMvY2FsbGJhY2svIiwic3RhdGUiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIn19.L2EJo7T3HYUHZeCLvrxj7O2LNrsYgc6-jYKmYF6-svA
       User-Agent:
       - python-requests/2.32.2
     method: POST
-    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=w1J2289ez32ZeBivhaVZQeOxA63El8HdQt2isfP9Plk&execution=2f7726ff-4b94-4587-be31-b509cccb7e18&client_id=testid&tab_id=NE07L3LUO24
+    uri: http://localhost:8080/realms/test/login-actions/authenticate?session_code=J-JSyP1uxuxo-qUTbW44gbujvIwNjvkvtBoGg5t7Ykw&execution=257fa8d9-e016-4306-9122-85f5032a978f&client_id=testid&tab_id=N23K0q-wVVY
   response:
     body:
       string: ''
@@ -181,7 +181,7 @@ interactions:
       Content-Security-Policy:
       - frame-src 'self'; frame-ancestors 'self'; object-src 'none';
       Location:
-      - http://example.com/org-oidc/callback/?state=not-a-random-string&session_state=a99cdc8c-0559-4255-852c-fe559a4df828&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=574cf9a6-0281-4847-9444-677ded1a89b6.a99cdc8c-0559-4255-852c-fe559a4df828.adf4ad83-4550-4619-9231-73bd8d700f45
+      - http://example.com/auth/oidc/callback/?state=not-a-random-string&session_state=9555f64e-d7a9-439d-82fc-987f3ca7d268&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest&code=cd04ab18-12f5-4e14-be2e-1b55a0be3b2c.9555f64e-d7a9-439d-82fc-987f3ca7d268.adf4ad83-4550-4619-9231-73bd8d700f45
       Referrer-Policy:
       - no-referrer
       Set-Cookie:
@@ -191,15 +191,15 @@ interactions:
         Path=/realms/test/; HttpOnly
       - KC_AUTH_STATE=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
         Path=/realms/test/
-      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTIwNzMsImlhdCI6MTczMjYxNjA3MywianRpIjoiMGFjYjM2ZjAtMWYwNy00YWEwLTk0ZmItZWYyMzdiNzE4MGQ0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJzaWQiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJzdGF0ZV9jaGVja2VyIjoiNXF1U2pqcDNlVDBrVlBfMC1YTTV0aGVFbEFwN193MGI1Mjk3X2xDREpicyJ9.DRZP9smn5jFb0uM4Xe5LJz3HccB_1PgcouOmG6MrjsQ;
+      - KEYCLOAK_IDENTITY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ2MzksImlhdCI6MTczNDAzODYzOSwianRpIjoiYzlkNDYwNWUtYWY1My00NTIzLWE2YWUtMDZjY2QxMjAzOTM2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJzaWQiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJzdGF0ZV9jaGVja2VyIjoia2M4YXFOWW9rRTExUm5hVXV0bGZKcXp2cFFEODdFcTNtVjBpbk05LUZCUSJ9.n6ukjhUyEduj4sUq8Du0fhBVB5yULGHVDPrcIBRnhsg;
         Version=1; Path=/realms/test/; SameSite=None; Secure; HttpOnly
-      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2NTIwNzMsImlhdCI6MTczMjYxNjA3MywianRpIjoiMGFjYjM2ZjAtMWYwNy00YWEwLTk0ZmItZWYyMzdiNzE4MGQ0IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJzaWQiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJzdGF0ZV9jaGVja2VyIjoiNXF1U2pqcDNlVDBrVlBfMC1YTTV0aGVFbEFwN193MGI1Mjk3X2xDREpicyJ9.DRZP9smn5jFb0uM4Xe5LJz3HccB_1PgcouOmG6MrjsQ;
+      - KEYCLOAK_IDENTITY_LEGACY=eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNzQ2MzksImlhdCI6MTczNDAzODYzOSwianRpIjoiYzlkNDYwNWUtYWY1My00NTIzLWE2YWUtMDZjY2QxMjAzOTM2IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiU2VyaWFsaXplZC1JRCIsInNlc3Npb25fc3RhdGUiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJzaWQiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJzdGF0ZV9jaGVja2VyIjoia2M4YXFOWW9rRTExUm5hVXV0bGZKcXp2cFFEODdFcTNtVjBpbk05LUZCUSJ9.n6ukjhUyEduj4sUq8Du0fhBVB5yULGHVDPrcIBRnhsg;
         Version=1; Path=/realms/test/; HttpOnly
-      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/a99cdc8c-0559-4255-852c-fe559a4df828;
-        Version=1; Expires=Tue, 26-Nov-2024 20:14:33 GMT; Max-Age=36000; Path=/realms/test/;
+      - KEYCLOAK_SESSION=test/6db2db87-de31-4e30-9f25-cefe5da8b154/9555f64e-d7a9-439d-82fc-987f3ca7d268;
+        Version=1; Expires=Fri, 13-Dec-2024 07:23:59 GMT; Max-Age=36000; Path=/realms/test/;
         SameSite=None; Secure
-      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/a99cdc8c-0559-4255-852c-fe559a4df828;
-        Version=1; Expires=Tue, 26-Nov-2024 20:14:33 GMT; Max-Age=36000; Path=/realms/test/
+      - KEYCLOAK_SESSION_LEGACY=test/6db2db87-de31-4e30-9f25-cefe5da8b154/9555f64e-d7a9-439d-82fc-987f3ca7d268;
+        Version=1; Expires=Fri, 13-Dec-2024 07:23:59 GMT; Max-Age=36000; Path=/realms/test/
       - KEYCLOAK_REMEMBER_ME=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
         00:00:10 GMT; Max-Age=0; Path=/realms/test/; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       code: 302
       message: Found
 - request:
-    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=574cf9a6-0281-4847-9444-677ded1a89b6.a99cdc8c-0559-4255-852c-fe559a4df828.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Fexample.com%2Forg-oidc%2Fcallback%2F
+    body: client_id=testid&client_secret=7DB3KUAAizYCcmZufpHRVOcD0TOkNO3I&grant_type=authorization_code&code=cd04ab18-12f5-4e14-be2e-1b55a0be3b2c.9555f64e-d7a9-439d-82fc-987f3ca7d268.adf4ad83-4550-4619-9231-73bd8d700f45&redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Foidc%2Fcallback%2F
     headers:
       Accept:
       - '*/*'
@@ -227,7 +227,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '272'
+      - '275'
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
@@ -236,7 +236,7 @@ interactions:
     uri: http://localhost:8080/realms/test/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYzNzMsImlhdCI6MTczMjYxNjA3MywiYXV0aF90aW1lIjoxNzMyNjE2MDczLCJqdGkiOiI3ZDYwZGRlMy1jNjljLTRjNWItYmZkNS0zNWM2ODI5ZmIzOGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImE5OWNkYzhjLTA1NTktNDI1NS04NTJjLWZlNTU5YTRkZjgyOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImE5OWNkYzhjLTA1NTktNDI1NS04NTJjLWZlNTU5YTRkZjgyOCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.Rb7BSfYd_qfmv2Sq0iTplcrq2TWyRJFDCh5qKHAmeeAV9g8oLWir_m1Tai76TkLzGOzgQCcrG7k7qO5biCHobPFJi2CKTTjL5bOFKAx3-k5w2oiZ9W-0IVuh66UxA1XqnO6TGxrhcWSFYYghjTlI57CeLZmgktwGONxVX_WtXABh9LA6SgOX7t2cTKB92viskMkLXmWmxCi5hOmN3MKdzvP4bSWhczpTfUZdpXFmycHNj1nv1bkrUxFAuubsyVLZrS1Wx1I2N6GYOF3bTIX9I0T9A3R3HAgn44-8bga0CTxi943tELRkXyX3m4gXL5hc6LGnSwMS8sAUEt3v0fLTIw","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzI2MTc4NzMsImlhdCI6MTczMjYxNjA3MywianRpIjoiN2I5YzlmMDEtNzIxYy00YTZlLTkzYWYtZGE3MTg2MjM3ZDI1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiYTk5Y2RjOGMtMDU1OS00MjU1LTg1MmMtZmU1NTlhNGRmODI4In0.AoiGRLiJnc47-WwukDbDMVKz2KtXFYMM0p7aCPCMq5g","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYzNzMsImlhdCI6MTczMjYxNjA3MywiYXV0aF90aW1lIjoxNzMyNjE2MDczLCJqdGkiOiJiYmY1OWQ5ZC1jMGZlLTRlOWYtYWEyMS1mODQzN2NiZWE4Y2IiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJhdF9oYXNoIjoiWnRXcU96T2xzZWxDenoxZDVEaEgwUSIsImFjciI6IjEiLCJzaWQiOiJhOTljZGM4Yy0wNTU5LTQyNTUtODUyYy1mZTU1OWE0ZGY4MjgiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.JFzhKHHQ_WYM3HqDG7_-7XE25C4QDdcXaxZbRKrUGujpVXygE9RiOGic24_Q2yFmrMPw6CZwoSOL7epEIVvT9mVQNTU80_bm7o7YvENY_kow0nJpWQWaaEmySFcvGNDXpmeXNfYK9-h0QK1EIjbVwtrRyl3sKTVLTD54sVn-m245IMVrQMmwPKfv_hudEUq-4Mp7vuFo9rP0xOBqm0Zszdh0PXhpyDGREIq_D1E45zZPfe5vlJ99or44Q7O1tREy2lElOmR4qZDLf41ZX__KwfQA_3neaAjZSz-1OI9Emu_muLJVAVkd18xFjaKwKu3qO9CN8qxSIZKshG-zM1AdWA","not-before-policy":0,"session_state":"a99cdc8c-0559-4255-852c-fe559a4df828","scope":"openid
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg5MzksImlhdCI6MTczNDAzODYzOSwiYXV0aF90aW1lIjoxNzM0MDM4NjM5LCJqdGkiOiI1YWZiOTE1MS1kM2FjLTQ2ZTMtOWZlNi1jYWY1Yjg5ZmUwNGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk1NTVmNjRlLWQ3YTktNDM5ZC04MmZjLTk4N2YzY2E3ZDI2OCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk1NTVmNjRlLWQ3YTktNDM5ZC04MmZjLTk4N2YzY2E3ZDI2OCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.0iuV-lKKSjoIMmUZP54hVDqUo_M8F4aIgowK-3DpjhiM86K-F2seLuZEUdY4Mm0I7DkXkD_QEElxzZisujOz2sYAhe4o8_6w8PXUEs3uhAwVcKZt6NXkLfIWbeMbBo81D1yQRZ4Lysit3AIyuzhzXMQMw7J16BVpAjKJa6RInwPbcNHvT54ias-23msNvY3kDd-UZcpyzn4DfA5uS6mogoJfBzFEMZ_Mi_mLuIOFwC_AjuClmdl5fvkQ-VDlggZlBtIlEBNQiL1lSJauuOAG1qsVtJ931IHiohXU943yAlo6lJjWnmH1JsktCWUZnNiqFfTuKwlTuDrGkV22c3qeOA","expires_in":300,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJlNzE1ZTA1MS02Y2RiLTQ4Y2MtYjRmNC1mMDcyMmM4MWY5ZDMifQ.eyJleHAiOjE3MzQwNDA0MzksImlhdCI6MTczNDAzODYzOSwianRpIjoiMWM2ZDVjZTItNTY2OS00N2RlLThiMWYtZjZhMTY5YjM4OWRjIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0IiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3JlYWxtcy90ZXN0Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIGt2ayBncm91cHMgYnNuIiwic2lkIjoiOTU1NWY2NGUtZDdhOS00MzlkLTgyZmMtOTg3ZjNjYTdkMjY4In0.3xsMbmX32jKUqKLNNnohSx4DOChasNlsClofPbjWABo","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg5MzksImlhdCI6MTczNDAzODYzOSwiYXV0aF90aW1lIjoxNzM0MDM4NjM5LCJqdGkiOiIyMjA1MTY0MS1jNjQwLTRmODAtOWUzMy0wNzk1ZjMxMzAzYzAiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJ0ZXN0aWQiLCJzdWIiOiI2ZGIyZGI4Ny1kZTMxLTRlMzAtOWYyNS1jZWZlNWRhOGIxNTQiLCJ0eXAiOiJJRCIsImF6cCI6InRlc3RpZCIsIm5vbmNlIjoibm90LWEtcmFuZG9tLXN0cmluZyIsInNlc3Npb25fc3RhdGUiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJhdF9oYXNoIjoiYm45NGhBVGk0VnFCaHpvTjlCRG5TQSIsImFjciI6IjEiLCJzaWQiOiI5NTU1ZjY0ZS1kN2E5LTQzOWQtODJmYy05ODdmM2NhN2QyNjgiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZ3JvdXBzIjpbIlJlZ2lzdHJlZXJkZXJzIiwiZGVmYXVsdC1yb2xlcy10ZXN0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20ifQ.RxF_5LCjKKZdvXHRNHwGPwz89HJtc7OlmPh5FQ7GI5FvNgswwj9qzA6ci0ZGR_9B5NEjw_zUea3NG4RYgp80j4i8szgm0Wo6s9cmygmywAHqqq02VgdoRPq-_NZL7Zi2oltCaL_I41XUTCrqiU_rYW5O96pydinD5Cso9JWI0pBFU2-Ui6At2foUUaLrlxAq1WD7895m6KaD9rvEjcYhW3TJzj1cz0wzcG5b-lsiQoBFv8-NuprXzEckbZ-R2WG6GuddkuhyE1obQKdagvBzc_MKdr1c144QeA-fPWm8KSajjr5Ki420qdzHhVWN-6_QGt6GecLnIPqtnkwqtcVN8g","not-before-policy":0,"session_state":"9555f64e-d7a9-439d-82fc-987f3ca7d268","scope":"openid
         email profile kvk groups bsn"}'
     headers:
       Cache-Control:
@@ -304,7 +304,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzI2MTYzNzMsImlhdCI6MTczMjYxNjA3MywiYXV0aF90aW1lIjoxNzMyNjE2MDczLCJqdGkiOiI3ZDYwZGRlMy1jNjljLTRjNWItYmZkNS0zNWM2ODI5ZmIzOGEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6ImE5OWNkYzhjLTA1NTktNDI1NS04NTJjLWZlNTU5YTRkZjgyOCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6ImE5OWNkYzhjLTA1NTktNDI1NS04NTJjLWZlNTU5YTRkZjgyOCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.Rb7BSfYd_qfmv2Sq0iTplcrq2TWyRJFDCh5qKHAmeeAV9g8oLWir_m1Tai76TkLzGOzgQCcrG7k7qO5biCHobPFJi2CKTTjL5bOFKAx3-k5w2oiZ9W-0IVuh66UxA1XqnO6TGxrhcWSFYYghjTlI57CeLZmgktwGONxVX_WtXABh9LA6SgOX7t2cTKB92viskMkLXmWmxCi5hOmN3MKdzvP4bSWhczpTfUZdpXFmycHNj1nv1bkrUxFAuubsyVLZrS1Wx1I2N6GYOF3bTIX9I0T9A3R3HAgn44-8bga0CTxi943tELRkXyX3m4gXL5hc6LGnSwMS8sAUEt3v0fLTIw
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0VU5RQWN2VWN2LURGVU94XzRPMWd0MTNPZEpTb3RxRUtQWnVyczJ2UVc4In0.eyJleHAiOjE3MzQwMzg5MzksImlhdCI6MTczNDAzODYzOSwiYXV0aF90aW1lIjoxNzM0MDM4NjM5LCJqdGkiOiI1YWZiOTE1MS1kM2FjLTQ2ZTMtOWZlNi1jYWY1Yjg5ZmUwNGMiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcmVhbG1zL3Rlc3QiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNmRiMmRiODctZGUzMS00ZTMwLTlmMjUtY2VmZTVkYThiMTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidGVzdGlkIiwibm9uY2UiOiJub3QtYS1yYW5kb20tc3RyaW5nIiwic2Vzc2lvbl9zdGF0ZSI6Ijk1NTVmNjRlLWQ3YTktNDM5ZC04MmZjLTk4N2YzY2E3ZDI2OCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cDovLzEyNy4wLjAuMTo4MDAwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSBrdmsgZ3JvdXBzIGJzbiIsInNpZCI6Ijk1NTVmNjRlLWQ3YTktNDM5ZC04MmZjLTk4N2YzY2E3ZDI2OCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJncm91cHMiOlsiUmVnaXN0cmVlcmRlcnMiLCJkZWZhdWx0LXJvbGVzLXRlc3QiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSJ9.0iuV-lKKSjoIMmUZP54hVDqUo_M8F4aIgowK-3DpjhiM86K-F2seLuZEUdY4Mm0I7DkXkD_QEElxzZisujOz2sYAhe4o8_6w8PXUEs3uhAwVcKZt6NXkLfIWbeMbBo81D1yQRZ4Lysit3AIyuzhzXMQMw7J16BVpAjKJa6RInwPbcNHvT54ias-23msNvY3kDd-UZcpyzn4DfA5uS6mogoJfBzFEMZ_Mi_mLuIOFwC_AjuClmdl5fvkQ-VDlggZlBtIlEBNQiL1lSJauuOAG1qsVtJ931IHiohXU943yAlo6lJjWnmH1JsktCWUZnNiqFfTuKwlTuDrGkV22c3qeOA
       Connection:
       - keep-alive
       User-Agent:


### PR DESCRIPTION
Part of #3283 - stumbled on this while working on #4911

**Changes**

While the removal of the legacy endpoints is postponed to Open Forms 4.0, I thought we should grab the chance now to switch the default value for the configuration options from legacy-enabled to legacy-disabled. This makes it more likely that fresh instances are set up with the best situation possible and won't have to deal with breaking changes later for 4.0.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
