### PR TITLE
[#5192] Fix buttons in cosign,cookies and registrator

### DIFF
--- a/src/openforms/authentication/templates/of_authentication/registrator_subject_info.html
+++ b/src/openforms/authentication/templates/of_authentication/registrator_subject_info.html
@@ -31,29 +31,32 @@
 
                 {% include "includes/forms/field_wrapper.html" with field=form.bsn type='bsn' only %}
 
-                <div class="openforms-toolbar openforms-toolbar--reverse">
-                    <button class="utrecht-button utrecht-button--primary-action" type="submit">
+                <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit">
                         {% trans "Continue" %}
+                        <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
                     </button>
-                </div>
+                </p>
             </div>
 
             <div class="auth-mode auth-mode--company">
                 {% include "includes/forms/field_wrapper.html" with field=form.kvk only %}
 
-                <div class="openforms-toolbar openforms-toolbar--reverse">
-                    <button class="utrecht-button utrecht-button--primary-action" type="submit">
+                <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit">
                         {% trans "Continue" %}
+                        <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
                     </button>
-                </div>
+                </p>
             </div>
 
             <div class="auth-mode auth-mode--employee">
-                <div class="openforms-toolbar openforms-toolbar--reverse">
-                    <button class="utrecht-button utrecht-button--primary-action" type="submit" name="skip_subject" value="on">
+                <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit" name="skip_subject" value="on">
                         {{ form.skip_subject.label }}
+                        <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
                     </button>
-                </div>
+                </p>
             </div>
 
         </form>

--- a/src/openforms/submissions/templates/submissions/find_submission_for_cosign.html
+++ b/src/openforms/submissions/templates/submissions/find_submission_for_cosign.html
@@ -17,15 +17,17 @@
 
                         {% include "includes/forms/field_wrapper.html" with field=form.code type='text' only %}
 
-                        <div class="openforms-toolbar openforms-toolbar--reverse openforms-toolbar--bottom">
-                            <button class="utrecht-button utrecht-button--primary-action" type="submit">
+                        <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+                            <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit">
                                 {% trans "Submit" %}
+                                <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
                             </button>
-                        </div>
+                        </p>
                     </form>
                     <form method="post" action="{% url "authentication:logout" %}">{% csrf_token %}
-                        <div class="openforms-toolbar openforms-toolbar--reverse openforms-toolbar--bottom">
-                            <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger" type="submit">
+                        <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+                            <button class="utrecht-link-button utrecht-link-button--html-button utrecht-link-button--openforms" type="submit" name="abort">
+                                <i class="fa fas fa-icon fa-xmark" aria-hidden="true"></i>
                                 {% trans "Log out" %}
                             </button>
                         </div>

--- a/src/openforms/templates/includes/cookie-notice.html
+++ b/src/openforms/templates/includes/cookie-notice.html
@@ -20,23 +20,14 @@
                 You can <a class="utrecht-link utrecht-link--openforms" href="{{ manage_url }}">manage your preferences</a>.
                 {% endblocktrans %}
             </span>
-
-            <div class="openforms-toolbar">
-                <ul class="openforms-toolbar__list">
-                    <li class="openforms-toolbar__list-item">
-                        <button
-                            type="submit"
-                            class="utrecht-button utrecht-button--primary-action cookie-notice__accept"
-                        >{% trans "Accept all" %}</button>
-                    </li>
-                    <li class="openforms-toolbar__list-item">
-                        <button
-                            type="submit"
-                            class="utrecht-button utrecht-button--primary-action cookie-notice__decline"
-                        >{% trans "Decline all" %}</button>
-                    </li>
-                </ul>
-            </div>
+            <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+                <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action cookie-notice__accept" type="submit">
+                    {% trans "Accept all" %}
+                </button>
+                <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action cookie-notice__decline" type="submit">
+                    {% trans "Decline all" %}
+                </button>
+            </p>
         </section>
     </template>
 {% endif %}

--- a/src/openforms/ui/static/ui/scss/components/cookie-notice/_index.scss
+++ b/src/openforms/ui/static/ui/scss/components/cookie-notice/_index.scss
@@ -37,8 +37,4 @@
   @include bem.element('form') {
     width: 100%;
   }
-
-  .openforms-toolbar__list:last-child .openforms-toolbar__list-item:last-child {
-    padding-bottom: 0;
-  }
 }


### PR DESCRIPTION
Closes #5192

**Changes**

- Applied `utrecht-button-group` to cosign, cookies and registrator buttons. All these were using the old way of structuring the buttons (toolbar).

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
