### PR TITLE
:speech_balloon: Tailor field help texts to registration/prefill context

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -221,12 +221,6 @@
       "value": "Confirm"
     }
   ],
-  "1Hb/pK": [
-    {
-      "type": 0,
-      "value": "This is used to perform validation to verify that the authenticated user is the owner of the object."
-    }
-  ],
   "1HfdUc": [
     {
       "type": 0,
@@ -3725,6 +3719,12 @@
       "value": "Active"
     }
   ],
+  "X18/UP": [
+    {
+      "type": 0,
+      "value": "Owner identifier"
+    }
+  ],
   "XAKzo5": [
     {
       "type": 0,
@@ -4677,6 +4677,12 @@
       "value": "Amount of days incomplete submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
     }
   ],
+  "fB1baI": [
+    {
+      "type": 0,
+      "value": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user to verify ownership of the object being updated. This is important to prevent malicious users modifying information of other people than themselves."
+    }
+  ],
   "fGTdJz": [
     {
       "type": 0,
@@ -4789,6 +4795,12 @@
     {
       "type": 0,
       "value": "Do nothing"
+    }
+  ],
+  "g1i5ru": [
+    {
+      "type": 0,
+      "value": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user. This is important to prevent malicious users looking up private information of other people."
     }
   ],
   "gAf9pR": [
@@ -5509,12 +5521,6 @@
     {
       "type": 0,
       "value": "Partner 1"
-    }
-  ],
-  "lu7yMK": [
-    {
-      "type": 0,
-      "value": "Path to auth attribute (e.g. BSN/KVK) in objects"
     }
   ],
   "m20av3": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -221,12 +221,6 @@
       "value": "Bevestigen"
     }
   ],
-  "1Hb/pK": [
-    {
-      "type": 0,
-      "value": "Dit attribuut wordt gebruikt om te controleren dat de ingelogde gebruiker bij het object hoort dat bijgewerkt wordt."
-    }
-  ],
   "1HfdUc": [
     {
       "type": 0,
@@ -3738,6 +3732,12 @@
       "value": "Actief"
     }
   ],
+  "X18/UP": [
+    {
+      "type": 0,
+      "value": "Identificatie-attribuut"
+    }
+  ],
   "XAKzo5": [
     {
       "type": 0,
@@ -4695,6 +4695,12 @@
       "value": "Aantal dagen dat een sessie bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken."
     }
   ],
+  "fB1baI": [
+    {
+      "type": 0,
+      "value": "Het attribuut dat vergeleken wordt met de identificatiewaarde (bijv. BSN/KVK-nummer) van de ingelogde gebruiker om de eigenaar van het object dat bijgewerkt wordt te controleren. Dit is belangrijk om te voorkomen dat kwaadwillenden gegevens van anderen bijwerken in plaast van zichzelf."
+    }
+  ],
   "fGTdJz": [
     {
       "type": 0,
@@ -4807,6 +4813,12 @@
     {
       "type": 0,
       "value": "Negeren"
+    }
+  ],
+  "g1i5ru": [
+    {
+      "type": 0,
+      "value": "Het attribuut dat vergeleken wordt met de identificatiewaarde (bijv. BSN/KVK-nummer) van de ingelogde gebruiker. Dit is belangrijk om te voorkomen dat kwaadwillenden gegevens van anderen kunnen opvragen."
     }
   ],
   "gAf9pR": [
@@ -5527,12 +5539,6 @@
     {
       "type": 0,
       "value": "Partner 1"
-    }
-  ],
-  "lu7yMK": [
-    {
-      "type": 0,
-      "value": "Bronpad van het autorisatiekenmerk (bijv. BSN/KVK)"
     }
   ],
   "m20av3": [

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -18,6 +18,7 @@ import {
 import {
   AdminChangeFormDecorator,
   FormDecorator,
+  FormModalContentDecorator,
   ValidationErrorsDecorator,
 } from 'components/admin/form_design/story-decorators';
 import {rsSelect} from 'utils/storybookTestHelpers';
@@ -26,7 +27,12 @@ import RegistrationFields from './RegistrationFields';
 
 export default {
   title: 'Form design / Registration / RegistrationFields',
-  decorators: [ValidationErrorsDecorator, FormDecorator, AdminChangeFormDecorator],
+  decorators: [
+    ValidationErrorsDecorator,
+    FormDecorator,
+    AdminChangeFormDecorator,
+    FormModalContentDecorator,
+  ],
   component: RegistrationFields,
   args: {
     availableBackends: [

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -799,9 +799,7 @@ export const ObjectsAPI = {
         expect(otherSettingsTitle).toBeVisible();
         await userEvent.click(within(otherSettingsTitle).getByRole('link', {name: '(Tonen)'}));
 
-        const authAttributePath = modal.getByText(
-          'Bronpad van het autorisatiekenmerk (bijv. BSN/KVK)'
-        );
+        const authAttributePath = modal.getByText('Identificatie-attribuut');
 
         expect(authAttributePath.parentElement.parentElement).toHaveClass('field--disabled');
 

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -7,7 +7,6 @@ import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
 import {TextArea, TextInput} from 'components/admin/forms/Inputs';
 import {
-  AuthAttributePath,
   ObjectTypeSelect,
   ObjectTypeVersionSelect,
   ObjectsAPIGroup,
@@ -15,6 +14,7 @@ import {
 import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {
+  AuthAttributePath,
   DocumentTypesFieldet,
   LegacyDocumentTypesFieldet,
   OrganisationRSIN,
@@ -129,14 +129,7 @@ const LegacyConfigFields = ({apiGroupChoices}) => {
         fieldNames={['updateExistingObject', 'authAttributePath']}
       >
         <UpdateExistingObject />
-        <AuthAttributePath
-          name="authAttributePath"
-          objectsApiGroup={objectsApiGroup}
-          objecttypeUuid={objecttype}
-          objecttypeVersion={objecttypeVersion}
-          disabled={!updateExistingObject}
-          required={updateExistingObject}
-        />
+        <AuthAttributePath />
       </Fieldset>
 
       <Fieldset

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -1,9 +1,9 @@
 import {expect, fn, userEvent, waitFor, within} from '@storybook/test';
 import {Form, Formik} from 'formik';
-import selectEvent from 'react-select-event';
 
 import {
   FeatureFlagsDecorator,
+  FormModalContentDecorator,
   ValidationErrorsDecorator,
 } from 'components/admin/form_design/story-decorators';
 import {rsSelect} from 'utils/storybookTestHelpers';
@@ -30,7 +30,7 @@ const render = ({apiGroups, formData}) => (
 
 export default {
   title: 'Form design/Registration/Objects API',
-  decorators: [ValidationErrorsDecorator, FeatureFlagsDecorator],
+  decorators: [ValidationErrorsDecorator, FeatureFlagsDecorator, FormModalContentDecorator],
   render,
   args: {
     apiGroups: [

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -5,7 +5,6 @@ import {FormattedMessage} from 'react-intl';
 import useConfirm from 'components/admin/form_design/useConfirm';
 import Fieldset from 'components/admin/forms/Fieldset';
 import {
-  AuthAttributePath,
   ObjectTypeSelect,
   ObjectTypeVersionSelect,
   ObjectsAPIGroup,
@@ -13,6 +12,7 @@ import {
 import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {
+  AuthAttributePath,
   DocumentTypesFieldet,
   LegacyDocumentTypesFieldet,
   OrganisationRSIN,
@@ -152,14 +152,7 @@ const V2ConfigFields = ({apiGroupChoices}) => {
         fieldNames={['updateExistingObject', 'authAttributePath']}
       >
         <UpdateExistingObject />
-        <AuthAttributePath
-          name={'authAttributePath'}
-          objectsApiGroup={objectsApiGroup}
-          objecttypeUuid={objecttype}
-          objecttypeVersion={objecttypeVersion}
-          disabled={!updateExistingObject}
-          required={updateExistingObject}
-        />
+        <AuthAttributePath />
       </Fieldset>
 
       <Fieldset

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/AuthAttributePath.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/AuthAttributePath.js
@@ -1,0 +1,36 @@
+import {useFormikContext} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import {AuthAttributePath as SharedAuthAttributePath} from 'components/admin/forms/objects_api';
+
+const AuthAttributePath = () => {
+  const {
+    values: {
+      objectsApiGroup = null,
+      objecttype = '',
+      objecttypeVersion = null,
+      updateExistingObject = false,
+    },
+  } = useFormikContext();
+  return (
+    <SharedAuthAttributePath
+      name={'authAttributePath'}
+      objectsApiGroup={objectsApiGroup}
+      objecttypeUuid={objecttype}
+      objecttypeVersion={objecttypeVersion}
+      disabled={!updateExistingObject}
+      required={updateExistingObject}
+      helpText={
+        <FormattedMessage
+          description="Objects API registration: authAttributePath helpText"
+          defaultMessage={`The property that gets compared with the identifier (e.g.
+        BSN/KVK) of the authenticated user to verify ownership of the object being
+        updated. This is important to prevent malicious users modifying information
+        of other people than themselves.`}
+        />
+      }
+    />
+  );
+};
+
+export default AuthAttributePath;

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/index.js
@@ -3,3 +3,4 @@ export {DocumentTypesFieldet} from './DocumentTypes';
 export {default as UpdateExistingObject} from './UpdateExistingObject';
 export {default as UploadSubmissionCsv} from './UploadSubmissionCSV';
 export {default as OrganisationRSIN} from './OrganisationRSIN';
+export {default as AuthAttributePath} from './AuthAttributePath';

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -4,6 +4,7 @@ import {Form, Formik} from 'formik';
 import {
   FeatureFlagsDecorator,
   FormDecorator,
+  FormModalContentDecorator,
   ValidationErrorsDecorator,
 } from 'components/admin/form_design/story-decorators';
 import {rsSelect} from 'utils/storybookTestHelpers';
@@ -56,7 +57,12 @@ const render = ({apiGroups, objectsApiGroupChoices, confidentialityLevelChoices,
 export default {
   title: 'Form design/Registration/ZGW',
   component: ZGWFormFields,
-  decorators: [ValidationErrorsDecorator, FormDecorator, FeatureFlagsDecorator],
+  decorators: [
+    ValidationErrorsDecorator,
+    FormDecorator,
+    FeatureFlagsDecorator,
+    FormModalContentDecorator,
+  ],
   render,
   args: {
     apiGroups: [

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -1,6 +1,6 @@
 import {fn} from '@storybook/test';
 import {Form, Formik} from 'formik';
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 
 import {
   FeatureFlagsContext,
@@ -44,6 +44,27 @@ export const AdminChangeFormDecorator = (Story, {parameters}) => {
         <Story />
       </Wrapper>
     </form>
+  );
+};
+
+/**
+ * Decorator to mark story as being rendered inside a modal.
+ *
+ * It ensures that the DOM layout/hierarchy is as expected w/r to styling effects.
+ */
+export const FormModalContentDecorator = Story => {
+  // // remove the change-form body class which affects the positioning of validation errors
+  // useEffect(() => {
+  //   // body of the story inside the story iframe
+  //   const body = document.querySelector('body');
+  //   body.classList.remove('change-form');
+  // }, []);
+  return (
+    <div className="react-modal">
+      <div className="react-modal__form">
+        <Story />
+      </div>
+    </div>
   );
 };
 

--- a/src/openforms/js/components/admin/form_design/variables/prefill/objects_api/ObjectsAPIFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/objects_api/ObjectsAPIFields.js
@@ -255,6 +255,14 @@ const ObjectsAPIFields = () => {
             objecttypeUuid={objecttypeUuid}
             objecttypeVersion={objecttypeVersion}
             required
+            helpText={
+              <FormattedMessage
+                description="Objects API prefill: authAttributePath helpText"
+                defaultMessage={`The property that gets compared with the identifier (e.g. BSN/KVK) of
+                the authenticated user. This is important to prevent malicious users
+                looking up private information of other people.`}
+              />
+            }
           />
         )}
       </Fieldset>

--- a/src/openforms/js/components/admin/forms/Field.stories.js
+++ b/src/openforms/js/components/admin/forms/Field.stories.js
@@ -7,7 +7,19 @@ export default {
   title: 'Admin/Django/Field',
   component: Field,
 
-  decorators: [AdminChangeFormDecorator],
+  decorators: [
+    Story => (
+      <div class="form-row">
+        <Story />
+      </div>
+    ),
+    AdminChangeFormDecorator,
+    Story => (
+      <div class="react-form-create">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: {
     adminChangeForm: {
       wrapFieldset: true,

--- a/src/openforms/js/components/admin/forms/objects_api/AuthAttributePath.js
+++ b/src/openforms/js/components/admin/forms/objects_api/AuthAttributePath.js
@@ -18,6 +18,7 @@ const AuthAttributePath = ({
   objecttypeVersion,
   disabled = false,
   required = false,
+  helpText = undefined,
 }) => {
   const intl = useIntl();
   const {csrftoken} = useContext(APIContext);
@@ -57,15 +58,10 @@ const AuthAttributePath = ({
         label={
           <FormattedMessage
             description="Objects API registration: authAttributePath label"
-            defaultMessage="Path to auth attribute (e.g. BSN/KVK) in objects"
+            defaultMessage="Owner identifier"
           />
         }
-        helpText={
-          <FormattedMessage
-            description="Objects API registration: authAttributePath helpText"
-            defaultMessage="This is used to perform validation to verify that the authenticated user is the owner of the object."
-          />
-        }
+        helpText={helpText}
         disabled={disabled}
         required={required}
       >
@@ -89,6 +85,7 @@ AuthAttributePath.propTypes = {
   objecttypeVersion: PropTypes.number,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  helpText: PropTypes.node,
 };
 
 export default AuthAttributePath;

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -99,11 +99,6 @@
     "description": "Camunda complex process variables confirm button",
     "originalDefault": "Confirm"
   },
-  "1Hb/pK": {
-    "defaultMessage": "This is used to perform validation to verify that the authenticated user is the owner of the object.",
-    "description": "Objects API registration: authAttributePath helpText",
-    "originalDefault": "This is used to perform validation to verify that the authenticated user is the owner of the object."
-  },
   "1HfdUc": {
     "defaultMessage": "The API group specifies which objects and objecttypes services to use.",
     "description": "Objects API group field help text",
@@ -1769,6 +1764,11 @@
     "description": "Form list 'active' column header",
     "originalDefault": "Active"
   },
+  "X18/UP": {
+    "defaultMessage": "Owner identifier",
+    "description": "Objects API registration: authAttributePath label",
+    "originalDefault": "Owner identifier"
+  },
   "XAKzo5": {
     "defaultMessage": "Authentication automatic login",
     "description": "Auto-login field label",
@@ -2174,6 +2174,11 @@
     "description": "Incomplete Submissions Removal Limit help text",
     "originalDefault": "Amount of days incomplete submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
   },
+  "fB1baI": {
+    "defaultMessage": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user to verify ownership of the object being updated. This is important to prevent malicious users modifying information of other people than themselves.",
+    "description": "Objects API registration: authAttributePath helpText",
+    "originalDefault": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user to verify ownership of the object being updated. This is important to prevent malicious users modifying information of other people than themselves."
+  },
   "fLCWjk": {
     "defaultMessage": "Name",
     "description": "Variable table name title",
@@ -2228,6 +2233,11 @@
     "defaultMessage": "Do nothing",
     "description": "Session expiry warning \"do nothing\" button",
     "originalDefault": "Do nothing"
+  },
+  "g1i5ru": {
+    "defaultMessage": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user. This is important to prevent malicious users looking up private information of other people.",
+    "description": "Objects API prefill: authAttributePath helpText",
+    "originalDefault": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user. This is important to prevent malicious users looking up private information of other people."
   },
   "gAf9pR": {
     "defaultMessage": "(not configured yet)",
@@ -2553,11 +2563,6 @@
     "defaultMessage": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case.",
     "description": "ZGW APIs registration options 'objecttype' help text",
     "originalDefault": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case."
-  },
-  "lu7yMK": {
-    "defaultMessage": "Path to auth attribute (e.g. BSN/KVK) in objects",
-    "description": "Objects API registration: authAttributePath label",
-    "originalDefault": "Path to auth attribute (e.g. BSN/KVK) in objects"
   },
   "m83ECr": {
     "defaultMessage": "Copying the configuration from the registration backend will clear the existing configuration. Are you sure you want to continue?",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -100,11 +100,6 @@
     "description": "Camunda complex process variables confirm button",
     "originalDefault": "Confirm"
   },
-  "1Hb/pK": {
-    "defaultMessage": "Dit attribuut wordt gebruikt om te controleren dat de ingelogde gebruiker bij het object hoort dat bijgewerkt wordt.",
-    "description": "Objects API registration: authAttributePath helpText",
-    "originalDefault": "This is used to perform validation to verify that the authenticated user is the owner of the object."
-  },
   "1HfdUc": {
     "defaultMessage": "De API-groep bepaalt welke services voor de objecten- en objecttypen-API's gebruikt wordt.",
     "description": "Objects API group field help text",
@@ -1787,6 +1782,11 @@
     "description": "Form list 'active' column header",
     "originalDefault": "Active"
   },
+  "X18/UP": {
+    "defaultMessage": "Identificatie-attribuut",
+    "description": "Objects API registration: authAttributePath label",
+    "originalDefault": "Owner identifier"
+  },
   "XAKzo5": {
     "defaultMessage": "Authenticatie automatische login",
     "description": "Auto-login field label",
@@ -2194,6 +2194,11 @@
     "description": "Incomplete Submissions Removal Limit help text",
     "originalDefault": "Amount of days incomplete submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
   },
+  "fB1baI": {
+    "defaultMessage": "Het attribuut dat vergeleken wordt met de identificatiewaarde (bijv. BSN/KVK-nummer) van de ingelogde gebruiker om de eigenaar van het object dat bijgewerkt wordt te controleren. Dit is belangrijk om te voorkomen dat kwaadwillenden gegevens van anderen bijwerken in plaast van zichzelf.",
+    "description": "Objects API registration: authAttributePath helpText",
+    "originalDefault": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user to verify ownership of the object being updated. This is important to prevent malicious users modifying information of other people than themselves."
+  },
   "fLCWjk": {
     "defaultMessage": "Naam",
     "description": "Variable table name title",
@@ -2248,6 +2253,11 @@
     "defaultMessage": "Negeren",
     "description": "Session expiry warning \"do nothing\" button",
     "originalDefault": "Do nothing"
+  },
+  "g1i5ru": {
+    "defaultMessage": "Het attribuut dat vergeleken wordt met de identificatiewaarde (bijv. BSN/KVK-nummer) van de ingelogde gebruiker. Dit is belangrijk om te voorkomen dat kwaadwillenden gegevens van anderen kunnen opvragen.",
+    "description": "Objects API prefill: authAttributePath helpText",
+    "originalDefault": "The property that gets compared with the identifier (e.g. BSN/KVK) of the authenticated user. This is important to prevent malicious users looking up private information of other people."
   },
   "gAf9pR": {
     "defaultMessage": "(nog niet ingesteld)",
@@ -2574,11 +2584,6 @@
     "defaultMessage": "Objecttyperesource-URL in de Objecttypen-API. Wanneer dit ingesteld is, dan wordt een object van dit type aangemaakt en aan de zaak gerelateerd.",
     "description": "ZGW APIs registration options 'objecttype' help text",
     "originalDefault": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case."
-  },
-  "lu7yMK": {
-    "defaultMessage": "Bronpad van het autorisatiekenmerk (bijv. BSN/KVK)",
-    "description": "Objects API registration: authAttributePath label",
-    "originalDefault": "Path to auth attribute (e.g. BSN/KVK) in objects"
   },
   "m83ECr": {
     "defaultMessage": "Wanneer je de instellingen van een registratiepluginoptie overneemt, dan worden alle bestaande instellingen overschreven. Ben je zeker dat je door wil gaan?",


### PR DESCRIPTION
**Changes**

* Provide help text as prop to component instead of baking it in
* Tweak labels/help texts

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
