### PR TITLE
[#5037] Fix wrong Date type

### DIFF
--- a/src/openforms/formio/formatters/custom.py
+++ b/src/openforms/formio/formatters/custom.py
@@ -1,4 +1,5 @@
 # TODO implement: iban, bsn, postcode, licenseplate, npFamilyMembers, cosign
+from datetime import date
 from typing import NotRequired, TypedDict
 
 from django.template.defaultfilters import date as fmt_date, time as fmt_time
@@ -13,8 +14,10 @@ from .base import FormatterBase
 
 
 class DateFormatter(FormatterBase):
-    def format(self, component: Component, value: str) -> str:
-        return fmt_date(parse_date(value))
+    def format(self, component: Component, value: str | date | None) -> str:
+        if isinstance(value, str):
+            value = parse_date(value)
+        return fmt_date(value)
 
 
 class DateTimeFormatter(FormatterBase):

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
@@ -10,7 +10,9 @@ from pyquery import PyQuery as pq
 from testfixtures import LogCapture
 
 from openforms.config.models import GlobalConfiguration
+from openforms.forms.tests.factories import FormLogicFactory
 
+from ..form_logic import evaluate_form_logic
 from ..models import SubmissionReport
 from ..tasks.pdf import generate_submission_report
 from .factories import SubmissionFactory, SubmissionReportFactory
@@ -107,6 +109,45 @@ class SubmissionReportGenerationTests(TestCase):
         self.assertNotIn("Input 1", html)
         # step has no visible children -> also not visible
         self.assertNotIn(step_title, html)
+
+    @tag("gh-5037")
+    def test_date_object_is_converted_to_str_when_it_comes_from_logic_rule(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "date",
+                    "key": "date1",
+                },
+                {
+                    "type": "date",
+                    "key": "updatedDate",
+                },
+            ],
+            submitted_data={"date1": "2025-01-01"},
+            completed=True,
+            with_report=True,
+        )
+
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger={"==": [{"var": "date1"}, "2025-01-01"]},
+            actions=[
+                {
+                    "variable": "updatedDate",
+                    "action": {
+                        "type": "variable",
+                        "value": {"+": [{"var": "date1"}, {"duration": "P1M"}]},
+                    },
+                },
+            ],
+        )
+        evaluate_form_logic(
+            submission, submission.submissionstep_set.get(), submission.data
+        )
+
+        html = submission.report.generate_submission_report_pdf()
+
+        self.assertIn("31 januari 2025", html)
 
     def test_visible_output_included(self):
         """


### PR DESCRIPTION
Closes #5037

**Changes**

- Added a regression test for generating pdf report
- Added check for a date passed to the `DateFormatter` and it's not a string

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
