### PR TITLE
:arrow_up: Bump playwright to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - uses: ./.github/actions/report-flaky
 
   e2etests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -472,7 +472,7 @@ glom==23.5.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-greenlet==3.0.3
+greenlet==3.1.1
     # via playwright
 html5lib==1.1
     # via
@@ -683,7 +683,7 @@ platformdirs==2.2.0
     #   -r requirements/base.txt
     #   black
     #   zeep
-playwright==1.44.0
+playwright==1.49.1
     # via -r requirements/test-tools.in
 pluggy==0.13.1
     # via pytest
@@ -743,7 +743,7 @@ pydyf==0.8.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
-pyee==11.1.0
+pyee==12.0.0
     # via playwright
 pyflakes==3.2.0
     # via flake8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -516,7 +516,7 @@ glom==23.5.0
     #   mozilla-django-oidc-db
 gprof2dot==2021.2.21
     # via django-silk
-greenlet==3.0.3
+greenlet==3.1.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -760,7 +760,7 @@ platformdirs==2.2.0
     #   -r requirements/ci.txt
     #   black
     #   zeep
-playwright==1.44.0
+playwright==1.49.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -831,7 +831,7 @@ pydyf==0.8.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-pyee==11.1.0
+pyee==12.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -507,7 +507,7 @@ glom==23.5.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-greenlet==3.0.3
+greenlet==3.1.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -751,7 +751,7 @@ platformdirs==2.2.0
     #   -r requirements/ci.txt
     #   black
     #   zeep
-playwright==1.44.0
+playwright==1.49.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -819,7 +819,7 @@ pydyf==0.8.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-pyee==11.1.0
+pyee==12.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
See if this allows us to run on Ubuntu 24.04 runners instead of having to pin to an older version.

