### PR TITLE
Deprecate the Camunda registration backend

### DIFF
--- a/docs/configuration/registration/camunda.rst
+++ b/docs/configuration/registration/camunda.rst
@@ -6,6 +6,11 @@ Camunda
 
 Camunda_ is a process engine using BPM models. Open Forms supports Camunda 7.x
 
+.. deprecated:: 3.2.0
+
+   The Camunda registration backend will be removed in Open Forms 4.0. There is no
+   replacement scheduled - if you rely on this plugin, please get in touch.
+
 .. note::
 
     This service requires a connection to an external Camunda instance, offered

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -17,6 +17,7 @@ from django_camunda.api import get_process_definitions
 from django_camunda.models import CamundaConfig
 from django_camunda.tasks import start_process
 from django_camunda.utils import serialize_variables
+from typing_extensions import deprecated
 
 from openforms.submissions.models import Submission
 
@@ -70,6 +71,10 @@ def get_process_variables(
     return variables
 
 
+@deprecated(
+    "The camunda registration backend is scheduled for removal in Open Forms 4.0",
+    category=DeprecationWarning,
+)
 @register("camunda")
 class CamundaRegistration(BasePlugin):
     verbose_name = _("Camunda")


### PR DESCRIPTION
Partly closes #5223

**Changes**

* Added deprecation marker in code
* Added deprecation notice to the docs

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
