### PR TITLE
Update eherkenning docs

### DIFF
--- a/docs/configuration/authentication/digid.rst
+++ b/docs/configuration/authentication/digid.rst
@@ -4,11 +4,6 @@
 DigiD authentication
 ====================
 
-.. warning::
-
-    This plugin cannot be configured via the admin interface and requires an
-    update of the Open Forms installation.
-
 Some forms can require authentication. Open Forms supports authentication
 using `DigiD`_. Access to DigiD can typically be obtained via `Logius`_.
 
@@ -16,69 +11,11 @@ Using DigiD for authentication will provide the BSN (social security number) of
 the authenticated person to the form context. Using the BSN, certain fields can
 be :ref:`prefilled <configuration_prefill_index>` with relevant personal data.
 
-.. note::
-
-    Open Forms currently only supports security level (betrouwbaarheidsniveau)
-    "Midden".
-
-    ============= =================================================================
-    DigiD         SAML2 AuthnContextClassRef element
-    ============= =================================================================
-    Basis         urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
-    Midden        urn:oasis:names:tc:SAML:2.0:ac:classes:MobileTwoFactorContract
-    Substantieel  urn:oasis:names:tc:SAML:2.0:ac:classes:Smartcard
-    Hoog          urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI
-    ============= =================================================================
-
-    Source: `Logius <https://www.logius.nl/diensten/digid/documentatie/koppelvlakspecificatie-digid-saml-authenticatie>`__
-
-Obtaining the Service Provider metadata
-=======================================
-
-Once access to a DigiD (pre-)production environment has been obtained, Open-Forms has to be configured.
-This can be done by navigating to **Configuration** > **DigiD configuration**.
-
-#. **Key pair**: Upload the `PKIoverheid Private Services Server G1`_ and the private key (see point 2 of the next section).
-   The certificate will be used in the metadata that will be generated, and the private key will be used to sign the metadata.
-
-#. **Metadata file(XML) URL**: This is the URL where the metadata (XML) for the Identity Provider can be obtained.
-   The entity ID (of the identity provider) will automatically be extracted from the XML.
-
-#. **Entity ID**: This is the entity ID of Open-Forms. For DigiD, this can be the URL where Open-Forms is deployed, for
-   example ``https://openforms.test.nl``.
-
-#. **Base URL**: This is the URL where Open-Forms is deployed.
-
-#. **Resolve artifact binding content type**: This is the the value of the ``Content-Type`` header for the resolve artifact binding request.
-   Modern brokers typically expect ``text/xml`` while ``application/soap+xml`` is considered legacy.
-
-#. **Want assertions signed**: This should be **checked**.
-
-#. **Signature algorithm**: Select ``RSA_SHA1``.
-
-#. **Digest algorithm**: Select ``SHA1``.
-
-#. **Service name**: This is the name of the service for which authentication is needed.
-
-#. **Service description**: A description of the service for which authentication is needed.
-
-#. **Requested attributes**: What attributes are expected to be returned by DigiD after authentication. This should be ``["bsn"]``.
-
-#. **Organisation details**: Telephone/e-mail contacts of the organisation responsible for the service requiring DigiD authentication.
-
-Click then on **Save and continue editing** to persist the configuration changes.
-
-On the top right corner of the configuration page, there is a button **View SAML metadata**. Click on this button and save this metadata.
-The metadata needs to be sent to the broker to obtain access to a (pre-)production environment.
-
-.. note::
-
-   Any changes to the configuration in the Admin page cause a change in the metadata. The updated metadata must be then
-   sent to the broker again for the changes to be effective.
-
-
 Steps to request access to a DigiD environment
 ==============================================
+
+The high-level overview of steps you need to perform are described here. The following
+sections provide more details.
 
 1. Read the requirements for getting access to DigiD on the `Logius`_ website.
    There are several steps that need to be taken on your end that are not
@@ -89,14 +26,18 @@ Steps to request access to a DigiD environment
    communication with Logius (if you already have one for Open Forms, it can be
    re-used).
 
+   You can :ref:`prepare the certificates <configuration_authentication_digid_prepare_certificates>`
+   from the admin interface.
+
 3. Send the following information to your Open Forms supplier in a secure way:
 
-   * Public and private certificate (obtained in step 2)
+   * Public and private certificate (obtained in step 2, private certificate is already
+     present if you generated the Signing Request (CSR) via the admin)
    * Desired service name (for example: "Digitaal Loket") shown in DigiD
    * Privacy policy URL of your main website
 
    Your Open Forms supplier will install the certificates in Open Forms,
-   generate some XML metadata files and sends these back to you.
+   generate some XML metadata files and send these back to you.
 
 4. Request access to the pre-production environment on the `Logius`_ website
    and follow the steps there. To request access, you will need the following
@@ -111,6 +52,119 @@ Steps to request access to a DigiD environment
 
    As technical contact, you should provide your Open Forms supplier contact
    details.
+
+.. tip::
+
+    You can specify a different security level (betrouwbaarheidsniveau) on a per-form
+    basis.
+
+    ============= =================================================================
+    DigiD         SAML2 AuthnContextClassRef element
+    ============= =================================================================
+    Basis         urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+    Midden        urn:oasis:names:tc:SAML:2.0:ac:classes:MobileTwoFactorContract
+    Substantieel  urn:oasis:names:tc:SAML:2.0:ac:classes:Smartcard
+    Hoog          urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI
+    ============= =================================================================
+
+    Source: `Logius <https://www.logius.nl/diensten/digid/documentatie/koppelvlakspecificatie-digid-saml-authenticatie>`__
+
+
+.. _configuration_authentication_digid_prepare_certificates:
+
+Preparing the certificates
+==========================
+
+To request a *PKIoverheid certificate*, you need a private key and a certificate signing
+request. You can generate these using ``openssl`` or other utilities, or use the built-in
+signing requests in the admin interface.
+
+.. tip:: Creating the signing requests from the admin ensures the private key never
+   leaves the server, lessening the chances that it is accidentally leaked.
+
+**Using the admin interface**
+
+#. Navigate to the **Admin**.
+#. In the menu, navigate to **Configuration** > **Signing requests**.
+#. In the top right of the page, click the **Add signing request** button.
+#. Enter the desired fields - the information will be included in the signing request.
+   Consult with your certificate supplier which data is required and what values are
+   expected.
+#. Click **Save** to persist the changes. The page is reloaded.
+#. Under the section *Signing request (CSR)*, click the **Download CSR** link.
+
+Now, send the downloaded CSR to your certificate supplier and wait for them to verify
+it and provide you with the matching certificate. This can take some time (hours to
+days), as verification is often a manual process.
+
+Once you have received the certificate, navigate back to the admin and locate your
+signing request.
+
+#. Edit the original signing request record in the admin.
+#. Navigate to the *Upload signed certificate* section.
+#. Upload the certificate provided by the certificate supplier.
+#. Save the changes.
+
+If everything is valid, the private key + public cerificate pair is now available and
+almost ready for use. You can verify it in the admin via **Configuration** >
+**Certificates**.
+
+You can now proceed to :ref:`configuration_authentication_digid_metadata`.
+
+.. _configuration_authentication_digid_metadata:
+
+Generating the Service Provider metadata
+========================================
+
+In the admin environment we can configure the DigiD identity provider and select our
+required certificate pair(s). Once this is done, we can generate our service provider
+metadata.
+
+#. Navigate to the **Admin**.
+#. In the menu, navigate to **Configuration** > **DigiD configuration**.
+#. Under the *X.509 Certificate* section, click the **Manage (number)** link.
+#. Click the **Add Digid/eHerkenning certificate** button in the top right of the page.
+#. For **Config type**, select "DigiD".
+#. For **Certificate**, click the search icon and select the certificate pair that was
+   created earlier (in the :ref:`configuration_authentication_digid_prepare_certificates`
+   section).
+#. **Save** the configuration and close the window/tab.
+#. Continue on the *DigiD configuration* page.
+#. In the section *Identity provider*, enter the identity provider **metadata file (XML) URL**.
+   E.g. for pre-production: ``https://was-preprod1.digid.nl/saml/idp/metadata``. The
+   metadata will be retrieved and processed.
+#. Next, in the section *SAML configuration*, enter the fields:
+
+   * **Entity ID**: This is the entity ID of Open-Forms. For DigiD, this can be the URL
+     where Open-Forms is deployed, for example ``https://openforms.test.nl``.
+   * **Base URL**: Enter the URL where Open-Forms is deployed (and publicly accessible).
+   * **Resolve artifact binding content type**: select ``text/xml`` unless you're using
+     old/legacy brokers or are instructed to pick ``application/soap+xml``.
+   * **Want assertions signed**: This should be **checked**.
+   * **Signature algorithm**: Select ``RSA_SHA1``.
+   * **Digest algorithm**: Select ``SHA1``.
+
+#. Continue to the section *Service details* and fill out the fields:
+
+   * **Service name**: This is the name of the service for which authentication is needed.
+   * **Service description**: A description of the service for which authentication is needed.
+   * **Requested attributes**: What attributes are expected to be returned by DigiD
+     after authentication. This should be ``["bsn"]``.
+   * Leave **Single logout** unchecked, as we currently don't support this.
+
+#. Finally, you should provide some *organization details* - provide the telephone/e-mail
+   contacts of the organisation responsible for the service requiring DigiD authentication.
+
+Click on **Save and continue editing** to persist the configuration changes.
+
+On the top right corner of the configuration page, there is a button
+**View SAML metadata (XML)**. Click this button to download the metadata. The metadata
+needs to be sent to the broker to obtain access to a (pre-)production environment.
+
+.. note::
+
+   Any changes to the configuration in the Admin page cause a change in the metadata.
+   The updated metadata must be then sent to the broker again for the changes to be effective.
 
 .. _`PKIoverheid Private Services Server G1`: https://cert.pkioverheid.nl/
 .. _`PKIO SSL certificate supplier`: https://www.logius.nl/domeinen/toegang/pkioverheidcertificaat-aanvragen

--- a/docs/configuration/authentication/eherkenning_eidas.rst
+++ b/docs/configuration/authentication/eherkenning_eidas.rst
@@ -4,11 +4,6 @@
 eHerkenning and eIDAS authentication
 ====================================
 
-.. warning::
-
-    This plugin cannot be configured via the admin interface and requires an
-    update of the Open Forms installation.
-
 Some forms can require authentication. Open Forms supports authentication
 using `eHerkenning`_ and `eIDAS`_. To use eHerkenning and/or eIDAS, you must
 have a contract with an `approved eHerkenning supplier`_.

--- a/docs/configuration/authentication/eherkenning_eidas.rst
+++ b/docs/configuration/authentication/eherkenning_eidas.rst
@@ -18,7 +18,32 @@ that describes the authenticated entity (person or company).
 
 .. note::
 
-    Open Forms currently only supports the same security level for all forms.
+    Authentication via eIDAS uses the same supplier and generated files as
+    eHerkenning. If you plan on adding eIDAS support to Open Forms, it's best
+    to do these 2 at the same time.
+
+Limitations
+===========
+
+Some limitations apply.
+
+**KVKNr identifier required**
+
+Open Forms only supports the ``KVKNr`` identifier. Other identification numbers exist,
+but we don't support these (yet). Ensure that your supplier specifies the relevant
+identifying attribute, since this can not be specified in Open Forms.
+
+Additional identifying attributes may be specified - these will be ignored.
+
+**Security level**
+
+Open Forms currently only supports the same security level for all forms. You can not
+override this, and the security level is recorded in the service catalog so it is
+outside of our control. We're aware of this feature request though.
+
+.. note::
+
+    The available security levels are:
 
     =========== =============== ===========================================
     eHerkenning eIDAS           SAML2 AuthnContextClassRef element
@@ -31,15 +56,11 @@ that describes the authenticated entity (person or company).
 
     Source: `Afsprakenstelsel eToegang <https://afsprakenstelsel.etoegang.nl/Startpagina/AS1.24b/level-of-assurance>`_
 
-.. note::
-
-    Authentication via eIDAS uses the same supplier and generated files as
-    eHerkenning. If you plan on adding eIDAS support to Open Forms, it's best
-    to do these 2 at the same time.
-
-
 Step by step overview
 =====================
+
+The high-level overview of steps you need to perform are described here. The following
+sections provide more details.
 
 1. Contact an `approved eHerkenning supplier`_ to get started. Sometimes, your
    Open Forms supplier can communicate directly with the eHerkenning supplier.
@@ -51,9 +72,13 @@ Step by step overview
    communication with your eHerkenning supplier (if you already have one for
    Open Forms, it can be re-used).
 
+   You can :ref:`prepare the certificates <configuration_authentication_eh_prepare_certificates>`
+   from the admin interface.
+
 3. Send the following information to your Open Forms supplier:
 
-   * Public and private certificate (obtained in step 2)
+   * Public and private certificate (obtained in step 2, private certificate is already
+     present if you generated the Signing Request (CSR) via the admin)
    * Name of the approved eHerkenning supplier
    * The desired consuming service indexes (or Service IDs)
    * Desired service name(s) in Dutch and English (for example: "Digitaal Loket")
@@ -65,6 +90,115 @@ Step by step overview
    eHerkenning supplier directly.
 
 4. Your eHerkenning supplier will inform you when everything is set up.
+
+.. _configuration_authentication_eh_prepare_certificates:
+
+Preparing the certificates
+==========================
+
+To request a *PKIoverheid certificate*, you need a private key and a certificate signing
+request. You can generate these using ``openssl`` or other utilities, or use the built-in
+signing requests in the admin interface.
+
+.. tip:: Creating the signing requests from the admin ensures the private key never
+   leaves the server, lessening the chances that it is accidentally leaked.
+
+**Using the admin interface**
+
+#. Navigate to the **Admin**.
+#. In the menu, navigate to **Configuration** > **Signing requests**.
+#. In the top right of the page, click the **Add signing request** button.
+#. Enter the desired fields - the information will be included in the signing request.
+   Consult with your certificate supplier which data is required and what values are
+   expected.
+#. Click **Save** to persist the changes. The page is reloaded.
+#. Under the section *Signing request (CSR)*, click the **Download CSR** link.
+
+Now, send the downloaded CSR to your certificate supplier and wait for them to verify
+it and provide you with the matching certificate. This can take some time (hours to
+days), as verification is often a manual process.
+
+Once you have received the certificate, navigate back to the admin and locate your
+signing request.
+
+#. Edit the original signing request record in the admin.
+#. Navigate to the *Upload signed certificate* section.
+#. Upload the certificate provided by the certificate supplier.
+#. Save the changes.
+
+If everything is valid, the private key + public cerificate pair is now available and
+almost ready for use. You can verify it in the admin via **Configuration** >
+**Certificates**.
+
+You can now proceed to :ref:`configuration_authentication_eh_metadata`.
+
+
+.. _configuration_authentication_eh_metadata:
+
+Generating the Service Provider metadata
+========================================
+
+In the admin environment we can configure the DigiD identity provider and select our
+required certificate pair(s). Once this is done, we can generate our service provider
+metadata.
+
+#. Navigate to the **Admin**.
+#. In the menu, navigate to **Configuration** > **EHerkenning/eIDAS configuration**.
+#. Under the *X.509 Certificate* section, click the **Manage (number)** link.
+#. Click the **Add Digid/eHerkenning certificate** button in the top right of the page.
+#. For **Config type**, select "eHerkenning".
+#. For **Certificate**, click the search icon and select the certificate pair that was
+   created earlier (in the :ref:`configuration_authentication_eh_prepare_certificates`
+   section).
+#. **Save** the configuration and close the window/tab.
+#. Continue on the *EHerkenning/eIDAS configuration* page.
+#. In the section *Identity provider*, enter the identity provider
+   **metadata file (XML) URL**. This URL should be provided by your broker/supplier. The
+   metadata will be retrieved and processed.
+#. Next, in the section *SAML configuration*, enter the fields:
+
+   * **Entity ID**: This is the entity ID of Open-Forms.
+   * **Base URL**: Enter the URL where Open-Forms is deployed (and publicly accessible).
+   * **Resolve artifact binding content type**: select ``text/xml`` unless you're using
+     old/legacy brokers or are instructed to pick ``application/soap+xml``.
+   * **Want assertions signed**: This should be **checked**.
+   * **Want assertions encrypted**: This should be **unchecked**.
+   * **Signature algorithm**: Select ``RSA_SHA256``.
+   * **Digest algorithm**: Select ``SHA256``.
+
+#. Continue to the section *Service details* and fill out the fields:
+
+   * **Service name**: This is the name of the service for which authentication is needed.
+   * **Service description**: A description of the service for which authentication is needed.
+   * **OIN**: Enter your OIN_.
+   * **Broker ID**: Specify the OIN_ of your broker.
+   * **Privacy policy**: Enter the link to the webpage where your privacy policy is
+     hosted.
+   * **Service language**: Enter ``nl``.
+
+#. Next, in the section *eHerkenning* you can configurare parameters for eHerkenning:
+
+    * **Requested attributes**: leave empty. Definitely do *not* include
+      ``urn:etoegang:1.9:EntityConcernedID:KvKnr`` as this is managed elsewhere.
+    * **EHerkenning LOA**: "Low (2+)" is the minimum required level.
+
+#. Optionally, configure the same parameters for *eIDAS* or check the **No eIDAS**
+   checkbox to omit it.
+
+#. Finally, you should provide some *organization details* - provide the telephone/e-mail
+   contacts of the organisation responsible for the service requiring eHerkenning/eIDAS
+   authentication.
+
+Click on **Save and continue editing** to persist the configuration changes.
+
+On the top right corner of the configuration page, there is a button
+**View SAML metadata (XML)**. Click this button to download the metadata. The metadata
+needs to be sent to the broker to obtain access to a (pre-)production environment.
+
+.. note::
+
+   Any changes to the configuration in the Admin page cause a change in the metadata.
+   The updated metadata must be then sent to the broker again for the changes to be effective.
 
 .. _`PKIoverheid Private Services Server G1`: https://cert.pkioverheid.nl/
 .. _`PKIO SSL certificate supplier`: https://www.logius.nl/domeinen/toegang/pkioverheidcertificaat-aanvragen

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -155,7 +155,7 @@ django-csp==3.8
     # via -r requirements/base.in
 django-csp-reports==1.8.1
     # via -r requirements/base.in
-django-digid-eherkenning==0.17.2
+django-digid-eherkenning==0.18.0
     # via -r requirements/base.in
 django-filter==24.2
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -257,7 +257,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.17.2
+django-digid-eherkenning==0.18.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -280,7 +280,7 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
-django-digid-eherkenning==0.17.2
+django-digid-eherkenning==0.18.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -245,7 +245,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.17.2
+django-digid-eherkenning==0.18.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -273,7 +273,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.17.2
+django-digid-eherkenning==0.18.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Partly closes #4785 

The documentation update is independent from the [library changes](https://github.com/maykinmedia/django-digid-eherkenning/pull/83), but it would be great if both are done in one go.

**Changes**

* Removed the warnings that configuration in the admin is not possible
* Added section about CSR generation
* Updated configuration steps with moved/new fields from django-digid-eherkenning library fields

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
