### PR TITLE
Avoid empty variables being marked as geometry fields (objects API registration)

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiSummaryHandler.js
@@ -17,7 +17,7 @@ import {FormattedMessage} from 'react-intl';
 const ObjectsApiSummaryHandler = ({variable, backendOptions}) => {
   const geometryVariableKey = backendOptions.geometryVariableKey;
 
-  if (geometryVariableKey === variable.key) {
+  if (geometryVariableKey && geometryVariableKey === variable.key) {
     return (
       <FormattedMessage
         description="'Mapped to geometry' registration summary message"

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -51,7 +51,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
 
   if (version !== 2) throw new Error('Not supported, must be config version 2.');
 
-  const isGeometry = geometryVariableKey === variable.key;
+  const isGeometry = geometryVariableKey && geometryVariableKey === variable.key;
 
   // get the index of our variable in the mapping, if it exists
   let index = variablesMapping.findIndex(

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -284,6 +284,7 @@ export const WithObjectsAPIRegistrationBackends = {
               targetPath: ['other', 'path'],
             },
           ],
+          geometryVariableKey: '',
         },
       },
       {
@@ -301,6 +302,7 @@ export const WithObjectsAPIRegistrationBackends = {
               targetPath: ['path', 'to.the', 'target'],
             },
           ],
+          geometryVariableKey: '',
         },
       },
       {
@@ -372,6 +374,62 @@ export const WithObjectsAPIRegistrationBackends = {
     // With a single backend, the heading shouldn't display:
     const objectsApiTitle = canvas.queryByRole('heading', {name: 'Objects API registration'});
     expect(objectsApiTitle).toBeNull();
+  },
+};
+
+// gh-4978 regression for geometry field on empty variable
+export const EmptyUserDefinedVariableWithObjectsAPIRegistration = {
+  args: {
+    registrationBackends: [
+      {
+        backend: 'objects_api',
+        key: 'objects_api_1',
+        name: 'Example Objects API reg.',
+        options: {
+          version: 2,
+          objectsApiGroup: 1,
+          objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+          objecttypeVersion: 2,
+          variablesMapping: [
+            {
+              variableKey: 'formioComponent',
+              targetPath: ['path', 'to.the', 'target'],
+            },
+            {
+              variableKey: 'userDefined',
+              targetPath: ['other', 'path'],
+            },
+          ],
+          geometryVariableKey: '',
+        },
+      },
+    ],
+    variables: [
+      // add a variable as if the user clicked "add new user defined variable"
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: undefined,
+        name: '',
+        key: '',
+        source: 'user_defined',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataType: 'string',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: '',
+        prefillOptions: {},
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const userDefinedVarsTab = canvas.getByRole('tab', {name: 'Gebruikersvariabelen'});
+    await userEvent.click(userDefinedVarsTab);
+    expect(canvas.queryAllByText('record.geometry')).toHaveLength(0);
   },
 };
 


### PR DESCRIPTION
Closes #4978 (partially)

**Changes**

Variables with empty keys are not usable so these are now excluded from the `isGeometry` checks.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
