### PR TITLE
:arrow_up: Bump kombu to 5.4+

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -303,7 +303,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/base.in
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.3.7
+kombu==5.5.0
     # via celery
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
@@ -528,9 +528,10 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2023.3
+tzdata==2025.1
     # via
     #   celery
+    #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1
     # via o365

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -548,7 +548,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/base.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.3.7
+kombu==5.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1032,11 +1032,12 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2023.3
+tzdata==2025.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
+    #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -606,7 +606,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/ci.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.3.7
+kombu==5.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1176,11 +1176,12 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2023.3
+tzdata==2025.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
+    #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1
     # via

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -503,7 +503,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/base.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.3.7
+kombu==5.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -907,11 +907,12 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2023.3
+tzdata==2025.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
+    #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1
     # via

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -597,7 +597,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/ci.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.3.7
+kombu==5.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1179,11 +1179,12 @@ typing-extensions==4.12.2
     #   qrcode
     #   types-lxml
     #   zgw-consumers
-tzdata==2023.3
+tzdata==2025.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
+    #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1
     # via


### PR DESCRIPTION
Closes #4937

Kombu is the underlying transport library used by Celery and v5.4.0 should fix the redis stability errors where workers cannot reconnect after connection loss to redis. It should work with Celery 5.4 and we should not need to wait for Celery 5.5 to get this fix.

This problem and fix are tough to validate so we'll just have to try it out. Team Bron also bumped Kombu in Open Zaak etc.

If it's stable, we could also backport this, but let's hold off on that and validate that we don't get new issues.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
