### PR TITLE
:recycle: [#5044] Add constant for dataSrc options

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -29,6 +29,7 @@ from rest_framework.utils.formatting import lazy_format
 from csp_post_processor import post_process_html
 from openforms.config.constants import UploadFileType
 from openforms.config.models import GlobalConfiguration
+from openforms.formio.constants import DataSrcOptions
 from openforms.submissions.attachments import temporary_upload_from_url
 from openforms.submissions.models import EmailVerification
 from openforms.typing import DataMapping, JSONObject
@@ -700,7 +701,7 @@ class SelectBoxes(BasePlugin[SelectBoxesComponent]):
         data_src = component.get("openForms", {}).get("dataSrc")
 
         base = {"title": label, "type": "object"}
-        if data_src != "variable":
+        if data_src != DataSrcOptions.variable:
             # Only add properties if the data source IS NOT another variable, because
             # component[values] is not updated when it IS. So it does not make sense to
             # add properties in that case.
@@ -775,7 +776,7 @@ class Select(BasePlugin[SelectComponent]):
         data_src = component.get("openForms", {}).get("dataSrc")
 
         base = {"type": "string"}
-        if data_src != "variable":
+        if data_src != DataSrcOptions.variable:
             # Only add properties if the data source IS NOT another variable, because
             # component[data][values] is not updated when it IS. So it does not make
             # sense to add properties in that case.
@@ -863,7 +864,7 @@ class Radio(BasePlugin[RadioComponent]):
         data_src = component.get("openForms", {}).get("dataSrc")
 
         base = {"title": label, "type": "string"}
-        if data_src != "variable":
+        if data_src != DataSrcOptions.variable:
             # Only add enum if the data source IS NOT another variable, because
             # component[values] is not updated when it IS. So it does not make sense to
             # add a list of choices to the enum in that case.

--- a/src/openforms/formio/constants.py
+++ b/src/openforms/formio/constants.py
@@ -1,3 +1,5 @@
+from enum import StrEnum
+
 COMPONENT_DATATYPES = {
     "date": "date",
     "time": "time",
@@ -11,3 +13,9 @@ COMPONENT_DATATYPES = {
     "editgrid": "array",
     "datetime": "datetime",
 }
+
+
+class DataSrcOptions(StrEnum):
+    manual = "manual"
+    variable = "variable"
+    referentielijsten = "referentielijsten"

--- a/src/openforms/formio/dynamic_config/dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/dynamic_options.py
@@ -7,6 +7,7 @@ from glom import assign, glom
 from json_logic import jsonLogic
 
 from openforms.api.exceptions import ServiceUnavailable
+from openforms.formio.constants import DataSrcOptions
 from openforms.logging import logevent
 from openforms.submissions.models import Submission
 from openforms.typing import DataMapping, JSONValue
@@ -108,13 +109,13 @@ def add_options_to_config(
 ) -> None:
     data_src = glom(component, "openForms.dataSrc", default=None)
     match data_src:
-        case "referentielijsten":
+        case DataSrcOptions.referentielijsten:
             items_array = fetch_options_from_referentielijsten(component, submission)
             if not items_array:
                 raise ServiceUnavailable(
                     _("Could not retrieve options from Referentielijsten API."),
                 )
-        case "variable":
+        case DataSrcOptions.variable:
             items_array = get_options_from_variable(component, data, submission)
             if items_array is None:
                 return

--- a/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
@@ -5,6 +5,7 @@ from pyquery import PyQuery as pq
 from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.formio.constants import DataSrcOptions
 from openforms.formio.datastructures import FormioConfigurationWrapper
 from openforms.formio.dynamic_config import rewrite_formio_components
 from openforms.forms.tests.factories import (
@@ -30,7 +31,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "A", "value": "a"},
                         {"label": "B", "value": "b"},
                     ],
-                    "dataSrc": "manual",
+                    "dataSrc": DataSrcOptions.manual,
                 },
                 {
                     "label": "Select",
@@ -40,7 +41,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                             {"label": "A", "value": "a"},
                             {"label": "B", "value": "b"},
                         ],
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                         "json": "",
                         "url": "",
                         "resource": "",
@@ -56,7 +57,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "A", "value": "a"},
                         {"label": "B", "value": "b"},
                     ],
-                    "dataSrc": "manual",
+                    "dataSrc": DataSrcOptions.manual,
                 },
             ]
         }
@@ -105,7 +106,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
                         },
@@ -120,7 +121,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         ],
                     },
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
                         },
@@ -138,7 +139,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
                         },
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                     },
                 },
             ]
@@ -189,7 +190,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                     "values": [
                         {"label": "", "value": ""},
                     ],
-                    "dataSrc": "variable",
+                    "dataSrc": DataSrcOptions.variable,
                     "data": {
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
@@ -203,7 +204,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         "values": [
                             {"label": "", "value": ""},
                         ],
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
                         },
@@ -217,7 +218,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                     "values": [
                         {"label": "", "value": ""},
                     ],
-                    "dataSrc": "variable",
+                    "dataSrc": DataSrcOptions.variable,
                     "data": {
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
@@ -264,7 +265,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                 },
@@ -277,7 +278,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         ],
                     },
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                     "type": "select",
@@ -290,7 +291,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                 },
@@ -342,7 +343,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                     "values": [
                         {"label": "", "value": ""},
                     ],
-                    "dataSrc": "variable",
+                    "dataSrc": DataSrcOptions.variable,
                     "data": {
                         "itemsExpression": {"var": "textField"},
                     },
@@ -354,7 +355,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         "values": [
                             {"label": "", "value": ""},
                         ],
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                     "type": "select",
@@ -366,7 +367,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                     "values": [
                         {"label": "", "value": ""},
                     ],
-                    "dataSrc": "variable",
+                    "dataSrc": DataSrcOptions.variable,
                     "data": {
                         "itemsExpression": {"var": "textField"},
                     },
@@ -411,7 +412,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "var": "repeatingGroup"
                         },  # No map operation to transform dict into str
@@ -426,7 +427,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         ],
                     },
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "var": "repeatingGroup"
                         },  # No map operation to transform dict into str
@@ -444,7 +445,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         "itemsExpression": {
                             "var": "repeatingGroup"
                         },  # No map operation to transform dict into str
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                     },
                 },
             ]
@@ -506,7 +507,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                 },
@@ -547,7 +548,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                 },
@@ -593,7 +594,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "textField"},
                     },
                 },
@@ -628,7 +629,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "map": [{"var": "repeatingGroup"}, {"var": "name"}]
                         },
@@ -660,7 +661,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "map": [{"var": "externalData"}, {"var": "id"}]
                         },
@@ -722,7 +723,7 @@ class TestDynamicConfigAddingOptions(TestCase):
                         {"label": "", "value": ""},
                     ],
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "map": [
                                 {"var": "repeatingGroup"},
@@ -781,7 +782,7 @@ class TestDynamicConfigAddingOptionsForRequest(SubmissionsMixin, APITestCase):
                     <div>
                         <style nonce="my-malicious-and-bad-nonce"></style>
                         <script>alert('xss')</script>
-                    </div> 
+                    </div>
                     """,
                 },
                 {

--- a/src/openforms/formio/dynamic_config/tests/test_referentielijsten_config.py
+++ b/src/openforms/formio/dynamic_config/tests/test_referentielijsten_config.py
@@ -12,6 +12,7 @@ from zgw_consumers.constants import AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.api.exceptions import ServiceUnavailable
+from openforms.formio.constants import DataSrcOptions
 from openforms.formio.registry import register
 from openforms.formio.typing import (
     RadioComponent,
@@ -60,7 +61,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -85,7 +86,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel-with-many-items",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -107,7 +108,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": "",
                 "translations": {},
             },
@@ -136,7 +137,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -165,7 +166,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -196,7 +197,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "non-existent",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -226,7 +227,7 @@ class SelectReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -285,7 +286,7 @@ class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -310,7 +311,7 @@ class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": "",
                 "translations": {},
             },
@@ -340,7 +341,7 @@ class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -370,7 +371,7 @@ class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -402,7 +403,7 @@ class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "non-existent",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -433,7 +434,7 @@ class SelectboxesReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -493,7 +494,7 @@ class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -518,7 +519,7 @@ class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": "",
                 "translations": {},
             },
@@ -547,7 +548,7 @@ class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -576,7 +577,7 @@ class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -607,7 +608,7 @@ class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "non-existent",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -637,7 +638,7 @@ class RadioReferentielijstenOptionsTests(OFVCRMixin, TestCase):
             "dataType": "string",
             "openForms": {
                 "code": "tabel1",
-                "dataSrc": "referentielijsten",
+                "dataSrc": DataSrcOptions.referentielijsten,
                 "service": self.service.slug,
                 "translations": {},
             },
@@ -682,7 +683,7 @@ class SubmissionStepDetailTest(SubmissionsMixin, APITestCase):
                         "dataType": "string",
                         "openForms": {
                             "code": "tabel1",
-                            "dataSrc": "referentielijsten",
+                            "dataSrc": DataSrcOptions.referentielijsten,
                             "service": "non-existent",
                             "translations": {},
                         },

--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -11,6 +11,7 @@ from typing import Protocol, cast
 
 from glom import assign, glom
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.formio.typing.vanilla import ColumnsComponent, FileComponent
 from openforms.typing import JSONObject
 
@@ -81,7 +82,7 @@ def set_openforms_datasrc(component: Component) -> bool:
     # if a dataSrc is specified, there is nothing to do
     if glom(component, "openForms.dataSrc", default=None):
         return False
-    assign(component, "openForms.dataSrc", val="manual", missing=dict)
+    assign(component, "openForms.dataSrc", val=DataSrcOptions.manual, missing=dict)
     return True
 
 

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.test import TestCase, tag
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.submissions.rendering import Renderer, RenderModes
 from openforms.submissions.tests.factories import SubmissionFactory
 
@@ -637,7 +638,7 @@ class ComponentNodeTests(TestCase):
                     "label": "Select single",
                     "multiple": False,
                     "openForms": {
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                     "data": {
                         "values": [
@@ -652,7 +653,7 @@ class ComponentNodeTests(TestCase):
                     "label": "Select multiple",
                     "multiple": True,
                     "openForms": {
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                     "data": {
                         "values": [
@@ -846,7 +847,7 @@ class ComponentNodeTests(TestCase):
                     "label": "Select single",
                     "multiple": False,
                     "openForms": {
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                     "data": {
                         "values": [
@@ -861,7 +862,7 @@ class ComponentNodeTests(TestCase):
                     "label": "Select multiple",
                     "multiple": True,
                     "openForms": {
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                     "data": {
                         "values": [

--- a/src/openforms/formio/tests/search_strategies.py
+++ b/src/openforms/formio/tests/search_strategies.py
@@ -20,6 +20,7 @@ from string import ascii_letters, digits
 
 from hypothesis import strategies as st
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.tests.search_strategies import jsonb_text
 
 
@@ -206,7 +207,13 @@ def option():
 
 
 def data_sources():
-    return st.sampled_from(["manual", "variable"])
+    return st.sampled_from(
+        [
+            DataSrcOptions.manual,
+            DataSrcOptions.variable,
+            DataSrcOptions.referentielijsten,
+        ]
+    )
 
 
 def select_component():

--- a/src/openforms/formio/tests/test_component_json_schemas.py
+++ b/src/openforms/formio/tests/test_component_json_schemas.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 
 from jsonschema import Draft202012Validator
 
+from openforms.formio.constants import DataSrcOptions
+
 from ..service import as_json_schema
 from ..typing import (
     AddressNLComponent,
@@ -279,7 +281,7 @@ class RadioTests(TestCase):
             "values": [
                 {"label": "", "value": ""},
             ],
-            "openForms": {"dataSrc": "variable"},
+            "openForms": {"dataSrc": DataSrcOptions.variable},
             "type": "radio",
         }
 
@@ -331,7 +333,7 @@ class SelectTests(TestCase):
                     {"label": "", "value": ""},
                 ],
             },
-            "openForms": {"dataSrc": "variable"},
+            "openForms": {"dataSrc": DataSrcOptions.variable},
             "type": "select",
         }
 
@@ -383,7 +385,7 @@ class SelectBoxesTests(TestCase):
             "values": [
                 {"label": "", "value": ""},
             ],
-            "openForms": {"dataSrc": "variable"},
+            "openForms": {"dataSrc": DataSrcOptions.variable},
             "type": "selectboxes",
         }
 

--- a/src/openforms/formio/tests/validation/test_editgrid.py
+++ b/src/openforms/formio/tests/validation/test_editgrid.py
@@ -4,6 +4,7 @@ from django.test import SimpleTestCase, tag
 
 from rest_framework import serializers
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.typing import JSONObject, JSONValue
 
@@ -245,7 +246,7 @@ class EditGridValidationTests(SimpleTestCase):
                 "key": "heeftUEenWerkgever",
                 "label": "Heeft u een werkgever?",
                 "validate": {"required": True},
-                "openForms": {"dataSrc": "manual"},
+                "openForms": {"dataSrc": DataSrcOptions.manual},
                 "values": [
                     {"label": "Ja", "value": "ja"},
                     {"label": "Nee", "value": "nee"},
@@ -282,7 +283,7 @@ class EditGridValidationTests(SimpleTestCase):
                                 "key": "periodeNettoLoon",
                                 "label": "Over welke periode ontvangt u dit loon?",
                                 "validate": {"required": True},
-                                "openForms": {"dataSrc": "manual"},
+                                "openForms": {"dataSrc": DataSrcOptions.manual},
                                 "values": [
                                     {"label": "Per week", "value": "week"},
                                     {"label": "Per 4 weken", "value": "vierWeken"},

--- a/src/openforms/formio/tests/validation/test_radio.py
+++ b/src/openforms/formio/tests/validation/test_radio.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase, tag
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.typing import JSONObject
 
 from ...typing import RadioComponent
@@ -14,7 +15,7 @@ class RadioValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "validate": {"required": True},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},
@@ -42,7 +43,7 @@ class RadioValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "validate": {"required": False},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},

--- a/src/openforms/formio/tests/validation/test_selectboxes.py
+++ b/src/openforms/formio/tests/validation/test_selectboxes.py
@@ -2,6 +2,7 @@ from django.test import SimpleTestCase
 
 from hypothesis import given, strategies as st
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.typing import JSONValue
 
 from ...typing import SelectBoxesComponent
@@ -16,7 +17,7 @@ class SelectboxesValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "validate": {"required": True},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},
@@ -51,7 +52,7 @@ class SelectboxesValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "validate": {"required": False},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},
@@ -81,7 +82,7 @@ class SelectboxesValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "validate": {"required": required},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},
@@ -101,7 +102,7 @@ class SelectboxesValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "validate": {"required": False},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},
@@ -123,7 +124,7 @@ class SelectboxesValidationTests(SimpleTestCase):
                 "required": False,
                 "minSelectedCount": 2,
             },
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},
@@ -147,7 +148,7 @@ class SelectboxesValidationTests(SimpleTestCase):
                 "required": False,
                 "maxSelectedCount": 1,
             },
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -8,6 +8,7 @@ from typing import Literal, NotRequired, TypeAlias, TypedDict
 
 from openforms.typing import JSONValue
 
+from ..constants import DataSrcOptions
 from .dates import DateConstraintConfiguration
 
 TranslationsDict: TypeAlias = dict[str, dict[str, str]]
@@ -44,7 +45,7 @@ class OpenFormsConfig(TypedDict):
     translations: NotRequired[TranslationsDict]
     components: NotRequired[AddressValidationComponents]
     requireVerification: NotRequired[bool]
-    dataSrc: NotRequired[Literal["manual", "variable", "referentielijsten"]]
+    dataSrc: NotRequired[DataSrcOptions]
     code: NotRequired[str]
     service: NotRequired[str]
 

--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -7,6 +7,7 @@ from asgiref.sync import sync_to_async
 from furl import furl
 from playwright.async_api import Page, expect
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.products.tests.factories import ProductFactory
 from openforms.tests.e2e.base import (
     E2ETestCase,
@@ -110,7 +111,7 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
                             "description": "Description 2",
                             "tooltip": "Tooltip 2",
                             "openForms": {
-                                "dataSrc": "manual",
+                                "dataSrc": DataSrcOptions.manual,
                             },
                             "data": {
                                 "values": [
@@ -1406,7 +1407,7 @@ class FormDesignerTooltipTests(E2ETestCase):
                             "type": "radio",
                             "key": "radio",
                             "label": "Radio 1",
-                            "openForms": {"dataSrc": "manual"},
+                            "openForms": {"dataSrc": DataSrcOptions.manual},
                             "values": [
                                 {"value": "option", "label": "Option"},
                             ],
@@ -1415,7 +1416,7 @@ class FormDesignerTooltipTests(E2ETestCase):
                             "type": "select",
                             "key": "select",
                             "label": "Select 1",
-                            "openForms": {"dataSrc": "manual"},
+                            "openForms": {"dataSrc": DataSrcOptions.manual},
                             "dataSrc": "values",
                             "data": {
                                 "values": [
@@ -1427,7 +1428,7 @@ class FormDesignerTooltipTests(E2ETestCase):
                             "type": "selectboxes",
                             "key": "selectBoxes",
                             "label": "Select Boxes 1",
-                            "openForms": {"dataSrc": "manual"},
+                            "openForms": {"dataSrc": DataSrcOptions.manual},
                             "values": [
                                 {"value": "option", "label": "Option"},
                             ],

--- a/src/openforms/forms/tests/test_json_schema.py
+++ b/src/openforms/forms/tests/test_json_schema.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.forms.tests.factories import (
     FormDefinitionFactory,
     FormFactory,
@@ -32,7 +33,7 @@ class GenerateJsonSchemaTests(TestCase):
                                 {"label": "A", "value": "a"},
                                 {"label": "B", "value": "b"},
                             ],
-                            "dataSrc": "manual",
+                            "dataSrc": DataSrcOptions.manual,
                             "json": "",
                             "url": "",
                             "resource": "",
@@ -57,7 +58,7 @@ class GenerateJsonSchemaTests(TestCase):
                             {"label": "A", "value": "a"},
                             {"label": "B", "value": "b"},
                         ],
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                 ]
             }

--- a/src/openforms/registrations/contrib/json_dump/plugin.py
+++ b/src/openforms/registrations/contrib/json_dump/plugin.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from zgw_consumers.client import build_client
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.formio.service import rewrite_formio_components
 from openforms.formio.typing import (
     FileComponent,
@@ -136,13 +137,13 @@ def post_process(
                 values[key] = value
                 schema["properties"][key] = base_schema  # type: ignore
 
-            case {"type": "radio", "openForms": {"dataSrc": "variable"}}:
+            case {"type": "radio", "openForms": {"dataSrc": DataSrcOptions.variable}}:
                 component = cast(RadioComponent, component)
                 choices = [options["value"] for options in component["values"]]
                 choices.append("")  # Take into account an unfilled field
                 schema["properties"][key]["enum"] = choices  # type: ignore
 
-            case {"type": "select", "openForms": {"dataSrc": "variable"}}:
+            case {"type": "select", "openForms": {"dataSrc": DataSrcOptions.variable}}:
                 component = cast(SelectComponent, component)
                 choices = [options["value"] for options in component["data"]["values"]]  # type: ignore[reportTypedDictNotRequiredAccess]
                 choices.append("")  # Take into account an unfilled field
@@ -156,7 +157,7 @@ def post_process(
                 component = cast(SelectBoxesComponent, component)
                 data_src = component.get("openForms", {}).get("dataSrc")
 
-                if data_src == "variable":
+                if data_src == DataSrcOptions.variable:
                     properties = {
                         options["value"]: {"type": "boolean"}
                         for options in component["values"]

--- a/src/openforms/registrations/contrib/json_dump/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/json_dump/tests/test_backend.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from requests import RequestException
 from zgw_consumers.test.factories import ServiceFactory
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.submissions.tests.factories import (
     FormVariableFactory,
     SubmissionFactory,
@@ -515,7 +516,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
                     "type": "select",
                     "multiple": True,
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {"var": "valuesForSelect"},
                     },
                     "data": {
@@ -568,7 +569,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
                     "key": "selectBoxes",
                     "type": "selectboxes",
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "translations": {},
                         "itemsExpression": {"var": "valuesForSelectBoxes"},
                     },
@@ -659,7 +660,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
                     "key": "radio",
                     "type": "radio",
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "translations": {},
                         "itemsExpression": {"var": "valuesForRadio"},
                     },

--- a/src/openforms/registrations/contrib/objects_api/tests/test_template.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_template.py
@@ -10,6 +10,7 @@ import tablib
 from freezegun import freeze_time
 
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
+from openforms.formio.constants import DataSrcOptions
 from openforms.submissions.tests.factories import (
     SubmissionFactory,
     SubmissionFileAttachmentFactory,
@@ -351,7 +352,7 @@ class JSONTemplatingRegressionTests(SubmissionsMixin, TestCase):
                     ],
                     "defaultValue": None,
                     "validate": {"required": True},
-                    "openForms": {"dataSrc": "manual"},
+                    "openForms": {"dataSrc": DataSrcOptions.manual},
                 },
                 {
                     "type": "textfield",

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -21,6 +21,7 @@ from rest_framework.test import APITestCase
 
 from openforms.authentication.service import FORM_AUTH_SESSION_KEY, AuthAttribute
 from openforms.config.models import GlobalConfiguration
+from openforms.formio.constants import DataSrcOptions
 from openforms.forms.constants import StatementCheckboxChoices, SubmissionAllowedChoices
 from openforms.forms.tests.factories import (
     FormFactory,
@@ -594,7 +595,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                         "key": "someCondition",
                         "type": "radio",
                         "openForms": {
-                            "dataSrc": "variable",
+                            "dataSrc": DataSrcOptions.variable,
                             "itemsExpression": [
                                 ["a", "A"],
                             ],

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.formio.tests.factories import (
     SubmittedFileFactory,
     TemporaryFileUploadFactory,
@@ -364,7 +365,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                         "maxSelectedCount": 3,
                     },
                     "openForms": {
-                        "dataSrc": "variable",
+                        "dataSrc": DataSrcOptions.variable,
                         "itemsExpression": {
                             "var": "items",
                         },

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -10,6 +10,7 @@ from pyquery import PyQuery as pq
 from testfixtures import LogCapture
 
 from openforms.config.models import GlobalConfiguration
+from openforms.formio.constants import DataSrcOptions
 from openforms.forms.tests.factories import FormLogicFactory
 
 from ..form_logic import evaluate_form_logic
@@ -379,7 +380,7 @@ class SubmissionReportGenerationTests(TestCase):
                     "label": "Select single",
                     "multiple": False,
                     "openForms": {
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                     "data": {
                         "values": [
@@ -394,7 +395,7 @@ class SubmissionReportGenerationTests(TestCase):
                     "label": "Select multiple",
                     "multiple": True,
                     "openForms": {
-                        "dataSrc": "manual",
+                        "dataSrc": DataSrcOptions.manual,
                     },
                     "data": {
                         "values": [

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -17,6 +17,7 @@ from asgiref.sync import async_to_sync
 from furl import furl
 from playwright.async_api import Page, expect
 
+from openforms.formio.constants import DataSrcOptions
 from openforms.formio.tests.factories import SubmittedFileFactory
 from openforms.formio.typing import (
     AddressNLComponent,
@@ -209,7 +210,7 @@ class RadioTests(ValidationsTestCase):
             "key": "requiredRadio",
             "label": "Required radio",
             "validate": {"required": True},
-            "openForms": {"dataSrc": "manual"},  # type: ignore
+            "openForms": {"dataSrc": DataSrcOptions.manual},
             "values": [
                 {"value": "a", "label": "A"},
                 {"value": "b", "label": "B"},


### PR DESCRIPTION
Closes #5044 

**Changes**

* Add constant for dataSrc options

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
