### PR TITLE
Support broader range of geojson in schema generation

### DIFF
--- a/src/openforms/forms/json_schema.py
+++ b/src/openforms/forms/json_schema.py
@@ -24,7 +24,7 @@ def _iter_form_variables(
         yield from get_static_variables(
             variables_registry=additional_variables_registry
         )
-    # Handle from variables holding dynamic data (component and user defined)
+    # Handle form variables holding dynamic data (component and user defined)
     yield from form.formvariable_set.all()
 
 

--- a/src/openforms/utils/json_schema.py
+++ b/src/openforms/utils/json_schema.py
@@ -1,4 +1,38 @@
+from openforms.api.geojson import GeoJsonGeometryTypes
 from openforms.typing import JSONObject
+
+GEO_JSON_COORDINATE_SCHEMA = {
+    "type": "array",
+    "prefixItems": [
+        {"title": "Longitude", "type": "number"},
+        {"title": "Latitude", "type": "number"},
+    ],
+    "items": False,
+    "minItems": 2,
+}
+
+GEO_JSON_LINE_COORDINATE_SCHEMA = {
+    "type": "array",
+    "minItems": 2,
+    "items": GEO_JSON_COORDINATE_SCHEMA,
+}
+
+GEO_JSON_POLYGON_COORDINATE_SCHEMA = {
+    "type": "array",
+    "minItems": 1,
+    "maxItems": 1,
+    "items": {
+        "type": "array",
+        "minItems": 4,
+        "items": GEO_JSON_COORDINATE_SCHEMA,
+    },
+}
+
+GEO_JSON_COORDINATE_SCHEMAS = {
+    GeoJsonGeometryTypes.point: GEO_JSON_COORDINATE_SCHEMA,
+    GeoJsonGeometryTypes.line_string: GEO_JSON_LINE_COORDINATE_SCHEMA,
+    GeoJsonGeometryTypes.polygon: GEO_JSON_POLYGON_COORDINATE_SCHEMA,
+}
 
 
 def to_multiple(schema: JSONObject) -> JSONObject:


### PR DESCRIPTION
Closes #5027

[skip: e2e]

**Changes**
Update the JSON schema of the map component to include line and polygon shapes

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
