### PR TITLE
:wastebasket: [#4978] Make v2 Objects API config the default

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.js
@@ -15,11 +15,20 @@ import {
 import LegacyConfigFields from './LegacyConfigFields';
 import V2ConfigFields from './V2ConfigFields';
 
+const VERSION_TO_INDEX_MAP = {
+  2: 0, // first tab
+  1: 1, // second tab
+};
+
+const INDEX_TO_VERSION_MAP = Object.fromEntries(
+  Object.entries(VERSION_TO_INDEX_MAP).map(([version, index]) => [index, parseInt(version, 10)])
+);
+
 const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
   const intl = useIntl();
   const {values, setValues} = useFormikContext();
   const validationErrors = useContext(ValidationErrorContext);
-  const {version = 1} = values;
+  const {version = 2} = values;
 
   const v1SwitchMessage = intl.formatMessage({
     defaultMessage: `Switching to the legacy registration options will remove the existing variables mapping.
@@ -48,7 +57,7 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
   } = useConfirm();
 
   const changeVersion = async tabIndex => {
-    const newVersion = tabIndex + 1;
+    const newVersion = INDEX_TO_VERSION_MAP[tabIndex];
 
     // change form fields values depending on the newly selected version
     const newValues = {...values, version: newVersion};
@@ -82,30 +91,30 @@ const ObjectsApiOptionsFormFields = ({name, apiGroupChoices}) => {
   const relevantErrors = filterErrors(name, validationErrors);
   return (
     <ValidationErrorsProvider errors={relevantErrors}>
-      <Tabs selectedIndex={version - 1} onSelect={changeVersion}>
+      <Tabs selectedIndex={VERSION_TO_INDEX_MAP[version]} onSelect={changeVersion}>
         <TabList>
-          <Tab>
-            <FormattedMessage
-              defaultMessage="Legacy"
-              description="Objects API registration backend options 'Legacy' tab label"
-            />
-          </Tab>
           <Tab>
             <FormattedMessage
               defaultMessage="Variables Mapping"
               description="Objects API registration backend options 'Variables Mapping' tab label"
             />
           </Tab>
+          <Tab>
+            <FormattedMessage
+              defaultMessage="Legacy"
+              description="Objects API registration backend options 'Legacy' tab label"
+            />
+          </Tab>
         </TabList>
-
-        {/* Legacy format, template based */}
-        <TabPanel>
-          <LegacyConfigFields apiGroupChoices={apiGroupChoices} />
-        </TabPanel>
 
         {/* Tight objecttypes integration */}
         <TabPanel>
           <V2ConfigFields apiGroupChoices={apiGroupChoices} />
+        </TabPanel>
+
+        {/* Legacy format, template based */}
+        <TabPanel>
+          <LegacyConfigFields apiGroupChoices={apiGroupChoices} />
         </TabPanel>
       </Tabs>
       <ConfirmationModalV1 {...confirmationModalV1Props} message={v1SwitchMessage} />

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -84,18 +84,8 @@ export const SwitchToV2Empty = {
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await step('Activate v2 tab', async () => {
-      const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
-      await userEvent.click(v2Tab);
-      // Close the confirmation modal
-      await userEvent.click(
-        within(await canvas.findByRole('dialog')).getByRole('button', {name: 'Accepteren'})
-      );
-      // Wait for v2Tab to be the selected tab
-      await waitFor(() => {
-        expect(v2Tab).toHaveAttribute('aria-selected', 'true');
-      });
-    });
+    const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
+    expect(v2Tab).toHaveAttribute('aria-selected', 'true');
 
     const groupSelect = canvas.getByLabelText('API-groep');
     await rsSelect(groupSelect, 'Objects API group 1');
@@ -132,43 +122,28 @@ export const SwitchToV2Existing = {
     const canvas = within(canvasElement);
 
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
-    await userEvent.click(v2Tab);
-
-    await waitFor(async () => {
-      // Close the confirmation modal
-      await userEvent.click(
-        within(await canvas.findByRole('dialog')).getByRole('button', {
-          name: 'Accepteren',
-        })
-      );
-
-      // Expect v2Tab to be the selected tab
-      expect(v2Tab).toHaveAttribute('aria-selected', 'true');
-    });
+    expect(v2Tab).toHaveAttribute('aria-selected', 'true');
 
     const testForm = await canvas.findByTestId('test-form');
 
-    await waitFor(() => {
-      expect(testForm).toHaveFormValues({
-        objectsApiGroup: '1',
-        objecttype: '2c77babf-a967-4057-9969-0200320d23f2',
-        objecttypeVersion: '1',
-      });
+    expect(await canvas.findByText('Person (open)')).toBeVisible();
+    expect(await canvas.findByText('1 (published)')).toBeVisible();
+    expect(testForm).toHaveFormValues({
+      objectsApiGroup: '1',
+      objecttype: '2c77babf-a967-4057-9969-0200320d23f2',
+      objecttypeVersion: '1',
     });
-    expect(canvas.getByText('Person (open)')).toBeVisible();
-    expect(canvas.getByText('1 (published)')).toBeVisible();
 
     const v1Tab = canvas.getByRole('tab', {name: 'Verouderd (sjabloon)'});
     await userEvent.click(v1Tab);
 
-    await waitFor(async () => {
-      // Close the confirmation modal
-      await userEvent.click(
-        within(await canvas.findByRole('dialog')).getByRole('button', {
-          name: 'Accepteren',
-        })
-      );
-
+    // Close the confirmation modal
+    await userEvent.click(
+      within(await canvas.findByRole('dialog')).getByRole('button', {
+        name: 'Accepteren',
+      })
+    );
+    await waitFor(() => {
       // Expect v1Tab to be the selected tab
       expect(v1Tab).toHaveAttribute('aria-selected', 'true');
     });
@@ -194,18 +169,8 @@ export const SwitchToV2NonExisting = {
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await step('Activate v2 tab', async () => {
-      const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
-      await userEvent.click(v2Tab);
-      // Close the confirmation modal
-      await userEvent.click(
-        within(await canvas.findByRole('dialog')).getByRole('button', {name: 'Accepteren'})
-      );
-      // Wait for v2Tab to be the selected tab
-      await waitFor(() => {
-        expect(v2Tab).toHaveAttribute('aria-selected', 'true');
-      });
-    });
+    const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
+    expect(v2Tab).toHaveAttribute('aria-selected', 'true');
 
     const testForm = await canvas.findByTestId('test-form');
     await waitFor(() => {
@@ -230,19 +195,7 @@ export const APIFetchError = {
     const canvas = within(canvasElement);
 
     const v2Tab = canvas.getByRole('tab', {name: 'Variabelekoppelingen'});
-    await userEvent.click(v2Tab);
-
-    await waitFor(async () => {
-      // Close the confirmation modal
-      await userEvent.click(
-        within(await canvas.findByRole('dialog')).getByRole('button', {
-          name: 'Accepteren',
-        })
-      );
-
-      // Expect v2Tab to be the selected tab
-      expect(v2Tab).toHaveAttribute('aria-selected', 'true');
-    });
+    expect(v2Tab).toHaveAttribute('aria-selected', 'true');
 
     await step('Retrieving object types', async () => {
       const groupSelect = canvas.getByLabelText('API-groep');

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -89,7 +89,7 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
             "The schema version of the objects API Options. Not to be confused with the objecttype version."
         ),
         choices=VersionChoices.choices,
-        default=1,
+        default=2,
     )
     objecttype = serializers.UUIDField(
         label=_("objecttype"),


### PR DESCRIPTION
This is the first step towards deprecating/removing the template based configuration. Users now see the v2 configuration as default/first configuration option.

Closes #4978 (partly)

**Changes**

* Swapped around the legacy/variable mappings tab
* Made the variables (v2) registration the default instead of legacy template based config.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
