### PR TITLE
[#4821] Fixed email digest for BRK and addressNL component

### DIFF
--- a/src/openforms/contrib/brk/service.py
+++ b/src/openforms/contrib/brk/service.py
@@ -1,16 +1,28 @@
+from glom import glom
+
 from openforms.forms.models.form import Form
 from openforms.plugins.exceptions import InvalidPluginConfiguration
 
 from .checks import BRKValidatorCheck
+from .models import BRKConfig
+from .validators import BRK_ZAKELIJK_GERECHTIGD_VALIDATOR_ID
 
 
 def check_brk_config_for_addressNL() -> str:
     live_forms = Form.objects.live()
 
-    if any(form.has_component("addressNL") for form in live_forms):
-        try:
-            BRKValidatorCheck.check_config()
-        except InvalidPluginConfiguration as e:
-            return e.args[0]
+    for form in live_forms:
+        components = form.iter_components()
+        for component in components:
+            if (
+                component["type"] == "addressNL"
+                and (plugins := glom(component, "validate.plugins", default=[]))
+                and BRK_ZAKELIJK_GERECHTIGD_VALIDATOR_ID in plugins
+                and BRKConfig.get_solo().service
+            ):
+                try:
+                    BRKValidatorCheck.check_config()
+                except InvalidPluginConfiguration as e:
+                    return e.args[0]
 
     return ""

--- a/src/openforms/contrib/brk/tests/base.py
+++ b/src/openforms/contrib/brk/tests/base.py
@@ -12,11 +12,16 @@ BRK_API_KEY = os.getenv("BRK_API_KEY", "placeholder_key")
 
 BRK_SERVICE = ServiceFactory.build(
     api_root="https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v2/",
-    oas="https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v2/",  # ignored/unused
     api_type=APITypes.orc,
     auth_type=AuthTypes.api_key,
     header_key="X-Api-Key",
     header_value=BRK_API_KEY,
+)
+
+INVALID_BRK_SERVICE = ServiceFactory.build(
+    api_root="https://api.brk.kadaster.nl/invalid",
+    api_type=APITypes.orc,
+    auth_type=AuthTypes.api_key,
 )
 
 

--- a/src/openforms/contrib/brk/validators.py
+++ b/src/openforms/contrib/brk/validators.py
@@ -21,6 +21,8 @@ from .constants import AddressValue
 
 logger = logging.getLogger(__name__)
 
+BRK_ZAKELIJK_GERECHTIGD_VALIDATOR_ID = "brk-zakelijk-gerechtigd"
+
 
 @contextmanager
 def suppress_api_errors(error_message: str) -> Iterator[None]:

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -675,11 +675,6 @@ class Form(models.Model):
         logger.debug("Deactivating form %s", self.admin_name)
         self.save(update_fields=["active", "deactivate_on"])
 
-    def has_component(self, component_type: str) -> bool:
-        return any(
-            component["type"] == component_type for component in self.iter_components()
-        )
-
 
 class FormsExportQuerySet(DeleteFilesQuerySetMixin, models.QuerySet):
     pass


### PR DESCRIPTION
Closes #4821

**Changes**

- We want the email digest to report problems (broken configuration) for the addressNL component only when a valid BRK service and the validator are defined/configured.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
