### PR TITLE
:green_heart: Ignore GitHub links with anchors in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,10 @@ linkcheck_ignore = [
     r"https://www\.miniwebtool\.com/django-secret-key-generator/",  # seems to block the requests user agent
 ]
 
+linkcheck_anchors_ignore_for_url = [
+    r"https://.*github.*",
+]
+
 extlinks = {
     "backend": ("https://github.com/open-formulieren/open-forms/issues/%s", "#%s"),
     "sdk": ("https://github.com/open-formulieren/open-forms-sdk/issues/%s", "#%s"),


### PR DESCRIPTION
Fixes documentation build. Linkcheck doesn't like GitHub anchors, see https://github.com/pypa/packaging.python.org/issues/1272 and https://github.com/sphinx-doc/sphinx/issues/9016