### PR TITLE
Load map tile layers fixture automatically

### DIFF
--- a/bin/generate_default_map_tile_layers_fixture.sh
+++ b/bin/generate_default_map_tile_layers_fixture.sh
@@ -8,4 +8,9 @@
 #
 # Run this script from the root of the repository
 
-src/manage.py dumpdata --indent=4 --natural-foreign --natural-primary config.MapTileLayer > src/openforms/fixtures/default_map_tile_layers.json
+src/manage.py dumpdata \
+    --indent=4 \
+    --natural-foreign \
+    --natural-primary \
+    config.MapTileLayer \
+    > src/openforms/fixtures/default_map_tile_layers.json

--- a/src/openforms/config/apps.py
+++ b/src/openforms/config/apps.py
@@ -1,6 +1,16 @@
+from io import StringIO
+
 from django.apps import AppConfig
+from django.core.management import call_command
+from django.db.models.signals import post_migrate
+from django.dispatch import receiver
 
 
 class OpenFormsConfigConfig(AppConfig):
     name = "openforms.config"
     verbose_name = "Configuration"
+
+
+@receiver(post_migrate, dispatch_uid="load_default_map_tile_layers")
+def update_map_tile_layers(sender, **kwargs):
+    call_command("loaddata", "default_map_tile_layers", verbosity=0, stdout=StringIO())

--- a/src/openforms/config/models/map.py
+++ b/src/openforms/config/models/map.py
@@ -1,5 +1,12 @@
+from __future__ import annotations
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+
+class MapTileLayerManager(models.Manager["MapTileLayer"]):
+    def get_by_natural_key(self, identifier: str) -> MapTileLayer:
+        return self.get(identifier=identifier)
 
 
 class MapTileLayer(models.Model):
@@ -27,6 +34,8 @@ class MapTileLayer(models.Model):
         ),
     )
 
+    objects = MapTileLayerManager()
+
     class Meta:
         verbose_name = _("map tile layer")
         verbose_name_plural = _("map tile layers")
@@ -34,3 +43,6 @@ class MapTileLayer(models.Model):
 
     def __str__(self):
         return self.label
+
+    def natural_key(self):
+        return (self.identifier,)

--- a/src/openforms/fixtures/default_map_tile_layers.json
+++ b/src/openforms/fixtures/default_map_tile_layers.json
@@ -1,7 +1,6 @@
 [
 {
     "model": "config.maptilelayer",
-    "pk": 1,
     "fields": {
         "identifier": "brt",
         "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png",
@@ -10,7 +9,6 @@
 },
 {
     "model": "config.maptilelayer",
-    "pk": 2,
     "fields": {
         "identifier": "luchtfoto",
         "url": "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0/Actueel_orthoHR/EPSG:28992/{z}/{x}/{y}.png",


### PR DESCRIPTION
Closes #4969 (partly)

**Changes**

* Map tile layers fixture is now loaded on migrate
* Fixture supports natural keys

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
