### PR TITLE
:bug: [#4579] Ensure triggerFromStep uses the correct current_step

### DIFF
--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -200,7 +200,11 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer):
         return super().create(validated_data)
 
     def to_representation(self, instance):
-        check_submission_logic(instance, unsaved_data=self.context.get("unsaved_data"))
+        check_submission_logic(
+            instance,
+            unsaved_data=self.context.get("unsaved_data"),
+            current_step=self.context.get("current_step"),
+        )
         return super().to_representation(instance)
 
 

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -635,6 +635,10 @@ class SubmissionStepViewSet(
 
         submission_state_logic_serializer = SubmissionStateLogicSerializer(
             instance=SubmissionStateLogic(submission=submission, step=submission_step),
-            context={"request": request, "unsaved_data": data},
+            context={
+                "request": request,
+                "unsaved_data": data,
+                "current_step": submission_step,
+            },
         )
         return Response(submission_state_logic_serializer.data)

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -188,7 +188,9 @@ def evaluate_form_logic(
 
 
 def check_submission_logic(
-    submission: "Submission", unsaved_data: dict | None = None
+    submission: "Submission",
+    unsaved_data: dict | None = None,
+    current_step: "SubmissionStep | None" = None,
 ) -> None:
     if getattr(submission, "_form_logic_evaluated", False):
         return
@@ -198,7 +200,7 @@ def check_submission_logic(
     if not submission_state.form_steps:
         return
 
-    rules = get_rules_to_evaluate(submission)
+    rules = get_rules_to_evaluate(submission, current_step)
 
     # load the data state and all variables
     submission_variables_state = submission.load_submission_value_variables_state()


### PR DESCRIPTION
previously the current step was inferred by looking at the last completed step and considering the step after that the current step. This does not work however if you complete a step and go back to the previous step, so instead we explicitly pass the current form step via the serializer context

Closes #4579

**Changes**

* Ensure triggerFromStep uses the correct current_step

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
