### PR TITLE
[#5077] Improve performance in loading logic rules in admin

### DIFF
--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -531,7 +531,7 @@ class FormViewSet(viewsets.ModelViewSet):
         form = self.get_object()
         filterset = FormVariableFilter(
             request.GET,
-            queryset=form.formvariable_set.select_related("form", "form_definition"),
+            queryset=form.formvariable_set.prefetch_related("form", "form_definition"),
         )
 
         serializer = FormVariableSerializer(
@@ -590,7 +590,10 @@ class FormViewSet(viewsets.ModelViewSet):
     @logic_rules_bulk_update.mapping.get
     def logic_rules_list(self, request, *args, **kwargs):
         form = self.get_object()
-        logic_rules = form.formlogic_set.all()
+
+        logic_rules = form.formlogic_set.prefetch_related(
+            "form", "trigger_from_step__form"
+        )
 
         serializer = FormLogicSerializer(
             instance=logic_rules,


### PR DESCRIPTION
Closes #5077

**Changes**

- Logic rules list in the admin was really slow as the logic rules increase because of the same queries happening for the form and the form step. Some joins were added in order to reduce the amount of the queries.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
