### PR TITLE
[#5090] Make `softRequiredErrors` component always non required

### DIFF
--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -387,6 +387,11 @@ const _mayNeverBeRequired = component => {
     return true;
   }
 
+  // Issue #5090 - Soft required components shouldn't be marked as required, since they take no input.
+  if (component.type === 'softRequiredErrors') {
+    return true;
+  }
+
   // Special case for #2548 - an editgrid ('repeating group') itself _can_ be marked
   // required.
   if (component.type === 'editgrid') {


### PR DESCRIPTION
Closes #5090

**Changes**

Made `softReuiredErrors` always non required

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
