### PR TITLE
Upgrade django-digid-eherkenning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -157,7 +157,7 @@ django-csp==3.8
     # via -r requirements/base.in
 django-csp-reports==1.8.1
     # via -r requirements/base.in
-django-digid-eherkenning==0.19.2
+django-digid-eherkenning==0.20.0
     # via -r requirements/base.in
 django-filter==24.2
     # via -r requirements/base.in
@@ -307,7 +307,7 @@ kombu==5.3.7
     # via celery
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
-lxml==5.2.2
+lxml==5.3.1
     # via
     #   -r requirements/base.in
     #   django-camunda
@@ -567,7 +567,9 @@ xlrd==2.0.1
 xlwt==1.3.0
     # via tablib
 xmlsec==1.3.14
-    # via maykin-python3-saml
+    # via
+    #   django-digid-eherkenning
+    #   maykin-python3-saml
 xmltodict==0.12.0
     # via -r requirements/base.in
 zeep==4.2.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -261,7 +261,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.19.2
+django-digid-eherkenning==0.20.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -558,7 +558,7 @@ lazy-object-proxy==1.9.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   openapi-spec-validator
-lxml==5.2.2
+lxml==5.3.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1118,6 +1118,7 @@ xmlsec==1.3.14
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   maykin-python3-saml
 xmltodict==0.12.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -284,7 +284,7 @@ django-csp-reports==1.8.1
     #   -r requirements/ci.txt
 django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
-django-digid-eherkenning==0.19.2
+django-digid-eherkenning==0.20.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -616,7 +616,7 @@ lazy-object-proxy==1.9.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   openapi-spec-validator
-lxml==5.2.2
+lxml==5.3.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1275,6 +1275,7 @@ xmlsec==1.3.14
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   maykin-python3-saml
 xmltodict==0.12.0
     # via

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -249,7 +249,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-digid-eherkenning==0.19.2
+django-digid-eherkenning==0.20.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -513,7 +513,7 @@ lazy-object-proxy==1.9.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   openapi-spec-validator
-lxml==5.2.2
+lxml==5.3.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -982,6 +982,7 @@ xmlsec==1.3.14
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-digid-eherkenning
     #   maykin-python3-saml
 xmltodict==0.12.0
     # via

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -277,7 +277,7 @@ django-csp-reports==1.8.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-digid-eherkenning==0.19.2
+django-digid-eherkenning==0.20.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -607,7 +607,7 @@ lazy-object-proxy==1.9.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   openapi-spec-validator
-lxml==5.2.2
+lxml==5.3.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1279,6 +1279,7 @@ xmlsec==1.3.14
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-digid-eherkenning
     #   maykin-python3-saml
 xmltodict==0.12.0
     # via


### PR DESCRIPTION
Closes #5136 

**Changes**

* Upgrade to django-digid-eherkenning 0.20.0
* Upgrade to lxml 5.3.1

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
