### PR TITLE
:boom: Normalize api endpoints to kebab case

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -23,7 +23,7 @@ info:
   license:
     name: UNLICENSED
 paths:
-  /api/v2/analytics/analytics_tools_config_info:
+  /api/v2/analytics/analytics-tools-config-info:
     get:
       operationId: analytics_analytics_tools_config_info_retrieve
       description: Haal informatie op over de analytics-tools voor de frontend.
@@ -597,7 +597,7 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
-  /api/v2/config/privacy_policy_info:
+  /api/v2/config/privacy-policy-info:
     get:
       operationId: config_privacy_policy_info_retrieve
       summary: Privacybeleid informatie
@@ -4537,7 +4537,7 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
-  /api/v2/submissions/{submission_uuid}/steps/{step_uuid}/_check_logic:
+  /api/v2/submissions/{submission_uuid}/steps/{step_uuid}/_check-logic:
     post:
       operationId: submissions_steps__check_logic_create
       description: Apply/check the logic rules specified on the form step.

--- a/src/openforms/analytics_tools/api/urls.py
+++ b/src/openforms/analytics_tools/api/urls.py
@@ -6,7 +6,7 @@ app_name = "analytics_tools"
 
 urlpatterns = [
     path(
-        "analytics_tools_config_info",
+        "analytics-tools-config-info",
         AnalyticsToolsConfigurationView.as_view(),
         name="analytics-tools-config-info",
     ),

--- a/src/openforms/api/urls.py
+++ b/src/openforms/api/urls.py
@@ -101,10 +101,6 @@ urlpatterns = [
                 path("prefill/", include("openforms.prefill.api.urls")),
                 path("validation/", include("openforms.validations.api.urls")),
                 path(
-                    "location/get-street-name-and-city",
-                    RedirectView.as_view(pattern_name="api:geo:address-autocomplete"),
-                ),
-                path(
                     "logic/description",
                     GenerateLogicDescriptionView.as_view(),
                     name="generate-logic-description",

--- a/src/openforms/config/api/urls.py
+++ b/src/openforms/config/api/urls.py
@@ -6,7 +6,7 @@ app_name = "config"
 
 urlpatterns = [
     path(
-        "privacy_policy_info",
+        "privacy-policy-info",
         PrivacyPolicyInfoView.as_view(),
         name="privacy-policy-info",
     ),

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -609,7 +609,7 @@ class SubmissionStepViewSet(
     @action(
         detail=True,
         methods=["post"],
-        url_path="_check_logic",
+        url_path="_check-logic",
         throttle_classes=[PollingRateThrottle],
     )
     def logic_check(self, request, *args, **kwargs):


### PR DESCRIPTION
Part of #3283

**Changes**

* API endpoints are now consistently using dashes rather than underscores (except for the action prefix for non-REST endpoints)
* Removed obsolete redirect - the SDK has been updated

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
