### PR TITLE
Hidden map fails form validation

### DIFF
--- a/src/openforms/formio/constants.py
+++ b/src/openforms/formio/constants.py
@@ -9,7 +9,7 @@ COMPONENT_DATATYPES = {
     "checkbox": "boolean",
     "selectboxes": "object",
     "npFamilyMembers": "object",
-    "map": "array",
+    "map": "object",
     "editgrid": "array",
     "datetime": "datetime",
 }

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -193,6 +193,13 @@ def get_component_empty_value(component):
         # However, the empty value is with all the options not selected (ex. {"a": False, "b": False})
         return component.get("defaultValue", {})
 
+    if component["type"] == "map":
+        # Issue 5151
+        # Component map is of 'object' type, which would return a {} for an empty component.
+        # However, an empty object would fail validation, as the required properties
+        # `type` and `coordinates` would be missing.
+        return component.get("defaultValue", None)
+
     return DEFAULT_INITIAL_VALUE.get(data_type, "")
 
 

--- a/src/openforms/js/components/form/map.js
+++ b/src/openforms/js/components/form/map.js
@@ -50,7 +50,7 @@ export default class Map extends TextFieldComponent {
   }
 
   get emptyValue() {
-    return '';
+    return undefined;
   }
 
   renderElement(value, index) {

--- a/src/openforms/tests/e2e/test_input_validation.py
+++ b/src/openforms/tests/e2e/test_input_validation.py
@@ -31,7 +31,7 @@ from openforms.submissions.models import TemporaryFileUpload
 from openforms.submissions.tests.factories import TemporaryFileUploadFactory
 
 from .base import browser_page
-from .input_validation_base import ValidationsTestCase, create_form
+from .input_validation_base import ValidationsTestCase, create_form, omit
 
 TEST_CASES = (Path(__file__).parent / "input_validation").resolve()
 TEST_FILES = Path(__file__).parent / "data"
@@ -561,6 +561,7 @@ class SingleMapTests(ValidationsTestCase):
         self.assertValidationIsAligned(
             component,
             ui_input="",
+            api_value=omit,
             expected_ui_error="Het verplichte veld Required map is niet ingevuld.",
         )
 
@@ -808,7 +809,9 @@ class SingleFileTests(ValidationsTestCase):
             self._assertFileFrontendValidation(form, ui_files, expected_ui_error)
 
         with self.subTest("backend validation"):
-            self._assertBackendValidation(form, component["key"], api_value)
+            self._assertBackendValidation(
+                form, component["key"], component["type"], api_value
+            )
 
     @async_to_sync
     async def _assertFileFrontendValidation(
@@ -989,7 +992,9 @@ class SingleAddressNLTests(ValidationsTestCase):
             self._assertAddressNLFrontendValidation(form, ui_inputs, expected_ui_error)
 
         with self.subTest("backend validation"):
-            self._assertBackendValidation(form, component["key"], api_value)
+            self._assertBackendValidation(
+                form, component["key"], component["type"], api_value
+            )
 
     @async_to_sync
     async def _assertAddressNLFrontendValidation(


### PR DESCRIPTION
Closes #5151

**Changes**

If a map component is `hidden` (with `clearOnHide` set to `True`), the check-logic call would return an empty value for the map component. This empty value would then in turn be merged into the SDK form data. If we then click on "next step", the form data will be validated and the empty value for the map component won't be conform the map component serializer validation, causing errors the user cannot fix (and locking the form).

The only correct empty value for a map component, is **NO** value.

These changes make sure that missing map components don't receive empty object values. Ensuring that forms cannot be locked by hidden and empty map components.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
