### PR TITLE
add registrator omschrijving

### DIFF
--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -160,6 +160,7 @@
                     <ZKN:identificatie>{{ registrator.medewerker.identificatie }}</ZKN:identificatie>
                 </ZKN:medewerker>
             </ZKN:gerelateerde>
+            <ZKN:omschrijving>registrator</ZKN:omschrijving>
         </ZKN:heeftAlsOverigBetrokkene>
         {% endif %}
         {% if zds_zaaktype_status_code or zds_zaaktype_status_omschrijving %}


### PR DESCRIPTION
Changes

Added the <ZKN:omschrijving> element to the heeftAlsOverigBetrokkene block to explicitly indicate the role of the related medewerker. This enables generic mapping of the omschrijving field to roles in external systems like XXLNC Zaken.

Previously, it was implicitly assumed that a medewerker related via heeftAlsOverigBetrokkene was always the registrator. With this change, the role is explicitly set using the omschrijving field (<ZKN:omschrijving>registrator</ZKN:omschrijving>), allowing for more flexible and accurate role mapping, especially in cases where the medewerker fulfills a different function within the case.