### PR TITLE
Only define `variablesMapping` in the admin for V2 Objects API registrations

### DIFF
--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsForm.js
@@ -15,6 +15,9 @@ const ObjectsApiOptionsForm = ({index, name, label, schema, formData, onChange})
   const numErrors = filterErrors(name, validationErrors).length;
   const defaultGroup = apiGroupChoices.length === 1 ? apiGroupChoices[0][0] : undefined;
 
+  // default to version 2, existing form data can override this
+  const version = formData?.version ?? 2;
+
   return (
     <ModalOptionsConfiguration
       name={name}
@@ -27,8 +30,9 @@ const ObjectsApiOptionsForm = ({index, name, label, schema, formData, onChange})
         />
       }
       initialFormData={{
-        version: 2, // default to version 2, existing form data can override this
-        variablesMapping: [],
+        version,
+        // Only for version 2 we set the `variablesMapping`
+        variablesMapping: version === 2 ? [] : undefined,
         ...formData,
         // Ensure that if there's only one option, it is automatically selected.
         objectsApiGroup: formData.objectsApiGroup ?? defaultGroup,


### PR DESCRIPTION
Closes #5031

**Changes**

The V1 Objects API registration should not have the `variablesMapping` property. This will result in error when validation in the backend.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
