### PR TITLE
[#4825] Log prefill retrieve empty only for the used authentication flow

### DIFF
--- a/src/openforms/prefill/sources.py
+++ b/src/openforms/prefill/sources.py
@@ -70,7 +70,11 @@ def fetch_prefill_values_from_attribute(
             if values:
                 logevent.prefill_retrieve_success(submission, plugin, fields)
             else:
-                logevent.prefill_retrieve_empty(submission, plugin, fields)
+                if (required_attribute := plugin.requires_auth) is None or (
+                    (auth_info := getattr(submission, "auth_info", None))
+                    and auth_info.attribute == required_attribute
+                ):
+                    logevent.prefill_retrieve_empty(submission, plugin, fields)
         return fields, values
 
     invoke_plugin_args = []


### PR DESCRIPTION
Closes #4825

**Changes**

- Updated logging to only log empty data for the authentication flow that is used in the submission.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
