### PR TITLE
[#5124] Hidden/disabled prefill fields trigger validation

### DIFF
--- a/src/openforms/submissions/api/validators.py
+++ b/src/openforms/submissions/api/validators.py
@@ -33,6 +33,11 @@ class ValidatePrefillData:
             if not (component_key := component.get("key")):
                 continue
 
+            # in case the component or its parent component is hidden the key will not be
+            # part of the data.
+            if component_key not in data:
+                continue
+
             original_prefill_value = prefill_data.get(component_key)
             if original_prefill_value is None:
                 # the value will be `None` if there is no actual prefill data available, so there is nothing to compare to. This

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -244,6 +244,53 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
 
+    def test_prefill_data_is_persisted_when_submission_data_omitted(self):
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "display": "form",
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "name",
+                        "label": "Name",
+                        "prefill": {"plugin": "test-prefill", "attribute": "name"},
+                        "disabled": True,
+                        "defaultValue": "",
+                        "hidden": False,
+                    },
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form, prefill_data={"name": "test"})
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": step.uuid,
+            },
+        )
+
+        with self.subTest("empty data field"):
+            response = self.client.post(endpoint, {"data": {}})
+
+            submission.refresh_from_db()
+            variable = submission.submissionvaluevariable_set.get()
+
+            self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+            self.assertEqual(variable.value, "test")
+
+        with self.subTest("data field not present"):
+            response = self.client.post(endpoint, {})
+
+            submission.refresh_from_db()
+            variable = submission.submissionvaluevariable_set.get()
+
+            self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+            self.assertEqual(variable.value, "test")
+
     def test_prefilled_data_normalised(self):
         form = FormFactory.create()
         step = FormStepFactory.create(


### PR DESCRIPTION
Closes #5124 

**Changes**

- When  a component (or its parent is disabled and hidden, the validation in the backend is triggered since there is no data for the specific key. This means, for our validator, that the data has been changed and raises an error.

- Additional  test for the case someone omits the submission data (affects the prefill data).

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
