### PR TITLE
Fix non-existing variables being included in the required property of JSON schema

### DIFF
--- a/src/openforms/forms/json_schema.py
+++ b/src/openforms/forms/json_schema.py
@@ -59,7 +59,7 @@ def generate_json_schema(
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": requested_variables_schema,
-        "required": limit_to_variables,
+        "required": list(requested_variables_schema.keys()),
         "additionalProperties": False,
     }
 

--- a/src/openforms/forms/tests/test_json_schema.py
+++ b/src/openforms/forms/tests/test_json_schema.py
@@ -188,17 +188,17 @@ class GenerateJsonSchemaTests(TestCase):
                 },
                 "foo": {"type": "array", "title": "Foo"},
             },
-            "required": (
+            "required": [
+                "today",
+                "auth_bsn",
                 "firstName",
                 "lastName",
                 "select",
                 "selectboxes",
                 "radio",
                 "file",
-                "auth_bsn",
-                "today",
                 "foo",
-            ),
+            ],
             "additionalProperties": False,
         }
 

--- a/src/openforms/forms/tests/test_json_schema.py
+++ b/src/openforms/forms/tests/test_json_schema.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from openforms.formio.constants import DataSrcOptions
 from openforms.forms.tests.factories import (
@@ -203,6 +203,24 @@ class GenerateJsonSchemaTests(TestCase):
         }
 
         self.assertEqual(schema, expected_schema)
+
+    @tag("gh-5205")
+    def test_non_existing_variable_not_in_required(self):
+        form = FormFactory.create()
+        form_def_1 = FormDefinitionFactory.create(
+            configuration={
+                "components": [
+                    {"key": "firstName", "type": "textfield", "label": "First Name"},
+                    {"key": "lastName", "type": "textfield", "label": "Last Name"},
+                ]
+            }
+        )
+        FormStepFactory.create(form=form, form_definition=form_def_1)
+
+        vars_to_include = ("firstName", "lastName", "nonExistingVariable")
+        schema = generate_json_schema(form, vars_to_include)
+
+        self.assertEqual(schema["required"], ["firstName", "lastName"])
 
 
 class FormVariableAsJsonSchemaTests(TestCase):


### PR DESCRIPTION
Partly closes #5205 

**Changes**

The required property now accurately reflects the variables that are in the schema

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
