### PR TITLE
Upgrade Celery and related dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ attrs==23.2.0
     #   zeep
 beautifulsoup4==4.10.0
     # via o365
-billiard==4.2.0
+billiard==4.2.1
     # via celery
 bleach==5.0.1
     # via -r requirements/base.in
@@ -32,7 +32,7 @@ brotli==1.1.0
     # via fonttools
 cbor2==5.6.2
     # via webauthn
-celery==5.4.0
+celery==5.5.0
     # via
     #   -r requirements/base.in
     #   celery-once
@@ -303,7 +303,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/base.in
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.5.0
+kombu==5.5.2
     # via celery
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
@@ -528,9 +528,8 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2025.1
+tzdata==2025.2
     # via
-    #   celery
     #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -44,7 +44,7 @@ beautifulsoup4==4.10.0
     #   -r requirements/base.txt
     #   o365
     #   webtest
-billiard==4.2.0
+billiard==4.2.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -71,7 +71,7 @@ cbor2==5.6.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   webauthn
-celery==5.4.0
+celery==5.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -548,7 +548,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/base.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.5.0
+kombu==5.5.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1032,11 +1032,10 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   celery
     #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ beautifulsoup4==4.10.0
     #   -r requirements/ci.txt
     #   o365
     #   webtest
-billiard==4.2.0
+billiard==4.2.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -87,7 +87,7 @@ cbor2==5.6.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   webauthn
-celery==5.4.0
+celery==5.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -622,7 +622,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/ci.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.5.0
+kombu==5.5.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1214,11 +1214,10 @@ typing-extensions==4.12.2
     #   qrcode
     #   rich-click
     #   zgw-consumers
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   celery
     #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -38,7 +38,7 @@ beautifulsoup4==4.10.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   o365
-billiard==4.2.0
+billiard==4.2.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -63,7 +63,7 @@ cbor2==5.6.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   webauthn
-celery==5.4.0
+celery==5.5.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -503,7 +503,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/base.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.5.0
+kombu==5.5.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -907,11 +907,10 @@ typing-extensions==4.12.2
     #   pyopenssl
     #   qrcode
     #   zgw-consumers
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   celery
     #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -51,7 +51,7 @@ beautifulsoup4==4.10.0
     #   -r requirements/ci.txt
     #   o365
     #   webtest
-billiard==4.2.0
+billiard==4.2.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -80,7 +80,7 @@ cbor2==5.6.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   webauthn
-celery==5.4.0
+celery==5.5.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -597,7 +597,7 @@ jsonschema-specifications==2023.7.1
     #   -r requirements/ci.txt
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.5.0
+kombu==5.5.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1179,11 +1179,10 @@ typing-extensions==4.12.2
     #   qrcode
     #   types-lxml
     #   zgw-consumers
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   celery
     #   kombu
     #   pytz-deprecation-shim
 tzlocal==4.3.1


### PR DESCRIPTION
Closes #5060 (partially)

**Changes**

We upgraded kombu earlier, which should have fixed the reliability issues, but now Celery 5.5 is out we can finally upgrade the whole stack.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
