### PR TITLE
Fix broken demo prefill plugin

### DIFF
--- a/src/openforms/prefill/contrib/demo/plugin.py
+++ b/src/openforms/prefill/contrib/demo/plugin.py
@@ -5,6 +5,7 @@ from typing import Any
 from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.config.data import Action
 from openforms.submissions.models import Submission
 
@@ -23,6 +24,12 @@ CALLBACKS = {
 class DemoPrefill(BasePlugin):
     verbose_name = _("Demo")
     is_demo_plugin = True
+    requires_auth = (
+        AuthAttribute.bsn,
+        AuthAttribute.kvk,
+        AuthAttribute.pseudo,
+        AuthAttribute.employee_id,
+    )
 
     @staticmethod
     def get_available_attributes():


### PR DESCRIPTION
Closes #5185

**Changes**

Added all the available auth attributes so that the plugin always runs.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
