### PR TITLE
Fix test flakiness

### DIFF
--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -438,6 +438,9 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
             furl(self.live_server_url)
             / reverse("admin:forms_form_change", args=(form.pk,))
         )
+        admin_changelist_url = str(
+            furl(self.live_server_url) / reverse("admin:forms_form_changelist")
+        )
 
         async with browser_page() as page:
             await self._admin_login(page)
@@ -491,10 +494,8 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
                     await close_modal(page, "Save", exact=True)
 
                 # Save form
-                await page.get_by_role(
-                    "button", name="Save and continue editing", exact=True
-                ).click()
-                await page.wait_for_url(admin_url)
+                await page.get_by_role("button", name="Save", exact=True).click()
+                await page.wait_for_url(admin_changelist_url)
 
             with phase("Validate default values"):
 
@@ -527,12 +528,15 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
             furl(self.live_server_url)
             / reverse("admin:forms_form_change", args=(form.pk,))
         )
+        admin_changelist_url = str(
+            furl(self.live_server_url) / reverse("admin:forms_form_changelist")
+        )
 
         async with browser_page() as page:
             await self._admin_login(page)
-            await page.goto(str(admin_url))
 
             with phase("Populate and save form"):
+                await page.goto(str(admin_url))
                 await page.get_by_role("tab", name="Steps and fields").click()
 
                 await drag_and_drop_component(page, "Radio", "group-panel-custom")
@@ -542,10 +546,8 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
                 await close_modal(page, "Save")
 
                 # Save form
-                await page.get_by_role(
-                    "button", name="Save and continue editing"
-                ).click()
-                await page.wait_for_url(admin_url)
+                await page.get_by_role("button", name="Save", exact=True).click()
+                await page.wait_for_url(admin_changelist_url)
 
             with phase("Validate default value after create"):
 
@@ -573,6 +575,7 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
             # So to test if this bug happens, we just save it again, and then check the
             # database.
             with phase("Edit the form"):
+                await page.goto(str(admin_url))
                 await page.get_by_role("tab", name="Steps and fields").click()
 
                 # The defaultValue in the bug is set to `null`.
@@ -582,10 +585,8 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
                 await close_modal(page, "Save", exact=True)
 
                 # Save form
-                await page.get_by_role(
-                    "button", name="Save and continue editing"
-                ).click()
-                await page.wait_for_url(admin_url)
+                await page.get_by_role("button", name="Save", exact=True).click()
+                await page.wait_for_url(admin_changelist_url)
 
             with phase("Validate default value after editing"):
 


### PR DESCRIPTION
Avoids a race condition where the DB transaction was not saved yet by the API call made through the Javascript before asserting the DB state.

The page.wait_for_url was probably a no-op because the page URL is already satisfied when editing a form and reloading that same page. This is mitigated by hitting the save that redirects to the form list page, which has a different URL and provides stronger guarantees that the changes have been persisted in the database.