### PR TITLE
:boom: Remove OR-filter behaviour on form definitions endpoint

### DIFF
--- a/src/openforms/forms/api/filters.py
+++ b/src/openforms/forms/api/filters.py
@@ -1,10 +1,6 @@
-import warnings
-
-from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from django_filters import rest_framework as filters
-from django_filters.constants import EMPTY_VALUES
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 
@@ -31,36 +27,3 @@ class FormDefinitionFilter(filters.FilterSet):
     class Meta:
         model = FormDefinition
         fields = ("is_reusable",)
-        or_fields = ("is_reusable", "used_in")
-
-    def filter_queryset(self, queryset):
-        """
-        Override base implementation to add OR-behaviour instead of the standard AND.
-
-        See https://github.com/carltongibson/django-filter/discussions/1426
-        """
-        _or = Q()
-
-        for name in self.Meta.or_fields:
-            # this essentially re-implements django_filters.filters.Filter.filter,
-            # as otherwise we would have to introspect private django query/queryset API
-            # *shudders*
-            or_filter_value = self.form.cleaned_data.pop(name)
-            if or_filter_value in EMPTY_VALUES:
-                continue
-            or_filter = self.filters[name]
-            if or_filter.distinct:
-                queryset = queryset.distinct()
-            lookup = "%s__%s" % (or_filter.field_name, or_filter.lookup_expr)
-            q_expr = Q(**{lookup: or_filter_value})
-            if or_filter.exclude:
-                q_expr = ~q_expr
-            _or |= q_expr
-
-        if _or:
-            warnings.warn(
-                "Using OR filters is deprecated and will be removed starting with Open Forms 3.0",
-                DeprecationWarning,
-            )
-            queryset = queryset.filter(_or)
-        return super().filter_queryset(queryset)

--- a/src/openforms/forms/tests/test_api_formdefinition.py
+++ b/src/openforms/forms/tests/test_api_formdefinition.py
@@ -483,40 +483,6 @@ class FormDefinitionsAPITests(APITestCase):
             fd["uuid"], str(form_1.formstep_set.get().form_definition.uuid)
         )
 
-    def test_filter_by_used_in_or_reusable(self):
-        user = StaffUserFactory.create(user_permissions=["change_form"])
-        self.client.force_authenticate(user=user)
-        FormDefinitionFactory.create(is_reusable=False, slug="fd-0")
-        fd2 = FormDefinitionFactory.create(is_reusable=True, slug="fd-1")
-        FormFactory.create(
-            generate_minimal_setup=True,
-            formstep__form_definition__slug="fd-2",
-            formstep__form_definition__is_reusable=False,
-        )
-        form_2 = FormFactory.create(
-            generate_minimal_setup=True,
-            formstep__form_definition__slug="fd-3",
-            formstep__form_definition__is_reusable=True,
-        )
-        url = reverse("api:formdefinition-list")
-
-        response = self.client.get(
-            url,
-            {
-                "used_in": form_2.uuid,
-                "is_reusable": "true",
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        self.assertEqual(response_data["count"], 2)
-        fd_2, fd_4 = response_data["results"]
-        self.assertEqual(fd_2["uuid"], str(fd2.uuid))
-        self.assertEqual(
-            fd_4["uuid"], str(form_2.formstep_set.get().form_definition.uuid)
-        )
-
     @override_settings(LANGUAGE_CODE="en")
     def test_duplicate_components(self):
         user = StaffUserFactory.create(user_permissions=["change_form"])


### PR DESCRIPTION
Part of #3283

Providing both the used_in and is_reusable filter parameters no longer returns records that match either condition, instead it applies the default AND behaviour.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
