### PR TITLE
[#4853] Fix non required fields in registration backends serializers

### DIFF
--- a/src/openforms/registrations/contrib/demo/config.py
+++ b/src/openforms/registrations/contrib/demo/config.py
@@ -9,4 +9,5 @@ class DemoOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     extra_line = serializers.CharField(
         label=_("Extra print statement"),
         required=False,
+        allow_blank=True,
     )

--- a/src/openforms/registrations/contrib/email/config.py
+++ b/src/openforms/registrations/contrib/email/config.py
@@ -50,6 +50,7 @@ class EmailOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
             "number to the submission in the subject."
         ),
         required=False,
+        allow_blank=True,
         validators=[
             DjangoTemplateValidator(backend="openforms.template.openforms_backend")
         ],
@@ -60,6 +61,7 @@ class EmailOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
             "Subject of the email sent to the registration backend to notify a change in the payment status."
         ),
         required=False,
+        allow_blank=True,
         validators=[
             DjangoTemplateValidator(backend="openforms.template.openforms_backend")
         ],
@@ -68,6 +70,7 @@ class EmailOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         label=_("email content template HTML"),
         help_text=_("Content of the registration email message (as text)."),
         required=False,
+        allow_blank=True,
         validators=[
             DjangoTemplateValidator(
                 backend="openforms.template.openforms_backend",
@@ -79,6 +82,7 @@ class EmailOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         label=_("email content template text"),
         help_text=_("Content of the registration email message (as text)."),
         required=False,
+        allow_blank=True,
         validators=[
             DjangoTemplateValidator(
                 backend="openforms.template.openforms_backend",

--- a/src/openforms/registrations/contrib/microsoft_graph/config.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/config.py
@@ -37,4 +37,5 @@ class MicrosoftGraphOptionsSerializer(
             "ID of the drive to use. If left empty, the default drive will be used."
         ),
         required=False,
+        allow_blank=True,
     )

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -185,6 +185,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             "to be used for the submission report PDF."
         ),
         required=False,
+        allow_blank=True,
     )
     informatieobjecttype_submission_csv = serializers.URLField(
         label=_("submission report CSV informatieobjecttype"),
@@ -193,6 +194,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             "to be used for the submission report CSV."
         ),
         required=False,
+        allow_blank=True,
     )
     informatieobjecttype_attachment = serializers.URLField(
         label=_("attachment informatieobjecttype"),
@@ -201,6 +203,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             "to be used for the submission attachments."
         ),
         required=False,
+        allow_blank=True,
     )
 
     # V1 only fields:
@@ -208,6 +211,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         label=_("productaanvraag type"),
         help_text=_("The type of ProductAanvraag."),
         required=False,
+        allow_blank=True,
     )
     content_json = serializers.CharField(
         label=_("JSON content field"),
@@ -220,6 +224,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             ),
         ],
         required=False,
+        allow_blank=True,
     )
     payment_status_update_json = serializers.CharField(
         label=_("payment status update JSON template"),
@@ -233,6 +238,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             ),
         ],
         required=False,
+        allow_blank=True,
     )
 
     # V2 only fields:

--- a/src/openforms/registrations/contrib/stuf_zds/options.py
+++ b/src/openforms/registrations/contrib/stuf_zds/options.py
@@ -46,20 +46,24 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     )
     zds_zaaktype_omschrijving = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text=_("Zaaktype description for newly created Zaken in StUF-ZDS"),
     )
 
     zds_zaaktype_status_code = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text=_("Zaaktype status code for newly created zaken in StUF-ZDS"),
     )
     zds_zaaktype_status_omschrijving = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text=_("Zaaktype status omschrijving for newly created zaken in StUF-ZDS"),
     )
 
     zds_documenttype_omschrijving_inzending = serializers.CharField(
         required=True,
+        allow_blank=True,
         help_text=_("Documenttype description for newly created zaken in StUF-ZDS"),
     )
 


### PR DESCRIPTION
Closes #4853

**Changes**

- Updated serializers with non required fields. When we send empty strings to the backend we need `allow_blank=True`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
