### PR TITLE
:fire: Delete component_translations serializer fields

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7019,38 +7019,6 @@ components:
       description: |-
         * `bool` - Boolean
         * `json` - JSON
-    ComponentTranslations:
-      type: object
-      description: |-
-        Nest translations for literals used in the FormIO configuration inside the serializer.
-
-        This serializer produces a similar structure as the `translations` for model fields,
-        except that the literals are dependent on the literals used in the components defined
-        in the FormIO configuration.
-
-        Literals are mapped to their translation, e.g. a configuration with a `TextField`
-        with default label `Text field` and `FileField` with default label `File field`
-        could look as follows:
-
-            ParentModelSerializer:
-                ... other fields/serializers
-
-                ComponentTranslationsSerializer:
-                    nl:
-                        "Text field": "Tekstveld"
-                        "File field": "Uploadveld"
-                    en:
-                        "Text field": "Text field"
-                        "File field": "File field"
-      properties:
-        nl:
-          type: object
-          additionalProperties:
-            type: string
-        en:
-          type: object
-          additionalProperties:
-            type: string
     ConfirmationEmailTemplate:
       type: object
       properties:
@@ -7873,10 +7841,6 @@ components:
           description: Allow this definition to be re-used in multiple forms
         translations:
           $ref: '#/components/schemas/FormDefinitionModelTranslations'
-        componentTranslations:
-          allOf:
-          - $ref: '#/components/schemas/ComponentTranslations'
-          nullable: true
       required:
       - configuration
       - name
@@ -7924,10 +7888,6 @@ components:
           description: Allow this definition to be re-used in multiple forms
         translations:
           $ref: '#/components/schemas/FormDefinitionDetailModelTranslations'
-        componentTranslations:
-          allOf:
-          - $ref: '#/components/schemas/ComponentTranslations'
-          nullable: true
         usedIn:
           type: array
           items:
@@ -8339,12 +8299,7 @@ components:
           $ref: '#/components/schemas/FormStepLiterals'
         translations:
           $ref: '#/components/schemas/FormStepModelTranslations'
-        componentTranslations:
-          allOf:
-          - $ref: '#/components/schemas/ComponentTranslations'
-          readOnly: true
       required:
-      - componentTranslations
       - configuration
       - formDefinition
       - index
@@ -9443,10 +9398,6 @@ components:
           description: Allow this definition to be re-used in multiple forms
         translations:
           $ref: '#/components/schemas/FormDefinitionModelTranslations'
-        componentTranslations:
-          allOf:
-          - $ref: '#/components/schemas/ComponentTranslations'
-          nullable: true
     PatchedFormStep:
       type: object
       properties:
@@ -9491,10 +9442,6 @@ components:
           $ref: '#/components/schemas/FormStepLiterals'
         translations:
           $ref: '#/components/schemas/FormStepModelTranslations'
-        componentTranslations:
-          allOf:
-          - $ref: '#/components/schemas/ComponentTranslations'
-          readOnly: true
     PaymentBackendEnum:
       enum:
       - ogone-legacy

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -7,10 +7,7 @@ from rest_framework import serializers
 
 from openforms.api.serializers import PublicFieldsSerializerMixin
 from openforms.formio.service import rewrite_formio_components_for_request
-from openforms.translations.api.serializers import (
-    ComponentTranslationsSerializer,
-    ModelTranslationsSerializer,
-)
+from openforms.translations.api.serializers import ModelTranslationsSerializer
 
 from ...models import Form, FormDefinition
 from ...validators import (
@@ -68,9 +65,6 @@ class FormDefinitionSerializer(
     PublicFieldsSerializerMixin, serializers.HyperlinkedModelSerializer
 ):
     translations = ModelTranslationsSerializer()
-    component_translations = ComponentTranslationsSerializer(
-        required=False, allow_null=True
-    )
     configuration = FormDefinitionConfigurationSerializer(
         label=_("Form.io configuration"),
         help_text=_("The form definition as Form.io JSON schema"),
@@ -93,7 +87,6 @@ class FormDefinitionSerializer(
             "login_required",
             "is_reusable",
             "translations",
-            "component_translations",
         )
         public_fields = (
             "url",
@@ -104,7 +97,6 @@ class FormDefinitionSerializer(
             "configuration",
             "login_required",
             "is_reusable",
-            "component_translations",
         )
         extra_kwargs = {
             "url": {

--- a/src/openforms/forms/api/serializers/form_step.py
+++ b/src/openforms/forms/api/serializers/form_step.py
@@ -7,10 +7,7 @@ from rest_framework import serializers
 from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 
 from openforms.api.serializers import PublicFieldsSerializerMixin
-from openforms.translations.api.serializers import (
-    ComponentTranslationsSerializer,
-    ModelTranslationsSerializer,
-)
+from openforms.translations.api.serializers import ModelTranslationsSerializer
 
 from ...models import FormDefinition, FormStep
 from ...tasks import on_formstep_save_event
@@ -95,10 +92,6 @@ class FormStepSerializer(
         read_only=True,
     )
     translations = ModelTranslationsSerializer()
-    component_translations = ComponentTranslationsSerializer(
-        source="form_definition.component_translations",
-        read_only=True,
-    )
 
     parent_lookup_kwargs = {
         "form_uuid_or_slug": "form__uuid",
@@ -120,7 +113,6 @@ class FormStepSerializer(
             "is_reusable",
             "literals",
             "translations",
-            "component_translations",
         )
         public_fields = (
             "uuid",
@@ -135,7 +127,6 @@ class FormStepSerializer(
             "login_required",
             "is_reusable",
             "literals",
-            "component_translations",
         )
 
         extra_kwargs = {

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -321,11 +321,6 @@ def import_form_data(
                         deserialized.validated_data["configuration"]
                     )
 
-                    # field 'component_translations' has been deprecated and it's not part of
-                    # the 'form_definition' model anymore. We use it only in the serializer.
-                    if "component_translations" in deserialized.validated_data:
-                        del deserialized.validated_data["component_translations"]
-
                 if resource == "formLogic":
                     clear_old_service_fetch_config(deserialized.validated_data)
 

--- a/src/openforms/translations/api/serializers.py
+++ b/src/openforms/translations/api/serializers.py
@@ -105,37 +105,3 @@ class ModelTranslationsSerializer(serializers.Serializer):
         return build_translated_model_fields_serializer(
             base, language_code, translatable_fields
         )
-
-
-class ComponentTranslationsSerializer(serializers.Serializer):
-    """
-    Nest translations for literals used in the FormIO configuration inside the serializer.
-
-    This serializer produces a similar structure as the `translations` for model fields,
-    except that the literals are dependent on the literals used in the components defined
-    in the FormIO configuration.
-
-    Literals are mapped to their translation, e.g. a configuration with a `TextField`
-    with default label `Text field` and `FileField` with default label `File field`
-    could look as follows:
-
-        ParentModelSerializer:
-            ... other fields/serializers
-
-            ComponentTranslationsSerializer:
-                nl:
-                    "Text field": "Tekstveld"
-                    "File field": "Uploadveld"
-                en:
-                    "Text field": "Text field"
-                    "File field": "File field"
-    """
-
-    def get_fields(self):
-        fields = {
-            language_code: serializers.DictField(
-                child=serializers.CharField(), required=False
-            )
-            for language_code, label in settings.LANGUAGES
-        }
-        return fields


### PR DESCRIPTION
This was left-over from the previous version of component translations, but those are now baked into each component itself.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
