### PR TITLE
[#4825] Fix prefill when authentication is needed

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -9541,11 +9541,12 @@ components:
           type: string
           description: The human-readable name for a plugin.
         requiresAuth:
-          type: string
-          nullable: true
-          title: Required authentication attribute
-          description: The authentication attribute required for this plugin to lookup
-            remote data.
+          type: array
+          items:
+            type: string
+            title: Required authentication attribute
+            description: The authentication attribute required for this plugin to
+              lookup remote data.
         configurationContext:
           nullable: true
           title: Extra configuration context

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2649,6 +2649,28 @@
       "value": "Component"
     }
   ],
+  "MIrPon": [
+    {
+      "type": 0,
+      "value": "Component \""
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": "\" uses a prefill that requires one of the \""
+    },
+    {
+      "type": 1,
+      "value": "requiredAuthAttribute"
+    },
+    {
+      "type": 0,
+      "value": "\" attributes. Please select one or more authentication plugins that provide such an attribute."
+    }
+  ],
   "MTdKuN": [
     {
       "type": 0,
@@ -3527,28 +3549,6 @@
     {
       "type": 0,
       "value": "Maximum selected checkboxes (e.g. 1)"
-    }
-  ],
-  "VQYmOD": [
-    {
-      "type": 0,
-      "value": "Component \""
-    },
-    {
-      "type": 1,
-      "value": "label"
-    },
-    {
-      "type": 0,
-      "value": "\" uses a prefill that requires the \""
-    },
-    {
-      "type": 1,
-      "value": "requiredAuthAttribute"
-    },
-    {
-      "type": 0,
-      "value": "\" attribute. Please select an authentication plugin that provides this attribute."
     }
   ],
   "VUOOSy": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2666,6 +2666,28 @@
       "value": "Veld"
     }
   ],
+  "MIrPon": [
+    {
+      "type": 0,
+      "value": "Component \""
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": "\" uses a prefill that requires one of the \""
+    },
+    {
+      "type": 1,
+      "value": "requiredAuthAttribute"
+    },
+    {
+      "type": 0,
+      "value": "\" attributes. Please select one or more authentication plugins that provide such an attribute."
+    }
+  ],
   "MTdKuN": [
     {
       "type": 0,
@@ -3540,28 +3562,6 @@
     {
       "type": 0,
       "value": "Maximaal aantal aangevinkte opties (bijv. 1)"
-    }
-  ],
-  "VQYmOD": [
-    {
-      "type": 0,
-      "value": "De component \""
-    },
-    {
-      "type": 1,
-      "value": "label"
-    },
-    {
-      "type": 0,
-      "value": "\" gebruikt een prefill die het \""
-    },
-    {
-      "type": 1,
-      "value": "requiredAuthAttribute"
-    },
-    {
-      "type": 0,
-      "value": "\"-attribuut nodig heeft. Gebruik een authenticatiemethode die dit attribuut aanbiedt."
     }
   ],
   "VUOOSy": [

--- a/src/openforms/js/components/admin/form_design/PluginWarning.js
+++ b/src/openforms/js/components/admin/form_design/PluginWarning.js
@@ -35,7 +35,7 @@ const PluginWarning = ({loginRequired, configuration}) => {
       const authPlugin = availableAuthPlugins.find(plugin => plugin.id === pluginName);
       if (!authPlugin) break;
 
-      if (authPlugin.providesAuth.includes(requiredAuthAttribute)) {
+      if (requiredAuthAttribute.includes(authPlugin.providesAuth)) {
         pluginProvidesAttribute = true;
         break;
       }
@@ -46,12 +46,12 @@ const PluginWarning = ({loginRequired, configuration}) => {
         <FormattedMessage
           description="Prefill plugin requires unavailable auth attribute warning"
           defaultMessage={
-            'Component "{label}" uses a prefill that requires the "{requiredAuthAttribute}" attribute. \
-                        Please select an authentication plugin that provides this attribute.'
+            'Component "{label}" uses a prefill that requires one of the "{requiredAuthAttribute}" attributes. \
+            Please select one or more authentication plugins that provide such an attribute.'
           }
           values={{
             label: configuration.label,
-            requiredAuthAttribute,
+            requiredAuthAttribute: requiredAuthAttribute.join(', '),
           }}
         />
       );

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1279,6 +1279,11 @@
     "description": "Formio component selection label",
     "originalDefault": "Component"
   },
+  "MIrPon": {
+    "defaultMessage": "Component \"{label}\" uses a prefill that requires one of the \"{requiredAuthAttribute}\" attributes. Please select one or more authentication plugins that provide such an attribute.",
+    "description": "Prefill plugin requires unavailable auth attribute warning",
+    "originalDefault": "Component \"{label}\" uses a prefill that requires one of the \"{requiredAuthAttribute}\" attributes. Please select one or more authentication plugins that provide such an attribute."
+  },
   "MUfBmP": {
     "defaultMessage": "The value of the selected field will be the process variable value.",
     "description": "Column help text for variable to map to property",
@@ -1693,11 +1698,6 @@
     "defaultMessage": "Page content",
     "description": "Confirmation page content label",
     "originalDefault": "Page content"
-  },
-  "VQYmOD": {
-    "defaultMessage": "Component \"{label}\" uses a prefill that requires the \"{requiredAuthAttribute}\" attribute. Please select an authentication plugin that provides this attribute.",
-    "description": "Prefill plugin requires unavailable auth attribute warning",
-    "originalDefault": "Component \"{label}\" uses a prefill that requires the \"{requiredAuthAttribute}\" attribute. Please select an authentication plugin that provides this attribute."
   },
   "VUOOSy": {
     "defaultMessage": "Name",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1288,6 +1288,11 @@
     "description": "Formio component selection label",
     "originalDefault": "Component"
   },
+  "MIrPon": {
+    "defaultMessage": "Component \"{label}\" uses a prefill that requires one of the \"{requiredAuthAttribute}\" attributes. Please select one or more authentication plugins that provide such an attribute.",
+    "description": "Prefill plugin requires unavailable auth attribute warning",
+    "originalDefault": "Component \"{label}\" uses a prefill that requires one of the \"{requiredAuthAttribute}\" attributes. Please select one or more authentication plugins that provide such an attribute."
+  },
   "MUfBmP": {
     "defaultMessage": "De waarde van de geselecteerde variabele wordt de waarde van de zaakeigenschap.",
     "description": "Column help text for variable to map to property",
@@ -1709,11 +1714,6 @@
     "defaultMessage": "Inhoud",
     "description": "Confirmation page content label",
     "originalDefault": "Page content"
-  },
-  "VQYmOD": {
-    "defaultMessage": "De component \"{label}\" gebruikt een prefill die het \"{requiredAuthAttribute}\"-attribuut nodig heeft. Gebruik een authenticatiemethode die dit attribuut aanbiedt.",
-    "description": "Prefill plugin requires unavailable auth attribute warning",
-    "originalDefault": "Component \"{label}\" uses a prefill that requires the \"{requiredAuthAttribute}\" attribute. Please select an authentication plugin that provides this attribute."
   },
   "VUOOSy": {
     "defaultMessage": "Naam",

--- a/src/openforms/prefill/api/serializers.py
+++ b/src/openforms/prefill/api/serializers.py
@@ -12,12 +12,13 @@ from openforms.plugins.api.serializers import PluginBaseSerializer
 
 
 class PrefillPluginSerializer(PluginBaseSerializer):
-    requires_auth = serializers.CharField(
-        label=_("Required authentication attribute"),
-        help_text=_(
-            "The authentication attribute required for this plugin to lookup remote data."
+    requires_auth = serializers.ListField(
+        child=serializers.CharField(
+            label=_("Required authentication attribute"),
+            help_text=_(
+                "The authentication attribute required for this plugin to lookup remote data."
+            ),
         ),
-        allow_null=True,
     )
     configuration_context = serializers.JSONField(
         label=_("Extra configuration context"),

--- a/src/openforms/prefill/api/tests/test_endpoints.py
+++ b/src/openforms/prefill/api/tests/test_endpoints.py
@@ -12,7 +12,7 @@ from ...registry import Registry
 
 
 class TestPrefill(BasePlugin):
-    requires_auth = AuthAttribute.bsn
+    requires_auth = (AuthAttribute.bsn,)
     verbose_name = "Test"
 
     def get_available_attributes(self):
@@ -26,7 +26,7 @@ register("test")(TestPrefill)
 
 @register("onlyvars")
 class OnlyVarsPrefill(BasePlugin):
-    requires_auth = AuthAttribute.bsn
+    requires_auth = (AuthAttribute.bsn,)
     verbose_name = "Only Vars"
     for_components = ()
 
@@ -36,7 +36,7 @@ class OnlyVarsPrefill(BasePlugin):
 
 @register("vanityplates")
 class VanityPlatePrefill(BasePlugin):
-    requires_auth = AuthAttribute.bsn
+    requires_auth = (AuthAttribute.bsn,)
     verbose_name = "Vanity Plates"
     for_components = {"licenseplate"}
 
@@ -111,19 +111,19 @@ class ResponseTests(APITestCase):
             {
                 "id": "test",
                 "label": "Test",
-                "requiresAuth": AuthAttribute.bsn,
+                "requiresAuth": [AuthAttribute.bsn],
                 "configurationContext": None,
             },
             {
                 "id": "onlyvars",
                 "label": "Only Vars",
-                "requiresAuth": AuthAttribute.bsn,
+                "requiresAuth": [AuthAttribute.bsn],
                 "configurationContext": None,
             },
             {
                 "id": "vanityplates",
                 "label": "Vanity Plates",
-                "requiresAuth": AuthAttribute.bsn,
+                "requiresAuth": [AuthAttribute.bsn],
                 "configurationContext": None,
             },
         ]
@@ -141,14 +141,14 @@ class ResponseTests(APITestCase):
             {
                 "id": "test",
                 "label": "Test",
-                "requiresAuth": AuthAttribute.bsn,
+                "requiresAuth": [AuthAttribute.bsn],
                 "configurationContext": None,
             },
             # spec'd for licenseplate
             {
                 "id": "vanityplates",
                 "label": "Vanity Plates",
-                "requiresAuth": AuthAttribute.bsn,
+                "requiresAuth": [AuthAttribute.bsn],
                 "configurationContext": None,
             },
         ]

--- a/src/openforms/prefill/base.py
+++ b/src/openforms/prefill/base.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any, Container, Iterable, TypedDict
 
 from rest_framework import serializers
@@ -29,7 +30,7 @@ SerializerCls = type[serializers.Serializer]
 
 
 class BasePlugin[OptionsT: Options](AbstractBasePlugin):
-    requires_auth: AuthAttribute | None = None
+    requires_auth: Collection[AuthAttribute] = ()
     for_components: Container[str] = AllComponentTypes()
     options: SerializerCls = EmptyOptions
 
@@ -139,7 +140,8 @@ class BasePlugin[OptionsT: Options](AbstractBasePlugin):
 
         if (
             identifier_role == IdentifierRoles.main
-            and submission.auth_info.attribute == cls.requires_auth
+            and cls.requires_auth
+            and submission.auth_info.attribute in cls.requires_auth
         ):
             return submission.auth_info.value
 

--- a/src/openforms/prefill/contrib/haalcentraal_brp/plugin.py
+++ b/src/openforms/prefill/contrib/haalcentraal_brp/plugin.py
@@ -45,7 +45,7 @@ def get_attributes_cls():
 @register(PLUGIN_IDENTIFIER)
 class HaalCentraalPrefill(BasePlugin):
     verbose_name = _("Haal Centraal: BRP Personen Bevragen")
-    requires_auth = AuthAttribute.bsn
+    requires_auth = (AuthAttribute.bsn,)
 
     @staticmethod
     def get_available_attributes() -> list[tuple[str, str]]:
@@ -84,7 +84,8 @@ class HaalCentraalPrefill(BasePlugin):
 
         if (
             identifier_role == IdentifierRoles.main
-            and submission.auth_info.attribute == cls.requires_auth
+            and cls.requires_auth
+            and submission.auth_info.attribute in cls.requires_auth
         ):
             return submission.auth_info.value
 

--- a/src/openforms/prefill/contrib/haalcentraal_brp/tests/test_co_sign.py
+++ b/src/openforms/prefill/contrib/haalcentraal_brp/tests/test_co_sign.py
@@ -71,7 +71,7 @@ class CoSignPrefillTests:
             }
         )
 
-        add_co_sign_representation(submission, plugin.requires_auth)
+        add_co_sign_representation(submission, plugin.requires_auth[0])
 
         submission.refresh_from_db()
         expected = {
@@ -96,7 +96,7 @@ class CoSignPrefillTests:
             }
         )
 
-        add_co_sign_representation(submission, plugin.requires_auth)
+        add_co_sign_representation(submission, plugin.requires_auth[0])
 
         submission.refresh_from_db()
         expected = {
@@ -178,7 +178,7 @@ class CoSignPrefillEmptyConfigTests(TestCase):
             }
         )
 
-        add_co_sign_representation(submission, plugin.requires_auth)
+        add_co_sign_representation(submission, plugin.requires_auth[0])
 
         submission.refresh_from_db()
         expected = {

--- a/src/openforms/prefill/contrib/kvk/plugin.py
+++ b/src/openforms/prefill/contrib/kvk/plugin.py
@@ -35,7 +35,7 @@ def _select_address(items, type_):
 class KVK_KVKNumberPrefill(BasePlugin):
     verbose_name = _("KvK Company by KvK number")
 
-    requires_auth = AuthAttribute.kvk
+    requires_auth = (AuthAttribute.kvk,)
 
     @staticmethod
     def get_available_attributes() -> list[tuple[str, str]]:
@@ -50,7 +50,8 @@ class KVK_KVKNumberPrefill(BasePlugin):
 
         if (
             identifier_role == IdentifierRoles.main
-            and submission.auth_info.attribute == cls.requires_auth
+            and cls.requires_auth
+            and submission.auth_info.attribute in cls.requires_auth
         ):
             return submission.auth_info.value
 

--- a/src/openforms/prefill/contrib/stufbg/plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/plugin.py
@@ -95,7 +95,7 @@ ATTRIBUTES_TO_STUF_BG_MAPPING = {
 @register("stufbg")
 class StufBgPrefill(BasePlugin):
     verbose_name = _("StUF-BG")
-    requires_auth = AuthAttribute.bsn
+    requires_auth = (AuthAttribute.bsn,)
 
     @staticmethod
     def get_available_attributes() -> list[tuple[str, str]]:
@@ -138,7 +138,8 @@ class StufBgPrefill(BasePlugin):
 
         if (
             identifier_role == IdentifierRoles.main
-            and submission.auth_info.attribute == cls.requires_auth
+            and cls.requires_auth
+            and submission.auth_info.attribute in cls.requires_auth
         ):
             return submission.auth_info.value
 

--- a/src/openforms/prefill/contrib/stufbg/tests/test_co_sign.py
+++ b/src/openforms/prefill/contrib/stufbg/tests/test_co_sign.py
@@ -49,8 +49,7 @@ class CoSignPrefillTests(TestCase):
                 "fields": {},
             }
         )
-
-        add_co_sign_representation(submission, plugin.requires_auth)
+        add_co_sign_representation(submission, plugin.requires_auth[0])
 
         submission.refresh_from_db()
         self.assertEqual(

--- a/src/openforms/prefill/contrib/suwinet/plugin.py
+++ b/src/openforms/prefill/contrib/suwinet/plugin.py
@@ -28,7 +28,7 @@ def _get_client() -> SuwinetClient | None:
 
 @register("suwinet")
 class SuwinetPrefill(BasePlugin):
-    requires_auth = AuthAttribute.bsn
+    requires_auth = (AuthAttribute.bsn,)
     verbose_name = _("Suwinet")
     for_components = ()
 

--- a/src/openforms/prefill/fields.py
+++ b/src/openforms/prefill/fields.py
@@ -35,7 +35,7 @@ class PrefillPluginChoiceField(CharField):
     def _get_plugin_choices(self):
         choices = []
         for plugin in register.iter_enabled_plugins():
-            if plugin.requires_auth != self.auth_attribute:
+            if self.auth_attribute not in plugin.requires_auth:
                 continue
             choices.append((plugin.identifier, plugin.get_label()))
         return choices

--- a/src/openforms/prefill/tests/test_prefill_hook.py
+++ b/src/openforms/prefill/tests/test_prefill_hook.py
@@ -614,7 +614,7 @@ class PrefillHookTests(TransactionTestCase):
 
     def test_demo_prefill_get_identifier_authenticated(self):
         class TestPlugin(BasePlugin):
-            requires_auth = AuthAttribute.bsn
+            requires_auth = (AuthAttribute.bsn,)
 
         plugin = TestPlugin(identifier="test")
 
@@ -646,7 +646,7 @@ class PrefillHookTests(TransactionTestCase):
 
         @register("demo")
         class MismatchPlugin(DemoPrefill):
-            requires_auth = AuthAttribute.bsn
+            requires_auth = (AuthAttribute.bsn,)
 
             @staticmethod
             def get_prefill_values(submission, attributes, identifier_role):


### PR DESCRIPTION
Closes #4825 

**Changes**

- Run prefill plugin only when the authentication type matches the plugin's requirements. 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
