### PR TITLE
[#4662, #5147] Fix validation for `selectboxes` with no submitted values

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -640,6 +640,9 @@ class SelectboxesField(serializers.Serializer):
         validated_data: dict[str, bool] = super().to_internal_value(data)
         num_checked = len([value for value in validated_data.values() if value is True])
 
+        if not self.required and num_checked == 0:
+            return validated_data
+
         # min_selected_count trumps required checks
         if self.min_selected_count is not None:
             if num_checked < self.min_selected_count:

--- a/src/openforms/formio/tests/validation/test_selectboxes.py
+++ b/src/openforms/formio/tests/validation/test_selectboxes.py
@@ -115,7 +115,7 @@ class SelectboxesValidationTests(SimpleTestCase):
 
         self.assertTrue(is_valid)
 
-    def test_validate_min_checked(self):
+    def test_validate_min_checked_optional(self):
         component: SelectBoxesComponent = {
             "type": "selectboxes",
             "key": "foo",
@@ -160,6 +160,30 @@ class SelectboxesValidationTests(SimpleTestCase):
         is_valid, errors = validate_formio_data(component, data)
 
         self.assertTrue(is_valid)
+
+    def test_validate_min_checked_required(self):
+        component: SelectBoxesComponent = {
+            "type": "selectboxes",
+            "key": "foo",
+            "label": "Test",
+            "validate": {
+                "required": True,
+                "minSelectedCount": 2,
+            },
+            "openForms": {"dataSrc": DataSrcOptions.manual},
+            "values": [
+                {"value": "a", "label": "A"},
+                {"value": "b", "label": "B"},
+            ],
+        }
+
+        data: JSONValue = {"foo": {"a": True, "b": False}}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertFalse(is_valid)
+        error = extract_error(errors, "foo")
+        self.assertEqual(error.code, "min_selected_count")
 
     def test_validate_max_checked(self):
         component: SelectBoxesComponent = {

--- a/src/openforms/formio/tests/validation/test_selectboxes.py
+++ b/src/openforms/formio/tests/validation/test_selectboxes.py
@@ -139,6 +139,28 @@ class SelectboxesValidationTests(SimpleTestCase):
         error = extract_error(errors, "foo")
         self.assertEqual(error.code, "min_selected_count")
 
+    def test_validate_min_checked_optional_no_values(self):
+        component: SelectBoxesComponent = {
+            "type": "selectboxes",
+            "key": "foo",
+            "label": "Test",
+            "validate": {
+                "required": False,
+                "minSelectedCount": 2,
+            },
+            "openForms": {"dataSrc": DataSrcOptions.manual},
+            "values": [
+                {"value": "a", "label": "A"},
+                {"value": "b", "label": "B"},
+            ],
+        }
+
+        data: JSONValue = {"foo": {"a": False, "b": False}}
+
+        is_valid, errors = validate_formio_data(component, data)
+
+        self.assertTrue(is_valid)
+
     def test_validate_max_checked(self):
         component: SelectBoxesComponent = {
             "type": "selectboxes",

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -556,14 +556,6 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
         invalid_data_cases = [
             # missing keys
             {"a": True},
-            # minimum count checked not okay
-            {
-                "a": False,
-                "b": False,
-                "c": False,
-                "d": False,
-                "e": False,
-            },
             # maximum count checked not okay
             {
                 "a": True,


### PR DESCRIPTION
Closes #4662 
Closes #5147

**Changes**

- Added missing check for optional field with no submitted values

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
