### PR TITLE
[#5074] Transform data for `selectboxes` in the registrations (variables tab)

### DIFF
--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -363,6 +363,12 @@
       "value": "."
     }
   ],
+  "2arYfH": [
+    {
+      "type": 0,
+      "value": "If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option."
+    }
+  ],
   "2boL55": [
     {
       "type": 0,
@@ -5667,6 +5673,12 @@
     {
       "type": 0,
       "value": "Partner 1"
+    }
+  ],
+  "m/NVtu": [
+    {
+      "type": 0,
+      "value": "Transform to list"
     }
   ],
   "m20av3": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -363,6 +363,12 @@
       "value": " is."
     }
   ],
+  "2arYfH": [
+    {
+      "type": 0,
+      "value": "If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option."
+    }
+  ],
   "2boL55": [
     {
       "type": 0,
@@ -5685,6 +5691,12 @@
     {
       "type": 0,
       "value": "Partner 1"
+    }
+  ],
+  "m/NVtu": [
+    {
+      "type": 0,
+      "value": "Transform to list"
     }
   ],
   "m20av3": [

--- a/src/openforms/js/components/admin/form_design/registrations/json_dump/JSONDumpOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/json_dump/JSONDumpOptionsForm.js
@@ -58,6 +58,7 @@ const JSONDumpOptionsForm = ({name, label, schema, formData, onChange}) => {
         variables: [],
         fixedMetadataVariables: fixedMetadataVariables || [],
         additionalMetadataVariables: [],
+        transformToList: [],
         ...formData,
       }}
       onSubmit={values => onChange({formData: values})}

--- a/src/openforms/js/components/admin/form_design/registrations/json_dump/JSONDumpVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/json_dump/JSONDumpVariableConfigurationEditor.js
@@ -1,8 +1,9 @@
 import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import {FormContext} from 'components/admin/form_design/Context';
 import {VARIABLE_SOURCES} from 'components/admin/form_design/variables/constants';
 import {getVariableSource} from 'components/admin/form_design/variables/utils';
 import Field from 'components/admin/forms/Field';
@@ -11,12 +12,20 @@ import {Checkbox} from 'components/admin/forms/Inputs';
 
 const JSONDumpVariableConfigurationEditor = ({variable}) => {
   const {
-    values: {variables = [], additionalMetadataVariables = [], fixedMetadataVariables = []},
+    values: {
+      variables = [],
+      additionalMetadataVariables = [],
+      fixedMetadataVariables = [],
+      transformToList = [],
+    },
     setFieldValue,
   } = useFormikContext();
+  const {components} = useContext(FormContext);
   const isIncluded = variables.includes(variable.key);
   const isRequiredInMetadata = fixedMetadataVariables.includes(variable.key);
   const isInAdditionalMetadata = additionalMetadataVariables.includes(variable.key);
+  const componentType = components[variable.key]?.type;
+  const transformationNeeded = transformToList.includes(variable.key);
 
   return (
     <>
@@ -78,6 +87,36 @@ const JSONDumpVariableConfigurationEditor = ({variable}) => {
           />
         </Field>
       </FormRow>
+
+      {componentType === 'selectboxes' && (
+        <FormRow>
+          <Field name="transformToList">
+            <Checkbox
+              name="transformToListCheckbox"
+              label={
+                <FormattedMessage
+                  defaultMessage="Transform to list"
+                  description="'Transform to list' checkbox label"
+                />
+              }
+              helpText={
+                <FormattedMessage
+                  description="'Transform to list' checkbox help text"
+                  defaultMessage="If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option."
+                />
+              }
+              checked={transformationNeeded || false}
+              onChange={event => {
+                const shouldBeTransformed = event.target.checked;
+                const newTransformToList = shouldBeTransformed
+                  ? [...transformToList, variable.key]
+                  : transformToList.filter(key => key !== variable.key);
+                setFieldValue('transformToList', newTransformToList);
+              }}
+            />
+          </Field>
+        </FormRow>
+      )}
     </>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/AddressNlObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/AddressNlObjectsApiVariableConfigurationEditor.js
@@ -5,16 +5,15 @@ import {FormattedMessage} from 'react-intl';
 import {useAsync, useToggle} from 'react-use';
 
 import {APIContext} from 'components/admin/form_design/Context';
-import {REGISTRATION_OBJECTS_TARGET_PATHS} from 'components/admin/form_design/constants';
 import Field from 'components/admin/forms/Field';
 import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
 import {Checkbox} from 'components/admin/forms/Inputs';
 import {TargetPathSelect} from 'components/admin/forms/objects_api';
 import ErrorMessage from 'components/errors/ErrorMessage';
-import {post} from 'utils/fetch';
 
 import {MappedVariableTargetPathSelect} from './GenericObjectsApiVariableConfigurationEditor';
+import {fetchTargetPaths} from './utils';
 
 const ADDRESSNL_NESTED_PROPERTIES = {
   postcode: {type: 'string'},
@@ -23,27 +22,6 @@ const ADDRESSNL_NESTED_PROPERTIES = {
   houseNumberAddition: {type: 'string'},
   city: {type: 'string'},
   streetName: {type: 'string'},
-};
-
-const fetchTargetPaths = async (
-  csrftoken,
-  objectsApiGroup,
-  objecttype,
-  objecttypeVersion,
-  schemaType
-) => {
-  const response = await post(REGISTRATION_OBJECTS_TARGET_PATHS, csrftoken, {
-    objectsApiGroup,
-    objecttype,
-    objecttypeVersion,
-    variableJsonSchema: schemaType,
-  });
-
-  if (!response.ok) {
-    throw new Error(`Error when loading target paths for type: ${schemaType}`);
-  }
-
-  return response.data;
 };
 
 export const AddressNlEditor = ({

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiVariableConfigurationEditor.js
@@ -45,6 +45,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
     objecttype,
     objecttypeVersion,
     geometryVariableKey,
+    transformToList = [],
     variablesMapping,
     version,
   } = backendOptions;
@@ -99,6 +100,7 @@ const ObjectsApiVariableConfigurationEditor = ({variable}) => {
           components={components}
           namePrefix={namePrefix}
           isGeometry={isGeometry}
+          transformToList={transformToList}
           index={index}
           mappedVariable={mappedVariable}
           objecttype={objecttype}

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/utils.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/utils.js
@@ -1,3 +1,6 @@
+import {REGISTRATION_OBJECTS_TARGET_PATHS} from 'components/admin/form_design/constants';
+import {post} from 'utils/fetch';
+
 const VARIABLE_TYPE_MAP = {
   boolean: 'boolean',
   int: 'integer',
@@ -20,7 +23,7 @@ const FORMAT_TYPE_MAP = {
  * component definition.
  * @returns {Object} - The JSON Schema
  */
-const asJsonSchema = (variable, components) => {
+const asJsonSchema = (variable, components, transformToList = []) => {
   // Special handling for component types.
   if (variable.source === 'component') {
     const componentDefinition = components[variable.key];
@@ -45,6 +48,15 @@ const asJsonSchema = (variable, components) => {
           },
         };
       }
+      case 'selectboxes': {
+        return transformToList?.includes(variable.key)
+          ? {
+              type: 'array',
+            }
+          : {
+              type: 'object',
+            };
+      }
     }
   }
 
@@ -57,4 +69,25 @@ const asJsonSchema = (variable, components) => {
   };
 };
 
-export {asJsonSchema};
+const fetchTargetPaths = async (
+  csrftoken,
+  objectsApiGroup,
+  objecttype,
+  objecttypeVersion,
+  schemaType
+) => {
+  const response = await post(REGISTRATION_OBJECTS_TARGET_PATHS, csrftoken, {
+    objectsApiGroup,
+    objecttype,
+    objecttypeVersion,
+    variableJsonSchema: schemaType,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error when loading target paths for type: ${schemaType}`);
+  }
+
+  return response.data;
+};
+
+export {asJsonSchema, fetchTargetPaths};

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -403,6 +403,154 @@ export const WithObjectsAPIRegistrationBackends = {
   },
 };
 
+export const WithObjectsAPIRegistrationBackendsTransformToList = {
+  args: {
+    variables: [
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
+        name: 'Form.io component',
+        key: 'formioComponent',
+        source: 'component',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataType: 'string',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: '',
+      },
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: 'unsaved-step',
+        name: 'Select boxes list',
+        key: 'selectBoxesList',
+        source: 'component',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: [],
+      },
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: 'unsaved-step',
+        name: 'Select boxes object',
+        key: 'selectBoxesObj',
+        source: 'component',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: [],
+      },
+    ],
+    availableComponents: {
+      formioComponent: {
+        key: 'formioComponent',
+        type: 'textfield',
+      },
+      selectBoxesList: {
+        type: 'selectboxes',
+        multiple: false,
+        key: 'selectBoxesList',
+      },
+      selectBoxesObj: {
+        type: 'selectboxes',
+        multiple: false,
+        key: 'selectBoxesObj',
+      },
+    },
+    registrationBackends: [
+      {
+        backend: 'objects_api',
+        key: 'objects_api_1',
+        name: 'Example Objects API reg.',
+        options: {
+          version: 2,
+          objectsApiGroup: 1,
+          objecttype: '2c77babf-a967-4057-9969-0200320d23f1',
+          objecttypeVersion: 2,
+          variablesMapping: [],
+          transformToList: ['selectBoxesList'],
+        },
+      },
+    ],
+  },
+  parameters: {
+    msw: {
+      handlers: {
+        objectTypeTargetPaths: [
+          mockTargetPathsPost({
+            object: [
+              {
+                targetPath: ['path', 'to.the', 'target'],
+                isRequired: false,
+                jsonSchema: {type: 'object'},
+              },
+            ],
+            array: [
+              {
+                targetPath: ['other', 'path'],
+                isRequired: false,
+                jsonSchema: {type: 'array'},
+              },
+            ],
+            string: [
+              {
+                targetPath: ['path'],
+                isRequired: false,
+                jsonSchema: {type: 'string'},
+              },
+            ],
+          }),
+        ],
+      },
+    },
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    const editIcons = canvas.getAllByTitle('Registratie-instellingen bewerken');
+
+    expect(editIcons).toHaveLength(3);
+
+    await step('Simple component', async () => {
+      await userEvent.click(editIcons[0]);
+
+      const transformToListCheckbox = canvas.queryByLabelText('Transform to list');
+      expect(transformToListCheckbox).toBeNull();
+
+      const saveButton = canvas.getByRole('button', {name: 'Opslaan'});
+      await userEvent.click(saveButton);
+    });
+
+    await step('Select boxes with transform to list', async () => {
+      await userEvent.click(editIcons[1]);
+
+      const transformToListCheckbox = await canvas.findByLabelText('Transform to list');
+      expect(transformToListCheckbox).toBeChecked();
+
+      const saveButton = canvas.getByRole('button', {name: 'Opslaan'});
+      await userEvent.click(saveButton);
+    });
+
+    await step('Select boxes without transform to list (default behaviour -> object)', async () => {
+      await userEvent.click(editIcons[2]);
+
+      const transformToListCheckbox = await canvas.findByLabelText('Transform to list');
+      expect(transformToListCheckbox).not.toBeChecked();
+
+      const saveButton = canvas.getByRole('button', {name: 'Opslaan'});
+      await userEvent.click(saveButton);
+    });
+  },
+};
+
 // gh-4978 regression for geometry field on empty variable
 export const EmptyUserDefinedVariableWithObjectsAPIRegistration = {
   args: {
@@ -809,6 +957,133 @@ export const WithJSONDumpRegistrationBackend = {
         expect(checkboxes[1]).toBeDisabled();
       }
     );
+  },
+};
+
+export const WithJSONDumpRegistrationBackendTransformToList = {
+  args: {
+    variables: [
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
+        name: 'Form.io component',
+        key: 'formioComponent',
+        source: 'component',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataType: 'string',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: '',
+      },
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: 'unsaved-step',
+        name: 'Select boxes list',
+        key: 'selectBoxesList',
+        source: 'component',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: [],
+      },
+      {
+        form: 'http://localhost:8000/api/v2/forms/36612390',
+        formDefinition: 'unsaved-step',
+        name: 'Select boxes object',
+        key: 'selectBoxesObj',
+        source: 'component',
+        prefillPlugin: '',
+        prefillAttribute: '',
+        prefillIdentifierRole: 'main',
+        dataFormat: undefined,
+        isSensitiveData: false,
+        serviceFetchConfiguration: undefined,
+        initialValue: [],
+      },
+    ],
+    availableComponents: {
+      formioComponent: {
+        key: 'formioComponent',
+        type: 'textfield',
+      },
+      selectBoxesList: {
+        type: 'selectboxes',
+        multiple: false,
+        key: 'selectBoxesList',
+      },
+      selectBoxesObj: {
+        type: 'selectboxes',
+        multiple: false,
+        key: 'selectBoxesObj',
+      },
+    },
+    registrationBackends: [
+      {
+        backend: 'json_dump',
+        key: 'test_json_dump_backend',
+        name: 'JSON dump registration',
+        options: {
+          service: 2,
+          path: 'test',
+          variables: ['formioComponent', 'selectBoxesList', 'selectBoxesObj'],
+          fixedMetadataVariables: ['public_reference'],
+          additionalMetadataVariables: ['now'],
+          transformToList: ['selectBoxesList'],
+        },
+      },
+    ],
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    const editIcons = canvas.getAllByTitle('Registratie-instellingen bewerken');
+
+    expect(editIcons).toHaveLength(3);
+
+    await step('Simple component', async () => {
+      await userEvent.click(editIcons[0]);
+
+      const checkboxes = await canvas.findAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(2);
+
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).toBeDisabled();
+
+      const saveButton = canvas.getByRole('button', {name: 'Opslaan'});
+      await userEvent.click(saveButton);
+    });
+
+    await step('Select boxes with transform to list', async () => {
+      await userEvent.click(editIcons[1]);
+
+      const checkboxes = await canvas.findAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(3);
+
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).not.toBeChecked();
+      expect(checkboxes[2]).toBeChecked();
+
+      const saveButton = canvas.getByRole('button', {name: 'Opslaan'});
+      await userEvent.click(saveButton);
+    });
+
+    await step('Select boxes without transform to list (default behaviour -> object)', async () => {
+      await userEvent.click(editIcons[2]);
+
+      const checkboxes = await canvas.findAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(3);
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).not.toBeChecked();
+      expect(checkboxes[2]).not.toBeChecked();
+
+      const saveButton = canvas.getByRole('button', {name: 'Opslaan'});
+      await userEvent.click(saveButton);
+    });
   },
 };
 

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -164,6 +164,11 @@
     "description": "Camunda complex process var 'type' label",
     "originalDefault": "Type"
   },
+  "2arYfH": {
+    "defaultMessage": "If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option.",
+    "description": "'Transform to list' checkbox help text",
+    "originalDefault": "If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option."
+  },
   "2boL55": {
     "defaultMessage": "Query parameters",
     "description": "Service fetch configuration modal form query parameters field label",
@@ -2653,6 +2658,11 @@
     "defaultMessage": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case.",
     "description": "ZGW APIs registration options 'objecttype' help text",
     "originalDefault": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case."
+  },
+  "m/NVtu": {
+    "defaultMessage": "Transform to list",
+    "description": "'Transform to list' checkbox label",
+    "originalDefault": "Transform to list"
   },
   "m83ECr": {
     "defaultMessage": "Copying the configuration from the registration backend will clear the existing configuration. Are you sure you want to continue?",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -166,6 +166,11 @@
     "isTranslated": true,
     "originalDefault": "Type"
   },
+  "2arYfH": {
+    "defaultMessage": "If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option.",
+    "description": "'Transform to list' checkbox help text",
+    "originalDefault": "If enabled, the selected values are sent as an array of values instead of an object with a boolean value for each option."
+  },
   "2boL55": {
     "defaultMessage": "Query-parameters",
     "description": "Service fetch configuration modal form query parameters field label",
@@ -2674,6 +2679,11 @@
     "defaultMessage": "Objecttyperesource-URL in de Objecttypen-API. Wanneer dit ingesteld is, dan wordt een object van dit type aangemaakt en aan de zaak gerelateerd.",
     "description": "ZGW APIs registration options 'objecttype' help text",
     "originalDefault": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case."
+  },
+  "m/NVtu": {
+    "defaultMessage": "Transform to list",
+    "description": "'Transform to list' checkbox label",
+    "originalDefault": "Transform to list"
   },
   "m83ECr": {
     "defaultMessage": "Wanneer je de instellingen van een registratiepluginoptie overneemt, dan worden alle bestaande instellingen overschreven. Ben je zeker dat je door wil gaan?",

--- a/src/openforms/registrations/contrib/json_dump/config.py
+++ b/src/openforms/registrations/contrib/json_dump/config.py
@@ -70,6 +70,16 @@ class JSONDumpOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serialize
         required=False,
         default=list,
     )
+    transform_to_list = serializers.ListField(
+        child=FormioVariableKeyField(),
+        label=_("Transform to list"),
+        required=False,
+        default=list,
+        help_text=_(
+            "Component keys in this list will be sent as an array of values rather than "
+            "the default object-shape for selectboxes components."
+        ),
+    )
 
 
 class JSONDumpOptions(TypedDict):
@@ -85,3 +95,4 @@ class JSONDumpOptions(TypedDict):
     variables: list[str]
     fixed_metadata_variables: list[str]
     additional_metadata_variables: list[str]
+    transform_to_list: list[str]

--- a/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_list_transformation_in_selectboxes.yaml
+++ b/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_list_transformation_in_selectboxes.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '"{\"values\": {\"selectBoxes1\": [\"option1\"], \"selectBoxes2\": {\"option2\":
+      true}}, \"values_schema\": {\"$schema\": \"https://json-schema.org/draft/2020-12/schema\",
+      \"type\": \"object\", \"properties\": {\"selectBoxes1\": {\"type\": \"array\",
+      \"title\": \"Selectboxes1\"}, \"selectBoxes2\": {\"type\": \"object\", \"title\":
+      \"Selectboxes2\"}}, \"required\": [\"selectBoxes1\", \"selectBoxes2\"], \"additionalProperties\":
+      false}, \"metadata\": {}, \"metadata_schema\": {\"$schema\": \"https://json-schema.org/draft/2020-12/schema\",
+      \"type\": \"object\", \"properties\": {}, \"required\": [], \"additionalProperties\":
+      false}}"'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NDE3MTI4OTAsImNsaWVudF9pZCI6IiIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.hMJFjevhcgghL7iXVCYsc2o-PHyM4Gidz_PDV96lXfU
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '635'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"selectBoxes1\": [\n        \"option1\"\n
+        \     ],\n      \"selectBoxes2\": {\n        \"option2\": true\n      }\n
+        \   },\n    \"values_schema\": {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"selectBoxes1\":
+        {\n          \"title\": \"Selectboxes1\",\n          \"type\": \"array\"\n
+        \       },\n        \"selectBoxes2\": {\n          \"title\": \"Selectboxes2\",\n
+        \         \"type\": \"object\"\n        }\n      },\n      \"required\": [\n
+        \       \"selectBoxes1\",\n        \"selectBoxes2\"\n      ],\n      \"type\":
+        \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '860'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 11 Mar 2025 17:08:10 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.9
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/json_dump/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/json_dump/tests/test_backend.py
@@ -74,6 +74,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["firstName", "file", "auth_bsn"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -152,6 +153,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["firstName", "auth_bsn"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -209,6 +211,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["file"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -291,6 +294,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["file"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -351,6 +355,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["file"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -395,6 +400,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["file"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -453,6 +459,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["firstName", "file", "auth_bsn"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 
@@ -486,6 +493,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["selectboxes"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         result = json_plugin.register_submission(submission, options)
         assert result is not None
@@ -496,6 +504,55 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             ]["required"],
             [],
         )
+
+    def test_list_transformation_in_selectboxes(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {"key": "selectBoxes1", "type": "selectboxes"},
+                {"key": "selectBoxes2", "type": "selectboxes"},
+            ],
+            completed=True,
+            submitted_data={
+                "selectBoxes1": {"option1": True},
+                "selectBoxes2": {"option2": True},
+            },
+        )
+
+        options: JSONDumpOptions = {
+            "service": self.service,
+            "path": "json_plugin",
+            "variables": ["selectBoxes1", "selectBoxes2"],
+            "fixed_metadata_variables": [],
+            "additional_metadata_variables": [],
+            "transform_to_list": ["selectBoxes1"],
+        }
+        json_plugin = JSONDumpRegistration("json_registration_plugin")
+
+        expected_values = {
+            "selectBoxes1": ["option1"],
+            "selectBoxes2": {"option2": True},
+        }
+        expected_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "selectBoxes1": {"type": "array", "title": "Selectboxes1"},
+                "selectBoxes2": {"type": "object", "title": "Selectboxes2"},
+            },
+            "required": ["selectBoxes1", "selectBoxes2"],
+            "additionalProperties": False,
+        }
+
+        result = json_plugin.register_submission(submission, options)
+        assert result is not None
+
+        with self.subTest("values"):
+            self.assertEqual(result["api_response"]["data"]["values"], expected_values)
+
+        with self.subTest("schema"):
+            self.assertEqual(
+                result["api_response"]["data"]["values_schema"], expected_schema
+            )
 
     def test_select_component_with_manual_data_source(self):
         submission = SubmissionFactory.from_components(
@@ -531,6 +588,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["select"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -587,6 +645,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["select"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -637,6 +696,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["selectBoxes"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -687,6 +747,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["radio"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -736,6 +797,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["radio"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -830,6 +892,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["repeatingGroup"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -881,6 +944,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["foo.bar"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         result = json_plugin.register_submission(submission, options)
@@ -922,6 +986,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
                 "registration_timestamp",
             ],
             "additional_metadata_variables": ["auth_type"],
+            "transform_to_list": [],
         }
         result = json_plugin.register_submission(submission, options)
         assert result is not None
@@ -1086,6 +1151,7 @@ class JSONDumpBackendTests(OFVCRMixin, TestCase):
             "variables": ["repeatingGroup"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
         json_plugin = JSONDumpRegistration("json_registration_plugin")
 

--- a/src/openforms/registrations/contrib/json_dump/tests/test_config.py
+++ b/src/openforms/registrations/contrib/json_dump/tests/test_config.py
@@ -15,6 +15,7 @@ class JSONDumpConfigTests(TestCase):
             "variables": ["now"],
             "fixed_metadata_variables": [],
             "additional_metadata_variables": [],
+            "transform_to_list": [],
         }
 
         # Ensuring that the options are valid in the first place

--- a/src/openforms/registrations/contrib/objects_api/config.py
+++ b/src/openforms/registrations/contrib/objects_api/config.py
@@ -256,6 +256,16 @@ class ObjectsAPIOptionsSerializer(JsonSchemaSerializerMixin, serializers.Seriali
         required=False,
         allow_blank=True,
     )
+    transform_to_list = serializers.ListField(
+        child=FormioVariableKeyField(),
+        label=_("transform to list"),
+        required=False,
+        default=list,
+        help_text=_(
+            "The components which need special handling concerning the shape of the data "
+            "and need to be transformed to a list."
+        ),
+    )
 
     def _handle_import(self, attrs) -> None:
         # we're not importing, nothing to do

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -521,6 +521,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
         urls_map = self.get_attachment_urls_by_key(submission)
 
         variables_mapping = options["variables_mapping"]
+        transform_to_list = options["transform_to_list"]
 
         # collect all the assignments to be done to the object
         assignment_specs: list[AssignmentSpec] = []
@@ -571,6 +572,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
                 value=value,
                 component=component,
                 attachment_urls=urls_map,
+                transform_to_list=transform_to_list,
             )
             if isinstance(assignment_spec, AssignmentSpec):
                 assignment_specs.append(assignment_spec)

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
@@ -459,6 +459,7 @@ class ObjectsAPIBackendVCRTests(OFVCRMixin, TestCase):
                 },
             ],
             "upload_submission_csv": True,
+            "transform_to_list": [],
         }
 
         for suffix in ("attachment", "submission_report", "submission_csv"):
@@ -532,6 +533,7 @@ class ObjectsAPIBackendVCRTests(OFVCRMixin, TestCase):
             "iot_submission_report": "",
             "iot_submission_csv": "",
             "iot_attachment": "Attachment Informatieobjecttype",
+            "transform_to_list": [],
         }
 
         result = plugin.register_submission(submission, options)
@@ -596,6 +598,7 @@ class ObjectsAPIBackendVCRTests(OFVCRMixin, TestCase):
             "iot_submission_report": "",
             "iot_submission_csv": "",
             "iot_attachment": "Unpublished",
+            "transform_to_list": [],
         }
 
         result = plugin.register_submission(submission, options)

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -138,6 +138,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 # fmt: on
             ],
             "geometry_variable_key": "location",
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -218,6 +219,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                     "target_path": ["submission_provider_payment_ids"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -315,6 +317,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 },
                 # fmt: on
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -386,6 +389,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                     "target_path": ["multiple_files"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -471,6 +475,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                     "target_path": ["repeatingGroup"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -530,6 +535,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 },
                 # fmt: on
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -689,6 +695,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["pointCoordinates"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -737,6 +744,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["textfield"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -781,6 +789,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["textfield"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -813,6 +822,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["of_nummer"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -872,6 +882,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["cosign_kvk"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -931,6 +942,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["cosign_pseudo"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -979,6 +991,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["cosign_date"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -1051,6 +1064,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["authn", "soort_actor"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -1163,6 +1177,7 @@ class V2HandlerTests(TestCase):
                     "target_path": ["authn", "soort_actor"],
                 },
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -1299,6 +1314,7 @@ class V2HandlerTests(TestCase):
                     },
                 }
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -1366,6 +1382,7 @@ class V2HandlerTests(TestCase):
                     },
                 }
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -1418,6 +1435,7 @@ class V2HandlerTests(TestCase):
             "variables_mapping": [
                 {"variable_key": "addressNl", "target_path": ["addressNL"]}
             ],
+            "transform_to_list": [],
             "iot_attachment": "",
             "iot_submission_csv": "",
             "iot_submission_report": "",
@@ -1441,3 +1459,40 @@ class V2HandlerTests(TestCase):
                 }
             },
         )
+
+    def test_selectboxes_with_transform_to_list(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {"key": "selectBoxes1", "type": "selectboxes"},
+                {"key": "selectBoxes2", "type": "selectboxes"},
+            ],
+            completed=True,
+            submitted_data={
+                "selectBoxes1": {"option1": True},
+                "selectBoxes2": {"option2": True},
+            },
+        )
+        ObjectsAPIRegistrationData.objects.create(submission=submission)
+        v2_options: RegistrationOptionsV2 = {
+            "objects_api_group": self.group,
+            "version": 2,
+            "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
+            "objecttype_version": 1,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "variables_mapping": [
+                {"variable_key": "selectBoxes1", "target_path": ["path1"]},
+                {"variable_key": "selectBoxes2", "target_path": ["path2"]},
+            ],
+            "iot_attachment": "",
+            "iot_submission_csv": "",
+            "iot_submission_report": "",
+            "transform_to_list": ["selectBoxes1"],
+        }
+        handler = ObjectsAPIV2Handler()
+
+        record_data = handler.get_record_data(submission=submission, options=v2_options)
+
+        data = record_data["data"]
+
+        self.assertEqual(data, {"path1": ["option1"], "path2": {"option2": True}})

--- a/src/openforms/registrations/contrib/objects_api/typing.py
+++ b/src/openforms/registrations/contrib/objects_api/typing.py
@@ -70,6 +70,7 @@ class RegistrationOptionsV2(_BaseRegistrationOptions, total=False):
     version: Required[Literal[2]]
     variables_mapping: Required[list[ObjecttypeVariableMapping]]
     geometry_variable_key: str
+    transform_to_list: Required[list[str]]
 
 
 type RegistrationOptions = RegistrationOptionsV1 | RegistrationOptionsV2


### PR DESCRIPTION
Closes #5074 

**Changes**

- Add checkbox for transforming the data to a list for Objects API and JSON dump registations (variables tab)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
