### PR TITLE
Fix validation crash when a map component value is cleared/empty

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -241,7 +241,7 @@ drf-jsonschema-serializer==3.0.0
     # via -r requirements/base.in
 drf-nested-routers==0.93.4
     # via -r requirements/base.in
-drf-polymorphic==1.0.0
+drf-polymorphic==2.0.0
     # via -r requirements/base.in
 drf-spectacular==0.27.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -415,7 +415,7 @@ drf-nested-routers==0.93.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-drf-polymorphic==1.0.0
+drf-polymorphic==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -447,7 +447,7 @@ drf-nested-routers==0.93.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-drf-polymorphic==1.0.0
+drf-polymorphic==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -395,7 +395,7 @@ drf-nested-routers==0.93.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-drf-polymorphic==1.0.0
+drf-polymorphic==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -444,7 +444,7 @@ drf-nested-routers==0.93.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-drf-polymorphic==1.0.0
+drf-polymorphic==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #5191 (partly)

**Changes**

Fixed the underlying bug in drf-polymorphic, and updated the version.

The polymorphic serializer was added after 3.0 was released, so no backports needed for this.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
