### PR TITLE
Change when plugin fieldset is hidden in registration variables table

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/RegistrationVariables.js
+++ b/src/openforms/js/components/admin/form_design/variables/RegistrationVariables.js
@@ -45,6 +45,12 @@ const RegistrationVariables = ({onFieldChange}) => {
       plugin.pluginVariables.length
   );
 
+  // A plugin fieldset will not be included if there is only one registration backend configured,
+  // or if all configured backends are the same type
+  const hidePluginFieldset =
+    registrationBackends.length === 1 ||
+    new Set(registrationBackends.map(b => b.backend)).size === 1;
+
   const headColumns = (
     <>
       <HeadColumn content="" />
@@ -85,7 +91,7 @@ const RegistrationVariables = ({onFieldChange}) => {
           />
         );
 
-        if (registrationPluginsVariables.length === 1) return pluginVariables;
+        if (hidePluginFieldset) return pluginVariables;
 
         return (
           <Fieldset title={registrationPlugin.pluginVerboseName} key={index}>

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -371,7 +371,7 @@ export const WithObjectsAPIRegistrationBackends = {
     const pdfUrl = canvas.getByRole('cell', {name: 'pdf_url'});
     expect(pdfUrl).toBeVisible();
 
-    // With a single backend, the heading shouldn't display:
+    // With all backends of the same type, the heading shouldn't display
     const objectsApiTitle = canvas.queryByRole('heading', {name: 'Objects API registration'});
     expect(objectsApiTitle).toBeNull();
   },
@@ -462,6 +462,23 @@ export const FilesMappingAndObjectAPIRegistration = {
       {
         pluginIdentifier: 'objects_api',
         pluginVerboseName: 'Objects API registration',
+        pluginVariables: [
+          {
+            form: null,
+            formDefinition: null,
+            name: 'PDF Url',
+            key: 'pdf_url',
+            source: '',
+            prefillPlugin: '',
+            prefillAttribute: '',
+            prefillIdentifierRole: 'main',
+            dataType: 'string',
+            dataFormat: '',
+            isSensitiveData: false,
+            serviceFetchConfiguration: undefined,
+            initialValue: '',
+          },
+        ],
       },
     ],
   },
@@ -651,6 +668,21 @@ export const WithObjectsAPIAndTestRegistrationBackends = {
         }),
       ],
     },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const registrationTab = canvas.getByRole('tab', {name: 'Registratie'});
+    await userEvent.click(registrationTab);
+
+    // With multiple backends configured, and two of them introduce registration variables,
+    // the plugin headings should be visible.
+    expect(canvas.getByRole('heading', {name: 'Objects API registration'})).toBeVisible();
+    expect(canvas.getByRole('heading', {name: 'Test plugin'})).toBeVisible();
+
+    // Navigate back to component tab for visual regression testing
+    const componentTab = canvas.getByRole('tab', {name: /Component/});
+    await componentTab.click(componentTab);
   },
 };
 
@@ -1324,5 +1356,57 @@ export const AddressNLMappingSpecificTargetsDeriveAddress = {
     const streetNameSelect = await canvas.findByLabelText('Bestemmingspad straatnaam');
     expect(streetNameSelect).toBeVisible();
     expect(streetNameSelect).not.toBeDisabled();
+  },
+};
+
+export const TwoBackendsWhereOnlyOneIntroducesRegistrationVariables = {
+  args: {
+    registrationBackends: [
+      {
+        backend: 'objects_api',
+        key: 'objects_api_1',
+        name: 'Example Objects API reg.',
+        options: {},
+      },
+      {
+        backend: 'testPlugin',
+        key: 'test_backend',
+        name: 'Example test registration',
+        options: {},
+      },
+    ],
+    registrationPluginsVariables: [
+      {
+        pluginIdentifier: 'objects_api',
+        pluginVerboseName: 'Objects API registration',
+        pluginVariables: [
+          {
+            form: null,
+            formDefinition: null,
+            name: 'PDF Url',
+            key: 'pdf_url',
+            source: '',
+            prefillPlugin: '',
+            prefillAttribute: '',
+            prefillIdentifierRole: 'main',
+            dataType: 'string',
+            dataFormat: '',
+            isSensitiveData: false,
+            serviceFetchConfiguration: undefined,
+            initialValue: '',
+          },
+        ],
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const registrationTab = canvas.getByRole('tab', {name: 'Registratie'});
+    await userEvent.click(registrationTab);
+
+    // With multiple backends configured, but only one of them introduces registration variables,
+    // the plugin heading should be visible.
+    expect(canvas.getByRole('heading', {name: 'Objects API registration'})).toBeVisible();
   },
 };


### PR DESCRIPTION
Closes #4990

**Changes**

In the registration variables table, the plugin fieldset is now only hidden if there is only one configured backend, or if all the configured backends are of the same type.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
