### PR TITLE
Remove `glom` usage from `FormioData`

### DIFF
--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
-from datetime import date, datetime
+from datetime import datetime
 from decimal import Decimal
 from typing import (
     Any,
@@ -48,7 +48,7 @@ from openforms.submissions.models import (
 from openforms.submissions.models.submission_value_variable import (
     SubmissionValueVariable,
 )
-from openforms.typing import JSONObject, JSONValue
+from openforms.typing import JSONObject, VariableValue
 from openforms.utils.date import datetime_in_amsterdam
 from openforms.variables.constants import FormVariableSources
 from openforms.variables.utils import get_variables_for_context
@@ -539,7 +539,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
                 )
                 variable = None
 
-            value: JSONValue | date | datetime
+            value: VariableValue
             try:
                 value = all_values[key]
             except KeyError:


### PR DESCRIPTION
Closes #5179

**Changes**

Remove usage of `glom` from `__getitem__` and `__setitem__` in `FormioData`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
