### PR TITLE
Fix accidental submission counter reset

### DIFF
--- a/src/openforms/js/components/admin/form_design/data/complete-form.js
+++ b/src/openforms/js/components/admin/form_design/data/complete-form.js
@@ -121,6 +121,8 @@ const saveForm = async (state, csrftoken) => {
     form: {uuid},
   } = state;
   const cleanedState = produce(state, draft => {
+    // ensure we don't overwrite the submission counter with a stale state
+    delete draft.form.submissionCounter;
     delete draft.form.registrationBackend; // deprecated
     delete draft.form.registrationBackendOptions; // deprecated
     normalizeLimit(draft, 'successfulSubmissionsRemovalLimit');

--- a/src/openforms/js/components/admin/form_design/data/complete-form.js
+++ b/src/openforms/js/components/admin/form_design/data/complete-form.js
@@ -123,8 +123,6 @@ const saveForm = async (state, csrftoken) => {
   const cleanedState = produce(state, draft => {
     // ensure we don't overwrite the submission counter with a stale state
     delete draft.form.submissionCounter;
-    delete draft.form.registrationBackend; // deprecated
-    delete draft.form.registrationBackendOptions; // deprecated
     normalizeLimit(draft, 'successfulSubmissionsRemovalLimit');
     normalizeLimit(draft, 'incompleteSubmissionsRemovalLimit');
     normalizeLimit(draft, 'erroredSubmissionsRemovalLimit');


### PR DESCRIPTION
Closes #4969 (partially)

**Changes**

Fixed backend call to avoid sending stale counter data.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
