### PR TITLE
Accessible textual alternative for PDF logo

### DIFF
--- a/src/openforms/scss/pdfs/_index.scss
+++ b/src/openforms/scss/pdfs/_index.scss
@@ -7,5 +7,6 @@
 @import 'metadata';
 @import 'submission-step';
 @import 'submission-step-row';
+@import 'screen-reader';
 @import 'payment-info';
 @import 'privacy-policy';

--- a/src/openforms/scss/pdfs/_screen-reader.scss
+++ b/src/openforms/scss/pdfs/_screen-reader.scss
@@ -1,0 +1,10 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -39,8 +39,14 @@
             <header class="header {% if theme.logo %}header--has-logo{% endif %}">
                 <span
                     class="header__logo"
-                    {% if theme.logo %}role="img" aria-label="{{ logo_alt }}"{% endif %}
-                ></span>
+                    {% if theme.logo %}role="img"{% endif %}
+                >
+                    {% if theme.logo %}
+                        <span class="sr-only">
+                            {{ logo_alt }}
+                        </span>
+                    {% endif %}
+                </span>
             </header>
 
             <h1 class="title">{{ report.form.name }}</h1>


### PR DESCRIPTION
Part of #4622 #5047

**Changes**

The previous textual alternative, using `aria-label`, wasn't targetable by screen readers (tested using the macOS VoiceOver screen reader). By providing the textual alternative as real content the screen reader can find and read the content.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
