### PR TITLE
:sparkles: [#4993] Implement fetching select(boxes) options from Referentielijsten

### DIFF
--- a/docker/docker-compose.referentielijsten.yml
+++ b/docker/docker-compose.referentielijsten.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+name: referentielijsten
+
+services:
+  referentielijsten-redis:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes"]
+    networks:
+      - open-forms-dev
+
+  referentielijsten-db:
+    image: postgres:${PG_VERSION:-14}
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      - ./referentielijsten/docker-init-referentielijsten-db/:/docker-entrypoint-initdb.d
+      - referentielijsten-db:/var/lib/postgresql/data
+    networks:
+      - open-forms-dev
+
+  referentielijsten-web.local:
+    image: maykinmedia/referentielijsten-api:${REFERENTIELIJSTEN_VERSION:-0.2.0}
+    environment: &referentielijsten_web_env
+      - DJANGO_SETTINGS_MODULE=referentielijsten.conf.docker
+      - SECRET_KEY=${SECRET_KEY:-7&3f^bo1(-5($bre4iv-!nt%1xr!b54b&y7+97j5f&ndm_e=lz}
+      - ALLOWED_HOSTS=referentielijsten-web.local,localhost
+      - DB_NAME=referentielijsten
+      - DB_USER=referentielijsten
+      - DB_HOST=referentielijsten-db
+      - DISABLE_2FA=true
+      - IS_HTTPS=no
+      - CACHE_DEFAULT=referentielijsten-redis:6379/0
+      - CACHE_AXES=referentielijsten-redis:6379/0
+      - SUBPATH=${SUBPATH:-/}
+      - DJANGO_SUPERUSER_PASSWORD=admin
+    ports:
+      - 8004:8000
+    volumes: &referentielijsten_web_volumes
+      # mount fixtures dir to automatically populate the DB
+      - ./referentielijsten/fixtures/:/app/fixtures
+      - media:/app/media  # Shared media volume to get access to saved OAS files
+      - private-media:/app/private-media
+    depends_on:
+      - referentielijsten-db
+      - referentielijsten-redis
+    networks:
+      - open-forms-dev
+
+volumes:
+  referentielijsten-db:
+  media:
+  private-media:
+
+networks:
+  open-forms-dev:
+    name: open-forms-dev

--- a/docker/referentielijsten/README.md
+++ b/docker/referentielijsten/README.md
@@ -1,0 +1,41 @@
+# Referentielijsten API
+
+The `docker-compose.referentielijsten.yml` compose file is available to run an instance of Referentielijsten API.
+
+## docker compose
+
+Start an instance in your local environment from the parent directory:
+
+```bash
+docker compose -f docker-compose.referentielijsten.yml up -d
+```
+
+This brings up the admin at http://localhost:8004/admin/. You can log in with the `admin` / `admin`
+credentials.
+
+## Load fixtures
+
+The fixtures in `referentielijsten/fixtures` are automatically loaded when the Referentielijsten container starts.
+
+## Dump fixtures
+
+Whenever you make changes in the admin for the tests, you need to dump the fixtures again so that
+bringing up the containers the next time (or in other developers' environments) will still have the
+same data.
+
+Dump the fixtures with (in the `docker` directory):
+
+```bash
+docker compose -f docker-compose.referentielijsten.yml run referentielijsten-web.local \
+    python src/manage.py dumpdata \
+        --indent=4 \
+        --output /app/fixtures/referentielijsten_fixtures.json \
+        accounts \
+        api
+```
+
+Depending on your OS, you may need to grant extra write permissions:
+
+```bash
+chmod o+rwx ./referentielijsten/fixtures
+```

--- a/docker/referentielijsten/docker-init-referentielijsten-db/0001-docker-init-referentielijsten-db.sql
+++ b/docker/referentielijsten/docker-init-referentielijsten-db/0001-docker-init-referentielijsten-db.sql
@@ -1,0 +1,5 @@
+CREATE USER referentielijsten;
+CREATE DATABASE referentielijsten;
+GRANT ALL PRIVILEGES ON DATABASE referentielijsten TO referentielijsten;
+-- On Postgres 15+, connect to the database and grant schema permissions.
+-- GRANT USAGE, CREATE ON SCHEMA public TO referentielijsten;

--- a/docker/referentielijsten/fixtures/referentielijsten_fixtures.json
+++ b/docker/referentielijsten/fixtures/referentielijsten_fixtures.json
@@ -1,0 +1,57 @@
+[
+{
+    "model": "accounts.user",
+    "pk": 1,
+    "fields": {
+        "password": "pbkdf2_sha256$600000$DCgCQRA6R57PicaatiWGHU$S65r6Yedgkfv/exr8gFZogpyuCgortmrloq7+LBdnyY=",
+        "last_login": "2025-01-07T14:17:06.242Z",
+        "is_superuser": true,
+        "username": "admin",
+        "first_name": "",
+        "last_name": "",
+        "email": "",
+        "is_staff": true,
+        "is_active": true,
+        "date_joined": "2025-01-07T14:10:46.508Z",
+        "groups": [],
+        "user_permissions": []
+    }
+},
+{
+    "model": "api.tabel",
+    "pk": 1,
+    "fields": {
+        "code": "tabel1",
+        "naam": "Tabel1",
+        "einddatum_geldigheid": null,
+        "beheerder_naam": "John Doe",
+        "beheerder_email": "john@doe.nl",
+        "beheerder_afdeling": "",
+        "beheerder_organisatie": ""
+    }
+},
+{
+    "model": "api.item",
+    "pk": 1,
+    "fields": {
+        "tabel": 1,
+        "code": "option1",
+        "naam": "Option 1",
+        "begindatum_geldigheid": "2025-01-07T14:17:53Z",
+        "einddatum_geldigheid": null,
+        "aanvullende_gegevens": null
+    }
+},
+{
+    "model": "api.item",
+    "pk": 2,
+    "fields": {
+        "tabel": 1,
+        "code": "option2",
+        "naam": "Option 2",
+        "begindatum_geldigheid": "2025-01-07T14:17:59Z",
+        "einddatum_geldigheid": null,
+        "aanvullende_gegevens": null
+    }
+}
+]

--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -32,6 +32,7 @@ include = [
     # Interaction with the outside world
     "src/openforms/contrib/zgw/service.py",
     "src/openforms/contrib/objects_api/",
+    "src/openforms/contrib/referentielijsten/",
     # Emails
     "src/openforms/emails/templatetags/cosign_information.py",
     # Logging

--- a/src/openforms/contrib/referentielijsten/client.py
+++ b/src/openforms/contrib/referentielijsten/client.py
@@ -1,0 +1,35 @@
+from functools import partial
+from typing import Any, TypedDict
+
+from django.core.cache import cache
+
+from ape_pie import APIClient
+from zgw_consumers.service import pagination_helper
+
+REFERENTIELIJSTEN_LOOKUP_CACHE_TIMEOUT = 5 * 60
+
+
+class TabelItem(TypedDict):
+    code: str
+    naam: str
+    begindatumGeldigheid: str  # ISO 8601 datetime string
+    einddatumGeldigheid: str | None  # ISO 8601 datetime string
+    aanvullendeGegevens: Any
+
+
+class ReferentielijstenClient(APIClient):
+    def get_items_for_tabel(self, code: str) -> list[TabelItem]:
+        response = self.get("items", params={"tabel__code": code}, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        all_data = list(pagination_helper(self, data))
+        return all_data
+
+    def get_items_for_tabel_cached(self, code: str) -> list[TabelItem]:
+        result = cache.get_or_set(
+            key=f"referentielijsten|get_items_for_tabel|code:{code}",
+            default=partial(self.get_items_for_tabel, code),
+            timeout=REFERENTIELIJSTEN_LOOKUP_CACHE_TIMEOUT,
+        )
+        assert result is not None
+        return result

--- a/src/openforms/formio/dynamic_config/referentielijsten.py
+++ b/src/openforms/formio/dynamic_config/referentielijsten.py
@@ -1,0 +1,71 @@
+from django.utils.translation import gettext as _
+
+from glom import glom
+from requests.exceptions import RequestException
+from zgw_consumers.client import build_client
+from zgw_consumers.models import Service
+
+from openforms.contrib.referentielijsten.client import ReferentielijstenClient
+from openforms.logging import logevent
+from openforms.submissions.models import Submission
+
+from ..typing import Component
+
+
+def fetch_options_from_referentielijsten(
+    component: Component, submission: Submission
+) -> list[tuple[str, str]] | None:
+    service_slug = glom(component, "openForms.service", default=None)
+    code = glom(component, "openForms.code", default=None)
+    if not service_slug:
+        logevent.form_configuration_error(
+            submission.form,
+            component,
+            _(
+                "Cannot fetch from Referentielijsten API, because no `service` is configured."
+            ),
+        )
+        return
+
+    if not code:
+        logevent.form_configuration_error(
+            submission.form,
+            component,
+            _(
+                "Cannot fetch from Referentielijsten API, because no `code` is configured."
+            ),
+        )
+        return
+
+    try:
+        service = Service.objects.get(slug=service_slug)
+    except Service.DoesNotExist:
+        logevent.form_configuration_error(
+            submission.form,
+            component,
+            _(
+                "Cannot fetch from Referentielijsten API, service with {service_slug} does not exist."
+            ).format(service_slug=service_slug),
+        )
+        return
+
+    try:
+        with build_client(service, client_factory=ReferentielijstenClient) as client:
+            result = client.get_items_for_tabel_cached(code)
+    except RequestException as e:
+        logevent.referentielijsten_failure_response(
+            submission.form,
+            component,
+            _(
+                "Exception occurred while fetching from Referentielijsten API: {exception}."
+            ).format(exception=e),
+        )
+        return
+    else:
+        if not result:
+            logevent.referentielijsten_failure_response(
+                submission.form,
+                component,
+                _("No results found from Referentielijsten API."),
+            )
+        return [[item["code"], item["naam"]] for item in result]

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/RadioReferentielijstenOptionsTests/RadioReferentielijstenOptionsTests.test_items_not_found.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/RadioReferentielijstenOptionsTests/RadioReferentielijstenOptionsTests.test_items_not_found.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=non-existent
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'font-src ''self'' fonts.gstatic.com; script-src ''self'' ''unsafe-inline'';
+        base-uri ''self''; object-src ''none''; worker-src ''self'' blob:; style-src
+        ''self'' ''unsafe-inline'' fonts.googleapis.com; img-src ''self'' data: cdn.redoc.ly;
+        default-src ''self''; frame-src ''self''; frame-ancestors ''none''; form-action
+        ''self'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/RadioReferentielijstenOptionsTests/RadioReferentielijstenOptionsTests.test_success.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/RadioReferentielijstenOptionsTests/RadioReferentielijstenOptionsTests.test_success.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=tabel1
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"code":"option1","naam":"Option
+        1","begindatumGeldigheid":"2025-01-07T14:17:53Z","einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"option2","naam":"Option
+        2","begindatumGeldigheid":"2025-01-07T14:17:59Z","einddatumGeldigheid":null,"aanvullendeGegevens":null}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '325'
+      Content-Security-Policy:
+      - 'font-src ''self'' fonts.gstatic.com; script-src ''self'' ''unsafe-inline'';
+        base-uri ''self''; object-src ''none''; worker-src ''self'' blob:; style-src
+        ''self'' ''unsafe-inline'' fonts.googleapis.com; img-src ''self'' data: cdn.redoc.ly;
+        default-src ''self''; frame-src ''self''; frame-ancestors ''none''; form-action
+        ''self'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectReferentielijstenOptionsTests/SelectReferentielijstenOptionsTests.test_items_not_found.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectReferentielijstenOptionsTests/SelectReferentielijstenOptionsTests.test_items_not_found.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=non-existent
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; base-uri ''self'';
+        frame-src ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        default-src ''self''; script-src ''self'' ''unsafe-inline''; object-src ''none'';
+        form-action ''self''; worker-src ''self'' blob:; font-src ''self'' fonts.gstatic.com'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectReferentielijstenOptionsTests/SelectReferentielijstenOptionsTests.test_success.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectReferentielijstenOptionsTests/SelectReferentielijstenOptionsTests.test_success.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=tabel1
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"code":"option1","naam":"Option
+        1","begindatumGeldigheid":"2025-01-07T14:17:53Z","einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"option2","naam":"Option
+        2","begindatumGeldigheid":"2025-01-07T14:17:59Z","einddatumGeldigheid":null,"aanvullendeGegevens":null}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '325'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; base-uri ''self'';
+        frame-src ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        default-src ''self''; script-src ''self'' ''unsafe-inline''; object-src ''none'';
+        form-action ''self''; worker-src ''self'' blob:; font-src ''self'' fonts.gstatic.com'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectReferentielijstenOptionsTests/SelectReferentielijstenOptionsTests.test_table_with_paginated_items.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectReferentielijstenOptionsTests/SelectReferentielijstenOptionsTests.test_table_with_paginated_items.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=tabel-with-many-items
+  response:
+    body:
+      string: '{"count":101,"next":"http://localhost:8004/api/v1/items?page=2&tabel__code=tabel-with-many-items","previous":null,"results":[{"code":"0","naam":"0","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"1","naam":"1","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"2","naam":"2","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"3","naam":"3","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"4","naam":"4","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"5","naam":"5","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"6","naam":"6","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"7","naam":"7","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"8","naam":"8","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"9","naam":"9","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"10","naam":"10","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"11","naam":"11","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"12","naam":"12","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"13","naam":"13","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"14","naam":"14","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"15","naam":"15","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"16","naam":"16","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"17","naam":"17","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"18","naam":"18","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"19","naam":"19","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"20","naam":"20","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"21","naam":"21","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"22","naam":"22","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"23","naam":"23","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"24","naam":"24","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"25","naam":"25","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"26","naam":"26","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"27","naam":"27","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"28","naam":"28","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"29","naam":"29","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"30","naam":"30","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"31","naam":"31","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"32","naam":"32","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"33","naam":"33","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"34","naam":"34","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"35","naam":"35","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"36","naam":"36","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"37","naam":"37","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"38","naam":"38","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"39","naam":"39","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"40","naam":"40","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"41","naam":"41","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"42","naam":"42","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"43","naam":"43","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"44","naam":"44","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"45","naam":"45","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"46","naam":"46","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"47","naam":"47","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"48","naam":"48","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"49","naam":"49","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"50","naam":"50","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"51","naam":"51","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"52","naam":"52","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"53","naam":"53","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"54","naam":"54","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"55","naam":"55","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"56","naam":"56","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"57","naam":"57","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"58","naam":"58","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"59","naam":"59","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"60","naam":"60","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"61","naam":"61","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"62","naam":"62","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"63","naam":"63","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"64","naam":"64","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"65","naam":"65","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"66","naam":"66","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"67","naam":"67","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"68","naam":"68","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"69","naam":"69","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"70","naam":"70","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"71","naam":"71","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"72","naam":"72","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"73","naam":"73","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"74","naam":"74","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"75","naam":"75","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"76","naam":"76","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"77","naam":"77","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"78","naam":"78","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"79","naam":"79","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"80","naam":"80","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"81","naam":"81","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"82","naam":"82","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"83","naam":"83","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"84","naam":"84","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"85","naam":"85","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"86","naam":"86","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"87","naam":"87","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"88","naam":"88","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"89","naam":"89","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"90","naam":"90","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"91","naam":"91","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"92","naam":"92","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"93","naam":"93","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"94","naam":"94","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"95","naam":"95","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"96","naam":"96","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"97","naam":"97","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"98","naam":"98","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"99","naam":"99","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '10906'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; base-uri ''self'';
+        frame-src ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        default-src ''self''; script-src ''self'' ''unsafe-inline''; object-src ''none'';
+        form-action ''self''; worker-src ''self'' blob:; font-src ''self'' fonts.gstatic.com'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?page=2&tabel__code=tabel-with-many-items
+  response:
+    body:
+      string: '{"count":101,"next":null,"previous":"http://localhost:8004/api/v1/items?tabel__code=tabel-with-many-items","results":[{"code":"100","naam":"100","begindatumGeldigheid":null,"einddatumGeldigheid":null,"aanvullendeGegevens":null}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '229'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; base-uri ''self'';
+        frame-src ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        default-src ''self''; script-src ''self'' ''unsafe-inline''; object-src ''none'';
+        form-action ''self''; worker-src ''self'' blob:; font-src ''self'' fonts.gstatic.com'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectboxesReferentielijstenOptionsTests/SelectboxesReferentielijstenOptionsTests.test_items_not_found.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectboxesReferentielijstenOptionsTests/SelectboxesReferentielijstenOptionsTests.test_items_not_found.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=non-existent
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; base-uri ''self'';
+        frame-src ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        default-src ''self''; script-src ''self'' ''unsafe-inline''; object-src ''none'';
+        form-action ''self''; worker-src ''self'' blob:; font-src ''self'' fonts.gstatic.com'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectboxesReferentielijstenOptionsTests/SelectboxesReferentielijstenOptionsTests.test_success.yaml
+++ b/src/openforms/formio/dynamic_config/tests/files/vcr_cassettes/SelectboxesReferentielijstenOptionsTests/SelectboxesReferentielijstenOptionsTests.test_success.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.2
+    method: GET
+    uri: http://localhost:8004/api/v1/items?tabel__code=tabel1
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"code":"option1","naam":"Option
+        1","begindatumGeldigheid":"2025-01-07T14:17:53Z","einddatumGeldigheid":null,"aanvullendeGegevens":null},{"code":"option2","naam":"Option
+        2","begindatumGeldigheid":"2025-01-07T14:17:59Z","einddatumGeldigheid":null,"aanvullendeGegevens":null}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '325'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; base-uri ''self'';
+        frame-src ''self''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com;
+        default-src ''self''; script-src ''self'' ''unsafe-inline''; object-src ''none'';
+        form-action ''self''; worker-src ''self'' blob:; font-src ''self'' fonts.gstatic.com'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/formio/dynamic_config/tests/test_referentielijsten_config.py
+++ b/src/openforms/formio/dynamic_config/tests/test_referentielijsten_config.py
@@ -1,0 +1,711 @@
+from pathlib import Path
+
+from django.test import TestCase, tag
+from django.utils.translation import gettext as _
+
+import requests_mock
+from requests import RequestException
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+from zgw_consumers.constants import AuthTypes
+from zgw_consumers.test.factories import ServiceFactory
+
+from openforms.api.exceptions import ServiceUnavailable
+from openforms.formio.registry import register
+from openforms.formio.typing import (
+    RadioComponent,
+    SelectBoxesComponent,
+    SelectComponent,
+)
+from openforms.forms.tests.factories import FormFactory
+from openforms.logging.models import TimelineLogProxy
+from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.submissions.tests.mixins import SubmissionsMixin
+from openforms.utils.tests.cache import clear_caches
+from openforms.utils.tests.vcr import OFVCRMixin
+
+TESTS_DIR = Path(__file__).parent.resolve()
+TEST_FILES = TESTS_DIR / "files"
+
+
+@tag("gh-4993")
+class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
+    VCR_TEST_FILES = TEST_FILES
+
+    def setUp(self):
+        super().setUp()
+
+        # The requests to Referentielijsten are cached, we need to make sure
+        # that the cache is reset between tests to correctly test different scenarios
+        self.addCleanup(clear_caches)
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.service = ServiceFactory.create(
+            api_root="http://localhost:8004/api/v1/",
+            slug="referentielijsten",
+            auth_type=AuthTypes.no_auth,
+        )
+        cls.submission = SubmissionFactory.create()
+
+    def test_success(self):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(
+            component["data"].get("values"),
+            [
+                {"label": "Option 1", "value": "option1"},
+                {"label": "Option 2", "value": "option2"},
+            ],
+        )
+
+    def test_table_with_paginated_items(self):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel-with-many-items",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(
+            component["data"].get("values"),
+            [{"label": str(i), "value": str(i)} for i in range(101)],
+        )
+
+    def test_no_service_configured(self):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": "",
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertNotIn("values", component["data"])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, because no `service` is configured."
+            ),
+        )
+
+    def test_no_code_configured(self):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertNotIn("values", component["data"])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, because no `code` is configured."
+            ),
+        )
+
+    def test_service_does_not_exist(self):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        self.service.delete()
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertNotIn("values", component["data"])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, service with {service_slug} does not exist."
+            ).format(service_slug=self.service.slug),
+        )
+
+    def test_items_not_found(self):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "non-existent",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertNotIn("values", component["data"])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(
+            log.template, "logging/events/referentielijsten_failure_response.txt"
+        )
+        self.assertEqual(
+            log.extra_data["error"],
+            _("No results found from Referentielijsten API."),
+        )
+
+    @requests_mock.Mocker()
+    def test_request_exception(self, m):
+        component: SelectComponent = {
+            "key": "select",
+            "type": "select",
+            "label": "Select",
+            "data": {},
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        m.get(
+            f"{self.service.api_root}items?tabel__code=tabel1",
+            exc=RequestException("something went wrong"),
+        )
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertNotIn("values", component["data"])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(
+            log.template, "logging/events/referentielijsten_failure_response.txt"
+        )
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Exception occurred while fetching from Referentielijsten API: something went wrong."
+            ),
+        )
+
+
+@tag("gh-4993")
+class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
+    VCR_TEST_FILES = TEST_FILES
+
+    def setUp(self):
+        super().setUp()
+
+        # The requests to Referentielijsten are cached, we need to make sure
+        # that the cache is reset between tests to correctly test different scenarios
+        self.addCleanup(clear_caches)
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.service = ServiceFactory.create(
+            api_root="http://localhost:8004/api/v1/",
+            slug="referentielijsten",
+            auth_type=AuthTypes.no_auth,
+        )
+        cls.submission = SubmissionFactory.create()
+
+    def test_success(self):
+        component: SelectBoxesComponent = {
+            "key": "selectboxes",
+            "type": "selectboxes",
+            "label": "Selectboxes",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(
+            component["values"],
+            [
+                {"label": "Option 1", "value": "option1"},
+                {"label": "Option 2", "value": "option2"},
+            ],
+        )
+
+    def test_no_service_configured(self):
+        component: SelectBoxesComponent = {
+            "key": "selectboxes",
+            "type": "selectboxes",
+            "label": "Selectboxes",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": "",
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, because no `service` is configured."
+            ),
+        )
+
+    def test_no_code_configured(self):
+        component: SelectBoxesComponent = {
+            "key": "selectboxes",
+            "type": "selectboxes",
+            "label": "Selectboxes",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, because no `code` is configured."
+            ),
+        )
+
+    def test_service_does_not_exist(self):
+        component: SelectBoxesComponent = {
+            "key": "selectboxes",
+            "type": "selectboxes",
+            "label": "Selectboxes",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        self.service.delete()
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, service with {service_slug} does not exist."
+            ).format(service_slug=self.service.slug),
+        )
+
+    def test_items_not_found(self):
+        component: SelectBoxesComponent = {
+            "key": "selectboxes",
+            "type": "selectboxes",
+            "label": "Selectboxes",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "non-existent",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(
+            log.template, "logging/events/referentielijsten_failure_response.txt"
+        )
+        self.assertEqual(
+            log.extra_data["error"],
+            _("No results found from Referentielijsten API."),
+        )
+
+    @requests_mock.Mocker()
+    def test_request_exception(self, m):
+        component: SelectBoxesComponent = {
+            "key": "selectboxes",
+            "type": "selectboxes",
+            "label": "Selectboxes",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        m.get(
+            f"{self.service.api_root}items?tabel__code=tabel1",
+            exc=RequestException("something went wrong"),
+        )
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(
+            log.template, "logging/events/referentielijsten_failure_response.txt"
+        )
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Exception occurred while fetching from Referentielijsten API: something went wrong."
+            ),
+        )
+
+
+@tag("gh-4993")
+class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
+    VCR_TEST_FILES = TEST_FILES
+
+    def setUp(self):
+        super().setUp()
+
+        # The requests to Referentielijsten are cached, we need to make sure
+        # that the cache is reset between tests to correctly test different scenarios
+        self.addCleanup(clear_caches)
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.service = ServiceFactory.create(
+            api_root="http://localhost:8004/api/v1/",
+            slug="referentielijsten",
+            auth_type=AuthTypes.no_auth,
+        )
+        cls.submission = SubmissionFactory.create()
+
+    def test_success(self):
+        component: RadioComponent = {
+            "key": "radio",
+            "type": "radio",
+            "label": "Radio",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(
+            component["values"],
+            [
+                {"label": "Option 1", "value": "option1"},
+                {"label": "Option 2", "value": "option2"},
+            ],
+        )
+
+    def test_no_service_configured(self):
+        component: RadioComponent = {
+            "key": "radio",
+            "type": "radio",
+            "label": "Radio",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": "",
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, because no `service` is configured."
+            ),
+        )
+
+    def test_no_code_configured(self):
+        component: RadioComponent = {
+            "key": "radio",
+            "type": "radio",
+            "label": "Radio",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, because no `code` is configured."
+            ),
+        )
+
+    def test_service_does_not_exist(self):
+        component: RadioComponent = {
+            "key": "radio",
+            "type": "radio",
+            "label": "Radio",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        self.service.delete()
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(log.template, "logging/events/form_configuration_error.txt")
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Cannot fetch from Referentielijsten API, service with {service_slug} does not exist."
+            ).format(service_slug=self.service.slug),
+        )
+
+    def test_items_not_found(self):
+        component: RadioComponent = {
+            "key": "radio",
+            "type": "radio",
+            "label": "Radio",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "non-existent",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(
+            log.template, "logging/events/referentielijsten_failure_response.txt"
+        )
+        self.assertEqual(
+            log.extra_data["error"],
+            _("No results found from Referentielijsten API."),
+        )
+
+    @requests_mock.Mocker()
+    def test_request_exception(self, m):
+        component: RadioComponent = {
+            "key": "radio",
+            "type": "radio",
+            "label": "Radio",
+            "values": [],
+            "dataType": "string",
+            "openForms": {
+                "code": "tabel1",
+                "dataSrc": "referentielijsten",
+                "service": self.service.slug,
+                "translations": {},
+            },
+        }
+
+        m.get(
+            f"{self.service.api_root}items?tabel__code=tabel1",
+            exc=RequestException("something went wrong"),
+        )
+
+        with self.assertRaises(ServiceUnavailable):
+            register.update_config(component, submission=self.submission, data={})
+
+        self.assertEqual(component["values"], [])
+        log = TimelineLogProxy.objects.for_object(self.submission.form).get()
+        assert log.extra_data
+        self.assertEqual(
+            log.template, "logging/events/referentielijsten_failure_response.txt"
+        )
+        self.assertEqual(
+            log.extra_data["error"],
+            _(
+                "Exception occurred while fetching from Referentielijsten API: something went wrong."
+            ),
+        )
+
+
+@tag("gh-4993")
+class SubmissionStepDetailTest(SubmissionsMixin, APITestCase):
+    def test_get_submissionstep_detail_raises_error_for_referentielijsten_if_service_is_incorrect(
+        self,
+    ):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "selectboxes",
+                        "type": "selectboxes",
+                        "label": "Selectboxes",
+                        "values": [{"label": "", "value": ""}],
+                        "dataType": "string",
+                        "openForms": {
+                            "code": "tabel1",
+                            "dataSrc": "referentielijsten",
+                            "service": "non-existent",
+                            "translations": {},
+                        },
+                        "id": "ew0bwv7",
+                    }
+                ]
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form.formstep_set.get().uuid,
+            },
+        )
+        self._add_submission_to_session(submission)
+
+        response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        # the detail message should be passed for errors that occur when fetching referentielijsten
+        self.assertEqual(
+            response.json()["detail"],
+            _("Could not retrieve options from Referentielijsten API."),
+        )

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -44,6 +44,9 @@ class OpenFormsConfig(TypedDict):
     translations: NotRequired[TranslationsDict]
     components: NotRequired[AddressValidationComponents]
     requireVerification: NotRequired[bool]
+    dataSrc: NotRequired[Literal["manual", "variable", "referentielijsten"]]
+    code: NotRequired[str]
+    service: NotRequired[str]
 
 
 class OpenFormsOptionExtension(TypedDict):

--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -626,6 +626,19 @@ def stuf_bg_response(service: StufService, url):
 # - - -
 
 
+def referentielijsten_failure_response(
+    form: Form, component: JSONObject, error_message: str
+):
+    _create_log(
+        form,
+        "referentielijsten_failure_response",
+        extra_data={"component": component, "error": error_message},
+    )
+
+
+# - - -
+
+
 def hijack_started(hijacker, hijacked):
     _create_log(
         hijacked,

--- a/src/openforms/logging/templates/logging/events/referentielijsten_failure_response.txt
+++ b/src/openforms/logging/templates/logging/events/referentielijsten_failure_response.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktrans trimmed with lead=log.fmt_lead url=log.fmt_url %}
+   {{ lead }}: Failed to fetch items from Referentielijsten API: {{ error }}
+{% endblocktrans %}


### PR DESCRIPTION
Closes #4993

**Changes**

* Implement fetching select(boxes) options from Referentielijsten
* Add docker-compose file and fixtures for Referentielijsten

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
