### PR TITLE
Fix bugs in email registraton + objects API prefill combination

### DIFF
--- a/src/openforms/authentication/templates/of_authentication/registrator_subject_info.html
+++ b/src/openforms/authentication/templates/of_authentication/registrator_subject_info.html
@@ -1,13 +1,6 @@
 {% extends 'ui/views/abstract/detail.html' %}
 {% load i18n static %}
 
-{% block extra_css %}
-    {{ block.super }}
-
-    {# Needed for the styling of the auth-mode class #}
-    <link href="{% static 'bundles/public-styles.css' %}" media="all" rel="stylesheet"/>
-{% endblock %}
-
 {% block card %}
 <div class="openforms-card">
     <header class="openforms-card__header">

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -45,6 +45,14 @@ class EmailRegistration(BasePlugin[Options]):
     verbose_name = _("Email registration")
     configuration_options = EmailOptionsSerializer
 
+    def verify_initial_data_ownership(
+        self, submission: Submission, options: Options
+    ) -> None:
+        """
+        Ownership checks for email registration are not meaningful, allow anything.
+        """
+        pass
+
     @staticmethod
     def get_recipients(submission: Submission, options: Options) -> list[str]:
         state = submission.load_submission_value_variables_state()

--- a/src/openforms/templates/includes/forms/radio.html
+++ b/src/openforms/templates/includes/forms/radio.html
@@ -8,7 +8,7 @@
             utrecht-form-fieldset__legend
             utrecht-form-fieldset__legend--html-legend
             utrecht-form-field__label">
-            <label class="utrecht-form-label utrecht-form-label--openforms-required">
+            <label class="utrecht-form-label utrecht-form-label--openforms utrecht-form-label--openforms-required">
                 {{ field.label }}
             </label>
         </legend>

--- a/src/openforms/ui/static/ui/scss/components/_index.scss
+++ b/src/openforms/ui/static/ui/scss/components/_index.scss
@@ -5,6 +5,8 @@
 @import 'page-header';
 
 // Custom
+@import '../../../../../scss/components/form-choices';
+
 @import 'a11y-toolbar';
 @import 'auth-mode';
 @import 'fa-icon';

--- a/src/openforms/utils/templates/of_utils/widgets/radio_option.html
+++ b/src/openforms/utils/templates/of_utils/widgets/radio_option.html
@@ -1,7 +1,7 @@
 <div class="utrecht-form-field utrecht-form-field--radio utrecht-form-field--openforms">
     {% include "django/forms/widgets/input.html" %}
     <p class="utrecht-paragraph utrecht-form-field__label utrecht-form-field__label--radio">
-        <label for="{{ widget.attrs.id }}" class="utrecht-form-label utrecht-form-label--radio">
+        <label for="{{ widget.attrs.id }}" class="utrecht-form-label utrecht-form-label--radio utrecht-form-label--openforms">
             {{ widget.label }}
         </label>
     </p>


### PR DESCRIPTION
Closes #4650

**Changes**

* Fixed styling issue in registrator info template
* Fixed registration plugin issue when objects prefill is used

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
