### PR TITLE
Ensure backwards compatibility button link styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",
-        "@open-formulieren/design-tokens": "^0.57.0",
+        "@open-formulieren/design-tokens": "^0.59.0",
         "@open-formulieren/formio-builder": "^0.39.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
@@ -4526,9 +4526,9 @@
       }
     },
     "node_modules/@open-formulieren/design-tokens": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.57.0.tgz",
-      "integrity": "sha512-oUm/NvhE2+N3h0igrqy3YAvXlZQWVmxOWeoVxcxlm8vhYyiZWdHrQRnxTikAa+uh2RaDPR/zZn2BF6SjbXoBjg=="
+      "version": "0.59.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.59.1.tgz",
+      "integrity": "sha512-2Xzzwqov16E0GmAOebr5pAHKfaR//DbJ1veCSg++53VuKvRhurMQIZhcRVHEIViDBrotugiZu4QkFtgnx3Qskg=="
     },
     "node_modules/@open-formulieren/formio-builder": {
       "version": "0.39.0",
@@ -21705,9 +21705,9 @@
       }
     },
     "@open-formulieren/design-tokens": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.57.0.tgz",
-      "integrity": "sha512-oUm/NvhE2+N3h0igrqy3YAvXlZQWVmxOWeoVxcxlm8vhYyiZWdHrQRnxTikAa+uh2RaDPR/zZn2BF6SjbXoBjg=="
+      "version": "0.59.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.59.1.tgz",
+      "integrity": "sha512-2Xzzwqov16E0GmAOebr5pAHKfaR//DbJ1veCSg++53VuKvRhurMQIZhcRVHEIViDBrotugiZu4QkFtgnx3Qskg=="
     },
     "@open-formulieren/formio-builder": {
       "version": "0.39.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://maykinmedia.nl",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.57.0",
+    "@open-formulieren/design-tokens": "^0.59.0",
     "@open-formulieren/formio-builder": "^0.39.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",

--- a/src/openforms/authentication/templates/of_authentication/registrator_subject_info.html
+++ b/src/openforms/authentication/templates/of_authentication/registrator_subject_info.html
@@ -28,13 +28,14 @@
             {% include "includes/forms/field_wrapper.html" with field=form.mode type='radio' only %}
 
             <div class="auth-mode auth-mode--citizen">
-
                 {% include "includes/forms/field_wrapper.html" with field=form.bsn type='bsn' only %}
 
-                <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
-                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit">
+                <p role="group" class="utrecht-button-group utrecht-button-group--column openforms-form-navigation">
+                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-form-navigation__next-button" type="submit">
                         {% trans "Continue" %}
-                        <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
+                        <span class="utrecht-icon" aria-hidden="true">
+                            <i class="fa fas fa-fw fa-icon" aria-hidden="true"></i>
+                        </span>
                     </button>
                 </p>
             </div>
@@ -42,19 +43,23 @@
             <div class="auth-mode auth-mode--company">
                 {% include "includes/forms/field_wrapper.html" with field=form.kvk only %}
 
-                <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
-                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit">
+                <p role="group" class="utrecht-button-group utrecht-button-group--column openforms-form-navigation">
+                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-form-navigation__next-button" type="submit">
                         {% trans "Continue" %}
-                        <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
+                        <span class="utrecht-icon" aria-hidden="true">
+                            <i class="fa fas fa-fw fa-icon" aria-hidden="true"></i>
+                        </span>
                     </button>
                 </p>
             </div>
 
             <div class="auth-mode auth-mode--employee">
-                <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
-                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit" name="skip_subject" value="on">
+                <p role="group" class="utrecht-button-group utrecht-button-group--column openforms-form-navigation">
+                    <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-form-navigation__next-button" type="submit" name="skip_subject" value="on">
                         {{ form.skip_subject.label }}
-                        <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
+                        <span class="utrecht-icon" aria-hidden="true">
+                            <i class="fa fas fa-fw fa-icon" aria-hidden="true"></i>
+                        </span>
                     </button>
                 </p>
             </div>

--- a/src/openforms/submissions/templates/submissions/find_submission_for_cosign.html
+++ b/src/openforms/submissions/templates/submissions/find_submission_for_cosign.html
@@ -11,28 +11,45 @@
 
         <div class="openforms-card__body">
             {% block card_body %}
-                <p class="body">
-                    <form method="post" action=".">{% csrf_token %}
+                <div class="body">
+
+                    <form method="post" action="." id="find-submission-form">
+                        {% csrf_token %}
                         {% include "includes/forms/errorlist.html" with errors=form.non_field_errors only %}
-
                         {% include "includes/forms/field_wrapper.html" with field=form.code type='text' only %}
+                    </form>
 
-                        <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
-                            <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-button-with-icon" type="submit">
-                                {% trans "Submit" %}
-                                <i class="fa fas fa-icon fa-arrow-right-long" aria-hidden="true"></i>
-                            </button>
-                        </p>
+                    <form method="post" action="{% url "authentication:logout" %}" id="logout-form">
+                        {% csrf_token %}
                     </form>
-                    <form method="post" action="{% url "authentication:logout" %}">{% csrf_token %}
-                        <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
-                            <button class="utrecht-link-button utrecht-link-button--html-button utrecht-link-button--openforms" type="submit" name="abort">
-                                <i class="fa fas fa-icon fa-xmark" aria-hidden="true"></i>
-                                {% trans "Log out" %}
-                            </button>
-                        </div>
-                    </form>
-                </p>
+
+                    <p role="group" class="utrecht-button-group utrecht-button-group--column openforms-form-navigation">
+                        <button
+                            class="utrecht-button utrecht-button--submit utrecht-button--primary-action openforms-form-navigation__next-button"
+                            type="submit"
+                            form="find-submission-form"
+                            name="next"
+                        >
+                            {% trans "Submit" %}
+                            <span class="utrecht-icon" aria-hidden="true">
+                                <i class="fa fas fa-fw fa-icon" aria-hidden="true"></i>
+                            </span>
+                        </button>
+
+                        <button
+                            class="utrecht-link-button utrecht-link-button--html-button openforms-abort-button"
+                            type="submit"
+                            form="logout-form"
+                            name="abort"
+                        >
+                            <span class="utrecht-icon" aria-hidden="true">
+                                <i class="fa fas fa-fw  fa-icon" aria-hidden="true"></i>
+                            </span>
+                            {% trans "Log out" %}
+                        </button>
+                    </p>
+
+                </div>
             {% endblock %}
         </div>
     </div>

--- a/src/openforms/templates/cookie_consent/cookiegroup_list.html
+++ b/src/openforms/templates/cookie_consent/cookiegroup_list.html
@@ -21,7 +21,7 @@
             </ul>
 
             {% if referer %}
-                <a href="{{ referer }}" class="utrecht-link utrecht-link--openforms">
+                <a href="{{ referer }}" class="utrecht-link utrecht-link--html-a utrecht-link--openforms">
                     {% trans "Close" %}
                 </a>
             {% endif %}

--- a/src/openforms/templates/includes/a11y_toolbar.html
+++ b/src/openforms/templates/includes/a11y_toolbar.html
@@ -2,10 +2,10 @@
 <nav class="a11y-toolbar">
     <ul class="a11y-toolbar__list">
         <li class="a11y-toolbar__list-item">
-            <a class="utrecht-link utrecht-link--openforms a11y-toolbar__window-print-action" href="#">{% trans "Print this page" %}</a>
+            <a class="utrecht-link utrecht-link--html-a utrecht-link--openforms a11y-toolbar__window-print-action" href="#">{% trans "Print this page" %}</a>
         </li>
         <li class="a11y-toolbar__list-item">
-            <a class="utrecht-link utrecht-link--openforms" href="#main-content">{% trans "Back to top" %}</a>
+            <a class="utrecht-link utrecht-link--html-a utrecht-link--openforms" href="#main-content">{% trans "Back to top" %}</a>
         </li>
     </ul>
 </nav>

--- a/src/openforms/templates/includes/cookie-notice.html
+++ b/src/openforms/templates/includes/cookie-notice.html
@@ -20,7 +20,7 @@
                 You can <a class="utrecht-link utrecht-link--html-a utrecht-link--openforms" href="{{ manage_url }}">manage your preferences</a>.
                 {% endblocktrans %}
             </span>
-            <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">
+            <p role="group" class="utrecht-button-group">
                 <button class="utrecht-button utrecht-button--submit utrecht-button--primary-action cookie-notice__accept" type="submit">
                     {% trans "Accept all" %}
                 </button>

--- a/src/openforms/templates/includes/cookie-notice.html
+++ b/src/openforms/templates/includes/cookie-notice.html
@@ -17,7 +17,7 @@
             <span class="cookie-notice__text">
                 {% blocktrans trimmed %}
                 We use cookies to optimize and improve our website and services.
-                You can <a class="utrecht-link utrecht-link--openforms" href="{{ manage_url }}">manage your preferences</a>.
+                You can <a class="utrecht-link utrecht-link--html-a utrecht-link--openforms" href="{{ manage_url }}">manage your preferences</a>.
                 {% endblocktrans %}
             </span>
             <p role="group" class="utrecht-button-group utrecht-button-group--column utrecht-button-group--distanced">

--- a/src/openforms/templates/includes/page-footer.html
+++ b/src/openforms/templates/includes/page-footer.html
@@ -8,20 +8,20 @@
             <li class="utrecht-link-list__item">
                 <a
                     href="{{ config.privacy_policy_url }}"
-                    class="utrecht-link utrecht-link--openforms utrecht-link--openforms-hover utrecht-link--openforms-inherit"
+                    class="utrecht-link utrecht-link--html-a utrecht-link--openforms utrecht-link--openforms-hover utrecht-link--openforms-inherit"
                 >{% trans "Privacy policy" %}</a>
             </li>
             <li class="utrecht-link-list__item">
                 <a
                     href="{% url 'cookie_consent_cookie_group_list' %}"
-                    class="utrecht-link utrecht-link--openforms utrecht-link--openforms-hover utrecht-link--openforms-inherit"
+                    class="utrecht-link utrecht-link--html-a utrecht-link--openforms utrecht-link--openforms-hover utrecht-link--openforms-inherit"
                 >{% trans "Manage cookies" %}</a>
             </li>
             {% if user.is_staff %}
                 <li class="utrecht-link-list__item">
                     <a
                         href="{% url 'api:api-docs' %}"
-                        class="utrecht-link utrecht-link--openforms utrecht-link--openforms-hover utrecht-link--openforms-inherit"
+                        class="utrecht-link utrecht-link--html-a utrecht-link--openforms utrecht-link--openforms-hover utrecht-link--openforms-inherit"
                     >{% trans "API docs" %}</a>
                 </li>
             {% endif %}

--- a/src/openforms/templates/includes/page-header.html
+++ b/src/openforms/templates/includes/page-header.html
@@ -18,7 +18,7 @@ include the SDK snippet directly.
 
 <header class="utrecht-page-header {% if theme.logo %}utrecht-page-header--openforms-with-logo{% endif %}">
     <a
-        class="utrecht-link utrecht-link--openforms utrecht-page-header__openforms-return-url"
+        class="utrecht-link utrecht-link--html-a utrecht-link--openforms utrecht-page-header__openforms-return-url"
         href="{% firstof config.main_website '#' %}"
         title="{{ logo_alt }}"
         aria-label="{{ logo_alt }}"

--- a/src/openforms/ui/static/ui/scss/_defaults.scss
+++ b/src/openforms/ui/static/ui/scss/_defaults.scss
@@ -1,0 +1,13 @@
+/**
+ * Default design tokens for backwards compatibility reasons.
+ * These *must* be overridden when someone includes their own theme (stylesheet or
+ * on-the-fly generated from design tokens).
+ *
+ * We use the :root selector because it has the lowest specificity.
+ */
+
+:root {
+  --utrecht-button-column-gap: 4px;
+  --of-form-navigation-row-gap: 12px;
+  --of-abort-button-color: var(--utrecht-button-primary-action-danger-background-color);
+}

--- a/src/openforms/ui/static/ui/scss/_nlds.scss
+++ b/src/openforms/ui/static/ui/scss/_nlds.scss
@@ -1,6 +1,6 @@
-@import '@utrecht/components/heading-2';
-@import '@utrecht/components/link-list';
-@import '@utrecht/components/page';
-@import '@utrecht/components/page-content';
-@import '@utrecht/components/page-header';
-@import '@utrecht/components/page-footer';
+@use '@utrecht/components/heading-2';
+@use '@utrecht/components/link-list';
+@use '@utrecht/components/page';
+@use '@utrecht/components/page-content';
+@use '@utrecht/components/page-header';
+@use '@utrecht/components/page-footer';

--- a/src/openforms/ui/static/ui/scss/components/_auth-mode.scss
+++ b/src/openforms/ui/static/ui/scss/components/_auth-mode.scss
@@ -11,6 +11,6 @@
   @include modifier('active') {
     display: flex;
     flex-direction: column;
-    gap: 2em;
+    gap: 0;
   }
 }

--- a/src/openforms/ui/static/ui/scss/screen.scss
+++ b/src/openforms/ui/static/ui/scss/screen.scss
@@ -1,5 +1,7 @@
+@use 'defaults';
+@use 'nlds';
+
 @import 'settings';
-@import 'nlds';
 
 @import 'components';
 

--- a/src/openforms/ui/templates/ui/views/abstract/list.html
+++ b/src/openforms/ui/templates/ui/views/abstract/list.html
@@ -14,7 +14,7 @@
                             <li class="list__item">
                                 <a
                                     href="{{ object.get_absolute_url }}"
-                                    class="utrecht-link utrecht-link--openforms"
+                                    class="utrecht-link utrecht-link--html-a utrecht-link--openforms"
                                 >{{ object }}</a>
                             </li>
                         {% endfor %}

--- a/src/openforms/ui/templatetags/style_dictionary.py
+++ b/src/openforms/ui/templatetags/style_dictionary.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.safestring import mark_safe
 
 from openforms.typing import JSONPrimitive
 
@@ -20,7 +21,12 @@ def extract_tokens(node: dict, prefix: str | None = None) -> dict[str, JSONPrimi
     # if a value is found, we have built up the entire token name and can return
     # the name + value combination
     if "value" in node:
-        tokens[prefix] = node["value"]
+        # escape possible HTML tag attempts, as that could break someone out of the
+        # style tag, but leave other characters intact.
+        # TODO: this should probably be more clever by default...
+        tokens[prefix] = mark_safe(
+            node["value"].replace("<", "&lt;").replace(">", "&gt;")
+        )
         return tokens
 
     # if nothing is found, we need to recurse and a node could contain multiple keys


### PR DESCRIPTION
Closes #4917 - requires the SDK PR https://github.com/open-formulieren/open-forms-sdk/pull/817

**Changes**

* Updated all our own HTML markup in Django templates to properly reflect the same markup as emitted by the react components
    * Handled the subject registrator info page
    * Handled the cosign submission lookup
* Fixed the cookie notice button alignment - those should not be stacked, that banner already takes up way too much vertical space
* Tweaked the styling/spacing of the subject registrator info page to be a bit more compact
* Provided some basic styles that should be overridden as soon as a theme specifies the same design token. This should cover 90% of the existing themes to be presentable.

Note: the DH logout button/link color can't be fixed from our perspective, they'll have to patch up their design tokens.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
