### PR TITLE
Feature/5074 transform selectboxes data

### DIFF
--- a/src/openforms/submissions/transform_data.py
+++ b/src/openforms/submissions/transform_data.py
@@ -1,0 +1,8 @@
+def transform_selectboxes_data(value: dict[str, bool] | None) -> list[str] | None:
+    if value:
+        return sorted([key for key, value in value.items() if value])
+
+
+TRANSFORM_DATA_MAPPING = {
+    "selectboxes": transform_selectboxes_data,
+}


### PR DESCRIPTION
Closes #5074

TODO 
- [ ] test locally -> does not work because get_data is used outside of registration as well
- [ ] tests with nested components (repeating groups)
- [ ] multiple steps

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages_js.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
