### PR TITLE
[#4832] Fix json schema matcher in Objects API

### DIFF
--- a/src/openforms/contrib/objects_api/json_schema.py
+++ b/src/openforms/contrib/objects_api/json_schema.py
@@ -199,7 +199,7 @@ def json_schema_matches(
     if "string" in target_types and (target_format := target_schema.get("format")):
         variable_format = variable_schema.get("format")
         if variable_format is None:
-            return False
+            return True
         return variable_format == target_format
 
     return True

--- a/src/openforms/contrib/objects_api/tests/test_json_schema.py
+++ b/src/openforms/contrib/objects_api/tests/test_json_schema.py
@@ -434,7 +434,7 @@ class MatchesJsonShemaTests(SimpleTestCase):
             variable_schema = {"type": "string"}
             target_schema = {"type": "string", "format": "email"}
 
-            self.assertFalse(
+            self.assertTrue(
                 json_schema_matches(
                     variable_schema=variable_schema, target_schema=target_schema
                 )


### PR DESCRIPTION
Closes #4832

**Changes**

This change has been made because we are not able to know if the type is the correct one when no format is defined in the variable. This is left to the user and we assume that the mapping is valid.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
