### PR TITLE
Start migration to django-upgrade-check

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -58,6 +58,7 @@ django-simple-certmanager
 django-solo
 django-tinymce
 django-treebeard
+django-upgrade-check
 django-yubin
 mozilla-django-oidc-db[setup-configuration]
 maykin-2fa

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -119,6 +119,7 @@ django==4.2.20
     #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   drf-jsonschema-serializer
     #   drf-nested-routers
@@ -224,6 +225,8 @@ django-treebeard==4.7
     # via -r requirements/base.in
 django-two-factor-auth==1.16.0
     # via maykin-2fa
+django-upgrade-check==1.0.0
+    # via -r requirements/base.in
 django-yubin==2.0.4
     # via -r requirements/base.in
 djangorestframework==3.15.2
@@ -480,7 +483,9 @@ schwifty==2024.5.3
 self-certifi==1.0.0
     # via -r requirements/base.in
 semantic-version==2.10.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   django-upgrade-check
 sentry-sdk==2.10.0
     # via -r requirements/base.in
 simplejson==3.19.3

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -200,6 +200,7 @@ django==4.2.20
     #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   drf-jsonschema-serializer
     #   drf-nested-routers
@@ -381,6 +382,10 @@ django-two-factor-auth==1.16.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-2fa
+django-upgrade-check==1.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-webtest==1.9.7
     # via -r requirements/test-tools.in
 django-yubin==2.0.4
@@ -924,6 +929,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-upgrade-check
 sentry-sdk==2.10.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -229,6 +229,7 @@ django==4.2.20
     #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   drf-jsonschema-serializer
     #   drf-nested-routers
@@ -419,6 +420,10 @@ django-two-factor-auth==1.16.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-2fa
+django-upgrade-check==1.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-webtest==1.9.7
     # via
     #   -c requirements/ci.txt
@@ -1054,6 +1059,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-upgrade-check
 sentry-sdk==2.10.0
     # via
     #   -c requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -186,6 +186,7 @@ django==4.2.20
     #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   drf-jsonschema-serializer
     #   drf-nested-routers
@@ -366,6 +367,10 @@ django-two-factor-auth==1.16.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-2fa
+django-upgrade-check==1.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-yubin==2.0.4
     # via
     #   -c requirements/base.txt
@@ -837,6 +842,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-upgrade-check
 sentry-sdk==2.10.0
     # via
     #   -c requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -216,6 +216,7 @@ django==4.2.20
     #   django-tinymce
     #   django-treebeard
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   drf-jsonschema-serializer
     #   drf-nested-routers
@@ -406,6 +407,10 @@ django-two-factor-auth==1.16.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-2fa
+django-upgrade-check==1.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-webtest==1.9.7
     # via
     #   -c requirements/ci.txt
@@ -1010,6 +1015,7 @@ semantic-version==2.10.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-upgrade-check
 sentry-sdk==2.10.0
     # via
     #   -c requirements/ci.txt

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -10,6 +10,8 @@ from celery.schedules import crontab
 from corsheaders.defaults import default_headers as default_cors_headers
 from log_outgoing_requests.datastructures import ContentType
 from log_outgoing_requests.formatters import HttpFormatter
+from upgrade_check import UpgradeCheck, VersionRange
+from upgrade_check.constraints import UpgradePaths
 
 from csp_post_processor.constants import NONCE_HTTP_HEADER
 
@@ -190,6 +192,7 @@ INSTALLED_APPS = [
     "flags",
     "django_setup_configuration",
     "rangefilter",
+    "upgrade_check",
     # Project applications.
     "openforms.accounts",
     "openforms.analytics_tools",
@@ -1218,6 +1221,14 @@ SETUP_CONFIGURATION_STEPS = [
     "openforms.contrib.objects_api.setup_configuration.steps.ObjectsAPIConfigurationStep",
     "openforms.registrations.contrib.zgw_apis.setup_configuration.steps.ZGWApiConfigurationStep",
 ]
+
+#
+# DJANGO-UPGRADE-CHECK
+#
+UPGRADE_CHECK_PATHS: UpgradePaths = {
+    "3.2.0": UpgradeCheck(VersionRange(minimum="3.0.1")),
+}
+UPGRADE_CHECK_STRICT = False
 
 #
 # Open Forms extensions

--- a/src/openforms/fixtures/admin_index_unlisted.json
+++ b/src/openforms/fixtures/admin_index_unlisted.json
@@ -26,6 +26,7 @@
     "stuf_bg.StufBGConfig",
     "stuf_zds.StufZDSConfig",
     "suwinet.SuwinetConfig",
+    "upgrade_check.Version",
     "upgrades.VersionInfo",
     "zgw_apis.ZGWApiGroupConfig"
 ]

--- a/src/openforms/upgrades/script_checks.py
+++ b/src/openforms/upgrades/script_checks.py
@@ -1,0 +1,47 @@
+import contextlib
+import logging
+import sys
+from pathlib import Path
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from upgrade_check.constraints import CodeCheck
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def setup_scripts_env():
+    """
+    Set up the python path for the script execution, if any.
+
+    Since the scripts in the ``bin`` dir are self-contained, we need to add the path
+    to the python path to dynamically import the ``main`` function from the scripts.
+    """
+    bin_dir = str(Path(settings.BASE_DIR) / "bin")
+    sys.path.insert(0, bin_dir)
+    try:
+        yield
+    finally:
+        sys.path.remove(bin_dir)
+
+
+class BinScriptCheck(CodeCheck):
+    """
+    Code check that execeutes a script in the ``bin`` directory.
+    """
+
+    def __init__(self, script: str):
+        self.script = script
+
+    def execute(self) -> bool:
+        with setup_scripts_env():
+            main_func = import_string(f"{self.script}.main")
+            try:
+                result = main_func(skip_setup=True)
+            except Exception as exc:
+                logger.error("Script check errored", exc_info=exc)
+                result = False
+        del main_func  # reduce memory usage
+        return True if result is None else result

--- a/src/openforms/upgrades/tests/test_upgrade_paths.py
+++ b/src/openforms/upgrades/tests/test_upgrade_paths.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from django.conf import settings
 from django.test import SimpleTestCase
 
+from ..script_checks import BinScriptCheck
 from ..upgrade_paths import (
     UpgradeConstraint,
     VersionParseError,
@@ -109,7 +110,7 @@ class DjangoScriptTests(SimpleTestCase):
         with mock_upgrade_paths(UPGRADE_PATHS):
             self.assertFalse(check_upgrade_path("1.2.0", "2.0.0"))
 
-    def test_check_script(self):
+    def test_check_script_legacy(self):
         script_dir = Path(settings.BASE_DIR) / "bin"
 
         UPGRADE_PATHS = {
@@ -145,3 +146,21 @@ class DjangoScriptTests(SimpleTestCase):
                 can_upgrade = check_upgrade_path("3.2.0", "4.0.0")
 
                 self.assertFalse(can_upgrade)
+
+    def test_check_script(self):
+        script_dir = Path(settings.BASE_DIR) / "bin"
+        scripts = (
+            ("check_pass", True),
+            ("check_fail", False),
+            ("check_error", False),
+        )
+        for script, expected_outcome in scripts:
+            with self.subTest(script=script):
+                src = FILES_DIR / f"{script}.py-tpl"
+                dest = script_dir / f"{script}.py"
+                shutil.copyfile(src, dest)
+                self.addCleanup(dest.unlink)
+
+                script_check = BinScriptCheck(script)
+
+                self.assertEqual(script_check.execute(), expected_outcome)


### PR DESCRIPTION
[skip: e2e]

**Changes**

* Add django-upgrade-check, which is an iteration of `openforms.upgrades`
* Configure it for 3.2.0, but at the moment it doesn't do anything because we don't have version history
* Re-implement running our `bin` check scripts for the expected django-upgrade-check interface

For the 3.1.0/3.2.0 release cycle, this initially has no effect (not for existing, nor fresh instances) because the version/deploy
history table is empty. Once we're in 3.3.0 release, existing instances will be on 3.2.0 and then we can drop our own `openforms.upgrades` in favour of the library.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
