### PR TITLE
Fix hidden fields present in JSON schema

### DIFF
--- a/src/openforms/registrations/contrib/json_dump/plugin.py
+++ b/src/openforms/registrations/contrib/json_dump/plugin.py
@@ -64,7 +64,7 @@ class JSONDumpRegistration(BasePlugin):
             for key, value in all_values.items()
             if key in options["variables"]
         }
-        values_schema = generate_json_schema(submission.form, options["variables"])
+        values_schema = generate_json_schema(submission.form, list(values.keys()))
         transform_to_list = options["transform_to_list"]
         post_process(values, values_schema, submission, transform_to_list)
 

--- a/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_hidden_field_not_in_schema.yaml
+++ b/src/openforms/registrations/contrib/json_dump/tests/files/vcr_cassettes/JSONDumpBackendTests/JSONDumpBackendTests.test_hidden_field_not_in_schema.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: '"{\"values\": {\"firstName\": \"Oscar\"}, \"values_schema\": {\"$schema\":
+      \"https://json-schema.org/draft/2020-12/schema\", \"type\": \"object\", \"properties\":
+      {\"firstName\": {\"title\": \"Firstname\", \"type\": \"string\"}}, \"required\":
+      [\"firstName\"], \"additionalProperties\": false}, \"metadata\": {}, \"metadata_schema\":
+      {\"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"type\": \"object\",
+      \"properties\": {}, \"required\": [], \"additionalProperties\": false}}"'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NDMwODkxOTIsImNsaWVudF9pZCI6IiIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.1Vq7jojxQly98sJ2B1BtHR0LKdTQPMtCaS_U1UDYFwc
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '492'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.2
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"firstName\": \"Oscar\"\n    },\n
+        \   \"values_schema\": {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"firstName\":
+        {\n          \"title\": \"Firstname\",\n          \"type\": \"string\"\n        }\n
+        \     },\n      \"required\": [\n        \"firstName\"\n      ],\n      \"type\":
+        \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '649'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 27 Mar 2025 15:26:32 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.8
+    status:
+      code: 201
+      message: CREATED
+version: 1


### PR DESCRIPTION
Partly closes #5205

**Changes**

Fields that are not present in the submission data are no longer added to the schema in the JSON dump plugin

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
