### PR TITLE
Modal close button on dark mode

### DIFF
--- a/src/openforms/scss/components/admin/_ReactModal.scss
+++ b/src/openforms/scss/components/admin/_ReactModal.scss
@@ -74,12 +74,14 @@
     right: 12px;
     padding: 8px;
     cursor: pointer;
+    color: var(--body-fg);
     background: transparent;
     border: none;
     opacity: 0.5;
     line-height: 1;
 
-    &:hover {
+    &:hover,
+    &:focus {
       opacity: 0.8;
     }
   }


### PR DESCRIPTION
Closes #4949

**Changes**

The modal close button changes color based on the light/dark mode of the page.

In addition, focus now increases the button opacity, making it more visible and user-friendly

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
