### PR TITLE
svg sanitizing 

### DIFF
--- a/src/openforms/utils/fields.py
+++ b/src/openforms/utils/fields.py
@@ -14,9 +14,8 @@ class StringUUIDField(models.UUIDField):
 
 
 class SVGOrImageField(models.ImageField):
-    # SVG's are not regular "images", so they get different treatment. Note that
-    # we're not doing extended sanitization *yet* here, so be careful when using
-    # this field.
+    # SVG's are not regular "images", so they get different treatment. Sanitization is
+    # done in the form_class, form_fields.SVGOrImageField.
     def formfield(self, **kwargs):
         return super().formfield(
             **{

--- a/src/openforms/utils/form_fields.py
+++ b/src/openforms/utils/form_fields.py
@@ -9,6 +9,8 @@ from django.core.validators import (
 from django.db import models
 from django.forms import CheckboxSelectMultiple, ImageField, MultipleChoiceField
 
+from .sanitizer import sanitize_svg_file
+
 image_or_svg_extension_validator = FileExtensionValidator(
     allowed_extensions=["svg"] + list(get_available_image_extensions())
 )
@@ -44,10 +46,10 @@ class SVGOrImageField(ImageField):
         # get the extension
         extension = get_extension(data)
 
-        # SVG's are not regular "images", so they get different treatment. Note that
-        # we're not doing extended sanitization *yet* here, so be careful when using
-        # this field.
+        # SVG's are not regular "images", so they get different treatment.
         if extension == "svg":
+            data = sanitize_svg_file(data)
+
             # we call the parent of the original ImageField instead of calling to_python
             # of ImageField (the direct superclass), as that one tries to validate the
             # image with PIL

--- a/src/openforms/utils/sanitizer.py
+++ b/src/openforms/utils/sanitizer.py
@@ -1,0 +1,196 @@
+from django.core.files import File
+
+import bleach
+
+ALLOWED_SVG_TAGS = (
+    "circle",
+    "clipPath",
+    "defs",
+    "desc",
+    "ellipse",
+    "feBlend",
+    "feColorMatrix",
+    "feComponentTransfer",
+    "feComposite",
+    "feConvolveMatrix",
+    "feDiffuseLighting",
+    "feDisplacementMap",
+    "feDistantLight",
+    "feDropShadow",
+    "feFlood",
+    "feFuncA",
+    "feFuncB",
+    "feFuncG",
+    "feFuncR",
+    "feGaussianBlur",
+    "feImage",
+    "feMerge",
+    "feMergeNode",
+    "feMorphology",
+    "feOffset",
+    "fePointLight",
+    "feSpecularLighting",
+    "feSpotLight",
+    "feTile",
+    "feTurbulence",
+    "filter",
+    "foreignObject",
+    "g",
+    "image",
+    "line",
+    "linearGradient",
+    "marker",
+    "mask",
+    "metadata",
+    "mpath",
+    "path",
+    "pattern",
+    "polygon",
+    "polyline",
+    "radialGradient",
+    "rect",
+    "set",
+    "stop",
+    "style",
+    "svg",
+    "symbol",
+    "text",
+    "textPath",
+    "title",
+    "tspan",
+    "use",
+    "view",
+    # --- Not allowing 'a', 'animate*' and 'script' tags
+)
+
+ALLOWED_SVG_ATTRIBUTES = {
+    "*": [
+        # --- Basic presentation attributes
+        "alignment-baseline",
+        "baseline-shift",
+        "clip",
+        "clip-path",
+        "clip-rule",
+        "color",
+        "color-interpolation",
+        "color-interpolation-filters",
+        "cursor",
+        "cx",
+        "cy",
+        "d",
+        "direction",
+        "display",
+        "dominant-baseline",
+        "fill",
+        "fill-opacity",
+        "fill-rule",
+        "filter",
+        "flood-color",
+        "flood-opacity",
+        "font-family",
+        "font-size",
+        "font-size-adjust",
+        "font-stretch",
+        "font-style",
+        "font-variant",
+        "font-weight",
+        "glyph-orientation-horizontal",
+        "glyph-orientation-vertical",
+        "height",
+        "image-rendering",
+        "letter-spacing",
+        "lighting-color",
+        "marker-end",
+        "marker-mid",
+        "marker-start",
+        "mask",
+        "mask-type",
+        "opacity",
+        "overflow",
+        "pointer-events",
+        "r",
+        "rx",
+        "ry",
+        "shape-rendering",
+        "stop-color",
+        "stop-opacity",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "stroke-linejoin",
+        "stroke-miterlimit",
+        "stroke-opacity",
+        "stroke-width",
+        "text-anchor",
+        "text-decoration",
+        "text-overflow",
+        "text-rendering",
+        "transform",
+        "transform-origin",
+        "unicode-bidi",
+        "vector-effect",
+        "visibility",
+        "white-space",
+        "width",
+        "word-spacing",
+        "writing-mode",
+        "x",
+        "y",
+        # --- Filter attributes
+        "amplitude",
+        "exponent",
+        "intercept",
+        "offset",
+        "slope",
+        "tableValues",
+        "type",
+        # --- Not allowing 'href', 'data-*', Animation and some other attributes
+    ],
+    "svg": ["xmlns", "viewBox"],
+}
+
+
+def sanitize_svg_file(data: File) -> File:
+    """
+    Defuse an uploaded SVG file.
+
+    The entire file content will be replaced with a sanitized version. All tags and
+    attributes that aren't explicitly allowed, are removed from the SVG content.
+
+    :arg data: the uploaded SVG file, opened in binary mode.
+    """
+    # Making sure that the file is reset properly
+    data.seek(0)
+
+    file_content = data.read().decode("utf-8")
+    sanitized_content = sanitize_svg_content(file_content)
+
+    # Replace svg file content with the bleached variant.
+    # `truncate(0)` doesn't reset the point, so start with a seek(0) to make sure the
+    # content is as expected.
+    data.seek(0)
+    data.truncate(0)
+    data.write(sanitized_content.encode("utf-8"))
+
+    # Reset pointer
+    data.seek(0)
+    return data
+
+
+def sanitize_svg_content(svg_content: str) -> str:
+    """
+    Strip (potentially) dangerous elements and attributes from the provided SVG string.
+
+    All tags and attributes that aren't explicitly allowed, are removed from the SVG
+    content.
+
+    :arg svg_content: decoded SVG content.
+    """
+
+    return bleach.clean(
+        svg_content,
+        tags=ALLOWED_SVG_TAGS,
+        attributes=ALLOWED_SVG_ATTRIBUTES,
+        strip=True,
+    )

--- a/src/openforms/utils/tests/test_sanitizer.py
+++ b/src/openforms/utils/tests/test_sanitizer.py
@@ -1,0 +1,89 @@
+import io
+
+from django.test import SimpleTestCase
+
+from ..sanitizer import sanitize_svg_content, sanitize_svg_file
+
+
+class SanitizeSvgFileTests(SimpleTestCase):
+    def test_sanitize_svg_content_removes_script_tags(self):
+        bad_svg_content = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="25" fill="green" />
+            <script>//<![CDATA[
+                alert("I am malicious >:)")
+            //]]></script>
+            <g>
+                <rect class="btn" x="0" y="0" width="10" height="10" fill="red" />
+            </g>
+        </svg>
+        """
+        sanitized_svg_content = b"""
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="25" fill="green"></circle>
+            //
+                alert("I am malicious &gt;:)")
+            //
+            <g>
+                <rect x="0" y="0" width="10" height="10" fill="red"></rect>
+            </g>
+        </svg>
+        """
+
+        temp_file = io.BytesIO(bad_svg_content.encode("utf-8"))
+
+        # Assert that sanitize_svg_content removed the script tag
+        sanitized_svg_file = sanitize_svg_file(temp_file)
+        self.assertEqual(sanitized_svg_file.read(), sanitized_svg_content)
+
+
+class SanitizeSvgContentTests(SimpleTestCase):
+    def test_sanitize_svg_content_removes_script_tags(self):
+        bad_svg_content = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="25" fill="green" />
+            <script>//<![CDATA[
+                alert("I am malicious >:)")
+            //]]></script>
+            <g>
+                <rect class="btn" x="0" y="0" width="10" height="10" fill="red" />
+            </g>
+        </svg>
+        """
+        sanitized_svg_content = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="25" fill="green"></circle>
+            //
+                alert("I am malicious &gt;:)")
+            //
+            <g>
+                <rect x="0" y="0" width="10" height="10" fill="red"></rect>
+            </g>
+        </svg>
+        """
+
+        # Assert that sanitize_svg_content removed the script tag
+        sanitized_bad_svg_content = sanitize_svg_content(bad_svg_content)
+        self.assertEqual(sanitized_svg_content, sanitized_bad_svg_content)
+
+    def test_sanitize_svg_content_removes_event_handlers(self):
+        bad_svg_content = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="25" fill="green" onclick="alert('forget about me?')" />
+            <g>
+                <rect class="btn" x="0" y="0" width="10" height="10" fill="red" onload="alert('click!')" />
+            </g>
+        </svg>
+        """
+        sanitized_svg_content = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="25" fill="green"></circle>
+            <g>
+                <rect x="0" y="0" width="10" height="10" fill="red"></rect>
+            </g>
+        </svg>
+        """
+
+        # Assert that sanitize_svg_content removed the event handlers
+        sanitized_bad_svg_content = sanitize_svg_content(bad_svg_content)
+        self.assertEqual(sanitized_svg_content, sanitized_bad_svg_content)


### PR DESCRIPTION
Closes open-formulieren/security-issues#35

**Changes**

Added svg sanitizing to `SVGOrImageField`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
