### PR TITLE
Adding email timeout env variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,7 +50,7 @@ Detailed changes
 * [:backend:`4785`] Updated the eHerkenning metadata generation to match the latest
   standard version(s).
 * Added the ability to configure ``EMAIL_TIMEOUT`` environment variable which will configure 
-the time after which the email service will timeout.  
+the time after which the email service will timeout.
 
 **Bugfixes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,8 @@ Detailed changes
   configuration.
 * [:backend:`4785`] Updated the eHerkenning metadata generation to match the latest
   standard version(s).
+* Added the ability to configure ``EMAIL_TIMEOUT`` environment variable which will configure 
+the time after which the email service will timeout.  
 
 **Bugfixes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,8 +49,6 @@ Detailed changes
   configuration.
 * [:backend:`4785`] Updated the eHerkenning metadata generation to match the latest
   standard version(s).
-* Added the ability to configure ``EMAIL_TIMEOUT`` environment variable which will configure 
-the time after which the email service will timeout.
 
 **Bugfixes**
 

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -83,7 +83,7 @@ Email settings
 * ``DEFAULT_FROM_EMAIL``: The email address to use a default sender. Defaults
   to ``openforms@example.com``.
 
-* ``EMAIL_TIMEOUT``: in seconds this variable is setting the maximum amount of time the email backend will wait when trying to connect to the email server. If the connection exceeds the time specified a timout error will be raised. The default value is set to ``10 seconds``, and in general it is not recommended to use a very high number. This setting ensures that any email-sending operation will fail quickly if the server doesn't respond within the given timeframe.
+* ``EMAIL_TIMEOUT``: How long to wait for blocking operations like the connection attempt, in seconds. Defaults to ``10``.
 
 .. _installation_config_cors:
 

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -83,6 +83,8 @@ Email settings
 * ``DEFAULT_FROM_EMAIL``: The email address to use a default sender. Defaults
   to ``openforms@example.com``.
 
+* ``EMAIL_TIMEOUT``: in seconds this variable is setting the maximum amount of time the email backend will wait when trying to connect to the email server. If the connection exceeds the time specified a timout error will be raised. The default value is set to ``10 seconds``, and in general it is not recommended to use a very high number. This setting ensures that any email-sending operation will fail quickly if the server doesn't respond within the given timeframe.
+
 .. _installation_config_cors:
 
 Cross-Origin Resource Sharing (CORS) settings

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -362,7 +362,7 @@ EMAIL_PORT = config(
 EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
 EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
 EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)
-EMAIL_TIMEOUT = 10
+EMAIL_TIMEOUT = config("EMAIL_TIMEOUT", default=10)
 
 DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", "openforms@example.com")
 


### PR DESCRIPTION
**Changes**

Setting env variable EMAIL_TIMEOUT to be defined during deployment.
[It was requested by the people from Het Hogeland]

Taiga Hogeland 54
