### PR TITLE
Wrapping array data fields in variable table

### DIFF
--- a/src/openforms/js/components/admin/form_design/logic/LiteralValueInput.js
+++ b/src/openforms/js/components/admin/form_design/logic/LiteralValueInput.js
@@ -67,6 +67,7 @@ const WrapperArrayInput = ({name, value, onChange}) => {
         checked={useRawJSON}
         onChange={() => setUseRawJSON(!useRawJSON)}
         disabled={anyItemNotString}
+        fullWidth
       />
       {actualInput}
     </>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -200,7 +200,11 @@ const EditableVariableRow = ({index, variable, onDelete, onChange, onFieldChange
         </Field>
       </td>
       <td>
-        <Field name="initialValue" errors={variable.errors?.initialValue}>
+        <Field
+          name="initialValue"
+          errors={variable.errors?.initialValue}
+          extraModifiers={['flex-wrap']}
+        >
           <LiteralValueInput
             key={`initialValue-${index}`}
             name="initialValue"

--- a/src/openforms/js/components/admin/forms/Field.js
+++ b/src/openforms/js/components/admin/forms/Field.js
@@ -59,6 +59,7 @@ const Field = ({
   errorClassPrefix = '',
   errorClassModifier = '',
   noManageChildProps = false,
+  extraModifiers = [],
 }) => {
   const intl = useIntl();
   const originalName = name;
@@ -78,10 +79,14 @@ const Field = ({
   }
   const [hasErrors, formattedErrors] = normalizeErrors(errors, intl);
 
-  const fieldClassName = classNames('flex-container', {
-    fieldBox: fieldBox,
-    errors: hasErrors,
-  });
+  const fieldClassName = classNames(
+    'flex-container',
+    {
+      fieldBox: fieldBox,
+      errors: hasErrors,
+    },
+    ...extraModifiers
+  );
   const wrapperClassName = classNames({'field--disabled': disabled});
 
   const fieldInputMarkup = (
@@ -146,6 +151,7 @@ Field.propTypes = {
   ]),
   fieldBox: PropTypes.bool,
   disabled: PropTypes.bool,
+  extraModifiers: PropTypes.arrayOf(PropTypes.oneOf(['flex-wrap'])),
 };
 
 export default Field;

--- a/src/openforms/js/components/admin/forms/Inputs.js
+++ b/src/openforms/js/components/admin/forms/Inputs.js
@@ -96,13 +96,20 @@ DateTimeInput.propTypes = {
   onChange: PropTypes.func,
 };
 
-const Checkbox = ({name, label, helpText, noVCheckbox = false, ...extraProps}) => {
+const Checkbox = ({
+  name,
+  label,
+  helpText,
+  noVCheckbox = false,
+  fullWidth = false,
+  ...extraProps
+}) => {
   const {disabled = false} = extraProps;
   const prefix = useContext(PrefixContext);
   name = prefix ? `${prefix}-${name}` : name;
   const idFor = disabled ? undefined : `id_${name}`;
   return (
-    <div className={classNames({'field--disabled': disabled})}>
+    <div className={classNames({'field--disabled': disabled, 'w-100': fullWidth})}>
       <div className="flex-container checkbox-row">
         <input type="checkbox" name={name} id={idFor} {...extraProps} />{' '}
         <label className={classNames('inline', {vCheckboxLabel: !noVCheckbox})} htmlFor={idFor}>
@@ -123,6 +130,7 @@ Checkbox.propTypes = {
   label: PropTypes.node.isRequired,
   helpText: PropTypes.node,
   noVCheckbox: PropTypes.bool,
+  fullWidth: PropTypes.bool,
 };
 
 const Radio = ({name, idFor, label, helpText, ...extraProps}) => {


### PR DESCRIPTION
Closes #5093

**Changes**

Displaying the array fields below the `Use raw JSON input` checkbox in the form variable table.

![Screenshot 2025-02-10 at 17 14 50](https://github.com/user-attachments/assets/ec43ada2-2860-4c41-a72e-e956a7c47de7)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
