### PR TITLE
Refactor the submission completion validation

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -52,6 +52,7 @@ include = [
     "src/openforms/registrations/contrib/objects_api/typing.py",
     "src/openforms/registrations/contrib/zgw_apis/",
     # core submissions app
+    "src/openforms/submissions/api/validation.py",
     "src/openforms/submissions/cosigning.py",
     "src/openforms/submissions/report.py",
     # our own template app/package on top of Django

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -4873,11 +4873,26 @@ paths:
         status endpoint that a retry is needed, the ID is added back to the session.
 
         ---
-        **Warning**
+        **Validation errors**
 
-        The schema of the validation errors response is currently marked as
-        experimental. See our versioning policy in the developer documentation for
-        what this means.
+        The validation errors are returned in the usual `invalidParams` structure. The
+        following errors can occur:
+
+        * name `privacyPolicyAccepted` - unchecked while accepting it is required
+        * name `statementOfTruthAccepted` - unchecked while accepting it is required
+        * name `steps[i].nonFieldErrors`:
+
+            * code `blocked` - a logic rule prevents the step from being submitted,
+              which blocks the submission as a whole from being completed.
+            * code `incomplete` - there is no or incomplete step data submitted for the
+              step at this index.
+
+        * name `steps[i].data.*` - validation errors related to the formio components
+          in the step data.
+
+        Additionally, if you try to complete a submission that doesn't allow this (due
+        to form-level configuration), you will get an HTTP 403 error.
+
         ---
       summary: Complete a submission
       parameters:
@@ -4898,14 +4913,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Submission'
+              $ref: '#/components/schemas/SubmissionCompletion'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/Submission'
+              $ref: '#/components/schemas/SubmissionCompletion'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Submission'
-        required: true
+              $ref: '#/components/schemas/SubmissionCompletion'
       security:
       - cookieAuth: []
       responses:
@@ -4928,7 +4942,22 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CompletionValidation'
+                $ref: '#/components/schemas/ValidationError'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exception'
           description: ''
           headers:
             X-Session-Expires-In:
@@ -6966,29 +6995,6 @@ components:
       - depth
       - name
       - url
-    CompletionValidation:
-      type: object
-      properties:
-        incompleteSteps:
-          type: array
-          items:
-            type: string
-          maxItems: 0
-        submissionAllowed:
-          $ref: '#/components/schemas/SubmissionAllowedEnum'
-        privacyPolicyAccepted:
-          type: boolean
-        statementOfTruthAccepted:
-          type: boolean
-        containsBlockedSteps:
-          type: boolean
-      required:
-      - containsBlockedSteps
-      - incompleteSteps
-      - privacyPolicyAccepted
-      - statementOfTruthAccepted
-      - submissionAllowed
-      x-experimental: true
     ComponentProperty:
       type: object
       properties:
@@ -9928,10 +9934,25 @@ components:
       - representation
     SubmissionCompletion:
       type: object
+      description: |-
+        Validate the submission completion.
+
+        The input validation requires the statement checkboxes to be provided before
+        completion can be considered. If that is fine, we run validation on the state of
+        the submission, which is a bit "weird" in the sense that we're double-checking
+        earlier user-input and not directly validating ``request.data`` items.
+
+        If all is well, we return the status URL to check the background processing,
+        otherwise the validation errors are raised for the frontend to handle.
       properties:
+        privacyPolicyAccepted:
+          type: boolean
+        statementOfTruthAccepted:
+          type: boolean
         statusUrl:
           type: string
           format: uri
+          readOnly: true
           title: status check endpoint
           description: The API endpoint where the background processing status can
             be checked. After calling the completion endpoint, this status URL should

--- a/src/openforms/submissions/api/fields.py
+++ b/src/openforms/submissions/api/fields.py
@@ -2,10 +2,8 @@ from functools import reduce
 
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework.fields import BooleanField, ChoiceField
+from rest_framework.fields import BooleanField
 from rest_framework_nested.relations import NestedHyperlinkedRelatedField
-
-from openforms.forms.constants import SubmissionAllowedChoices
 
 from .validators import CheckCheckboxAccepted
 
@@ -64,7 +62,7 @@ class URLRelatedField(NestedHyperlinkedRelatedField):
 
 class TruthDeclarationAcceptedField(BooleanField):
     default_validators = [
-        CheckCheckboxAccepted(
+        CheckCheckboxAccepted(  # pyright: ignore
             "ask_statement_of_truth",
             _("You must declare the form to be filled out truthfully."),
         )
@@ -73,23 +71,8 @@ class TruthDeclarationAcceptedField(BooleanField):
 
 class PrivacyPolicyAcceptedField(BooleanField):
     default_validators = [
-        CheckCheckboxAccepted(
+        CheckCheckboxAccepted(  # pyright: ignore
             "ask_privacy_consent",
             _("You must accept the privacy policy."),
         )
     ]
-
-
-# TODO: ideally this should be moved into a permission-check in the view rather than
-# input validation, as the end-user cannot correct this 'mistake'.
-class SubmissionAllowedField(ChoiceField):
-    default_error_messages = {"invalid": _("Submission of this form is not allowed.")}
-
-    def __init__(self, *args, **kwargs):
-        kwargs["choices"] = SubmissionAllowedChoices.choices
-        super().__init__(*args, **kwargs)
-
-    def to_internal_value(self, form_configuration_value: SubmissionAllowedChoices):
-        if form_configuration_value != SubmissionAllowedChoices.yes:
-            self.fail("invalid")
-        return form_configuration_value

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -1,69 +1,120 @@
 """
 Perform submission-level validation.
-
-TODO: refactor/rework the entire way we _run_ the validations and communicate them back
-to the frontend.
 """
 
-from django.core.validators import MaxLengthValidator
+from typing import TYPE_CHECKING, TypedDict
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
+from rest_framework.exceptions import ErrorDetail
+from rest_framework.request import Request
+from rest_framework.settings import api_settings
 
-from openforms.api.utils import mark_experimental
 from openforms.formio.service import build_serializer, get_dynamic_configuration
+from openforms.forms.models import FormDefinition, FormStep
 
-from ..form_logic import check_submission_logic
 from ..models import Submission, SubmissionStep
-from .fields import (
-    PrivacyPolicyAcceptedField,
-    SubmissionAllowedField,
-    TruthDeclarationAcceptedField,
-)
+from .fields import PrivacyPolicyAcceptedField, TruthDeclarationAcceptedField
+
+NON_FIELD_ERRORS_KEY = api_settings.NON_FIELD_ERRORS_KEY
 
 
-@mark_experimental
-class CompletionValidationSerializer(serializers.Serializer):
-    incomplete_steps = serializers.ListField(
-        child=serializers.CharField(),
-        validators=[
-            MaxLengthValidator(
-                limit_value=0,
-                message=_("Not all applicable steps have been completed: %(value)s"),
-            )
-        ],
+def is_step_unexpectedly_incomplete(submission_step: SubmissionStep) -> bool:
+    if not submission_step.completed and submission_step.is_applicable:
+        return True
+    return False
+
+
+class SubmissionCompletionSerializerContext(TypedDict):
+    request: Request
+    submission: Submission
+
+
+type StepValidationErrors = dict[str, ErrorDetail] | dict[str, StepValidationErrors]
+
+
+class SubmissionCompletionSerializer(serializers.Serializer):
+    """
+    Validate the submission completion.
+
+    The input validation requires the statement checkboxes to be provided before
+    completion can be considered. If that is fine, we run validation on the state of
+    the submission, which is a bit "weird" in the sense that we're double-checking
+    earlier user-input and not directly validating ``request.data`` items.
+
+    If all is well, we return the status URL to check the background processing,
+    otherwise the validation errors are raised for the frontend to handle.
+    """
+
+    _context: SubmissionCompletionSerializerContext  # pyright: ignore[reportIncompatibleVariableOverride]
+    if TYPE_CHECKING:
+
+        @property
+        def context(  # pyright: ignore[reportIncompatibleMethodOverride]
+            self,
+        ) -> SubmissionCompletionSerializerContext: ...
+
+    # statement checkboxes on the overview page
+    privacy_policy_accepted = PrivacyPolicyAcceptedField(required=False)
+    statement_of_truth_accepted = TruthDeclarationAcceptedField(required=False)
+
+    status_url = serializers.URLField(
+        label=_("status check endpoint"),
+        help_text=_(
+            "The API endpoint where the background processing status can be checked. "
+            "After calling the completion endpoint, this status URL should be polled "
+            "to report the processing status back to the end-user. Note that the "
+            "endpoint contains a token which invalidates on state changes and after "
+            "one day."
+        ),
+        read_only=True,
     )
-    submission_allowed = SubmissionAllowedField()
-    privacy_policy_accepted = PrivacyPolicyAcceptedField()
-    statement_of_truth_accepted = TruthDeclarationAcceptedField()
-    contains_blocked_steps = serializers.BooleanField()
 
-    def validate_contains_blocked_steps(self, value):
-        if value:
-            raise serializers.ValidationError(
-                _(
-                    "Submission of this form is not allowed due to the answers submitted in a step."
-                )
-            )
+    def validate(self, attrs):
+        submission = self.context["submission"]
 
-    def validate(self, attrs: dict):
-        self._run_formio_validation()
-        return attrs
-
-    def _run_formio_validation(self) -> None:
-        submission: Submission = self.context["submission"]
-        formio_validation_errors = []
+        # run the state validation for the submission as a whole, not depending on any
+        # particular user input from the request data. We build up an array of errors
+        # for a given step - if there are no issues, an empty dict is used as the index
+        # of errors must match the index of the steps in the form.
+        all_step_errors: list[StepValidationErrors] = []
+        step_errors: StepValidationErrors
 
         data = submission.data
-        for step in submission.steps:
-            errors = {}
-            assert step.form_step
 
+        for step in submission.steps:
+            form_step = step.form_step
+            assert isinstance(form_step, FormStep)
+            form_definition = form_step.form_definition
+            assert isinstance(form_definition, FormDefinition)
+            step_name: str = form_definition.name
+
+            step_errors = {}  # we must add *something* to the array
+
+            # check for blocked steps
+            if not step.can_submit:
+                step_errors = {
+                    NON_FIELD_ERRORS_KEY: ErrorDetail(
+                        _("Step '{name}' is blocked.").format(name=step_name),
+                        code="blocked",
+                    )
+                }
+            # check if the step was skipped somehow
+            elif is_step_unexpectedly_incomplete(step):
+                step_errors = {
+                    NON_FIELD_ERRORS_KEY: ErrorDetail(
+                        _("Step '{name}' is not yet completed.").format(name=step_name),
+                        code="incomplete",
+                    )
+                }
+
+            # run the full Formio validation for the step
             if step.is_applicable:
                 # evaluate dynamic configuration. We avoid calling `evaluate_form_logic`
                 # on purpose to avoid duplicate logic evaluation
                 configuration = get_dynamic_configuration(
-                    step.form_step.form_definition.configuration_wrapper,
+                    form_definition.configuration_wrapper,
                     self.context["request"],
                     submission=submission,
                     data=data,
@@ -74,56 +125,38 @@ class CompletionValidationSerializer(serializers.Serializer):
                     context={"submission": submission},
                 )
                 if not step_data_serializer.is_valid():
-                    errors = step_data_serializer.errors
+                    step_errors["data"] = (  # pyright: ignore[reportArgumentType]
+                        step_data_serializer.errors
+                    )
 
-            if errors:
-                formio_validation_errors.append({"data": errors})
-            else:
-                formio_validation_errors.append({})
+            all_step_errors.append(step_errors)
 
-        if any(formio_validation_errors):
-            raise serializers.ValidationError({"steps": formio_validation_errors})
+        assert len(all_step_errors) == len(
+            submission.steps
+        ), "Detected a mismatch in validation errors list with actual submission steps."
 
-    def save(self, **kwargs):
+        # as soon as one step has problems, we must raise a validation error
+        if any(all_step_errors):
+            raise serializers.ValidationError({"steps": all_step_errors})
+
+        return attrs
+
+    def save(self, **kwargs) -> None:
+        status_url: str = kwargs.pop("status_url")
         submission = self.context["submission"]
-        submission.privacy_policy_accepted = True
-        submission.statement_of_truth_accepted = True
-        submission.save()
+        data = self.validated_data
 
+        # persist which checkboxes were accepted
+        submission.privacy_policy_accepted = data.get("privacy_policy_accepted", False)
+        submission.statement_of_truth_accepted = data.get(
+            "statement_of_truth_accepted", False
+        )
+        submission.save(
+            update_fields=[
+                "privacy_policy_accepted",
+                "statement_of_truth_accepted",
+            ]
+        )
 
-def is_step_unexpectedly_incomplete(submission_step: "SubmissionStep") -> bool:
-    if not submission_step.completed and submission_step.is_applicable:
-        return True
-    return False
-
-
-def get_submission_completion_serializer(
-    submission: Submission, request
-) -> CompletionValidationSerializer:
-    # check that all required steps are completed
-    state = submission.load_execution_state()
-
-    # When loading the state, knowledge of which steps are not applicable is lost
-    check_submission_logic(submission)
-
-    incomplete_steps = [
-        submission_step.form_step.form_definition.name
-        for submission_step in state.submission_steps
-        if is_step_unexpectedly_incomplete(submission_step)
-    ]
-
-    return CompletionValidationSerializer(
-        data={
-            "incomplete_steps": incomplete_steps,
-            "submission_allowed": submission.form.submission_allowed,
-            "privacy_policy_accepted": request.data.get("privacy_policy_accepted"),
-            "statement_of_truth_accepted": request.data.get(
-                "statement_of_truth_accepted", False
-            ),
-            "contains_blocked_steps": any(
-                not submission_step.can_submit
-                for submission_step in state.submission_steps
-            ),
-        },
-        context={"request": request, "submission": submission},
-    )
+        # patch up the validated data so that we can emit the status URL
+        data["status_url"] = status_url

--- a/src/openforms/submissions/api/validators.py
+++ b/src/openforms/submissions/api/validators.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -64,16 +66,21 @@ class FormMaintenanceModeValidator:
             raise serializers.ValidationError(self.message, code=self.code)
 
 
+type StatementFieldName = Literal["ask_privacy_consent", "ask_statement_of_truth"]
+
+
 class CheckCheckboxAccepted:
     message = _("You must accept this statement.")
     requires_context = True
 
-    def __init__(self, ask_statement_field_name: str, message):
+    ask_statement_field_name: StatementFieldName
+
+    def __init__(self, ask_statement_field_name: StatementFieldName, message):
         self.ask_statement_field_name = ask_statement_field_name
         self.message = message or self.message
 
     def __call__(self, value: bool, field: serializers.BooleanField):
-        form = field.context["submission"].form
+        form: Form = field.context["submission"].form
         should_statement_be_accepted = form.get_statement_checkbox_required(
             self.ask_statement_field_name
         )


### PR DESCRIPTION
Partly closes #4510 - this is necessary to be able to display proper error messages in the SDK.

The completion validation + communicating the status URL back to the frontend was a weird and unconventional construct. The API documentation was also outdated with what is actually being returned.

This has now been reworked and stabilized to ensure a consistent format of validation errors that can be picked up and processed by the frontend/SDK reliably.

**Changes**

* Reworked how we run final validation of a submission before completing it and processing it
* There's now a properly documented validation error structure for steps
* The statement checkboxes validation remains as is
* The in- and output serializers are now correctly documented
* If the form is configured to not allow submissions, this now results in a 403 instead of a validation error (resolved a TODO)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
