### PR TITLE
Sanitizing HTML from component label, tooltip and description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "copy-to-clipboard": "^3.3.1",
         "design-token-editor": "^0.6.0",
         "django-cookie-consent": "^0.6.0",
+        "dompurify": "^3.2.4",
         "feelin": "^3.1.0",
         "flatpickr": "^4.6.9",
         "formik": "^2.2.9",
@@ -6328,6 +6329,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -8934,9 +8942,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -9957,6 +9969,12 @@
         "uuid": "^8.3.2",
         "vanilla-picker": "^2.11.2"
       }
+    },
+    "node_modules/formiojs/node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/fraction.js": {
       "version": "4.1.1",
@@ -22853,6 +22871,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -24867,9 +24891,12 @@
       }
     },
     "dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "domutils": {
       "version": "2.8.0",
@@ -25661,6 +25688,13 @@
         "tooltip.js": "^1.3.3",
         "uuid": "^8.3.2",
         "vanilla-picker": "^2.11.2"
+      },
+      "dependencies": {
+        "dompurify": {
+          "version": "2.5.8",
+          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+          "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw=="
+        }
       }
     },
     "fraction.js": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "copy-to-clipboard": "^3.3.1",
     "design-token-editor": "^0.6.0",
     "django-cookie-consent": "^0.6.0",
+    "dompurify": "^3.2.4",
     "feelin": "^3.1.0",
     "flatpickr": "^4.6.9",
     "formik": "^2.2.9",

--- a/src/openforms/formio/typing/base.py
+++ b/src/openforms/formio/typing/base.py
@@ -87,6 +87,8 @@ class Component(TypedDict):
     key: str
     label: str
     multiple: NotRequired[bool]
+    tooltip: NotRequired[str]
+    description: NotRequired[str]
     hidden: NotRequired[bool]
     defaultValue: NotRequired[JSONValue]
     validate: NotRequired[Validate]

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -7,9 +7,11 @@ from rest_framework import serializers
 
 from openforms.api.serializers import PublicFieldsSerializerMixin
 from openforms.formio.service import rewrite_formio_components_for_request
+from openforms.formio.utils import iter_components
 from openforms.translations.api.serializers import ModelTranslationsSerializer
 
 from ...models import Form, FormDefinition
+from ...sanitizer import sanitize_component
 from ...validators import (
     validate_form_definition_is_reusable,
     validate_no_duplicate_keys,
@@ -130,6 +132,20 @@ class FormDefinitionSerializer(
         representation["configuration"] = instance.configuration_wrapper.configuration
 
         return representation
+
+    def create(self, validated_data):
+        if configuration := validated_data.get("configuration"):
+            for component in iter_components(configuration):
+                sanitize_component(component)
+
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if configuration := validated_data.get("configuration"):
+            for component in iter_components(configuration):
+                sanitize_component(component)
+
+        return super().update(instance, validated_data)
 
     def validate(self, attrs):
         attrs = super().validate(attrs)

--- a/src/openforms/forms/sanitizer.py
+++ b/src/openforms/forms/sanitizer.py
@@ -1,0 +1,20 @@
+from openforms.formio.typing import Component
+from openforms.utils.sanitizer import sanitize_html_content
+
+
+def sanitize_component(component: Component):
+    """
+    Sanitize content of any form component.
+
+    The tooltip, description and label content will be replaced with a sanitized version.
+    All tags and attributes that aren't explicitly allowed, are removed from the
+    component content.
+
+    :arg component: the component data.
+    """
+    if "tooltip" in component:
+        component["tooltip"] = sanitize_html_content(component["tooltip"])
+    if "description" in component:
+        component["description"] = sanitize_html_content(component["description"])
+    if "label" in component:
+        component["label"] = sanitize_html_content(component["label"])

--- a/src/openforms/forms/tests/test_api_formdefinition.py
+++ b/src/openforms/forms/tests/test_api_formdefinition.py
@@ -202,6 +202,148 @@ class FormDefinitionsAPITests(APITestCase):
             ),
         )
 
+    def test_update_html_sanitizing_allowed_content_remains(self):
+        user = StaffUserFactory.create(user_permissions=["change_form"])
+        self.client.force_authenticate(user=user)
+
+        definition = FormDefinitionFactory.create(
+            name="test form definition",
+            slug="test-form-definition",
+            login_required=False,
+            configuration={
+                "display": "form",
+                "components": [
+                    {"key": "somekey", "type": "textfield", "label": "Existing field"}
+                ],
+            },
+        )
+
+        allowed_content = (
+            "Naked text",
+            "Naked text with cool stuff {% if true %}{{ variable }}{% endif %}",
+            "<p>Regular</p>",
+            "<b>Bold</b>",
+            "<strong>Strong</strong>",
+            "<u>Underlined</u>",
+            "<i>Italic</i>",
+            "<sup>Superscript</sup>",
+            "<s>Strike through</s>",
+            "<em>Emphasis</em>",
+            "<br>",
+            '<a href="mailto:example@mail.com" data-fr-linked="true">Hello</a>',
+            '<a href="https://www.example.com" target="_blank" rel="noopener noreferrer">hello</a>',
+            "<ul><li>Un-ordered list</li></ul>",
+            "<ol><li>Ordered list</li></ol>",
+            "<h1>H1</h1>",
+            "<h2>H2</h2>",
+            "<h3>H3</h3>",
+            "<h4>H4</h4>",
+            "<h5>H5</h5>",
+            "<h6>H6</h6>",
+            "<p><i><b>Nested</b></i><br><u>stuff</u></p>",
+            "<p><i><b>Nested variables {% if variable %}{{ variable }}{% endif %}</b></i><br></p>",
+        )
+
+        for content in allowed_content:
+            with self.subTest(label=content):
+                url = reverse(
+                    "api:formdefinition-detail", kwargs={"uuid": definition.uuid}
+                )
+                response = self.client.patch(
+                    url,
+                    data={
+                        "name": "Updated name",
+                        "slug": "updated-slug",
+                        "configuration": {
+                            "display": "form",
+                            "components": [
+                                {
+                                    "key": "somekey",
+                                    "type": "textfield",
+                                    "label": content,
+                                    "description": content,
+                                    "tooltip": content,
+                                },
+                            ],
+                        },
+                    },
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                definition.refresh_from_db()
+
+                config = definition.configuration
+                textfield = config["components"][0]
+
+                self.assertIn("label", textfield)
+                self.assertIn("description", textfield)
+                self.assertIn("tooltip", textfield)
+                self.assertEqual(textfield["label"], content)
+                self.assertEqual(textfield["description"], content)
+                self.assertEqual(textfield["tooltip"], content)
+
+    def test_update_html_sanitizing_disallowed_content_sanitized(self):
+        user = StaffUserFactory.create(user_permissions=["change_form"])
+        self.client.force_authenticate(user=user)
+
+        definition = FormDefinitionFactory.create(
+            name="test form definition",
+            slug="test-form-definition",
+            login_required=False,
+            configuration={
+                "display": "form",
+                "components": [
+                    {"key": "somekey", "type": "textfield", "label": "Existing field"}
+                ],
+            },
+        )
+
+        disallowed_content_expected_map = (
+            ("<img src=x onerror=alert('123') />", ""),
+            ("<a href=x onerror=alert('123')>foo</a>", '<a href="x">foo</a>'),
+            ("<div>foo bar</div>", "foo bar"),
+        )
+
+        for disallowed_content, expected in disallowed_content_expected_map:
+            with self.subTest(label=disallowed_content):
+                url = reverse(
+                    "api:formdefinition-detail", kwargs={"uuid": definition.uuid}
+                )
+                response = self.client.patch(
+                    url,
+                    data={
+                        "name": "Updated name",
+                        "slug": "updated-slug",
+                        "configuration": {
+                            "display": "form",
+                            "components": [
+                                {
+                                    "key": "somekey",
+                                    "type": "textfield",
+                                    "label": disallowed_content,
+                                    "description": disallowed_content,
+                                    "tooltip": disallowed_content,
+                                },
+                            ],
+                        },
+                    },
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                definition.refresh_from_db()
+
+                config = definition.configuration
+                textfield = config["components"][0]
+
+                self.assertIn("label", textfield)
+                self.assertIn("description", textfield)
+                self.assertIn("tooltip", textfield)
+                self.assertEqual(textfield["label"], expected)
+                self.assertEqual(textfield["description"], expected)
+                self.assertEqual(textfield["tooltip"], expected)
+
     def test_create(self):
         user = StaffUserFactory.create(user_permissions=["change_form"])
         self.client.force_authenticate(user=user)
@@ -302,6 +444,121 @@ class FormDefinitionsAPITests(APITestCase):
         date_component = response.json()["configuration"]["components"][0]
 
         self.assertIn("time_24hr", date_component["widget"])
+
+    def test_create_html_sanitizing_allowed_content_remains(self):
+        user = StaffUserFactory.create(user_permissions=["change_form"])
+        self.client.force_authenticate(user=user)
+
+        allowed_content = (
+            "Naked text",
+            "Naked text with cool stuff {% if true %}{{ variable }}{% endif %}",
+            "<p>Regular</p>",
+            "<b>Bold</b>",
+            "<strong>Strong</strong>",
+            "<u>Underlined</u>",
+            "<i>Italic</i>",
+            "<sup>Superscript</sup>",
+            "<s>Strike through</s>",
+            "<em>Emphasis</em>",
+            "<br>",
+            '<a href="mailto:example@mail.com" data-fr-linked="true">Hello</a>',
+            '<a href="https://www.example.com" target="_blank" rel="noopener noreferrer">hello</a>',
+            "<ul><li>Un-ordered list</li></ul>",
+            "<ol><li>Ordered list</li></ol>",
+            "<h1>H1</h1>",
+            "<h2>H2</h2>",
+            "<h3>H3</h3>",
+            "<h4>H4</h4>",
+            "<h5>H5</h5>",
+            "<h6>H6</h6>",
+            "<p><i><b>Nested</b></i><br><u>stuff</u></p>",
+            "<p><i><b>Nested variables {% if variable %}{{ variable }}{% endif %}</b></i><br></p>",
+        )
+
+        for content in allowed_content:
+            with self.subTest(label=content):
+                url = reverse("api:formdefinition-list")
+                response = self.client.post(
+                    url,
+                    data={
+                        "name": "Name",
+                        "slug": "a-slug",
+                        "configuration": {
+                            "display": "form",
+                            "components": [
+                                {
+                                    "key": "somekey",
+                                    "type": "textfield",
+                                    "label": content,
+                                    "description": content,
+                                    "tooltip": content,
+                                }
+                            ],
+                        },
+                    },
+                )
+
+                self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+                config = FormDefinition.objects.get().configuration
+
+                textfield = config["components"][0]
+                self.assertIn("label", textfield)
+                self.assertIn("description", textfield)
+                self.assertIn("tooltip", textfield)
+                self.assertEqual(textfield["label"], content)
+                self.assertEqual(textfield["description"], content)
+                self.assertEqual(textfield["tooltip"], content)
+
+                # Remove form definition, to create a clean instance for the next content to test
+                FormDefinition.objects.get().delete()
+
+    def test_create_html_sanitizing_disallowed_content_sanitized(self):
+        user = StaffUserFactory.create(user_permissions=["change_form"])
+        self.client.force_authenticate(user=user)
+
+        disallowed_content_expected_map = (
+            ("<img src=x onerror=alert('123') />", ""),
+            ("<a href=x onerror=alert('123')>foo</a>", '<a href="x">foo</a>'),
+            ("<div>foo bar</div>", "foo bar"),
+        )
+
+        for disallowed_content, expected in disallowed_content_expected_map:
+            with self.subTest(label=disallowed_content):
+                url = reverse("api:formdefinition-list")
+                response = self.client.post(
+                    url,
+                    data={
+                        "name": "Name",
+                        "slug": "a-slug",
+                        "configuration": {
+                            "display": "form",
+                            "components": [
+                                {
+                                    "key": "somekey",
+                                    "type": "textfield",
+                                    "label": disallowed_content,
+                                    "description": disallowed_content,
+                                    "tooltip": disallowed_content,
+                                }
+                            ],
+                        },
+                    },
+                )
+
+                self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+                config = FormDefinition.objects.get().configuration
+
+                textfield = config["components"][0]
+
+                self.assertIn("label", textfield)
+                self.assertIn("description", textfield)
+                self.assertIn("tooltip", textfield)
+                self.assertEqual(textfield["label"], expected)
+                self.assertEqual(textfield["description"], expected)
+                self.assertEqual(textfield["tooltip"], expected)
+
+                # Remove form definition, to create a clean instance for the next content to test
+                FormDefinition.objects.get().delete()
 
     def test_delete(self):
         user = StaffUserFactory.create(user_permissions=["change_form"])

--- a/src/openforms/js/components/formio_builder/WebformBuilder.js
+++ b/src/openforms/js/components/formio_builder/WebformBuilder.js
@@ -16,6 +16,7 @@ import {getAvailableAuthPlugins} from 'components/form/cosign';
 import {getAvailableDocumentTypes} from 'components/form/file';
 import {getComponentEmptyValue} from 'components/utils';
 import jsonScriptToVar from 'utils/json-script';
+import {sanitizeHTML} from 'utils/sanitize';
 import {currentTheme} from 'utils/theme';
 
 import {
@@ -207,6 +208,22 @@ class WebformBuilder extends WebformBuilderFormio {
     })();
   }
 
+  sanitizeComponentData(componentData) {
+    ['label', 'tooltip', 'description'].forEach(property => {
+      if (!componentData[property]) return;
+      componentData[property] = sanitizeHTML(componentData[property]);
+    });
+
+    // not-so-elegant input sanitation that formio does... FIXME: can't we just escape
+    // this with \" instead?
+    ['label', 'tooltip', 'placeholder'].forEach(property => {
+      if (!componentData[property]) return;
+      componentData[property] = componentData[property].replace(/"/g, "'");
+    });
+
+    return componentData;
+  }
+
   /**
    * saveComponent method when triggered from React events/formio builder.
    *
@@ -229,13 +246,9 @@ class WebformBuilder extends WebformBuilderFormio {
       return NativePromise.resolve();
     }
 
-    // not-so-elegant input sanitation that formio does... FIXME: can't we just escape
-    // this with \" instead?
     if (componentData) {
-      ['label', 'tooltip', 'placeholder'].forEach(property => {
-        if (!componentData[property]) return;
-        componentData[property] = componentData[property].replace(/"/g, "'");
-      });
+      // Perform some basic component data sanitizing
+      componentData = this.sanitizeComponentData(componentData);
     }
 
     // look up the component instance with the parent

--- a/src/openforms/js/utils/sanitize.js
+++ b/src/openforms/js/utils/sanitize.js
@@ -1,0 +1,35 @@
+import DOMPurify from 'dompurify';
+
+const ALLOWED_HTML_TAGS = [
+  // Basic text tags
+  'a',
+  'b',
+  'br',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'i',
+  'p',
+  's',
+  'strong',
+  'sup',
+  'u',
+  // Lists
+  'li',
+  'ol',
+  'ul',
+];
+
+const ALLOWED_HTML_ATTRIBUTES = ['href', 'target', 'rel'];
+
+export const sanitizeHTML = data => {
+  return DOMPurify.sanitize(data, {
+    ALLOWED_TAGS: ALLOWED_HTML_TAGS,
+    ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
+    ALLOW_DATA_ATTR: true,
+  });
+};

--- a/src/openforms/utils/sanitizer.py
+++ b/src/openforms/utils/sanitizer.py
@@ -150,6 +150,32 @@ ALLOWED_SVG_ATTRIBUTES = {
     "svg": ["xmlns", "viewBox"],
 }
 
+ALLOWED_HTML_TAGS = (
+    # Basic text tags
+    "a",
+    "b",
+    "br",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "i",
+    "p",
+    "s",
+    "strong",
+    "sup",
+    "u",
+    # Lists
+    "li",
+    "ol",
+    "ul",
+)
+
+ALLOWED_HTML_ATTRIBUTES = {"a": ("href", "target", "rel", "data-fr-linked")}
+
 
 def sanitize_svg_file(data: File) -> File:
     """
@@ -192,5 +218,22 @@ def sanitize_svg_content(svg_content: str) -> str:
         svg_content,
         tags=ALLOWED_SVG_TAGS,
         attributes=ALLOWED_SVG_ATTRIBUTES,
+        strip=True,
+    )
+
+
+def sanitize_html_content(html_content: str) -> str:
+    """
+    Defuse html string.
+
+    The provided string is replaced by a html sanitized version. All tags and attributes
+    that aren't explicitly allowed, are removed from the SVG content.
+
+    :arg html_content: the html string to sanitize.
+    """
+    return bleach.clean(
+        html_content,
+        tags=ALLOWED_HTML_TAGS,
+        attributes=ALLOWED_HTML_ATTRIBUTES,
         strip=True,
     )


### PR DESCRIPTION
Closes open-formulieren/security-issues#36

**Changes**

Added a simplistic sanitize function that sanitizes component label, tooltip and description when saving the component. This function allows a list of HTML tags and attributes, based on what formbuilders are currently using. Any html tags/attributes, that aren't in the allow list, are removed (only their content remains).

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
