### PR TITLE
Set a minimum width for the variable value column

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -247,6 +247,7 @@ const VariablesTable = ({variables, editable, onDelete, onChange, onFieldChange}
         }
       />
       <HeadColumn
+        className="variables-table__value"
         content={
           <FormattedMessage
             defaultMessage="Initial value"

--- a/src/openforms/scss/components/admin/_variables-table.scss
+++ b/src/openforms/scss/components/admin/_variables-table.scss
@@ -43,4 +43,8 @@
       font-size: 100%;
     }
   }
+
+  @include bem.element('value') {
+    width: 310px;
+  }
 }


### PR DESCRIPTION
Closes #5184

This is a bandaid fix to hold us over until the redesign, creating sufficient space for the json widget to not overflow.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
