### PR TITLE
Fix JSON dump plugin encodes data to JSON twice

### DIFF
--- a/docker/json-dump/app.py
+++ b/docker/json-dump/app.py
@@ -11,7 +11,7 @@ def json_plugin_post():
     app.logger.info(f"Data received: {data}")
 
     message = "No data" if data is None else "Data received"
-    return jsonify({"message": message, "data": json.loads(data)}), 201
+    return jsonify({"message": message, "data": data}), 201
 
 
 @app.route("/test_connection", methods=["GET"])

--- a/src/openforms/registrations/contrib/json_dump/plugin.py
+++ b/src/openforms/registrations/contrib/json_dump/plugin.py
@@ -98,7 +98,9 @@ class JSONDumpRegistration(BasePlugin):
             if ".." in (path := options["path"]):
                 raise SuspiciousOperation("Possible path traversal detected")
 
-            result = client.post(path, json=data)
+            result = client.post(
+                path, data=data, headers={"content-type": "application/json"}
+            )
             result.raise_for_status()
 
         result_json = result.json() if result.content else ""


### PR DESCRIPTION
Closes #5263

[skip: e2e]

**Changes**

Removed the double JSON encoding in the JSON registration plugin

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
