### PR TITLE
[#5039] Fix email registration errors

### DIFF
--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -1030,6 +1030,51 @@ export const Email = {
   },
 };
 
+export const EmailValidationNonFieldErrors = {
+  args: {
+    configuredBackends: [
+      {
+        key: 'backend3',
+        name: 'Email',
+        backend: 'email',
+        options: {
+          toEmails: ['example@example.nl'],
+          attachmentFormats: [],
+          paymentEmails: [],
+          attachFilesToEmail: false,
+          email_subject: '',
+          email_payment_subject: '',
+          email_content_template_html: '',
+          email_content_template_text: '',
+        },
+      },
+    ],
+    validationErrors: [
+      [
+        'form.registrationBackends.0.options.nonFieldErrors',
+        'Both email_content_template_html and email_content_template_text are required',
+      ],
+      ['form.registrationBackends.0.options.email_content_template_text', 'Specific field error'],
+    ],
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Opties instellen'}));
+
+    const modalForm = await screen.findByTestId('modal-form');
+    await expect(modalForm).toBeVisible();
+    const modal = within(modalForm);
+
+    await expect(
+      modal.getByText(
+        'Both email_content_template_html and email_content_template_text are required'
+      )
+    ).toBeVisible();
+  },
+};
+
 export const STUFZDS = {
   name: 'StUF ZDS',
   args: {

--- a/src/openforms/js/components/admin/form_design/registrations/email/EmailOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/email/EmailOptionsFormFields.js
@@ -8,6 +8,7 @@ import {
   ValidationErrorsProvider,
   filterErrors,
 } from 'components/admin/forms/ValidationErrors';
+import ErrorMessage from 'components/errors/ErrorMessage';
 import {getChoicesFromSchema} from 'utils/json-schema';
 
 import EmailAttachmentFormatsSelect from './fields/EmailAttachmentFormatsSelect';
@@ -34,8 +35,17 @@ const EmailOptionsFormFields = ({name, schema}) => {
   ).map(([value, label]) => ({value, label}));
 
   const relevantErrors = filterErrors(name, validationErrors);
+  const nonFieldErrors = relevantErrors.filter(([field]) => field === 'nonFieldErrors');
+
   return (
     <ValidationErrorsProvider errors={relevantErrors}>
+      {nonFieldErrors && (
+        <>
+          {nonFieldErrors.map(([field, message], index) => (
+            <ErrorMessage key={`${field}-${index}`}>{message}</ErrorMessage>
+          ))}
+        </>
+      )}
       <Fieldset
         title={
           <FormattedMessage


### PR DESCRIPTION
Closes #5039

**Changes**

- Email registration used `nonField` errors for a combination of fields and these were not shown on the frontend. Fixed these by showing them on the top of the modal.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
