### PR TITLE
Support custom TITLE and COM parameters in Ogone payment plugin

### DIFF
--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -304,7 +304,12 @@ class ImportExportTests(TempdirMixin, TestCase):
         self.assertEqual(imported_form.authentication_backends, ["digid"])
         self.assertEqual(imported_form.payment_backend, "ogone-legacy")
         self.assertEqual(
-            imported_form.payment_backend_options, {"merchant_id": merchant.id}
+            imported_form.payment_backend_options,
+            {
+                "merchant_id": merchant.id,
+                "com_template": "",
+                "title_template": "",
+            },
         )
 
         form_definitions = FormDefinition.objects.order_by("pk")

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2293,6 +2293,60 @@
       "value": "The data entered in this component will be removed in accordance with the privacy settings."
     }
   ],
+  "JHQfjZ": [
+    {
+      "type": 0,
+      "value": "Optional custom template for the the description, included in the payment overviews for the backoffice. Use this to link the payment back to a particular process or form."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": " You can use all form variables (using their keys) and the "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "public_reference"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " template variable. If unspecified, a default description is used."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Note"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": ": the length of the result is capped to 100 characters."
+    }
+  ],
   "JKq3TC": [
     {
       "type": 0,
@@ -3887,6 +3941,12 @@
       "value": "The processing (\"verwerking\") for queries to the BRP Persoon API."
     }
   ],
+  "ZSvQcR": [
+    {
+      "type": 0,
+      "value": "TITLE parameter"
+    }
+  ],
   "ZdZ2Mb": [
     {
       "type": 0,
@@ -4443,6 +4503,12 @@
     {
       "type": 0,
       "value": "'Save row' text"
+    }
+  ],
+  "eZJFP7": [
+    {
+      "type": 0,
+      "value": "COM parameter"
     }
   ],
   "ee4oWr": [
@@ -6241,6 +6307,36 @@
     {
       "type": 0,
       "value": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
+    }
+  ],
+  "vikURf": [
+    {
+      "type": 0,
+      "value": "Optional custom template for the title displayed on the payment page."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": " You can use all form variables (using their keys) and the "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "public_reference"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " template variable. If unspecified, a default description is used."
     }
   ],
   "vlY36U": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2314,6 +2314,60 @@
       "value": "Gegevens opgevoerd in dit component worden geschoond volgens de privacy-instellingen."
     }
   ],
+  "JHQfjZ": [
+    {
+      "type": 0,
+      "value": "Optional custom template for the the description, included in the payment overviews for the backoffice. Use this to link the payment back to a particular process or form."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": " You can use all form variables (using their keys) and the "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "public_reference"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " template variable. If unspecified, a default description is used."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Note"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": ": the length of the result is capped to 100 characters."
+    }
+  ],
   "JKq3TC": [
     {
       "type": 0,
@@ -3905,6 +3959,12 @@
       "value": "De waarde voor \"verwerking\" die meegestuurd wordt bij het bevragen van de BRP Personen API. Mogelijke waarden hiervoor zijn afhankelijk van je gateway-leverancier."
     }
   ],
+  "ZSvQcR": [
+    {
+      "type": 0,
+      "value": "TITLE parameter"
+    }
+  ],
   "ZdZ2Mb": [
     {
       "type": 0,
@@ -4465,6 +4525,12 @@
     {
       "type": 0,
       "value": "'Groep bewaren'-tekst"
+    }
+  ],
+  "eZJFP7": [
+    {
+      "type": 0,
+      "value": "COM parameter"
     }
   ],
   "ee4oWr": [
@@ -6263,6 +6329,36 @@
     {
       "type": 0,
       "value": "De inhoud van bevestigingspagina na het versturen van de inzending. Dit sjabloon mag variabelen bevatten met inzendings-gegevens. Laat dit veld leeg om de standaardinstelling te gebruiken."
+    }
+  ],
+  "vikURf": [
+    {
+      "type": 0,
+      "value": "Optional custom template for the title displayed on the payment page."
+    },
+    {
+      "children": [
+      ],
+      "type": 8,
+      "value": "br"
+    },
+    {
+      "type": 0,
+      "value": " You can use all form variables (using their keys) and the "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "public_reference"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " template variable. If unspecified, a default description is used."
     }
   ],
   "vlY36U": [

--- a/src/openforms/js/components/admin/form_design/payments/ogone_legacy/OgoneLegacyOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/payments/ogone_legacy/OgoneLegacyOptionsForm.js
@@ -11,7 +11,7 @@ import {
 import {getChoicesFromSchema} from 'utils/json-schema';
 
 import OptionsConfiguration from '../OptionsConfiguration';
-import {MerchantID} from './fields';
+import {ComTemplate, MerchantID, TitleTemplate} from './fields';
 
 const OgoneLegacyOptionsForm = ({schema, formData, onSubmit}) => {
   const validationErrors = useContext(ValidationErrorContext);
@@ -41,6 +41,8 @@ const OgoneLegacyOptionsForm = ({schema, formData, onSubmit}) => {
       <ValidationErrorsProvider errors={relevantErrors}>
         <Fieldset>
           <MerchantID options={merchantChoices} />
+          <TitleTemplate />
+          <ComTemplate />
         </Fieldset>
       </ValidationErrorsProvider>
     </OptionsConfiguration>

--- a/src/openforms/js/components/admin/form_design/payments/ogone_legacy/fields.js
+++ b/src/openforms/js/components/admin/form_design/payments/ogone_legacy/fields.js
@@ -1,8 +1,10 @@
+import {useField} from 'formik';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
 import Field from 'components/admin/forms/Field';
 import FormRow from 'components/admin/forms/FormRow';
+import {TextInput} from 'components/admin/forms/Inputs';
 import ReactSelect from 'components/admin/forms/ReactSelect';
 
 export const MerchantID = ({options}) => (
@@ -21,6 +23,7 @@ export const MerchantID = ({options}) => (
           defaultMessage="Which merchant should be used for payments related to this form."
         />
       }
+      required
     >
       <ReactSelect name="merchantId" options={options} required />
     </Field>
@@ -35,3 +38,73 @@ MerchantID.propTypes = {
     })
   ).isRequired,
 };
+
+export const TitleTemplate = () => {
+  const [fieldProps] = useField('titleTemplate');
+  return (
+    <FormRow>
+      <Field
+        name="titleTemplate"
+        label={
+          <FormattedMessage
+            description="Ogone legacy payment options 'titleTemplate' label"
+            defaultMessage="TITLE parameter"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Ogone legacy payment options 'titleTemplate' help text"
+            defaultMessage={`Optional custom template for the title displayed on the payment page.<br></br>
+            You can use all form variables (using their keys) and the <code>public_reference</code>
+            template variable. If unspecified, a default description is used.`}
+            values={{
+              br: () => <br />,
+              code: chunks => <code>{chunks}</code>,
+            }}
+          />
+        }
+      >
+        <TextInput {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+TitleTemplate.propTypes = {};
+
+export const ComTemplate = () => {
+  const [fieldProps] = useField('comTemplate');
+  return (
+    <FormRow>
+      <Field
+        name="comTemplate"
+        label={
+          <FormattedMessage
+            description="Ogone legacy payment options 'comTemplate' label"
+            defaultMessage="COM parameter"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="Ogone legacy payment options 'comTemplate' help text"
+            defaultMessage={`Optional custom template for the the description, included in the
+            payment overviews for the backoffice. Use this to link the payment back to a particular
+            process or form.<br></br>
+            You can use all form variables (using their keys) and the <code>public_reference</code>
+            template variable. If unspecified, a default description is used.<br></br>
+            <strong>Note</strong>: the length of the result is capped to 100 characters.`}
+            values={{
+              br: () => <br />,
+              code: chunks => <code>{chunks}</code>,
+              strong: chunks => <strong>{chunks}</strong>,
+            }}
+          />
+        }
+      >
+        <TextInput {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+ComTemplate.propTypes = {};

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1079,6 +1079,11 @@
     "description": "Modal title API call failed with HTTP 401",
     "originalDefault": "Authentication failure"
   },
+  "JHQfjZ": {
+    "defaultMessage": "Optional custom template for the the description, included in the payment overviews for the backoffice. Use this to link the payment back to a particular process or form.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used.<br></br> <strong>Note</strong>: the length of the result is capped to 100 characters.",
+    "description": "Ogone legacy payment options 'comTemplate' help text",
+    "originalDefault": "Optional custom template for the the description, included in the payment overviews for the backoffice. Use this to link the payment back to a particular process or form.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used.<br></br> <strong>Note</strong>: the length of the result is capped to 100 characters."
+  },
   "JKq3TC": {
     "defaultMessage": "Medewerker roltype",
     "description": "Objects API registration options 'medewerkerRoltype' label",
@@ -1839,6 +1844,11 @@
     "description": "Form 'BRP Personen processing header value' field help text",
     "originalDefault": "The processing (\"verwerking\") for queries to the BRP Persoon API."
   },
+  "ZSvQcR": {
+    "defaultMessage": "TITLE parameter",
+    "description": "Ogone legacy payment options 'titleTemplate' label",
+    "originalDefault": "TITLE parameter"
+  },
   "ZdZ2Mb": {
     "defaultMessage": "Set the registration backend to use for the submission",
     "description": "action type \"set-registration-backend\" label",
@@ -2083,6 +2093,11 @@
     "defaultMessage": "Zds zaaktype status code",
     "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
     "originalDefault": "Zds zaaktype status code"
+  },
+  "eZJFP7": {
+    "defaultMessage": "COM parameter",
+    "description": "Ogone legacy payment options 'comTemplate' label",
+    "originalDefault": "COM parameter"
   },
   "efsF8+": {
     "defaultMessage": "{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}",
@@ -2918,6 +2933,11 @@
     "defaultMessage": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used.",
     "description": "Confirmation template help text",
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
+  },
+  "vikURf": {
+    "defaultMessage": "Optional custom template for the title displayed on the payment page.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used.",
+    "description": "Ogone legacy payment options 'titleTemplate' help text",
+    "originalDefault": "Optional custom template for the title displayed on the payment page.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used."
   },
   "vng/5K": {
     "defaultMessage": "Set a key name before you can configure this variable",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1088,6 +1088,11 @@
     "description": "Modal title API call failed with HTTP 401",
     "originalDefault": "Authentication failure"
   },
+  "JHQfjZ": {
+    "defaultMessage": "Optional custom template for the the description, included in the payment overviews for the backoffice. Use this to link the payment back to a particular process or form.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used.<br></br> <strong>Note</strong>: the length of the result is capped to 100 characters.",
+    "description": "Ogone legacy payment options 'comTemplate' help text",
+    "originalDefault": "Optional custom template for the the description, included in the payment overviews for the backoffice. Use this to link the payment back to a particular process or form.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used.<br></br> <strong>Note</strong>: the length of the result is capped to 100 characters."
+  },
   "JKq3TC": {
     "defaultMessage": "Medewerkerroltype",
     "description": "Objects API registration options 'medewerkerRoltype' label",
@@ -1857,6 +1862,11 @@
     "description": "Form 'BRP Personen processing header value' field help text",
     "originalDefault": "The processing (\"verwerking\") for queries to the BRP Persoon API."
   },
+  "ZSvQcR": {
+    "defaultMessage": "TITLE parameter",
+    "description": "Ogone legacy payment options 'titleTemplate' label",
+    "originalDefault": "TITLE parameter"
+  },
   "ZdZ2Mb": {
     "defaultMessage": "Zet registratieplugin voor de inzending",
     "description": "action type \"set-registration-backend\" label",
@@ -2103,6 +2113,11 @@
     "defaultMessage": "Zaakstatuscode",
     "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
     "originalDefault": "Zds zaaktype status code"
+  },
+  "eZJFP7": {
+    "defaultMessage": "COM parameter",
+    "description": "Ogone legacy payment options 'comTemplate' label",
+    "originalDefault": "COM parameter"
   },
   "efsF8+": {
     "defaultMessage": "{label} {isPublished, select, false {<draft>(concept)</draft>} other {}}",
@@ -2939,6 +2954,11 @@
     "defaultMessage": "De inhoud van bevestigingspagina na het versturen van de inzending. Dit sjabloon mag variabelen bevatten met inzendings-gegevens. Laat dit veld leeg om de standaardinstelling te gebruiken.",
     "description": "Confirmation template help text",
     "originalDefault": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used."
+  },
+  "vikURf": {
+    "defaultMessage": "Optional custom template for the title displayed on the payment page.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used.",
+    "description": "Ogone legacy payment options 'titleTemplate' help text",
+    "originalDefault": "Optional custom template for the title displayed on the payment page.<br></br> You can use all form variables (using their keys) and the <code>public_reference</code> template variable. If unspecified, a default description is used."
   },
   "vng/5K": {
     "defaultMessage": "Er moet een sleutelnaam ingesteld worden voordat deze variabele geconfigureerd kan worden",

--- a/src/openforms/payments/contrib/ogone/client.py
+++ b/src/openforms/payments/contrib/ogone/client.py
@@ -27,7 +27,8 @@ class OgoneClient:
         amount_cents: int,
         return_url: str,
         return_action_param: str,
-        description: str = "",
+        title: str = "",
+        com: str = "",
         **extra_params
     ) -> PaymentInfo:
         # base params
@@ -37,8 +38,8 @@ class OgoneClient:
             LANGUAGE="nl_NL",
             ORDERID=order_id,
             PSPID=self.merchant.pspid,
-            TITLE=description,  # doesnt work??
-            COM=description,
+            TITLE=title,  # unsure if this works - doesn't seem to be displayed in simulator?
+            COM=com,
         )
         # add action variations to base return url
         url = furl(return_url)

--- a/src/openforms/payments/contrib/ogone/tests/files/vcr_cassettes/OgoneClientTest/OgoneClientTest.test_com_title_unicode_chars.yaml
+++ b/src/openforms/payments/contrib/ogone/tests/files/vcr_cassettes/OgoneClientTest/OgoneClientTest.test_com_title_unicode_chars.yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: PSPID=maykinmedia&ORDERID=xyz2024%2FOF-123456%2F987654321&AMOUNT=1000&CURRENCY=EUR&LANGUAGE=nl_NL&TITLE=l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21+l%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4mp%21&PMLISTTYPE=2&ACCEPTURL=http%3A%2F%2Ffoo.bar%2Freturn%3Fbazz%3Dbuzz%26action%3Daccept&DECLINEURL=http%3A%2F%2Ffoo.bar%2Freturn%3Fbazz%3Dbuzz%26action%3Dcancel&EXCEPTIONURL=http%3A%2F%2Ffoo.bar%2Freturn%3Fbazz%3Dbuzz%26action%3Dexception&CANCELURL=http%3A%2F%2Ffoo.bar%2Freturn%3Fbazz%3Dbuzz%26action%3Dcancel&BACKURL=http%3A%2F%2Ffoo.bar%2Freturn%3Fbazz%3Dbuzz%26action%3Dcancel&COM=br%C3%B8ther+i+desire+l%C3%B6%C3%B6ps&SHASIGN=EF6D7725AC3A447821DB9E5997FDC2A9B8F4A7403E091A45A25146E98950B6BF433EDEC00D1B7B542AF82C3912B64598F5A44493465C3C31070FE4DA4B72809B
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1570'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: https://ogone.test.v-psp.com/ncol/test/orderstandard_utf8.asp
+  response:
+    body:
+      string: "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n<head>\r\n    <meta HTTP-EQUIV=\"Content-Type\"
+        CONTENT=\"text/html;CHARSET=iso-8859-1\">\r\n    <meta charset=\"UTF-8\">\r\n
+        \   <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\">\r\n
+        \   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\r\n
+        \   <title>Payment confirmation</title>\r\n    <link rel=\"stylesheet\" href=\"https://external-assets.test.cdn.v-psp.com/t/92537cd607774b90a88cc73a76629f59/1716986701/IngenicoResponsivePaymentPageTemplate_reset.css\"
+        crossorigin=\"anonymous\" integrity=\"sha384-&#x2B;m4H86c8/NqPFGBf7RK/jW0vN/kJpOa1TCjX0YnbN6j5teYvK&#x2B;kuuB2F5ORwE/WS\">\r\n
+        \   <link rel=\"stylesheet\" href=\"https://external-assets.test.cdn.v-psp.com/t/92537cd607774b90a88cc73a76629f59/1716986701/IngenicoResponsivePaymentPageTemplate_template.css\"
+        crossorigin=\"anonymous\" integrity=\"sha384-BEHtpyeJehB0uHOBAhAYbb5jrb61TY184Hp6EbuvHh6I58cWuDoIq9fkegFJ&#x2B;Mf2\">\r\n</head>\r\n<body>\r\n<div
+        id=\"page\">\r\n    <div id=\"logo-zone\">\r\n        <img id=\"customer-logo\"
+        src=\"https://external-assets.test.cdn.v-psp.com/t/92537cd607774b90a88cc73a76629f59/1716986701/logo.png\"
+        crossorigin=\"anonymous\" integrity=\"sha384-fD6aXhSYV&#x2B;STX0QcQW7Po7ClyHgBzsjMCtZZUbkTQX2l/kORkd2OW3lMlFfOP7u7\"
+        class=\"logo\">\r\n    </div>\r\n    <div id=\"payment-zone\">\r\n<script
+        language=\"javascript\" type=\"text/Javascript\">\r\nvar ncolwaitwindow;\r\nvar
+        ncolwaitwindowopen = 0;\r\n\r\n<!--\r\ndocument.write('<div class=\"WaitMsgClass\"
+        id=\"WaitMsgId\" style=\"display: none;background-color: #FFFFFF;border: solid
+        #CCCCCC 4px;padding: 4px;color: #000000;font-family: Verdana;font-weight:
+        bold;position: absolute;width: 350px;\"><img id=\"waitGif\" src=\"https&#58;//ogone.test.v-psp.com/images/wait_turn.gif\"></div>');\r\n\r\n\r\n\r\nfunction
+        ShowWaitMsg(){\r\n\t\tvar wm;\r\n\t\tvar lg;\r\n\t\tvar ht;\r\n\t\twm = document.getElementById(\"WaitMsgId\");\r\n\t\twm.innerHTML
+        = '<p class=\"WaitMsgP\"><img id=\"waitGif\" src=\"https&#58;//ogone.test.v-psp.com/images/wait_turn.gif\">Gelieve
+        te wachten terwijl wij uw betaling uitvoeren!</p>';\r\n\t\tlg = document.body.offsetWidth;\r\n\t\tht
+        = document.body.offsetHeight;\r\n\t\twm.style.top = String(Math.round(ht/4+50))
+        + 'px';\r\n\t\twm.style.left = String(Math.round((lg-360)/2)) + 'px';\r\n\t\twm.style.display
+        = \"block\";\r\n\r\n\t}\r\n\r\n\r\nfunction my_submitAndWait(thisform,limitScriptU)\r\n{\r\n\tvar
+        RC;\r\n\tvar wm;\r\n\tvar lg;\r\n\tvar ht;\r\n\tvar bs;\r\n//\tvar l=string.length;\r\n\r\n\tif
+        (typeof fillHdJs != 'undefined')\r\n\t{\r\n\t\tfillHdJs();\r\n\t}\r\n\r\n\tRC
+        = evalFormFieldsN(formFields,limitScriptU);\r\n\tif (RC)\r\n\t{\r\n\t\tShowWaitMsg();\r\n\t\tfor
+        (i=0; i<thisform.elements.length;i++)\r\n\t\t{\r\n\t\t\tif (thisform.elements[i].type
+        == \"submit\")\r\n\t\t\t{\r\n\t\t\t\tthisform.elements[i].disabled = true;\r\n\t\t\t}\r\n\t\t}\r\n\t}\r\n\treturn
+        RC;\r\n}\r\nfunction justWait(string)\r\n{\r\n\t\tShowWaitMsg();\r\n}\r\nfunction
+        close_ncol_wait()\r\n{\r\n}\r\n//-->\r\n</script>\r\n\r\n\t<!-- Order overview
+        -->\r\n\t<h2 style=\"display: inline; position: absolute; left: -1000px; top:
+        -1000px; width: 0px; height: 0px; overflow: hidden;\">Overzicht van de bestelling</h2>\r\n\t<table
+        class=ncoltable1 border=\"0\" cellpadding=\"2\" cellspacing=\"0\" width=\"95%\"
+        id=\"ncol_ref\">\r\n\t\t\t\r\n\t\t\t\t\t\t\t<tr>\r\n\t\t\t\t\t\t\t\t<td class=ncoltxtl
+        colspan=\"1\" align=\"right\" width=\"50%\"><small>Referentie van de bestelling
+        :<!--External reference--></small></td>\r\n\t\t\t\t\t\t\t\t<td class=ncoltxtr
+        colspan=\"1\" width=\"50%\"><small>xyz2024/OF-123456/987654321</small></td>\r\n\t\t\t\t\t\t\t</tr>\r\n\t\t\t\t\t\t\r\n\r\n\t\t\t\t<tr>\r\n\t\t\t\t\t\r\n\t\t\t\t\t\t\t<td
+        class=ncoltxtl colspan=\"1\" align=\"right\" width=\"50%\"><small>\r\n\t\t\t\t\t\t\tTotale
+        kostprijs :<!--Total to pay-->\r\n\t\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t</small></td>\r\n\t\t\t\t\t\t\t<td
+        class=ncoltxtr colspan=\"1\" width=\"50%\">\r\n\t\t\t\t\t\t\t\t<small>10.00
+        EUR\r\n\t\t\t\t\t\t\t</small>\r\n\t\t\t\t\t\t\t</td>\r\n\t\t\t\t\t\r\n\t\t\t\t</tr>\r\n\t\t\t\t\r\n\t\t\t\t\t<tr>\r\n\t\t\t\t\t\t<td
+        class=ncoltxtl colspan=\"1\" align=\"right\"><small>Begunstigde  :<!--Beneficiary--></small></td>\r\n\t\t\t\t\t\t<td
+        class=ncoltxtr colspan=\"1\"><small>Maykin Media B.V.</small></td>\r\n\t\t\t\t\t</tr>\r\n\t\t\t\t\t\r\n\t</table>\r\n\t\r\n\t\t<script
+        type=\"text/javascript\" src=\"js/jquery.core/jquery-3.7.0.min.js\"></script>\r\n\t\t<script
+        type=\"text/javascript\" src=\"js/jquery.plugins/jquery-migrate-3.4.1.min.js\"></script>\r\n\t\r\n\t\t<script
+        type=\"text/javascript\" src=\"js/jquery.plugins/dependencies/Class.create.js\"></script>\r\n\t\t<script
+        type=\"text/javascript\" src=\"js/jquery.plugins/jquery.jquery-encoder-0.1.0.min.js\"></script>\r\n\t\t<script
+        type=\"text/JavaScript\">\r\n\t\t<!--\r\n\t\tfunction trustHTML(sStr) {\r\n\t\t\treturn
+        sStr;\r\n\t\t}\r\n\t\t//-->\r\n\t\t</script>\r\n\t\r\n\t\t<script type=\"text/javascript\">\r\n\t\t\tvar
+        OGONE = {};\r\n\t\t\tOGONE.jQuery = $.noConflict(true);\r\n\t\t</script>\r\n\t\r\n\r\n\t<script
+        type=\"text/javascript\" language=\"javascript\" src=\"js/required_fields.js\"></script>\r\n\t<script
+        type=\"text/javascript\" language=\"javascript\">\r\n\t\tfunction createHiddenInput(form,
+        name, value)\r\n\t\t{\r\n\t\t\tvar input = document.createElement(\"input\");\r\n\t\t\tinput.setAttribute(\"type\",
+        \"hidden\");\r\n            input.setAttribute(\"name\", name);\r\n            if
+        (typeof value === \"undefined\") {\r\n                input.setAttribute(\"value\",
+        \"\");\r\n            } else {\r\n                input.setAttribute(\"value\",
+        value);\r\n            }\r\n\t\t\t\r\n\r\n\t\t\tform.appendChild(input);\r\n\t\t}\r\n\r\n\t\tOGONE.jQuery(document).ready(function()\r\n\t\t{\r\n\t\t\tvar
+        ogoneCCForms = document.getElementsByName(\"OGONE_CC_FORM\");\r\n\t\t\tif
+        (ogoneCCForms != null && ogoneCCForms.length > 0)\r\n\t\t\t{\r\n\t\t\t\tvar
+        ogoneCCForm = ogoneCCForms[0];\r\n\r\n\t\t\t\tcreateHiddenInput(ogoneCCForm,
+        \"browserColorDepth\", screen.colorDepth);\r\n\t\t\t\tcreateHiddenInput(ogoneCCForm,
+        \"browserJavaEnabled\", navigator.javaEnabled());\r\n\t\t\t\tcreateHiddenInput(ogoneCCForm,
+        \"browserLanguage\", navigator.language);\r\n\t\t\t\tcreateHiddenInput(ogoneCCForm,
+        \"browserScreenHeight\", screen.height);\r\n\t\t\t\tcreateHiddenInput(ogoneCCForm,
+        \"browserScreenWidth\", screen.width);\r\n\t\t\t\tcreateHiddenInput(ogoneCCForm,
+        \"browserTimeZone\", new Date().getTimezoneOffset());\r\n\t\t\t}\r\n\t\t});\r\n\t</script>\r\n\r\n\r\n<style
+        type=\"text/css\">\r\n\t.sectionTitle {\r\n\t\tfont-weight: bold;\r\n\t\ttext-align:center;\r\n\t\tvertical-align:
+        baseline;\r\n\t\tfont-size: small;\r\n\t\tpadding : 10px;\r\n\t\ttext-decoration:
+        underline;\r\n\t}\r\n\t.fieldTitle {\r\n\t\tfont-weight: bold;\r\n\t\ttext-align:right;\r\n\t\tvertical-align:
+        baseline;\r\n\t\tfont-size: small;\r\n\t\tpadding : 3px;\r\n\t}\r\n\t.fieldValue
+        {\r\n\t\ttext-align:left;\r\n\t\tvertical-align: baseline;\r\n\t\tfont-size:
+        small;\r\n\t\tpadding : 3px;\r\n\t}\r\n\t.star {\r\n\t\tfont-size: 10px;\r\n\t}\r\n\t.note
+        {\r\n\t\tfont-size: 10px;\r\n\t\tpadding : 3px;\r\n\t}\r\n\t.tc {\r\n\t\tfont-size:
+        10px;\r\n\t\tpadding : 5px;\r\n\t}\r\n\t.justify {\r\n\t\ttext-align : justify;\r\n\t}\r\n</style>\r\n\r\n<script
+        type=\"text/javascript\">\r\n\tvar js_version = 1.0;\r\n</script>\r\n<script
+        language=\"Javascript1.1\" type=\"text/javascript\">\r\n\tjs_version = 1.1;\r\n</script>\r\n<script
+        language=\"Javascript1.2\" type=\"text/javascript\">\r\n\tjs_version = 1.2;\r\n</script>\r\n<script
+        language=\"Javascript1.3\" type=\"text/javascript\">\r\n\tjs_version = 1.3;\r\n</script>\r\n<script
+        language=\"Javascript1.4\" type=\"text/javascript\">\r\n\tjs_version = 1.4;\r\n</script>\r\n<script
+        language=\"Javascript1.5\" type=\"text/javascript\">\r\n\tjs_version = 1.5;\r\n</script>\r\n<script
+        language=\"Javascript1.6\" type=\"text/javascript\">\r\n\tjs_version = 1.6;\r\n</script>\r\n<script
+        language=\"Javascript1.7\" type=\"text/javascript\">\r\n\tjs_version = 1.7;\r\n</script>\r\n<script
+        language=\"Javascript1.8\" type=\"text/javascript\">\r\n\tjs_version = 1.8;\r\n</script>\r\n<script
+        language=\"Javascript1.9\" type=\"text/javascript\">\r\n\tjs_version = 1.9;\r\n</script>\r\n<script
+        language=\"Javascript1.10\" type=\"text/javascript\">\r\n\tjs_version = 1.10;\r\n</script>\r\n\r\n<script
+        type=\"text/javascript\" src=\"js/form_validation.js\"></script>\r\n\r\n<script
+        type=\"text/JavaScript\">\r\n<!--\r\n\r\n\tvar AlertMSG_109 = \"Dit veld is
+        verplicht\";\r\n\tvar AlertMSG_110 = \"U moet een keuze maken uit deze lijst\";\r\n\tvar
+        AlertMSG_173 = \"U moet een nummer invoeren in het veld\";\r\n\tvar AlertMSG_1205
+        = \"De ingevoerde waarde is verkeerd\";\r\n\tvar AlertMSG_111 = \"Uw e-mailadres
+        is ongeldig\";\r\n\tvar AlertERR_907 = \"Dit veld is niet geldig\";\r\n\tvar
+        AlertERR_95 = \"CVC is aanwezig maar reden waarom het niet aanwezig is eveneens.\";\r\n\tvar
+        AlertERR_96 = \"CVC is niet aanwezig en geen reden waarom.\";\r\n\r\n\r\n//-->\r\n\r\n\r\n</script>\r\n\r\n\t\t\t\t<form
+        name=\"IDEALOGFORM\" action=\"https&#58;//ogone.test.v-psp.com/ncol/test/orderstandard_UTF8.asp\"
+        method=\"POST\" onSubmit=\"return my_submitAndDisable(this,0);\">\r\n\t\t\t\t\t<input
+        type=\"hidden\" name=\"CSRFKEY\" value=\"A54528DBD9FD0CFEF6EC355297645E9B2C836911\"
+        >\r\n<input type=\"hidden\" name=\"CSRFTS\" value=\"20241216154234\" >\r\n<input
+        type=\"hidden\" name=\"CSRFSP\" value=\"/ncol/test/orderstandard_utf8.asp\"
+        >\r\n\t\t\t\t\t<input type=\"hidden\" name=\"WIN3DS\" value=\"\">\r\n\t\t\t\t\t<input
+        type=\"hidden\" name=\"PMListType\" value=\"2\">\r\n\t\t\t\t\t<input type=\"hidden\"
+        name=\"branding\" value=\"OGONE\">\r\n\t\t\t\t\t<input type=\"hidden\" name=\"PM\"
+        value=\"\">\r\n\t\t\t\t\t<input type=\"hidden\" name=\"payid\" value=\"4291070933\">\r\n\t\t\t\t\t<input
+        type=\"hidden\" name=\"hash_param\" value=\"8B4BE63A54DFC89759FD055EDCE2DAE37362F04A\">\r\n
+        \                   <input type=\"hidden\" name=\"CorrelationID\" value=\"DF2FA6DA-1199-4015-AB43-FD6A84ECBF44\">\r\n\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"hash_post\" value=\"\">\r\n\t\t\t\t\t\t\t\t<input type=\"hidden\"
+        name=\"allowcorrection\" value=\"\">\r\n\t\t\t\t\t<input type=\"hidden\" name=\"thisstep\"
+        value=\"1\">\r\n\t\t\t\t\t<input type=\"hidden\" name=\"idealstep\" value=\"2\">\r\n\t\t\t\t\t<input
+        type=\"hidden\" name=\"reselect\" value=\"\">\r\n\t\t\t\t\t\t\t\t<input type=\"hidden\"
+        name=\"version\" value=\"\">\r\n\t\t\t\t\t<input type=\"hidden\" name=\"paymethod\"
+        value=\"iDeal\">\r\n\t\t\t\t\t\t<table class=ncoltable2 border=\"0\" cellpadding=\"2\"
+        cellspacing=\"0\" width=\"95%\" id=\"iDealTbl\">\r\n\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t<tr>\r\n\t\t\t\t\t\t\t<td
+        class=ncoltxtc colspan=2>\r\n\t\t\t\t\t\t\t<small>Kies uw bank en klik op
+        &quot;Ga verder&quot; om bij uw bank met iDEAL te betalen.</small>\r\n\t\t\t\t\t\t\t</td>\r\n\t\t\t\t\t\t\t</tr>\r\n\t\t\t\t\t\t\r\n\t\t\t\t\t\t<tr>\r\n\t\t\t\t\t\t\t<td
+        class=ncoltxtl align=\"left\" width=\"50%\" valign=\"top\">\r\n\t\t\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t\t<img
+        src=\"https&#58;//ogone.test.v-psp.com/images/iDeal_STD.gif\" alt=\"iDEAL\"
+        title=\"iDEAL\">\r\n\t\t\t\t\t\t</td>\r\n\t\t\t\t\t\t\t\t<td class=ncoltxtr
+        align=\"left\" width=\"50%\" valign=\"CENTER\">\r\n\t\t\t\t\t\t<select name=\"ISSUERID\"
+        title=\"Selecteer uw bank\">\r\n\t\t\t\t\t\t<Option value=\"\">Selecteer uw
+        bank</option>\r\n\r\n\t\t\t\t\t\t<Option value=\"9999+TST\">TST iDEAL</option>\r\n\t\t\t\t\t\t</select>\r\n\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"brandissuer\" value=\"iDeal\">\r\n\t\t\t\t\t\t\t\t</td>\r\n\t\t\t\t\t</tr>\r\n\t\t\t\t\r\n\r\n\t\t\t\t<tr>\r\n\t\t\t\t\t<td
+        align=\"center\" colspan=\"2\" valign=\"top\" ><input type=\"submit\" name=\"IdealBT\"
+        value=\"Ga verder\" class=ncol id=\"btn_Continue\"></td>\r\n\t\t\t\t</tr>\r\n\t\t\t\t\r\n\t\t\t\t</table>\r\n\t\t\t\t</form>\r\n\t\t\t\r\n\t<script
+        type=\"text/javascript\" language=\"JavaScript\" src=\"js/fp/Fp_inc.1.2.js\"></script>\r\n\t<script
+        type=\"text/javascript\" language=\"JavaScript\" src=\"base64_inc.js\"></script>\r\n\t\r\n<!--
+        Further information / Cancel -->\r\n<h2 style=\"display: inline; position:
+        absolute; left: -1000px; top: -1000px; width: 0px; height: 0px; overflow:
+        hidden;\">Bijkomende informatie / Annuleren</h2>\r\n<table class=ncoltable3
+        border=\"0\" cellpadding=\"2\" cellspacing=\"0\" width=\"95%\" id=\"ie_cc\"
+        style=\"behavior:url(#default#clientCaps)\">\r\n\t<tr><td class=\"ncollogoc\"
+        valign=\"middle\" align=\"center\" width=\"33%\"><img border=\"0\" src=\"https&#58;//ogone.test.v-psp.com/images/ING.gif\"
+        hspace=\"5\" alt=\"ING\" title=\"ING\" id=\"NCOLACQ\"></td><td class=\"ncollogoc\"
+        valign=\"middle\" align=\"center\" width=\"33%\"><a href=\"https&#58;//ogone.test.v-psp.com/ncol/PSPabout.asp?lang=3&pspid=maykinmedia&branding=OGONE&CSRFSP=%2Fncol%2Ftest%2Forderstandard%5Futf8%2Easp&CSRFKEY=73266A7BAB575C2320081D9D21B0FDB56DF5CC13&CSRFTS=20241216154234\"
+        target=\"_blank\"><img border=\"0\" src=\"https&#58;//ogone.test.v-psp.com/images/pp_WorldLine3.png\"
+        alt=\"Betaling verwerkt door Worldline\" title=\"Betaling verwerkt door Worldline\"
+        vspace=\"2\" id=\"NCOLPP\"></a><br><small><small><a class=\"bottom\" href=\"https&#58;//worldline.com/&#63;lang=3&amp;pspid=maykinmedia&amp;branding=OGONE&amp;CSRFSP=%2Fncol%2Ftest%2Forderstandard%5Futf8%2Easp&amp;CSRFKEY=C4A2FD2F8FE68F2E324EB89F942E4CC43D7EFCC5&amp;CSRFTS=20241216154234\"
+        target=\"_blank\">Over Worldline</a> |<a class=\"bottom\" href=\"https&#58;//ogone.test.v-psp.com/ncol/security.asp&#63;lang=3&amp;mode=STD&amp;branding=OGONE&amp;CSRFSP=%2Fncol%2Ftest%2Forderstandard%5Futf8%2Easp&amp;CSRFKEY=A6D3BC4CD4F2FEF9F26038E7CAE53D580A92A98E&amp;CSRFTS=20241216154234\"
+        target=\"_blank\">Veiligheid<!--Security--></a>| <a class=\"bottom\" href=\"https&#58;//worldline.com/en/home/main-navigation/git/office-locations.html&#63;lang=3&amp;mode=STD&amp;branding=OGONE&amp;CSRFSP=%2Fncol%2Ftest%2Forderstandard%5Futf8%2Easp&amp;CSRFKEY=8A4E97DA3F23880B87ABE5C08C9A72A3442E1460&amp;CSRFTS=20241216154234\"
+        target=\"_blank\">Wettelijke informatie<!--Legal--></a></small></small></td><td
+        class=\"ncollogoc\" valign=\"middle\" align=\"center\" width=\"33%\">&nbsp;</td></tr>\r\n\t\t<tr>\r\n\t\t\t\t<td
+        class=ncollogoc align=\"center\" colspan=\"3\">\r\n\t\t\t\t\t\t<center>\r\n\t\t\t\t\t\t\t<table
+        border=\"0\" cellpadding=\"0\" cellspacing=\"0\" >\r\n\t\t\t\t\t\t\t\t\t<tr>\r\n\t\t\t\t\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t\t\t\t\t<td
+        class=ncollogoc align=\"center\" width=\"50%\">\r\n\t\t\t\t\t\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t<form
+        method=\"POST\" action=\"https&#58;//ogone.test.v-psp.com/ncol/test/Order_Cancel_UTF8.asp\"
+        id=form3 name=form3 onsubmit=\"return(window.confirm('Weet u zeker dat u deze
+        transactie wilt annuleren&#63;'))\"  style=\"margin-bottom:0px;\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"CSRFKEY\" value=\"3F201A5EF074B3BA71514BE2382A01823A008E17\"
+        >\r\n<input type=\"hidden\" name=\"CSRFTS\" value=\"20241216154234\" >\r\n<input
+        type=\"hidden\" name=\"CSRFSP\" value=\"/ncol/test/orderstandard_utf8.asp\"
+        >\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input type=\"hidden\" name=\"payid\" value=\"4291070933\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"ownerZIP\" value=\"\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"owneraddress\" value=\"\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"alias\" value=\"\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"aliasoperation\" value=\"\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"hash_param\" value=\"8B4BE63A54DFC89759FD055EDCE2DAE37362F04A\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<input
+        type=\"hidden\" name=\"branding\" value=\"OGONE\">\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<small><input
+        class=ncol ID=\"ncol_cancel\" type=\"submit\" name=\"cancel\" value=\"Annuleren\"></small><!--Cancel-->\r\n\t\t\t\t\t\t\t\t\t\t\t\t\t</form>\r\n\t\t\t\t\t\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t\t\t\t\t</td>\r\n\t\t\t\t\t\t\t\t\t\t\r\n\t\t\t\t\t\t\t\t\t</tr>\r\n\t\t\t\t\t\t\t</table>\r\n\t\t\t\t\t\t</center>\r\n\t\t\t\t</td>\r\n\r\n\t\t</tr>\r\n\t\t\r\n\r\n</table>\r\n</div>\r\n</div>\r\n</body>\r\n</html>"
+    headers:
+      cache-control:
+      - private, max-age=0
+      content-length:
+      - '14059'
+      content-type:
+      - text/html; Charset=utf-8
+      date:
+      - Mon, 16 Dec 2024 14:42:34 GMT
+      expires:
+      - Mon, 16 Dec 2024 14:41:34 GMT
+      set-cookie:
+      - sessionTest=a866c2ae-aa5f-4421-8eeb-ccf240ddff73; path=/ncol/test/; Secure;
+        HttpOnly
+      strict-transport-security:
+      - max-age=16000000; includeSubDomains; preload;
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/payments/contrib/ogone/tests/test_client.py
+++ b/src/openforms/payments/contrib/ogone/tests/test_client.py
@@ -53,6 +53,23 @@ class OgoneClientTest(OFVCRMixin, TestCase):
 
         self.assertIn("Er is een fout opgetreden", payment_request.text)
 
+    def test_com_title_unicode_chars(self):
+        client = OgoneClient(self.merchant)
+
+        info = client.get_payment_info(
+            "xyz2024/OF-123456/987654321",
+            1000,
+            "http://foo.bar/return?bazz=buzz",
+            RETURN_ACTION_PARAM,
+            title="läääääääääääääämp! " * 10,  # 190 chars
+            com="brøther i desire lööps",
+        )
+
+        payment_request = requests.post(info.url, data=info.data)
+
+        # Response is always a 200, so we assert on the content instead
+        self.assertNotIn("Er is een fout opgetreden", payment_request.text)
+
 
 class OgoneGetPaymentInfoTest(TestCase):
     maxDiff = None

--- a/src/openforms/payments/contrib/ogone/typing.py
+++ b/src/openforms/payments/contrib/ogone/typing.py
@@ -5,3 +5,5 @@ from .models import OgoneMerchant
 
 class PaymentOptions(TypedDict):
     merchant_id: OgoneMerchant  # FIXME: key is badly named in the serializer
+    title_template: str
+    com_template: str

--- a/src/openforms/variables/service.py
+++ b/src/openforms/variables/service.py
@@ -8,8 +8,9 @@ from openforms.submissions.models import Submission
 
 from .base import BaseStaticVariable
 from .registry import register_static_variable as static_variables_registry
+from .utils import get_variables_for_context
 
-__all__ = ["get_static_variables"]
+__all__ = ["get_static_variables", "get_variables_for_context"]
 
 
 type VariablesRegistry = BaseRegistry[BaseStaticVariable]


### PR DESCRIPTION
Closes #3457

**Changes**

* Added support for TITLE and COM parameter templates
* Exposed config options in the frontend

Tested this end-to-end with our Ogone test account and works as expected - the custom description is evaluated and displayed in the transaction history.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
