### PR TITLE
[#5034] Fix object ownership in Objects API

### DIFF
--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -62,6 +62,10 @@ class ObjectsAPIRegistration(BasePlugin[RegistrationOptions]):
     def verify_initial_data_ownership(
         self, submission: Submission, options: RegistrationOptions
     ) -> None:
+        # Object's ownership validation makes sense if we want to update an object
+        if not options["update_existing_object"]:
+            return
+
         assert submission.initial_data_reference
         api_group = options["objects_api_group"]
         assert api_group, "Can't do anything useful without an API group"

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -12,6 +12,8 @@ from openforms.authentication.service import AuthAttribute
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.payments.constants import PaymentStatus
 from openforms.payments.tests.factories import SubmissionPaymentFactory
+from openforms.submissions.constants import PostSubmissionEvents
+from openforms.submissions.tasks import pre_registration
 from openforms.submissions.tests.factories import (
     SubmissionFactory,
     SubmissionFileAttachmentFactory,
@@ -513,6 +515,30 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 }
             },
         )
+
+    @tag("gh-5034")
+    def test_object_ownership_not_validated_if_new_object(self):
+        submission = SubmissionFactory.from_components(
+            [{"key": "textfield", "type": "textfield"}],
+            completed_not_preregistered=True,
+            form__registration_backend=PLUGIN_IDENTIFIER,
+            form__registration_backend_options={
+                "objects_api_group": self.objects_api_group.pk,
+                "version": 2,
+                "objecttype": "8faed0fa-7864-4409-aa6d-533a37616a9e",
+                "objecttype_version": 1,
+                "update_existing_object": False,
+                "auth_attribute_path": [],
+                "variables_mapping": [],
+            },
+            submitted_data={"textfield": "test"},
+            initial_data_reference="some ref",
+        )
+
+        try:
+            pre_registration(submission.pk, PostSubmissionEvents.on_retry)
+        except AssertionError:
+            self.fail("Assertion should have passed.")
 
 
 class V2HandlerTests(TestCase):


### PR DESCRIPTION
Closes #5034

**Changes**

- Added regression tests
- Updated object ownership validation to be triggered only when the object needs update 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
