### PR TITLE
Refactor payments module to apply plugin mechanism consistently

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -10,8 +10,6 @@ include = [
     "src/openforms/dmn/registry.py",
     "src/openforms/formio/registry.py",
     "src/openforms/formio/rendering/registry.py",
-    "src/openforms/payments/base.py",
-    "src/openforms/payments/registry.py",
     "src/openforms/pre_requests/base.py",
     "src/openforms/pre_requests/registry.py",
     "src/openforms/prefill/base.py",
@@ -29,10 +27,7 @@ include = [
     # Core forms app
     "src/openforms/forms/api/serializers/logic/action_serializers.py",
     # Payments
-    "src/openforms/payments/models.py",
-    "src/openforms/payments/contrib/ogone/client.py",
-    "src/openforms/payments/contrib/ogone/plugin.py",
-    "src/openforms/payments/views.py",
+    "src/openforms/payments/",
     # Interaction with the outside world
     "src/openforms/contrib/zgw/service.py",
     "src/openforms/contrib/objects_api/",
@@ -64,6 +59,10 @@ exclude = [
     "src/openforms/contrib/objects_api/tests/",
     "src/openforms/contrib/objects_api/json_schema.py",
     "src/openforms/formio/formatters/tests/",
+    "src/openforms/payments/management/commands/checkpaymentemaildupes.py",
+    "src/openforms/payments/tests/",
+    "src/openforms/payments/contrib/demo/tests/",
+    "src/openforms/payments/contrib/ogone/tests/",
     "src/openforms/registrations/contrib/zgw_apis/tests/test_backend_partial_failure.py",
     "src/openforms/registrations/contrib/zgw_apis/tests/test_utils.py",
 ]

--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -10,6 +10,7 @@ include = [
     "src/openforms/dmn/registry.py",
     "src/openforms/formio/registry.py",
     "src/openforms/formio/rendering/registry.py",
+    "src/openforms/payments/base.py",
     "src/openforms/payments/registry.py",
     "src/openforms/pre_requests/base.py",
     "src/openforms/pre_requests/registry.py",
@@ -29,6 +30,9 @@ include = [
     "src/openforms/forms/api/serializers/logic/action_serializers.py",
     # Payments
     "src/openforms/payments/models.py",
+    "src/openforms/payments/contrib/ogone/client.py",
+    "src/openforms/payments/contrib/ogone/plugin.py",
+    "src/openforms/payments/views.py",
     # Interaction with the outside world
     "src/openforms/contrib/zgw/service.py",
     "src/openforms/contrib/objects_api/",

--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -12,7 +12,6 @@ from ordered_model.admin import OrderedInlineModelAdminMixin, OrderedTabularInli
 
 from openforms.api.utils import underscore_to_camel
 from openforms.emails.models import ConfirmationEmailTemplate
-from openforms.payments.admin import PaymentBackendChoiceFieldMixin
 from openforms.registrations.admin import RegistrationBackendFieldMixin
 from openforms.typing import StrOrPromise
 from openforms.utils.expressions import FirstNotBlank
@@ -127,7 +126,6 @@ class FormDeletedListFilter(admin.ListFilter):
 class FormAdmin(
     FormioConfigMixin,
     RegistrationBackendFieldMixin,
-    PaymentBackendChoiceFieldMixin,
     OrderedInlineModelAdminMixin,
     admin.ModelAdmin,
 ):

--- a/src/openforms/payments/admin.py
+++ b/src/openforms/payments/admin.py
@@ -1,20 +1,6 @@
 from django.contrib import admin
 
-from .fields import PaymentBackendChoiceField
 from .models import SubmissionPayment
-
-
-class PaymentBackendChoiceFieldMixin:
-    def formfield_for_dbfield(self, db_field, request, **kwargs):
-        if isinstance(db_field, PaymentBackendChoiceField):
-            assert not db_field.choices
-            _old = db_field.choices
-            db_field.choices = db_field._get_plugin_choices()
-            field = super().formfield_for_dbfield(db_field, request, **kwargs)
-            db_field.choices = _old
-            return field
-
-        return super().formfield_for_dbfield(db_field, request, **kwargs)
 
 
 @admin.register(SubmissionPayment)

--- a/src/openforms/payments/api/fields.py
+++ b/src/openforms/payments/api/fields.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from openforms.forms.models import Form
+
 from ..registry import register as payment_register
 from .serializers import PaymentOptionSerializer
 
@@ -20,7 +22,8 @@ class PaymentOptionsReadOnlyField(serializers.ListField):
     def to_internal_value(self, data):
         raise NotImplementedError("read only")
 
-    def to_representation(self, form):
+    def to_representation(self, value):
+        assert isinstance(value, Form)
         request = self.context["request"]
-        temp = payment_register.get_options(request, form)
+        temp = payment_register.get_options(request, value)
         return super().to_representation(temp)

--- a/src/openforms/payments/api/serializers.py
+++ b/src/openforms/payments/api/serializers.py
@@ -23,7 +23,7 @@ class PaymentPluginSerializer(PluginBaseSerializer):
 class PaymentOptionSerializer(serializers.Serializer):
     # serializer for form
     identifier = serializers.CharField(label=_("Identifier"), read_only=True)
-    label = serializers.CharField(
+    label = serializers.CharField(  # pyright: ignore[reportAssignmentType]
         label=_("Button label"), help_text=_("Button label"), read_only=True
     )
 
@@ -34,7 +34,7 @@ class PaymentInfoSerializer(serializers.Serializer):
         label=_("Request type"), choices=PaymentRequestType.choices, read_only=True
     )
     url = serializers.URLField(label=_("URL"), read_only=True)
-    data = serializers.DictField(
+    data = serializers.DictField(  # pyright: ignore[reportAssignmentType,reportIncompatibleMethodOverride]
         label=_("Data"),
         child=serializers.CharField(label=_("Value"), read_only=True),
         read_only=True,

--- a/src/openforms/payments/base.py
+++ b/src/openforms/payments/base.py
@@ -81,7 +81,7 @@ class BasePlugin[OptionsT: Options](AbstractBasePlugin):
             request=request,
         )
 
-    def get_webhook_url(self, request: HttpRequest) -> str:
+    def get_webhook_url(self, request: HttpRequest | None) -> str:
         return reverse_plus(
             "payments:webhook",
             kwargs={"plugin_id": self.identifier},

--- a/src/openforms/payments/contrib/demo/plugin.py
+++ b/src/openforms/payments/contrib/demo/plugin.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from django.http import HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
 
@@ -11,16 +13,20 @@ from ...constants import PaymentStatus, UserAction
 from ...registry import register
 
 
+class NoOptions(TypedDict):
+    pass
+
+
 @register("demo")
-class DemoPayment(BasePlugin):
+class DemoPayment(BasePlugin[NoOptions]):
     verbose_name = _("Demo")
     is_demo_plugin = True
 
-    def start_payment(self, request, payment):
+    def start_payment(self, request, payment, options):
         url = self.get_return_url(request, payment)
         return PaymentInfo(url=url, data={})
 
-    def handle_return(self, request, payment):
+    def handle_return(self, request, payment, options):
         payment.status = PaymentStatus.completed
         payment.save()
 

--- a/src/openforms/payments/contrib/ogone/constants.py
+++ b/src/openforms/payments/contrib/ogone/constants.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -60,45 +58,42 @@ class OgoneStatus(models.TextChoices):
         return OGONE_TO_PAYMENT_STATUS[ogone_status]
 
 
-OGONE_TO_PAYMENT_STATUS = cast(
-    dict[str, str],
-    {
-        OgoneStatus.invalid_or_incomplete: PaymentStatus.failed.value,
-        OgoneStatus.cancelled_by_customer: PaymentStatus.failed.value,
-        OgoneStatus.authorisation_declined: PaymentStatus.failed.value,
-        OgoneStatus.waiting_for_client_payment: PaymentStatus.processing.value,
-        OgoneStatus.waiting_authentication: PaymentStatus.processing.value,
-        OgoneStatus.authorised: PaymentStatus.processing.value,
-        OgoneStatus.authorised_waiting_external_result: PaymentStatus.processing.value,
-        OgoneStatus.authorisation_waiting: PaymentStatus.processing.value,
-        OgoneStatus.authorisation_not_known: PaymentStatus.processing.value,
-        OgoneStatus.standby: PaymentStatus.processing.value,
-        OgoneStatus.ok_with_scheduled_payments: PaymentStatus.processing.value,
-        OgoneStatus.not_ok_with_scheduled_payments: PaymentStatus.failed.value,
-        OgoneStatus.authorised_and_cancelled: PaymentStatus.failed.value,
-        OgoneStatus.author_deletion_waiting: PaymentStatus.failed.value,
-        OgoneStatus.author_deletion_uncertain: PaymentStatus.failed.value,
-        OgoneStatus.author_deletion_refused: PaymentStatus.failed.value,
-        OgoneStatus.payment_deleted: PaymentStatus.failed.value,
-        OgoneStatus.payment_deletion_pending: PaymentStatus.failed.value,
-        OgoneStatus.payment_deletion_uncertain: PaymentStatus.failed.value,
-        OgoneStatus.payment_deletion_refused: PaymentStatus.failed.value,
-        OgoneStatus.payment_deleted2: PaymentStatus.failed,  # doubl.valuee
-        OgoneStatus.refund: PaymentStatus.failed.value,
-        OgoneStatus.refund_pending: PaymentStatus.failed.value,
-        OgoneStatus.refund_uncertain: PaymentStatus.failed.value,
-        OgoneStatus.refund_refused: PaymentStatus.failed.value,
-        OgoneStatus.payment_declined_by_the_acquirer: PaymentStatus.failed.value,
-        OgoneStatus.refund_processed_by_merchant: PaymentStatus.failed.value,
-        OgoneStatus.payment_requested: PaymentStatus.completed.value,
-        OgoneStatus.payment_processing: PaymentStatus.processing.value,
-        OgoneStatus.payment_uncertain: PaymentStatus.processing.value,
-        OgoneStatus.payment_refused: PaymentStatus.failed.value,
-        OgoneStatus.refund_declined_by_the_acquirer: PaymentStatus.failed.value,
-        OgoneStatus.payment_processed_by_merchant: PaymentStatus.failed.value,
-        OgoneStatus.being_processed: PaymentStatus.processing.value,
-    },
-)
+OGONE_TO_PAYMENT_STATUS: dict[str, str] = {
+    OgoneStatus.invalid_or_incomplete.value: PaymentStatus.failed.value,
+    OgoneStatus.cancelled_by_customer.value: PaymentStatus.failed.value,
+    OgoneStatus.authorisation_declined.value: PaymentStatus.failed.value,
+    OgoneStatus.waiting_for_client_payment.value: PaymentStatus.processing.value,
+    OgoneStatus.waiting_authentication.value: PaymentStatus.processing.value,
+    OgoneStatus.authorised.value: PaymentStatus.processing.value,
+    OgoneStatus.authorised_waiting_external_result.value: PaymentStatus.processing.value,
+    OgoneStatus.authorisation_waiting.value: PaymentStatus.processing.value,
+    OgoneStatus.authorisation_not_known.value: PaymentStatus.processing.value,
+    OgoneStatus.standby.value: PaymentStatus.processing.value,
+    OgoneStatus.ok_with_scheduled_payments.value: PaymentStatus.processing.value,
+    OgoneStatus.not_ok_with_scheduled_payments.value: PaymentStatus.failed.value,
+    OgoneStatus.authorised_and_cancelled.value: PaymentStatus.failed.value,
+    OgoneStatus.author_deletion_waiting.value: PaymentStatus.failed.value,
+    OgoneStatus.author_deletion_uncertain.value: PaymentStatus.failed.value,
+    OgoneStatus.author_deletion_refused.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_deleted.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_deletion_pending.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_deletion_uncertain.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_deletion_refused.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_deleted2.value: PaymentStatus.failed,  # doubl.valuee
+    OgoneStatus.refund.value: PaymentStatus.failed.value,
+    OgoneStatus.refund_pending.value: PaymentStatus.failed.value,
+    OgoneStatus.refund_uncertain.value: PaymentStatus.failed.value,
+    OgoneStatus.refund_refused.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_declined_by_the_acquirer.value: PaymentStatus.failed.value,
+    OgoneStatus.refund_processed_by_merchant.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_requested.value: PaymentStatus.completed.value,
+    OgoneStatus.payment_processing.value: PaymentStatus.processing.value,
+    OgoneStatus.payment_uncertain.value: PaymentStatus.processing.value,
+    OgoneStatus.payment_refused.value: PaymentStatus.failed.value,
+    OgoneStatus.refund_declined_by_the_acquirer.value: PaymentStatus.failed.value,
+    OgoneStatus.payment_processed_by_merchant.value: PaymentStatus.failed.value,
+    OgoneStatus.being_processed.value: PaymentStatus.processing.value,
+}
 
 assert set(OgoneStatus.values) == set(
     OGONE_TO_PAYMENT_STATUS.keys()

--- a/src/openforms/payments/contrib/ogone/typing.py
+++ b/src/openforms/payments/contrib/ogone/typing.py
@@ -1,0 +1,7 @@
+from typing import TypedDict
+
+from .models import OgoneMerchant
+
+
+class PaymentOptions(TypedDict):
+    merchant_id: OgoneMerchant  # FIXME: key is badly named in the serializer

--- a/src/openforms/payments/models.py
+++ b/src/openforms/payments/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
@@ -92,6 +92,7 @@ class SubmissionPaymentManager(models.Manager.from_queryset(SubmissionPaymentQue
 
 
 class SubmissionPayment(models.Model):
+    id: int | None
     uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
     created = models.DateTimeField(auto_now_add=True)
 
@@ -139,7 +140,9 @@ class SubmissionPayment(models.Model):
         help_text=_("The ID assigned to the payment by the payment provider."),
     )
 
-    objects = SubmissionPaymentManager()
+    objects: ClassVar[  # pyright: ignore[reportIncompatibleVariableOverride]
+        SubmissionPaymentManager
+    ] = SubmissionPaymentManager()
 
     class Meta:
         verbose_name = _("submission payment details")

--- a/src/openforms/payments/tests/test_views.py
+++ b/src/openforms/payments/tests/test_views.py
@@ -23,14 +23,14 @@ class Plugin(BasePlugin):
     return_method = "GET"
     webhook_method = "POST"
 
-    def start_payment(self, request, payment):
+    def start_payment(self, request, payment, options):
         return PaymentInfo(type="get", url="http://testserver/foo")
 
-    def handle_return(self, request, payment):
+    def handle_return(self, request, payment, options):
         return HttpResponseRedirect(payment.submission.form_url)
 
     def handle_webhook(self, request):
-        return None
+        return SubmissionPayment(id=None)
 
 
 class ViewsTests(TestCase):
@@ -221,7 +221,7 @@ class PaymentPlugin(BasePlugin):
         return payment
 
     def handle_return(
-        self, request: HttpRequest, payment: "SubmissionPayment"
+        self, request: HttpRequest, payment: "SubmissionPayment", options
     ) -> HttpResponse:
         return HttpResponseRedirect(payment.submission.form_url)
 


### PR DESCRIPTION
Part of #3457 -  doing the refactor before making the required changes

All other modules operate on the idea that the generic code populates the plugin options from the generic information and the specified options serializer, which allows plugins to be generically typed and not needing to perform additional input validation or conversion from the raw JSON data for the options to the Python/Django objects that are easier to work with.

This does change the public API of the registry/plugins to take an extra argument, but enables us to apply static type checking (which already reveals some problems) and simpler plugin code.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
