### PR TITLE
Temporary fix for formio-builder

### DIFF
--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -163,6 +163,7 @@ class WebformBuilder extends WebformBuilderFormio {
             theme={currentTheme.getValue()}
             richTextColors={RICH_TEXT_COLORS}
             getFormComponents={() => this.webform.form.components}
+            getMapTileLayers={() => []}
             getValidatorPlugins={getValidatorPlugins}
             getRegistrationAttributes={getRegistrationAttributes}
             getPrefillPlugins={getPrefillPlugins}


### PR DESCRIPTION
**Changes**

The formio-builder, in the tests, expects a new property. This will be added with map background PR (https://github.com/open-formulieren/open-forms/pull/4881).

Without this property, the form won't render properly. For the time being, this will fix the issue

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
