### PR TITLE
Objects-api and zgw apis geometry coordinates data order

### DIFF
--- a/src/openforms/registrations/contrib/objects_api/handlers/v2.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v2.py
@@ -109,7 +109,8 @@ def process_mapped_variable(
             assert isinstance(value, list) and len(value) == 2
             value = {
                 "type": "Point",
-                "coordinates": [value[0], value[1]],
+                # Providing the coordinates as [lng, lat] #4955
+                "coordinates": [value[1], value[0]],
             }
 
         # not a component or standard behaviour where no transformation is necessary

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -72,7 +72,8 @@ logger = logging.getLogger(__name__)
 def _point_coordinate(value: Any) -> dict[str, Any] | object:
     if not isinstance(value, list) or len(value) != 2:
         return SKIP
-    return {"type": "Point", "coordinates": [value[0], value[1]]}
+    # Providing the coordinates as [lng, lat] #4955
+    return {"type": "Point", "coordinates": [value[1], value[0]]}
 
 
 def _resolve_documenttype(

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendV1Tests/ObjectsAPIBackendV1Tests.test_submission_with_objects_api_backend_override_defaults.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendV1Tests/ObjectsAPIBackendV1Tests.test_submission_with_objects_api_backend_override_defaults.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25",
-      "bronorganisatie": "123456782", "creatiedatum": "2024-11-26", "titel": "Form
-      018", "auteur": "Aanvrager", "taal": "eng", "formaat": "application/pdf", "inhoud":
-      "", "status": "definitief", "bestandsnaam": "open-forms-Form 018.pdf", "ontvangstdatum":
+      "bronorganisatie": "123456782", "creatiedatum": "2024-12-19", "titel": "Form
+      000", "auteur": "Aanvrager", "taal": "eng", "formaat": "application/pdf", "inhoud":
+      "", "status": "definitief", "bestandsnaam": "open-forms-Form 000.pdf", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulier", "indicatieGebruiksrecht": false,
       "bestandsomvang": 0}'
     headers:
@@ -12,7 +12,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjYxNjkyNywiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.UcUHWF3BT2_-ZD60vJMzRB7qxVYy7F85gYXPKpCcnxE
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczNDYwMjkxOSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.00_dWmh224upScM1cNgx9w91Hlyong-KQOJSRwNwUFw
       Connection:
       - keep-alive
       Content-Length:
@@ -25,9 +25,9 @@ interactions:
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8","identificatie":"DOCUMENT-2024-0000000033","bronorganisatie":"123456782","creatiedatum":"2024-11-26","titel":"Form
-        018","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"eng","versie":1,"beginRegistratie":"2024-11-26T10:28:47.709459Z","bestandsnaam":"open-forms-Form
-        018.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705","identificatie":"DOCUMENT-2024-0000000017","bronorganisatie":"123456782","creatiedatum":"2024-12-19","titel":"Form
+        000","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"eng","versie":1,"beginRegistratie":"2024-12-19T10:08:39.708635Z","bestandsnaam":"open-forms-Form
+        000.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
         formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -41,7 +41,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705
       Referrer-Policy:
       - same-origin
       Vary:
@@ -55,10 +55,10 @@ interactions:
       message: Created
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f",
-      "bronorganisatie": "123456782", "creatiedatum": "2024-11-26", "titel": "Form
-      018 (csv)", "auteur": "Aanvrager", "taal": "eng", "formaat": "text/csv", "inhoud":
-      "Rm9ybXVsaWVybmFhbSxJbnplbmRpbmdkYXR1bSxUYWFsY29kZSx2b29ybmFhbSxhY2h0ZXJuYWFtLHR1c3NlbnZvZWdzZWwsZ2Vib29ydGVkYXR1bSxjb29yZGluYWF0DQpGb3JtIDAxOCwsZW4sRm9vLEJhcixkZSwyMDAwLTEyLTMxLCJbNTIuMzY2NzMzNzg5NjcxMjIsIDQuODkzMTY0Mjc0NDcwMjk5XSINCg==",
-      "status": "definitief", "bestandsnaam": "open-forms-Form 018 (csv).csv", "ontvangstdatum":
+      "bronorganisatie": "123456782", "creatiedatum": "2024-12-19", "titel": "Form
+      000 (csv)", "auteur": "Aanvrager", "taal": "eng", "formaat": "text/csv", "inhoud":
+      "Rm9ybXVsaWVybmFhbSxJbnplbmRpbmdkYXR1bSxUYWFsY29kZSx2b29ybmFhbSxhY2h0ZXJuYWFtLHR1c3NlbnZvZWdzZWwsZ2Vib29ydGVkYXR1bSxjb29yZGluYWF0DQpGb3JtIDAwMCwsZW4sRm9vLEJhcixkZSwyMDAwLTEyLTMxLCJbNTIuMzY2NzMzNzg5NjcxMjIsIDQuODkzMTY0Mjc0NDcwMjk5XSINCg==",
+      "status": "definitief", "bestandsnaam": "open-forms-Form 000 (csv).csv", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulierdata", "indicatieGebruiksrecht":
       false, "bestandsomvang": 175}'
     headers:
@@ -67,7 +67,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjYxNjkyNywiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.UcUHWF3BT2_-ZD60vJMzRB7qxVYy7F85gYXPKpCcnxE
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczNDYwMjkxOSwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.00_dWmh224upScM1cNgx9w91Hlyong-KQOJSRwNwUFw
       Connection:
       - keep-alive
       Content-Length:
@@ -80,9 +80,9 @@ interactions:
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c","identificatie":"DOCUMENT-2024-0000000034","bronorganisatie":"123456782","creatiedatum":"2024-11-26","titel":"Form
-        018 (csv)","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/csv","taal":"eng","versie":1,"beginRegistratie":"2024-11-26T10:28:47.834166Z","bestandsnaam":"open-forms-Form
-        018 (csv).csv","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c/download?versie=1","bestandsomvang":175,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb","identificatie":"DOCUMENT-2024-0000000018","bronorganisatie":"123456782","creatiedatum":"2024-12-19","titel":"Form
+        000 (csv)","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/csv","taal":"eng","versie":1,"beginRegistratie":"2024-12-19T10:08:39.853537Z","bestandsnaam":"open-forms-Form
+        000 (csv).csv","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb/download?versie=1","bestandsomvang":175,"link":"","beschrijving":"Ingezonden
         formulierdata","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -96,7 +96,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb
       Referrer-Policy:
       - same-origin
       Vary:
@@ -139,11 +139,11 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 26 Nov 2024 10:28:47 GMT
+      - Thu, 19 Dec 2024 10:08:39 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.27.0
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -160,11 +160,11 @@ interactions:
       {"test-slug": {"voornaam": "Foo", "achternaam": "Bar", "tussenvoegsel": "de",
       "geboortedatum": "2000-12-31", "coordinaat": [52.36673378967122, 4.893164274470299]}},
       "taal": "en", "betrokkenen": [{"inpBsn": "", "rolOmschrijvingGeneriek": "initiator"}],
-      "pdf": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8",
-      "csv": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c",
+      "pdf": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705",
+      "csv": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb",
       "bijlagen": [], "payment": {"completed": false, "amount": 0, "public_order_ids":
-      [], "payment_ids": []}}, "startAt": "2024-11-26", "geometry": {"type": "Point",
-      "coordinates": [52.36673378967122, 4.893164274470299]}}}'
+      [], "payment_ids": []}}, "startAt": "2024-12-19", "geometry": {"type": "Point",
+      "coordinates": [4.893164274470299, 52.36673378967122]}}}'
     headers:
       Accept:
       - '*/*'
@@ -186,8 +186,8 @@ interactions:
     uri: http://localhost:8002/api/v2/objects
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/f722858a-f86d-41a4-b635-2b796992eb11","uuid":"f722858a-f86d-41a4-b635-2b796992eb11","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"bron":{"naam":"Open
-        Formulieren","kenmerk":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},"type":"testproduct","aanvraaggegevens":{"test-slug":{"voornaam":"Foo","achternaam":"Bar","tussenvoegsel":"de","geboortedatum":"2000-12-31","coordinaat":[52.36673378967122,4.893164274470299]}},"taal":"en","betrokkenen":[{"inpBsn":"","rolOmschrijvingGeneriek":"initiator"}],"pdf":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8","csv":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c","bijlagen":[],"payment":{"completed":false,"amount":0,"public_order_ids":[],"payment_ids":[]}},"geometry":{"type":"Point","coordinates":[52.36673378967122,4.893164274470299]},"startAt":"2024-11-26","endAt":null,"registrationAt":"2024-11-26","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/fc9304ce-c572-45e4-ba11-f0f7a45c592d","uuid":"fc9304ce-c572-45e4-ba11-f0f7a45c592d","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"bron":{"naam":"Open
+        Formulieren","kenmerk":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},"type":"testproduct","aanvraaggegevens":{"test-slug":{"voornaam":"Foo","achternaam":"Bar","tussenvoegsel":"de","geboortedatum":"2000-12-31","coordinaat":[52.36673378967122,4.893164274470299]}},"taal":"en","betrokkenen":[{"inpBsn":"","rolOmschrijvingGeneriek":"initiator"}],"pdf":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705","csv":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb","bijlagen":[],"payment":{"completed":false,"amount":0,"public_order_ids":[],"payment_ids":[]}},"geometry":{"type":"Point","coordinates":[4.893164274470299,52.36673378967122]},"startAt":"2024-12-19","endAt":null,"registrationAt":"2024-12-19","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
@@ -202,13 +202,13 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 26 Nov 2024 10:28:48 GMT
+      - Thu, 19 Dec 2024 10:08:40 GMT
       Location:
-      - http://localhost:8002/api/v2/objects/f722858a-f86d-41a4-b635-2b796992eb11
+      - http://localhost:8002/api/v2/objects/fc9304ce-c572-45e4-ba11-f0f7a45c592d
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.27.0
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -226,18 +226,18 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjYxNjkyOCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.cRLbABi3E29tb0dZlVpxaKWqZwW5So_jcG5rjdF-32I
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczNDYwMjkyMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.lw4EsPswHow8ne6BS3ZT2oNzNN722iFw3rlvWlqCVao
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c","identificatie":"DOCUMENT-2024-0000000034","bronorganisatie":"123456782","creatiedatum":"2024-11-26","titel":"Form
-        018 (csv)","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/csv","taal":"eng","versie":1,"beginRegistratie":"2024-11-26T10:28:47.834166Z","bestandsnaam":"open-forms-Form
-        018 (csv).csv","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/782ea672-554f-4ecf-b59c-e77b96752f0c/download?versie=1","bestandsomvang":175,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb","identificatie":"DOCUMENT-2024-0000000018","bronorganisatie":"123456782","creatiedatum":"2024-12-19","titel":"Form
+        000 (csv)","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/csv","taal":"eng","versie":1,"beginRegistratie":"2024-12-19T10:08:39.853537Z","bestandsnaam":"open-forms-Form
+        000 (csv).csv","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/f15953ce-b719-4680-9ee9-f3ae1d183bbb/download?versie=1","bestandsomvang":175,"link":"","beschrijving":"Ingezonden
         formulierdata","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d1cfb1d8-8593-4814-919d-72e38e80388f","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
     headers:
       API-version:
@@ -251,7 +251,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       ETag:
-      - '"97c1974d844753517b09d82805be7ea6"'
+      - '"68609009f1bc10a90f57829486c62768"'
       Referrer-Policy:
       - same-origin
       Vary:
@@ -271,18 +271,18 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczMjYxNjkyOCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.cRLbABi3E29tb0dZlVpxaKWqZwW5So_jcG5rjdF-32I
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTczNDYwMjkyMCwiY2xpZW50X2lkIjoidGVzdF9jbGllbnRfaWQiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.lw4EsPswHow8ne6BS3ZT2oNzNN722iFw3rlvWlqCVao
       Connection:
       - keep-alive
       User-Agent:
       - python-requests/2.32.2
     method: GET
-    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8","identificatie":"DOCUMENT-2024-0000000033","bronorganisatie":"123456782","creatiedatum":"2024-11-26","titel":"Form
-        018","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"eng","versie":1,"beginRegistratie":"2024-11-26T10:28:47.709459Z","bestandsnaam":"open-forms-Form
-        018.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/716a0a06-2b63-4d57-89ad-045ceb50c3d8/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705","identificatie":"DOCUMENT-2024-0000000017","bronorganisatie":"123456782","creatiedatum":"2024-12-19","titel":"Form
+        000","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"eng","versie":1,"beginRegistratie":"2024-12-19T10:08:39.708635Z","bestandsnaam":"open-forms-Form
+        000.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c037d213-d53b-4672-8165-486f7083c705/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
         formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/f2908f6f-aa07-42ef-8760-74c5234f2d25","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
     headers:
       API-version:
@@ -296,7 +296,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       ETag:
-      - '"fce5eb69d4ed04ab65c82db2c09fbb50"'
+      - '"76efcb1c5a3b54d841c5ee196d1867c9"'
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendV2Tests/ObjectsAPIBackendV2Tests.test_submission_with_objects_api_v2.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendV2Tests/ObjectsAPIBackendV2Tests.test_submission_with_objects_api_v2.yaml
@@ -2,8 +2,8 @@ interactions:
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b",
       "bronorganisatie": "000000000", "creatiedatum": "2024-03-19", "titel": "Form
-      032", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
-      "", "status": "definitief", "bestandsnaam": "open-forms-Form 032.pdf", "ontvangstdatum":
+      000", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
+      "", "status": "definitief", "bestandsnaam": "open-forms-Form 000.pdf", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulier", "indicatieGebruiksrecht": false,
       "bestandsomvang": 0}'
     headers:
@@ -25,9 +25,9 @@ interactions:
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/0771aa11-61d6-4dfc-9935-bb7cd376c65f","identificatie":"DOCUMENT-2024-0000000045","bronorganisatie":"000000000","creatiedatum":"2024-03-19","titel":"Form
-        032","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2024-11-26T10:28:52.594409Z","bestandsnaam":"open-forms-Form
-        032.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/0771aa11-61d6-4dfc-9935-bb7cd376c65f/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/ed5de000-7692-474a-b9e4-8dbded780e37","identificatie":"DOCUMENT-2024-0000000015","bronorganisatie":"000000000","creatiedatum":"2024-03-19","titel":"Form
+        000","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2024-12-19T10:06:16.789185Z","bestandsnaam":"open-forms-Form
+        000.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/ed5de000-7692-474a-b9e4-8dbded780e37/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
         formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -41,7 +41,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/0771aa11-61d6-4dfc-9935-bb7cd376c65f
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/ed5de000-7692-474a-b9e4-8dbded780e37
       Referrer-Policy:
       - same-origin
       Vary:
@@ -56,9 +56,9 @@ interactions:
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3",
       "bronorganisatie": "000000000", "creatiedatum": "2024-03-19", "titel": "Form
-      032 (csv)", "auteur": "Aanvrager", "taal": "nld", "formaat": "text/csv", "inhoud":
-      "Rm9ybXVsaWVybmFhbSxJbnplbmRpbmdkYXR1bSxhZ2UsbGFzdG5hbWUsbG9jYXRpb24NCkZvcm0gMDMyLDIwMjQtMDMtMDMgMDk6MTQ6MDguMzI3MDkyLDIwLE15IGxhc3QgbmFtZSwiWzUyLjM2NjczMzc4OTY3MTIyLCA0Ljg5MzE2NDI3NDQ3MDI5OV0iDQo=",
-      "status": "definitief", "bestandsnaam": "open-forms-Form 032 (csv).csv", "ontvangstdatum":
+      000 (csv)", "auteur": "Aanvrager", "taal": "nld", "formaat": "text/csv", "inhoud":
+      "Rm9ybXVsaWVybmFhbSxJbnplbmRpbmdkYXR1bSxhZ2UsbGFzdG5hbWUsbG9jYXRpb24NCkZvcm0gMDAwLDIwMjQtMDMtMDEgMTk6MDk6MjUuNDA4MjU5LDIwLE15IGxhc3QgbmFtZSwiWzUyLjM2NjczMzc4OTY3MTIyLCA0Ljg5MzE2NDI3NDQ3MDI5OV0iDQo=",
+      "status": "definitief", "bestandsnaam": "open-forms-Form 000 (csv).csv", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulierdata", "indicatieGebruiksrecht":
       false, "bestandsomvang": 146}'
     headers:
@@ -80,9 +80,9 @@ interactions:
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/1d3564ce-f7d8-41a9-85de-8f4213676e83","identificatie":"DOCUMENT-2024-0000000046","bronorganisatie":"000000000","creatiedatum":"2024-03-19","titel":"Form
-        032 (csv)","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/csv","taal":"nld","versie":1,"beginRegistratie":"2024-11-26T10:28:52.673480Z","bestandsnaam":"open-forms-Form
-        032 (csv).csv","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/1d3564ce-f7d8-41a9-85de-8f4213676e83/download?versie=1","bestandsomvang":146,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7a1d75a4-8fd7-4945-b99d-05fadcd45e0b","identificatie":"DOCUMENT-2024-0000000016","bronorganisatie":"000000000","creatiedatum":"2024-03-19","titel":"Form
+        000 (csv)","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"text/csv","taal":"nld","versie":1,"beginRegistratie":"2024-12-19T10:06:16.925004Z","bestandsnaam":"open-forms-Form
+        000 (csv).csv","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7a1d75a4-8fd7-4945-b99d-05fadcd45e0b/download?versie=1","bestandsomvang":146,"link":"","beschrijving":"Ingezonden
         formulierdata","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -96,7 +96,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/1d3564ce-f7d8-41a9-85de-8f4213676e83
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7a1d75a4-8fd7-4945-b99d-05fadcd45e0b
       Referrer-Policy:
       - same-origin
       Vary:
@@ -125,24 +125,24 @@ interactions:
     uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
   response:
     body:
-      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-11-25","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/4"]}'
     headers:
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       Connection:
       - keep-alive
       Content-Length:
-      - '790'
+      - '887'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 26 Nov 2024 10:28:52 GMT
+      - Thu, 19 Dec 2024 10:06:17 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.27.0
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -156,11 +156,11 @@ interactions:
     body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
       "record": {"typeVersion": 3, "data": {"age": 20, "name": {"last.name": "My last
       name"}, "submission_date": "2024-03-19T13:40:00+00:00", "submission_pdf_url":
-      "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/0771aa11-61d6-4dfc-9935-bb7cd376c65f",
-      "submission_csv_url": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/1d3564ce-f7d8-41a9-85de-8f4213676e83",
+      "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/ed5de000-7692-474a-b9e4-8dbded780e37",
+      "submission_csv_url": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7a1d75a4-8fd7-4945-b99d-05fadcd45e0b",
       "submission_payment_completed": false, "submission_payment_amount": null, "submission_payment_public_ids":
       [], "cosign_date": null}, "startAt": "2024-03-19", "geometry": {"type": "Point",
-      "coordinates": [52.36673378967122, 4.893164274470299]}}}'
+      "coordinates": [4.893164274470299, 52.36673378967122]}}}'
     headers:
       Accept:
       - '*/*'
@@ -182,8 +182,8 @@ interactions:
     uri: http://localhost:8002/api/v2/objects
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/09953ea1-d03e-4cde-93d3-87a416e6cb48","uuid":"09953ea1-d03e-4cde-93d3-87a416e6cb48","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"age":20,"name":{"last.name":"My
-        last name"},"submission_date":"2024-03-19T13:40:00+00:00","submission_pdf_url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/0771aa11-61d6-4dfc-9935-bb7cd376c65f","submission_csv_url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/1d3564ce-f7d8-41a9-85de-8f4213676e83","submission_payment_completed":false,"submission_payment_amount":null,"submission_payment_public_ids":[],"cosign_date":null},"geometry":{"type":"Point","coordinates":[52.36673378967122,4.893164274470299]},"startAt":"2024-03-19","endAt":null,"registrationAt":"2024-11-26","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/a73b1bd4-91c0-444b-9241-93b111f83681","uuid":"a73b1bd4-91c0-444b-9241-93b111f83681","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"age":20,"name":{"last.name":"My
+        last name"},"submission_date":"2024-03-19T13:40:00+00:00","submission_pdf_url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/ed5de000-7692-474a-b9e4-8dbded780e37","submission_csv_url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/7a1d75a4-8fd7-4945-b99d-05fadcd45e0b","submission_payment_completed":false,"submission_payment_amount":null,"submission_payment_public_ids":[],"cosign_date":null},"geometry":{"type":"Point","coordinates":[4.893164274470299,52.36673378967122]},"startAt":"2024-03-19","endAt":null,"registrationAt":"2024-12-19","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
@@ -198,13 +198,13 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 26 Nov 2024 10:28:52 GMT
+      - Thu, 19 Dec 2024 10:06:17 GMT
       Location:
-      - http://localhost:8002/api/v2/objects/09953ea1-d03e-4cde-93d3-87a416e6cb48
+      - http://localhost:8002/api/v2/objects/a73b1bd4-91c0-444b-9241-93b111f83681
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.27.0
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -175,7 +175,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
             result["record"]["geometry"],
             {
                 "type": "Point",
-                "coordinates": [52.36673378967122, 4.893164274470299],
+                "coordinates": [4.893164274470299, 52.36673378967122],
             },
         )
 
@@ -575,7 +575,7 @@ class V2HandlerTests(TestCase):
             data["pointCoordinates"],
             {
                 "type": "Point",
-                "coordinates": [52.36673378967122, 4.893164274470299],
+                "coordinates": [4.893164274470299, 52.36673378967122],
             },
         )
 

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -78,7 +78,8 @@ def get_property_mappings_from_submission(
 def _point_coordinate(value):
     if not value or not isinstance(value, list) or len(value) != 2:
         return SKIP
-    return {"type": "Point", "coordinates": [value[0], value[1]]}
+    # Providing the coordinates as [lng, lat] #4955
+    return {"type": "Point", "coordinates": [value[1], value[0]]}
 
 
 def _gender_choices(value):

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -312,7 +312,7 @@ class ZGWBackendTests(TestCase):
                 create_zaak_body["zaakgeometrie"],
                 {
                     "type": "Point",
-                    "coordinates": [52.36673378967122, 4.893164274470299],
+                    "coordinates": [4.893164274470299, 52.36673378967122],
                 },
             )
 
@@ -538,7 +538,7 @@ class ZGWBackendTests(TestCase):
                 create_zaak_body["zaakgeometrie"],
                 {
                     "type": "Point",
-                    "coordinates": [52.36673378967122, 4.893164274470299],
+                    "coordinates": [4.893164274470299, 52.36673378967122],
                 },
             )
 
@@ -833,7 +833,7 @@ class ZGWBackendTests(TestCase):
                 create_zaak_body["zaakgeometrie"],
                 {
                     "type": "Point",
-                    "coordinates": [52.36673378967122, 4.893164274470299],
+                    "coordinates": [4.893164274470299, 52.36673378967122],
                 },
             )
 
@@ -1885,7 +1885,7 @@ class ZGWBackendTests(TestCase):
                     "startAt": date.today().isoformat(),
                     "geometry": {
                         "type": "Point",
-                        "coordinates": [52.36673378967122, 4.893164274470299],
+                        "coordinates": [4.893164274470299, 52.36673378967122],
                     },
                     "endAt": None,
                     "registrationAt": date.today().isoformat(),


### PR DESCRIPTION
Closes #4955

**Changes**

Changes the order of the geometry coordinates data from `[lat, lng]` to `[lng, lat]`.

The coordinates that we receive from the map component are in [lat, lng] order. This same order was used when passing the coordinates to the Objects-api and zgw apis backends, but these expect the geometry data to adhere the geoJson geometry data (i.e. the coordinates in [lng, lat] order)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
