### PR TITLE
[stable/2.8.x] Don't error hard on API standard violations

### DIFF
--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date
 from functools import cached_property
 from operator import itemgetter
@@ -10,6 +11,8 @@ from zgw_consumers.nlx import NLXClient
 from openforms.utils.api_clients import PaginatedResponseData, pagination_helper
 
 from ..exceptions import StandardViolation
+
+logger = logging.getLogger(__name__)
 
 
 def noop_matcher(roltypen: list) -> list:
@@ -119,13 +122,15 @@ class CatalogiClient(NLXClient):
         try:
             version = response.headers["API-version"]
         except KeyError as exc:
-            raise StandardViolation(
-                "API-version is a required response header."
-            ) from exc
+            logger.error("API-version is a required response header.", exc_info=exc)
+            return (1, 0, 0)
         try:
             major, minor, patch = [int(bit) for bit in version.split(".")]
         except ValueError as exc:
-            raise StandardViolation("API-version must follow semver format.") from exc
+            logger.error(
+                "API-version must follow semver format, got %s.", version, exc_info=exc
+            )
+            return (1, 0, 0)
         return (major, minor, patch)
 
     @cached_property

--- a/src/openforms/contrib/zgw/tests/test_catalogi_client.py
+++ b/src/openforms/contrib/zgw/tests/test_catalogi_client.py
@@ -43,10 +43,10 @@ class CatalogiClientTests(TestCase):
             headers={"Wrong-Header": "1.2.3"},
         )
 
-        with self.assertRaisesMessage(
-            StandardViolation, "API-version is a required response header."
-        ):
-            client.api_version
+        # This *should* raise StandardViolation, but external vendors can not comply
+        # with this in time so we patch on our end, even though our strict rejection *is*
+        # correct behaviour.
+        self.assertEqual(client.api_version, (1, 0, 0))
 
     @requests_mock.Mocker()
     def test_version_is_not_semver(self, m: requests_mock.Mocker):
@@ -58,10 +58,10 @@ class CatalogiClientTests(TestCase):
             headers={"API-version": "latest"},
         )
 
-        with self.assertRaisesMessage(
-            StandardViolation, "API-version must follow semver format."
-        ):
-            client.api_version
+        # This *should* raise StandardViolation, but external vendors can not comply
+        # with this in time so we patch on our end, even though our strict rejection *is*
+        # correct behaviour.
+        self.assertEqual(client.api_version, (1, 0, 0))
 
     @requests_mock.Mocker()
     def test_returns_too_many_catalogues(self, m: requests_mock.Mocker):


### PR DESCRIPTION
Closes #5162

Before this patch, the behaviour was to outright reject non-standard compliant responses, since the API specifications for the ZGW API's (managed by VNG) are strictly versioned according to semver. Certain features are available only starting with certain versions, and we adapt our client behaviour to be as efficient as possible based on this API version. It is nonsense for an API server to reply with a version number that is not published by VNG on the documentation site https://vng-realisatie.github.io/gemma-zaken/standaard/.

That said, Dimpact is in a pickle because a vendor is not behaving according to the standard, triggering this hard rejection in Open Forms, and said vendor is not able to patch their own systems in time for a particular release time line. We agreed to coalesce the version to the lowest possible supported so that the application can actually be used still, however this triggers all the worst performance and UX paths.

This patch is *only* applied to the stable/2.8.x branch since we really want to bring the ecosystem to standard-compliant implementations.