### PR TITLE
Fix bug with collapsed metadata fieldset being hidden in JSON dump plugin

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/json_dump/JSONDumpOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/json_dump/JSONDumpOptionsForm.js
@@ -65,6 +65,7 @@ const JSONDumpOptionsForm = ({name, label, schema, formData, onChange}) => {
               defaultMessage="Metadata variables"
             />
           }
+          extraClassName="openforms-fieldset"
           collapsible
           initialCollapsed
         >

--- a/src/openforms/scss/components/admin/_fieldset.scss
+++ b/src/openforms/scss/components/admin/_fieldset.scss
@@ -1,0 +1,8 @@
+/**
+ * The django admin `.collapsed` styling on fieldset elements sets `overflow: hidden;`.
+ * Seeing how we already hide the fieldset content in the javascript code,
+ * the `overflow: hidden;` only hides the fieldset toggle (which we want to keep visible)
+ */
+.openforms-fieldset.collapsed {
+  overflow: visible !important;
+}

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -19,6 +19,7 @@
 @import './column-field-value';
 @import './confirmation-email-template';
 @import './variablemapping';
+@import './fieldset';
 
 // Form design UI
 @import './select';


### PR DESCRIPTION
Closes #5088 

**Changes**

Ensure `overflow: visible` is set for the metadata variables fieldset in the JSON Dump plugin

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
