### PR TITLE
Fix excessive logging of the registration backend resolution

### DIFF
--- a/src/openforms/logging/models.py
+++ b/src/openforms/logging/models.py
@@ -178,10 +178,6 @@ class TimelineLogProxy(TimelineLog):
         else:
             return self.extra_data.get("log_event", None)
 
-    @property
-    def debug_data(self):
-        return repr(self.extra_data)
-
 
 class AVGTimelineLogProxyManager(models.Manager):
     def get_queryset(self):

--- a/src/openforms/logging/templates/logging/events/registration_debug.txt
+++ b/src/openforms/logging/templates/logging/events/registration_debug.txt
@@ -1,4 +1,9 @@
-{% load i18n %}
-{% blocktrans trimmed with data=log.debug_data lead=log.fmt_lead %}
-   {{ lead }}: Registration debug data: {{ data }}
+{% load i18n capture_tags %}
+
+{% capture as resolved_backend silent %}{% if log.extra_data.backend %}
+{% blocktrans with key=log.extra_data.backend.key name=log.extra_data.backend.name|default:_('name unknown') %}Backend '{{ key }}' ({{ name }}){% endblocktrans %}
+{% endif %}{% endcapture %}
+
+{% blocktrans trimmed with message=log.extra_data.message lead=log.fmt_lead  %}
+   {{ lead }}: Registration debug: {{ message }}{{ resolved_backend }}
 {% endblocktrans %}

--- a/src/openforms/submissions/admin.py
+++ b/src/openforms/submissions/admin.py
@@ -359,8 +359,8 @@ class SubmissionAdmin(admin.ModelAdmin):
         return not obj.needs_on_completion_retry
 
     @admin.display(description=_("Registration backend"))
-    def get_registration_backend(self, obj):
-        return obj.registration_backend or "-"
+    def get_registration_backend(self, obj: Submission):
+        return obj.resolve_registration_backend(enable_log=False) or "-"
 
     @admin.display(description=_("Appointment status"))
     def get_appointment_status(self, obj):

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -810,7 +810,7 @@ class Submission(models.Model):
                 registration_debug(
                     self,
                     extra_data={
-                        "message": _("No registration backends defined on form")
+                        "message": _("No registration backends defined on form.")
                     },
                 )
                 return None
@@ -819,7 +819,7 @@ class Submission(models.Model):
                 registration_debug(
                     self,
                     extra_data={
-                        "message": _("Multiple backends defined on form"),
+                        "message": _("Multiple backends defined on form."),
                         "backend": {"key": default.key, "name": default.name},
                     },
                 )

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -800,33 +800,37 @@ class Submission(models.Model):
     def cosign_state(self) -> CosignState:
         return CosignState(submission=self)
 
-    @property
-    def default_registration_backend_key(self) -> RegistrationBackendKey | None:
+    def resolve_default_registration_backend_key(
+        self, enable_log: bool = False
+    ) -> RegistrationBackendKey | None:
         backends = list(self.form.registration_backends.order_by("id"))
         match len(backends):  # sanity check
             case 1:
                 return backends[0].key
             case 0:
-                registration_debug(
-                    self,
-                    extra_data={
-                        "message": _("No registration backends defined on form.")
-                    },
-                )
+                if enable_log:
+                    registration_debug(
+                        self,
+                        extra_data={
+                            "message": _("No registration backends defined on form.")
+                        },
+                    )
                 return None
             case _:
                 default = backends[0]
-                registration_debug(
-                    self,
-                    extra_data={
-                        "message": _("Multiple backends defined on form."),
-                        "backend": {"key": default.key, "name": default.name},
-                    },
-                )
+                if enable_log:
+                    registration_debug(
+                        self,
+                        extra_data={
+                            "message": _("Multiple backends defined on form."),
+                            "backend": {"key": default.key, "name": default.name},
+                        },
+                    )
                 return default.key
 
-    @property
-    def registration_backend(self) -> FormRegistrationBackend | None:
+    def resolve_registration_backend(
+        self, enable_log: bool = False
+    ) -> FormRegistrationBackend | None:
         if self.finalised_registration_backend_key:
             try:
                 return self.form.registration_backends.get(
@@ -847,9 +851,17 @@ class Submission(models.Model):
         # not/faulty set by logic; fallback to default
         return (
             self.form.registration_backends.get(key=default_key)
-            if (default_key := self.default_registration_backend_key)
+            if (
+                default_key := self.resolve_default_registration_backend_key(
+                    enable_log=enable_log
+                )
+            )
             else None
         )
+
+    @property
+    def registration_backend(self) -> FormRegistrationBackend | None:
+        return self.resolve_registration_backend(enable_log=True)
 
     @property
     def post_completion_task_ids(self) -> list[str]:


### PR DESCRIPTION
Closes #5186

**Changes**

* 'Fixed' the template for registration debug logs
* Avoid logging the dynamic lookup for the admin display, as this creates confusion.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
