### PR TITLE
:bug: [#4978] Fix accidental HTML escaping in summary PDF/confirmatio…

### DIFF
--- a/src/openforms/emails/tests/test_confirmation_email.py
+++ b/src/openforms/emails/tests/test_confirmation_email.py
@@ -227,9 +227,7 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
         self.assertTagWithTextIn("td", "Last name", rendered_content)
         self.assertTagWithTextIn("td", "Doe", rendered_content)
         self.assertTagWithTextIn("td", "File", rendered_content)
-        self.assertTagWithTextIn(
-            "td", _("attachment: %s") % "my-image.jpg", rendered_content
-        )
+        self.assertTagWithTextIn("td", "my-image.jpg", rendered_content)
 
     @patch(
         "openforms.emails.templatetags.appointments.get_plugin",

--- a/src/openforms/formio/formatters/formio.py
+++ b/src/openforms/formio/formatters/formio.py
@@ -81,10 +81,14 @@ class FileFormatter(FormatterBase):
             return value
 
     def process_result(self, component: Component, formatted: str) -> str:
-        # prefix joined filenames to match legacy
-        if formatted:
+        if not formatted:
+            return ""
+
+        # Make sure we don't mangle safe-strings!
+        if self.as_html:
+            return formatted
+        else:
             return _("attachment: %s") % formatted
-        return formatted
 
     def format(self, component: Component, value: dict) -> str:
         # this is only valid for display to the user (because filename component option, dedupe etc)


### PR DESCRIPTION
…n email

While the component/formatter properly takes care of conditional escaping by leveraging format_html and friends, the post-processor was converting the SafeString into a regular string again by doing string-interpolation for the file names, which leads to the full result being HTML escaped again.

In HTML mode, the prefix 'attachment' is now dropped, as the markup and context of the label/field should provide sufficient information and the 'attachment:' prefix looks odd in combination with the <ul> markup.

Closes #4978 (partially)

**Changes**

Fixed accidental double HTML escaping of file component markup.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
