### PR TITLE
:wrench: Remove 2.7.x from Docker hub description

### DIFF
--- a/docker/ci/config.json
+++ b/docker/ci/config.json
@@ -14,11 +14,6 @@
       "gitRef": "stable/2.8.x",
       "tag": null,
       "hasExtensionsVariant": true
-    },
-    {
-      "gitRef": "stable/2.7.x",
-      "tag": null,
-      "hasExtensionsVariant": true
     }
   ],
   "availableExtensions": [


### PR DESCRIPTION
Removed 2.7.x from the config file that generates the docker hub description - yesterday's patch release was the final one.