### PR TITLE
Read only submission report content

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -187,7 +187,7 @@ django-otp==1.3.0
     # via django-two-factor-auth
 django-phonenumber-field==7.3.0
     # via django-two-factor-auth
-django-privates==1.5.0
+django-privates==3.0.0
     # via
     #   -r requirements/base.in
     #   django-simple-certmanager

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -320,7 +320,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-two-factor-auth
-django-privates==1.5.0
+django-privates==3.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -347,7 +347,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
-django-privates==1.5.0
+django-privates==3.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -306,7 +306,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-two-factor-auth
-django-privates==1.5.0
+django-privates==3.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -338,7 +338,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
-django-privates==1.5.0
+django-privates==3.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/submissions/admin.py
+++ b/src/openforms/submissions/admin.py
@@ -500,6 +500,7 @@ class SubmissionReportAdmin(PrivateMediaMixin, admin.ModelAdmin):
     raw_id_fields = ("submission",)
 
     private_media_fields = ("content",)
+    readonly_fields = ("content",)
 
     def has_add_permission(self, request, obj=None):
         return False

--- a/src/openforms/submissions/admin.py
+++ b/src/openforms/submissions/admin.py
@@ -500,6 +500,7 @@ class SubmissionReportAdmin(PrivateMediaMixin, admin.ModelAdmin):
     raw_id_fields = ("submission",)
 
     private_media_fields = ("content",)
+    private_media_view_options = {"attachment": True}
     readonly_fields = ("content",)
 
     def has_add_permission(self, request, obj=None):


### PR DESCRIPTION
Closes open-formulieren/security-issues#34

**Changes**

The submission report content is now read-only in the admin

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
