### PR TITLE
[#5006] Ability to manually fill in `addressNL` streetname and city

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.53.0",
-        "@open-formulieren/formio-builder": "^0.35.0",
+        "@open-formulieren/formio-builder": "^0.36.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -4498,11 +4498,10 @@
       "integrity": "sha512-3Pv32ULCuFOJZ2GaqcpvB45u6xScr0lmW5ETB9P1Ox9TG5nvMcVSwuwYe/GwxbzmvtZgiMQRMKRFT9lNYLeREQ=="
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.35.0.tgz",
-      "integrity": "sha512-/qu3BgbqLnIE/YUpP7sjbI/p/xtZbMOLBNyFzUEdZbEM6st4a3vCC0A7xAb8uGFbl67qLOwunUN4Te0D6VsorA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.36.0.tgz",
+      "integrity": "sha512-ExclSZX9XdNPQIoxCRYlkYE681C0dDHJRBbNwZeU3j6oeFesnzISmvXPUSAUr3S61b36mFbjwLvF+FSTouE/qw==",
       "hasInstallScript": true,
-      "license": "EUPL-1.2",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",
@@ -21524,9 +21523,9 @@
       "integrity": "sha512-3Pv32ULCuFOJZ2GaqcpvB45u6xScr0lmW5ETB9P1Ox9TG5nvMcVSwuwYe/GwxbzmvtZgiMQRMKRFT9lNYLeREQ=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.35.0.tgz",
-      "integrity": "sha512-/qu3BgbqLnIE/YUpP7sjbI/p/xtZbMOLBNyFzUEdZbEM6st4a3vCC0A7xAb8uGFbl67qLOwunUN4Te0D6VsorA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.36.0.tgz",
+      "integrity": "sha512-ExclSZX9XdNPQIoxCRYlkYE681C0dDHJRBbNwZeU3j6oeFesnzISmvXPUSAUr3S61b36mFbjwLvF+FSTouE/qw==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@floating-ui/react": "^0.26.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.53.0",
-    "@open-formulieren/formio-builder": "^0.35.0",
+    "@open-formulieren/formio-builder": "^0.36.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/contrib/brk/constants.py
+++ b/src/openforms/contrib/brk/constants.py
@@ -9,3 +9,4 @@ class AddressValue(TypedDict):
     city: NotRequired[str]
     streetName: NotRequired[str]
     secretStreetCity: NotRequired[str]
+    autoPopulated: NotRequired[bool]

--- a/src/openforms/formio/formatters/custom.py
+++ b/src/openforms/formio/formatters/custom.py
@@ -50,6 +50,7 @@ class AddressValue(TypedDict):
     city: NotRequired[str]
     streetName: NotRequired[str]
     secretStreetCity: NotRequired[str]
+    autoPopulated: NotRequired[bool]
 
 
 class AddressNLFormatter(FormatterBase):

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -300,7 +300,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         step_data_serializer = build_serializer(
             configuration["components"],
             data=data,
-            context={"submission": submission},
+            context={"submission": submission, "validate_on_complete": False},
         )
         step_data_serializer.is_valid(raise_exception=True)
 

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -981,6 +981,7 @@ class SingleAddressNLTests(ValidationsTestCase):
         ui_inputs: dict[str, str],
         expected_ui_error: str,
         api_value: dict[str, Any],
+        expected_error_keys: list[str] = [],
     ) -> None:
         form = create_form(component)
 
@@ -988,7 +989,13 @@ class SingleAddressNLTests(ValidationsTestCase):
             self._assertAddressNLFrontendValidation(form, ui_inputs, expected_ui_error)
 
         with self.subTest("backend validation"):
-            self._assertBackendValidation(form, component["key"], api_value)
+            if not expected_error_keys:
+                self._assertBackendValidation(form, component["key"], api_value)
+            else:
+                for key in expected_error_keys:
+                    self._assertBackendValidation(
+                        form, f"{component['key']}.{key}", api_value
+                    )
 
     @async_to_sync
     async def _assertAddressNLFrontendValidation(
@@ -1029,6 +1036,7 @@ class SingleAddressNLTests(ValidationsTestCase):
                 "houseNumberAddition": "",
             },
             expected_ui_error="Dit veld mag niet leeg zijn.",
+            expected_error_keys=["postcode", "houseNumber"],
         )
 
     def test_regex_failure(self):


### PR DESCRIPTION
Closes #5006

- Needs

  - [x] new version of form-builder
  - [ ] frontend translations

**Changes**

- Updated street name and city serializer fields in order to be able to require these fields in case 
the component is required.


**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
