### PR TITLE
[#5202] Remove AppointmentsInfo from Submission (admin fixture)

### DIFF
--- a/src/openforms/fixtures/default_admin_index.json
+++ b/src/openforms/fixtures/default_admin_index.json
@@ -87,10 +87,6 @@
         "slug": "inzendingen",
         "models": [
             [
-                "appointments",
-                "appointmentinfo"
-            ],
-            [
                 "payments",
                 "submissionpayment"
             ],


### PR DESCRIPTION
Closes #5202 

**Changes**

- Remove `AppointmentsInfo` from `Submission` in the admin fixture 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
