### PR TITLE
Distribute script to remove empty API groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,27 @@
 Changelog
 =========
 
+2.8.8 (2025-04-??)
+==================
+
+Final bugfix release in the ``2.8.x`` series.
+
+.. warning:: Manual intervention required
+
+    We included a script to remove corrupt API group configuration to make the upgrade
+    to Open Forms 3.0 easier. This script removes API groups (Objects API and ZGW API's)
+    for which *no* services have been configured.
+
+    .. code-block:: bash
+
+        # in the container via ``docker exec`` or ``kubectl exec``:
+        python src/manage.py /app/bin/delete_empty_api_groups.py
+
+**Bugfixes**
+
+.. todo:: ...
+
+
 2.8.7 (2025-03-17)
 ==================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ COPY \
     ./bin/fix_objects_api_form_registration_variables_mapping.py \
     ./bin/check_api_groups_null.py \
     ./bin/check_temporary_uploads.py \
+    ./bin/delete_empty_api_groups.py \
     ./bin/
 
 # prevent writing to the container layer, which would degrade performance.

--- a/bin/delete_empty_api_groups.py
+++ b/bin/delete_empty_api_groups.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# Fix the API groups that were automatically created from their singleton configs but
+# hold no actual useful configuration. These API groups block upgrading to Open Forms
+# 3.0 otherwise, unless manually removed in the admin interface.
+#
+
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import django
+from django.db.models import Q
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR.resolve()))
+
+
+def fix_api_groups():
+    from openforms.contrib.objects_api.models import ObjectsAPIGroupConfig
+    from openforms.registrations.contrib.zgw_apis.models import ZGWApiGroupConfig
+
+    objects_api_groups = ObjectsAPIGroupConfig.objects.filter(
+        objects_service__isnull=True,
+        objecttypes_service__isnull=True,
+        drc_service__isnull=True,
+        catalogi_service__isnull=True,
+    ).only("pk")
+    if objects_api_groups:
+        ids = [str(group.pk) for group in objects_api_groups]
+        print(f"Deleting {len(ids)} Objects API Group(s) with IDS: {', '.join(ids)}")
+    objects_api_groups.delete()
+
+    zgw_api_groups = ZGWApiGroupConfig.objects.filter(
+        zrc_service__isnull=True,
+        drc_service__isnull=True,
+        ztc_service__isnull=True,
+    ).only("pk")
+    if zgw_api_groups:
+        ids = [str(group.pk) for group in zgw_api_groups]
+        print(f"Deleting {len(ids)} ZGW API Group(s) with IDS: {', '.join(ids)}")
+    zgw_api_groups.delete()
+
+
+def main():
+    from openforms.setup import setup_env
+
+    setup_env()
+    django.setup()
+    fix_api_groups()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #5229 

**Changes**

* Added one-off script to remove ZGW API groups
* Added changelog instructions

There is no output if nothing was done, if groups were deleted the output looks like:

```
Deleting 1 Objects API Group(s) with IDS: 1
Deleting 1 ZGW API Group(s) with IDS: 1
```

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
