### PR TITLE
Add initial data reference query parameter in `onLanguageChange` callback

### DIFF
--- a/docs/developers/embedding.rst
+++ b/docs/developers/embedding.rst
@@ -105,8 +105,10 @@ Available options
     content and changes the active language of the form. When using ``onLanguageChange``,
     your function will be executed on language change, instead of the default logic.
 
-    The new active language will be passed as an argument to the ``onLanguageChange``
-    function as a two-letter identifier.
+    Two parameters are passed as arguments to the ``onLanguageChange`` function:
+
+        1. The new active language as a two-letter identifier
+        2. The initial data reference (if applicable)
 
 ``sentryDSN``:
     Optional `Sentry DSN <https://docs.sentry.io/>`_ to monitor the SDK.

--- a/src/openforms/forms/templates/forms/sdk_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_snippet.html
@@ -39,7 +39,16 @@
             {% if sdk_sentry_dsn %}sentryDSN,{% endif %}
             {% if sdk_sentry_env %}sentryEnv,{% endif %}
             languageSelectorTarget: '#react-portal--language-selection',
-            onlanguagechange: () => window.location.reload(),
+            onLanguageChange: (newLanguageCode, initialDataReference) => {
+                // URL handling in JS requires a proper base since you can't just feed `foo` or `/foo`
+                // to the constructor. We only extract the pathname + query string again at the end.
+                const base = window.location.origin;
+                const url = new URL(basePath, base);
+                if (initialDataReference) {
+                    url.searchParams.set('initial_data_reference', initialDataReference);
+                }
+                window.location.replace(`${url.pathname}${url.search}`);
+            },
         }
     );
     form.init();

--- a/src/openforms/static/sdk-wrapper.mjs
+++ b/src/openforms/static/sdk-wrapper.mjs
@@ -27,6 +27,16 @@ const initializeSDK = async node => {
     formId,
     basePath,
     CSPNonce: cspNonce,
+    onLanguageChange: (newLanguageCode, initialDataReference) => {
+        // URL handling in JS requires a proper base since you can't just feed `foo` or `/foo`
+        // to the constructor. We only extract the pathname + query string again at the end.
+        const base = window.location.origin;
+        const url = new URL(basePath, base);
+        if (initialDataReference) {
+            url.searchParams.set('initial_data_reference', initialDataReference);
+        }
+        window.location.replace(`${url.pathname}${url.search}`);
+    },
   };
   if (sentryDsn) options.sentryDSN = sentryDsn;
   if (sentryEnv) options.sentryEnv = sentryEnv;


### PR DESCRIPTION
Closes #5155

Depends on open-formulieren/open-forms-sdk#809

**Changes**

Add initial data reference query parameter in `onLanguageChange` callback

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
