### PR TITLE
:technologist: Allow skipping e2e tests in PRs/commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,9 @@ jobs:
 
   e2etests:
     runs-on: ubuntu-24.04
+
+    if: "${{ !( (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip: e2e]')) || (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '[skip: e2e]')) ) }}"
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use the `[skip: e2e]` fragment in the PR body or, when pushing a commit directly, in the commit message.

Note that you can't include it in a commit message for a PR, as this is not exposed in the PR context easily. So it *must* go in the body of the PR description.