### PR TITLE
Process edit grid components in the json dump registration backend

### DIFF
--- a/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_components_with_form_variable_as_data_source_in_edit_grid_component.yaml
+++ b/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_components_with_form_variable_as_data_source_in_edit_grid_component.yaml
@@ -1,0 +1,81 @@
+interactions:
+- request:
+    body: '"{\"values\": {\"repeatingGroup\": [{\"radio\": \"A\", \"select\": \"B\",
+      \"selectBoxes\": {\"A\": false, \"B\": false, \"C\": true}}]}, \"values_schema\":
+      {\"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"type\": \"object\",
+      \"properties\": {\"repeatingGroup\": {\"title\": \"Repeating Group\", \"type\":
+      \"array\", \"items\": {\"type\": \"object\", \"properties\": {\"radio\": {\"title\":
+      \"Radio\", \"type\": \"string\", \"enum\": [\"A\", \"B\", \"C\", \"\"]}, \"select\":
+      {\"type\": \"string\", \"title\": \"Select\", \"enum\": [\"A\", \"B\", \"C\",
+      \"\"]}, \"selectBoxes\": {\"title\": \"Select Boxes\", \"type\": \"object\",
+      \"additionalProperties\": false, \"properties\": {\"A\": {\"type\": \"boolean\"},
+      \"B\": {\"type\": \"boolean\"}, \"C\": {\"type\": \"boolean\"}}, \"required\":
+      [\"A\", \"B\", \"C\"]}}, \"required\": [\"radio\", \"select\", \"selectBoxes\"],
+      \"additionalProperties\": false}}}, \"required\": [\"repeatingGroup\"], \"additionalProperties\":
+      false}, \"metadata\": {}, \"metadata_schema\": {\"$schema\": \"https://json-schema.org/draft/2020-12/schema\",
+      \"type\": \"object\", \"properties\": {}, \"required\": [], \"additionalProperties\":
+      false}}"'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3Mzg4NTA2NjYsImNsaWVudF9pZCI6IiIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.Rl0rTl_HiE1CgWXQMqR9Yfq9u31k6sN7Gj-Z3wSnX4Y
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1192'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"repeatingGroup\": [\n        {\n
+        \         \"radio\": \"A\",\n          \"select\": \"B\",\n          \"selectBoxes\":
+        {\n            \"A\": false,\n            \"B\": false,\n            \"C\":
+        true\n          }\n        }\n      ]\n    },\n    \"values_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {\n        \"repeatingGroup\": {\n          \"items\":
+        {\n            \"additionalProperties\": false,\n            \"properties\":
+        {\n              \"radio\": {\n                \"enum\": [\n                  \"A\",\n
+        \                 \"B\",\n                  \"C\",\n                  \"\"\n
+        \               ],\n                \"title\": \"Radio\",\n                \"type\":
+        \"string\"\n              },\n              \"select\": {\n                \"enum\":
+        [\n                  \"A\",\n                  \"B\",\n                  \"C\",\n
+        \                 \"\"\n                ],\n                \"title\": \"Select\",\n
+        \               \"type\": \"string\"\n              },\n              \"selectBoxes\":
+        {\n                \"additionalProperties\": false,\n                \"properties\":
+        {\n                  \"A\": {\n                    \"type\": \"boolean\"\n
+        \                 },\n                  \"B\": {\n                    \"type\":
+        \"boolean\"\n                  },\n                  \"C\": {\n                    \"type\":
+        \"boolean\"\n                  }\n                },\n                \"required\":
+        [\n                  \"A\",\n                  \"B\",\n                  \"C\"\n
+        \               ],\n                \"title\": \"Select Boxes\",\n                \"type\":
+        \"object\"\n              }\n            },\n            \"required\": [\n
+        \             \"radio\",\n              \"select\",\n              \"selectBoxes\"\n
+        \           ],\n            \"type\": \"object\"\n          },\n          \"title\":
+        \"Repeating Group\",\n          \"type\": \"array\"\n        }\n      },\n
+        \     \"required\": [\n        \"repeatingGroup\"\n      ],\n      \"type\":
+        \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2191'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 14:04:26 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.8
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_file_in_edit_grid_component.yaml
+++ b/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_file_in_edit_grid_component.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '"{\"values\": {\"repeatingGroup\": [{\"fileUploadInRepeating\": [{\"file_name\":
+      \"test_file.txt\", \"content\": \"VGhpcyBpcyBleGFtcGxlIGNvbnRlbnQu\"}, {\"file_name\":
+      \"test_file_2.txt\", \"content\": \"VGhpcyBpcyBleGFtcGxlIGNvbnRlbnQgMi4=\"}]},
+      {\"fileUploadInRepeating\": [{\"file_name\": \"test_file_3.txt\", \"content\":
+      \"VGhpcyBpcyBleGFtcGxlIGNvbnRlbnQgMy4=\"}]}]}, \"values_schema\": {\"$schema\":
+      \"https://json-schema.org/draft/2020-12/schema\", \"type\": \"object\", \"properties\":
+      {\"repeatingGroup\": {\"title\": \"Repeating Group\", \"type\": \"array\", \"items\":
+      {\"type\": \"object\", \"properties\": {\"fileUploadInRepeating\": {\"title\":
+      \"File upload\", \"type\": \"array\", \"items\": {\"type\": \"object\", \"properties\":
+      {\"file_name\": {\"type\": \"string\"}, \"content\": {\"type\": \"string\",
+      \"format\": \"base64\"}}, \"required\": [\"file_name\", \"content\"], \"additionalProperties\":
+      false}}}, \"required\": [\"fileUploadInRepeating\"], \"additionalProperties\":
+      false}}}, \"required\": [\"repeatingGroup\"], \"additionalProperties\": false},
+      \"metadata\": {}, \"metadata_schema\": {\"$schema\": \"https://json-schema.org/draft/2020-12/schema\",
+      \"type\": \"object\", \"properties\": {}, \"required\": [], \"additionalProperties\":
+      false}}"'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3Mzg4NTA2ODIsImNsaWVudF9pZCI6IiIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.op4T3SQm0BGvrqlxEZHTiZUriA5UWaBvvt2EK5uFUCo
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1275'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"repeatingGroup\": [\n        {\n
+        \         \"fileUploadInRepeating\": [\n            {\n              \"content\":
+        \"VGhpcyBpcyBleGFtcGxlIGNvbnRlbnQu\",\n              \"file_name\": \"test_file.txt\"\n
+        \           },\n            {\n              \"content\": \"VGhpcyBpcyBleGFtcGxlIGNvbnRlbnQgMi4=\",\n
+        \             \"file_name\": \"test_file_2.txt\"\n            }\n          ]\n
+        \       },\n        {\n          \"fileUploadInRepeating\": [\n            {\n
+        \             \"content\": \"VGhpcyBpcyBleGFtcGxlIGNvbnRlbnQgMy4=\",\n              \"file_name\":
+        \"test_file_3.txt\"\n            }\n          ]\n        }\n      ]\n    },\n
+        \   \"values_schema\": {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"repeatingGroup\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"fileUploadInRepeating\": {\n
+        \               \"items\": {\n                  \"additionalProperties\":
+        false,\n                  \"properties\": {\n                    \"content\":
+        {\n                      \"format\": \"base64\",\n                      \"type\":
+        \"string\"\n                    },\n                    \"file_name\": {\n
+        \                     \"type\": \"string\"\n                    }\n                  },\n
+        \                 \"required\": [\n                    \"file_name\",\n                    \"content\"\n
+        \                 ],\n                  \"type\": \"object\"\n                },\n
+        \               \"title\": \"File upload\",\n                \"type\": \"array\"\n
+        \             }\n            },\n            \"required\": [\n              \"fileUploadInRepeating\"\n
+        \           ],\n            \"type\": \"object\"\n          },\n          \"title\":
+        \"Repeating Group\",\n          \"type\": \"array\"\n        }\n      },\n
+        \     \"required\": [\n        \"repeatingGroup\"\n      ],\n      \"type\":
+        \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2110'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 14:04:42 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.8
+    status:
+      code: 201
+      message: CREATED
+version: 1


### PR DESCRIPTION
Closes #5065

**Changes**

Process edit grid components in the json dump registration backend

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
