### PR TITLE
[#5245] Fix wrong backend in the registration mapping (variables tab)

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
@@ -17,7 +17,6 @@ import ErrorBoundary from 'components/errors/ErrorBoundary';
  * @param {string} p.name - The name of the current registration backend
  * @param {Object} p.variable - The current variable
  * @param {Object} p.backend - The current backend
- * @param {number} p.backendIndex - The current backend index (used to update the base state)
  * @param {JSX.Element} p.registrationSummary - The rendered summary of the registration backend for the current variable
  * @param {JSX.Element} p.variableConfigurationEditor - The rendered configuration editor for the current variable
  * @param {(_: Object) => void} p.onChange - The base onChange function to update the base state
@@ -27,13 +26,15 @@ const RegistrationSummary = ({
   name,
   variable,
   backend,
-  backendIndex,
   registrationSummary,
   variableConfigurationEditor,
   onChange,
 }) => {
   const intl = useIntl();
   const [modalOpen, setModalOpen] = useState(false);
+  const formContext = useContext(FormContext);
+  // always pick the right index of the backend from the updated context
+  const backendIndex = formContext.registrationBackends.findIndex(item => item.key === backend.key);
 
   return (
     <>
@@ -107,7 +108,6 @@ RegistrationSummary.propTypes = {
   name: PropTypes.string.isRequired,
   variable: PropTypes.object.isRequired,
   backend: PropTypes.object.isRequired,
-  backendIndex: PropTypes.number.isRequired,
   registrationSummary: PropTypes.element.isRequired,
   variableConfigurationEditor: PropTypes.element.isRequired,
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
Closes #5245

**Changes**

- Fixed index of the backend used in the registration (variables tab)
 
Mapping a variable to a specific registration backend was not properly saved. When we modify a variable the target of this change is the backend which is found by the name. This name contained the wrong index number of the backend so it was replacing other backends.


**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
