### PR TITLE
Accessibility improvements for submission report pdf

### DIFF
--- a/src/openforms/formio/formatters/base.py
+++ b/src/openforms/formio/formatters/base.py
@@ -70,9 +70,14 @@ class FormatterBase(Generic[ComponentT]):
         # note all this depends on value not being unexpected type or shape
         values = self.normalise_value_to_list(component, value)
 
-        formatted_values = (
+        formatted_values = list(
             force_str(self.format(component, value)) for value in values
         )
+
+        # Check if formatted_values isn't empty
+        if len(formatted_values) == 0:
+            return self.process_result(component, "")
+
         # logically we'd want a .filter_formatted_values() step here
         return self.process_result(
             component, self.join_formatted_values(component, formatted_values)

--- a/src/openforms/formio/formatters/formio.py
+++ b/src/openforms/formio/formatters/formio.py
@@ -121,6 +121,8 @@ class SelectBoxesFormatter(FormatterBase):
             # For the html output, wrap the values in li tags and put it inside an ul tag.
             # The selectboxes formatter handles all values at the same time,
             # so handle the full html formatting here.
+            if not selected_labels:
+                return ""
             return format_html(
                 "<ul>{values}</ul>",
                 values=format_html_join(

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -6,11 +6,13 @@
 <html lang="{{ LANG }}" class="{{ theme.get_classname }}">
     <head>
         <meta charset="utf-8">
-        <title>{% block title %}
-            {% blocktrans with form_name=report.form.name trimmed %}
-                {{ form_name }}: PDF report
-            {% endblocktrans %}
-        {% endblock %}</title>
+        <title>{% spaceless %}
+            {% block title %}
+                {% blocktrans with form_name=report.form.name trimmed %}
+                    {{ form_name }}: PDF report
+                {% endblocktrans %}
+            {% endblock %}
+        {% endspaceless %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="{% static 'bundles/pdf-css.css' %}" media="all" rel="stylesheet" />
         {% block extra_css %}{% endblock %}

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -65,7 +65,7 @@
 
             {% for submission_step_node in report.renderer.get_children %}
                 {% if submission_step_node.has_children %}
-                    <div class="submission-step">
+                    <section class="submission-step">
                         <h2 class="subtitle">{{ submission_step_node.render }}</h2>
                         {% for component_node in submission_step_node.get_children %}
                             {% if component_node.label or component_node.display_value %}
@@ -76,19 +76,21 @@
                                         {% if component_node.component.type == "fieldset" %}
                                             <span class="submission-step-row__fieldset-label">{{ component_node.label }}</span>
                                         {% else %}
-                                            <div class="submission-step-row__label">
-                                                {{ component_node.label }}
-                                            </div>
+                                            {% with node_path=component_node.configuration_path|add:'.'|add:component_node.key %}
+                                                <span id="{{ node_path }}" class="submission-step-row__label">
+                                                    {{ component_node.label }}
+                                                </span>
 
-                                            <div class="submission-step-row__value{% if not component_node.display_value %} submission-step-row__value--empty{% endif %}">
-                                                {{ component_node.display_value|default:"" }}
-                                            </div>
+                                                <div aria-labelledby="{{ node_path }}" class="submission-step-row__value{% if not component_node.display_value %} submission-step-row__value--empty{% endif %}">
+                                                    {{ component_node.display_value|default:"" }}
+                                                </div>
+                                            {% endwith %}
                                         {% endif %}
                                     {% endif %}
                                 </div>
                             {% endif %}
                         {% endfor %}
-                    </div>
+                    </section>
                 {% endif %}
             {% endfor %}
 

--- a/src/openforms/submissions/templates/report/submission_report.html
+++ b/src/openforms/submissions/templates/report/submission_report.html
@@ -82,7 +82,11 @@
                                                 </span>
 
                                                 <div aria-labelledby="{{ node_path }}" class="submission-step-row__value{% if not component_node.display_value %} submission-step-row__value--empty{% endif %}">
-                                                    {{ component_node.display_value|default:"" }}
+                                                    {% if component_node.display_value %}
+                                                        {{ component_node.display_value }}
+                                                    {% elif not component_node.layout_modifier %}
+                                                        {% trans "No information provided" %}
+                                                    {% endif %}
                                                 </div>
                                             {% endwith %}
                                         {% endif %}

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -526,6 +526,139 @@ class SubmissionReportGenerationTests(TestCase):
         )
         self.assertInHTML(expected, html, count=1)
 
+    def test_components_with_no_content(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "textfield",
+                    "key": "textfield",
+                    "label": "Textfield",
+                },
+                {
+                    "type": "selectboxes",
+                    "key": "selectboxes",
+                    "label": "Selectboxes",
+                    "values": [
+                        {
+                            "value": "option1",
+                            "label": "Selectbox Option 1",
+                        },
+                        {
+                            "value": "option2",
+                            "label": "Selectbox Option 2",
+                        },
+                        {
+                            "value": "option3",
+                            "label": "Selectbox Option 3",
+                        },
+                    ],
+                },
+                {
+                    "type": "radio",
+                    "key": "radio",
+                    "label": "Radio",
+                    "values": [
+                        {
+                            "value": "firstradiooption",
+                            "label": "First radio option",
+                        },
+                        {
+                            "value": "secondradiooption",
+                            "label": "Second radio option",
+                        },
+                    ],
+                },
+                {
+                    "key": "fieldset",
+                    "type": "fieldset",
+                    "label": "Fieldset",
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "textfield1",
+                            "label": "Textfield 1",
+                        },
+                    ],
+                },
+                {
+                    "key": "repeatingGroup",
+                    "type": "editgrid",
+                    "label": "Repeating Group",
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "textfield2",
+                            "label": "Textfield 2",
+                        },
+                    ],
+                },
+            ],
+            submitted_data={"repeatingGroup": [{"textfield2": None}]},
+            with_report=True,
+        )
+        html = submission.report.generate_submission_report_pdf()
+
+        expected = format_html(
+            """
+            <div class="submission-step-row">
+                <span id="components.0.textfield" class="submission-step-row__label">Textfield</span>
+                <div aria-labelledby="components.0.textfield" class="submission-step-row__value submission-step-row__value--empty">
+                     No information provided
+                </div>
+            </div>
+
+            <div class="submission-step-row">
+                <span id="components.1.selectboxes" class="submission-step-row__label">Selectboxes</span>
+                <div aria-labelledby="components.1.selectboxes" class="submission-step-row__value submission-step-row__value--empty">
+                     No information provided
+                </div>
+            </div>
+
+            <div class="submission-step-row">
+                <span id="components.2.radio" class="submission-step-row__label">Radio</span>
+                <div aria-labelledby="components.2.radio" class="submission-step-row__value submission-step-row__value--empty">
+                     No information provided
+                </div>
+            </div>
+
+            <div class="submission-step-row submission-step-row--fieldset">
+                <span class="submission-step-row__fieldset-label">Fieldset</span>
+            </div>
+            <div class="submission-step-row">
+                <span id="components.3.components.0.textfield1" class="submission-step-row__label">
+                    Textfield 1
+                </span>
+                <div aria-labelledby="components.3.components.0.textfield1" class="submission-step-row__value submission-step-row__value--empty">
+                    No information provided
+                </div>
+            </div>
+
+            <div class="submission-step-row submission-step-row--editgrid">
+                <span id="components.4.repeatingGroup" class="submission-step-row__label">
+                    Repeating Group
+                </span>
+                <div aria-labelledby="components.4.repeatingGroup" class="submission-step-row__value submission-step-row__value--empty">
+                </div>
+            </div>
+            <div class="submission-step-row submission-step-row--editgrid-group">
+                <span id="components.4.components.repeatingGroup" class="submission-step-row__label">
+                    Item 1
+                </span>
+                <div aria-labelledby="components.4.components.repeatingGroup" class="submission-step-row__value submission-step-row__value--empty">
+                </div>
+            </div>
+            <div class="submission-step-row">
+                <span id="components.4.components.0.textfield2" class="submission-step-row__label">
+                    Textfield 2
+                </span>
+                <div aria-labelledby="components.4.components.0.textfield2" class="submission-step-row__value submission-step-row__value--empty">
+                    No information provided
+                </div>
+            </div>
+            """,
+        )
+        self.assertInHTML(expected, html, count=1)
+
 
 @temp_private_root()
 class SubmissionReportCoSignTests(TestCase):

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -356,14 +356,14 @@ class SubmissionReportGenerationTests(TestCase):
         expected = format_html(
             """
             <div class="submission-step-row">
-                <div class="submission-step-row__label">Textfield single</div>
-                <div class="submission-step-row__value">
+                <span id="components.0.textfield-single" class="submission-step-row__label">Textfield single</span>
+                <div aria-labelledby="components.0.textfield-single" class="submission-step-row__value">
                     foo
                 </div>
             </div>
             <div class="submission-step-row">
-                <div class="submission-step-row__label">Textfield multiple</div>
-                <div class="submission-step-row__value">
+                <span id="components.1.textfield-multiple" class="submission-step-row__label">Textfield multiple</span>
+                <div aria-labelledby="components.1.textfield-multiple" class="submission-step-row__value">
                     <ul><li>foo</li><li>bar</li></ul>
                 </div>
             </div>
@@ -426,14 +426,14 @@ class SubmissionReportGenerationTests(TestCase):
         expected = format_html(
             """
             <div class="submission-step-row">
-                <div class="submission-step-row__label">Select single</div>
-                <div class="submission-step-row__value">
+                <span id="components.0.select-single" class="submission-step-row__label">Select single</span>
+                <div aria-labelledby="components.0.select-single" class="submission-step-row__value">
                     Single select Option 1
                 </div>
             </div>
             <div class="submission-step-row">
-                <div class="submission-step-row__label">Select multiple</div>
-                <div class="submission-step-row__value">
+                <span id="components.1.select-multiple" class="submission-step-row__label">Select multiple</span>
+                <div aria-labelledby="components.1.select-multiple" class="submission-step-row__value">
                     <ul><li>Multiple select Option 1</li><li>Multiple select Option 3</li></ul>
                 </div>
             </div>
@@ -477,8 +477,10 @@ class SubmissionReportGenerationTests(TestCase):
         expected = format_html(
             """
             <div class="submission-step-row">
-                <div class="submission-step-row__label">Selectboxes</div>
-                <div class="submission-step-row__value">
+                <span id="components.0.selectboxes" class="submission-step-row__label">
+                    Selectboxes
+                </span>
+                <div aria-labelledby="components.0.selectboxes" class="submission-step-row__value">
                     <ul><li>Selectbox Option 1</li><li>Selectbox Option 3</li></ul>
                 </div>
             </div>
@@ -515,8 +517,8 @@ class SubmissionReportGenerationTests(TestCase):
         expected = format_html(
             """
             <div class="submission-step-row">
-                <div class="submission-step-row__label">Radio</div>
-                <div class="submission-step-row__value">
+                <span id="components.0.radio" class="submission-step-row__label">Radio</span>
+                <div aria-labelledby="components.0.radio" class="submission-step-row__value">
                     Second radio option
                 </div>
             </div>


### PR DESCRIPTION
Closes #5047

**Changes**

- Added semantic relationships between field label and field content.
- When a field is left empty by the user, the submission report will display 'No information provided' in place of the missing field content.
- Removed leading and trailing whitespace in pdf metadata title

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
