### PR TITLE
:pencil: [#3283] Document registration backend migration procedure

### DIFF
--- a/docs/installation/upgrade-300.rst
+++ b/docs/installation/upgrade-300.rst
@@ -130,3 +130,18 @@ The setting ``TEMPORARY_UPLOADS_REMOVED_AFTER_DAYS`` controls how long file uplo
 kept. Ensure that this many days have passed since the last legacy upload before
 upgrading to Open Forms 3.0, otherwise you will run into database errors during the
 upgrade.
+
+Deprecations in registration backends
+=====================================
+
+We've done extensive UX rework in the Objects API and ZGW API's registration backends -
+you can now select the case and/or document types to use in dropdowns rather than having
+to copy-paste the API resource URLs. The API resource URLs will continue to work and
+are scheduled for removal in Open Forms 4.0 (no planned date for this yet), but we
+recommend you to already migrate your forms to the new format:
+
+* it has a better UX for the people configuring forms :)
+* it automatically picks the correct version from the Catalogi API
+
+Migrating is as simple as opening the registration options, selecting the catalogue to
+use and then selecting the case type/document type to use and emptying the URL-field.

--- a/src/openforms/contrib/objects_api/models.py
+++ b/src/openforms/contrib/objects_api/models.py
@@ -141,7 +141,7 @@ class ObjectsAPIGroupConfig(models.Model):
     )
 
     # XXX: the URLFields are to be replaced with charfields storing the omschrijving.
-    # DeprecationWarning: remove in OF 3.0
+    # DeprecationWarning: remove in OF 4.0
     informatieobjecttype_submission_report = models.URLField(
         _("submission report informatieobjecttype"),
         max_length=1000,

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -175,7 +175,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         ),
     )
 
-    # DeprecationWarning: remove in OF 3.0
+    # DeprecationWarning: remove in OF 4.0
     informatieobjecttype_submission_report = serializers.URLField(
         label=_("submission report PDF informatieobjecttype"),
         help_text=_(

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -38,7 +38,7 @@ class _BaseRegistrationOptions(TypedDict, total=False):
     iot_submission_csv: Required[str]
     iot_attachment: Required[str]
 
-    # DeprecationWarning: URL properties will be removed in OF 3.0
+    # DeprecationWarning: URL properties will be removed in OF 4.0
     informatieobjecttype_submission_report: str
     informatieobjecttype_submission_csv: str
     informatieobjecttype_attachment: str

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -96,7 +96,7 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         default="",
     )
 
-    # DeprecationWarning - deprecated, will be removed in OF 3.0 or 4.0
+    # DeprecationWarning - deprecated, will be removed in OF 4.0
     zaaktype = serializers.URLField(
         help_text=_("URL of the ZAAKTYPE in the Catalogi API"),
         required=False,


### PR DESCRIPTION
Closes #3283

**Changes**

* Documented how to migrate registration options
* Updated comments to reflect real scheduled version for removal

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
