### PR TITLE
Adopt structlog for logging

### DIFF
--- a/docker/stuf-zds/app.py
+++ b/docker/stuf-zds/app.py
@@ -1,4 +1,4 @@
-import logging
+import logging  # noqa: TID251
 from secrets import token_hex
 
 from flask import Flask, Response, request

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ import sys
 import django
 
 sys.path.insert(0, os.path.abspath("../src"))
-os.environ["LOG_REQUESTS"] = "false"
+os.environ["LOG_OUTGOING_REQUESTS"] = "false"
 
 import openforms  # noqa isort:skip
 

--- a/docs/developers/backend/index.rst
+++ b/docs/developers/backend/index.rst
@@ -82,6 +82,7 @@ Development and debug tooling
     :maxdepth: 1
 
     tests
+    logging
     dev-rendering
     profiling
     file-uploads

--- a/docs/developers/backend/logging.rst
+++ b/docs/developers/backend/logging.rst
@@ -1,0 +1,136 @@
+.. _developers_backend_logging:
+
+=======
+Logging
+=======
+
+Logging is the practice of adding strategic log statements in the code to inform of
+particular events taking place. It's generally a good practice to make debugging
+certain data-flows easier and can provide insight in what the system is doing.
+
+Logs are typically emitted during development (with ``runserver``) but also in
+production (containers). In the latter situation, logs are usually scraped and aggregated
+by the infrastructure layer (Kubernetes, Docker on a virtual machine...) and made
+available in some visualization tool, like Grafana.
+
+Log tooling
+===========
+
+While Python provides the ``logging`` module in the standard library, we've opted to
+use ``structlog`` instead to really emphasize good practices for structured, rich logs
+that can be correlated. They are emitted as JSON (or key=value pairs, if desired). In
+development, this means we get nice colored output.
+
+.. tip:: Install the ``rich`` package in your dev environment for even nicer output,
+   particularly tracebacks.
+
+.. note:: Structlog wraps the stdlib logs emitted from third party packages, so we get
+   the best of both worlds.
+
+The general patterns with structlog are:
+
+.. code-block:: python
+
+    import structlog
+
+    logger = structlog.stdlib.get_logger(__name__)
+
+    def my_func():
+        with structlog.contextvars.bound_contextvars(module="example"):
+            result = helper_func("foo")
+            logger.debug("result_received", result=result)
+        return result
+
+    def helper_func(arg: str) -> str:
+        log = logger.bind(arg=arg)
+        log.info("argument_received")
+        return arg
+
+1. ``import structlog`` instead of ``import logging``. There is a Ruff check to prevent
+   accidents.
+2. Events are simple strings with underscores - do not interpolate anything! Instead,
+   provide keyword arguments - they will be emitted together with the log event. This
+   is much easier to parse and query in log aggregation tools.
+3. You can create a bound logger with ``log = logger.bind(**kwargs)``. Any additional log
+   statements from ``log`` will include the additional context that was bound - meaning
+   you can bind variables once without needing to pass them along everywhere or repeat
+   them.
+4. You can bind context variables across multiple calls using the context manager.
+   Downstream logger calls will include the context specified by the context manager,
+   and it will automatically unset them again.
+
+Log levels
+==========
+
+The following log levels may be used, with a description of when they're appropriate
+to use.
+
+By default, log levels INFO and above are emitted.
+
+``DEBUG``
+    Use with ``logger.debug(...)``. Generally not interesting unless you need to debug
+    the particular feature and users opt-in to this low log level. Put information under
+    this level that should only be displayed when chasing down a problem.
+
+``INFO``
+    General informative events that show the system is operating within normal parameters.
+    They don't warrant any actions, it's just "good to know" that *a thing* is happening.
+    Don't overuse this, as these log records are emitted by default and could create a lot
+    of noise.
+
+``WARNING``
+    Use ``logger.warning(...)`` for non-fatal problems that probably require someone to
+    take some action. It's a good candidate for situations that should not happen, yet
+    when they do you want to know so you can fix the root cause.
+
+``ERROR``
+    Use ``logger.error`` for suppressed errors that have an impact on the end-user(s).
+    For example, an external service is down or not operating as expected and prefill
+    is not working. These log records can be used to pinpoint what went wrong and when,
+    while still allowing the user to complete the form but with a worse user experience.
+
+``EXCEPTION``
+    Same as error above, except it will automatically grab the exception information if
+    not provided explicitly.
+
+
+Passing exception information
+=============================
+
+Specify the ``exc_info=True`` or ``exc_info=some_exception_instance`` kwarg to pass
+along exception information, if you have one. This can be very useful for the warning
+and error log levels. The exception log level will grab the exception by default, but
+there's no harm in passing the exception manually either.
+
+Log events and extra context
+============================
+
+Coming up with a good name for a log event is probably the hardest. You can take some
+inspiration from ``django_structlog``, which emits request events like:
+
+* ``request_started``
+* ``request_finished``
+
+Event names like ``start_pdf_generation`` are also acceptable, as they can sometimes
+be more natural.
+
+For certain Open Forms modules, it can be beneficial to apply some namespacing to
+identify which part of the application is emitting logs, for example:
+
+.. code-block:: python
+
+    logger.info("authentication.start_flow")
+
+For the extra context, there are some "typical" keys that you can use to get a consistent
+log pattern:
+
+* ``module``, for example ``authentication``, ``registrations``, ``prefill``. Helps
+  filtering down log events emitted by a particular part of functionality in Open Forms.
+* ``reason``, common with ``skip_FOO`` events. The event is that some operation was
+  skipped, but a quick look at the reason for skipping in the logs can be very useful.
+* ``outcome``, when something is detected or handled in a particular way, you can provide
+  a hint to the result, e.g. ``ignore`` or ``skip`` or even ``success``.
+* ``action``, a useful context variable that can act as a grouper for log records,
+  typically set via ``structlog.contextvars.bound_contextvars``
+* ``plugin``, Open Forms knows many plugins, being able to trace down at a higher level
+  which log records originate from where can be informative.

--- a/docs/developers/backend/tests.rst
+++ b/docs/developers/backend/tests.rst
@@ -117,8 +117,8 @@ cache, sometimes there is a cache miss and a database query is needed (e.g. when
 tests in reverse).
 
 This is typically a test-isolation smell and the root cause should be fixed. This may
-also be caused indirectly if you have ``LOG_REQUESTS`` set to ``True`` in your local
-``.env``, as it also results in a django-solo lookup.
+also be caused indirectly if you have ``LOG_OUTGOING_REQUESTS`` set to ``True`` in your
+local ``.env``, as it also results in a django-solo lookup.
 
 The preferred approach to mitigate these kind of issues is to mock the ``get_solo`` call
 to prevent cache or DB hits:

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -148,8 +148,8 @@ Content Security Policy (CSP) settings
 See also the :ref:`developer documentation <developers_csp>` and
 https://django-csp.readthedocs.io/en/latest/ for more information on CSP.
 
-Log settings
-------------
+Logging and monitoring settings
+-------------------------------
 
 * ``SENTRY_DSN``: URL of the sentry project to send error reports to. Defaults
   to an empty string (i.e. no monitoring). See `Sentry settings`_.
@@ -171,6 +171,8 @@ Log settings
 
 * ``LOG_STD_OUT``: Write all log entries to ``stdout`` instead of log files.
   Defaults to ``True`` when using Docker and otherwise ``False``.
+
+* ``LOG_REQUESTS``: When enabled, all incoming requests are logged. Enabled by default.
 
 .. _`Sentry settings`: https://docs.sentry.io/
 .. _`Elastic settings`: https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,13 +82,15 @@ extend-select = [
     # "DJ",  # django
     # "LOG", # logging
     # "G",
-    "I",   # isort
+    "I",     # isort
     # "E",   # pycodestyle
-    "F",   # pyflakes
+    "F",     # pyflakes
     # "PERF",# perflint
-    "B006",# flake8-bugbear
+    "B006",  # flake8-bugbear
     "B010",
     # "B904",
+    "TID251",# tidy-imports
+    "TID253",
 ]
 
 [tool.ruff.lint.isort]
@@ -104,3 +106,12 @@ section-order = [
 
 [tool.ruff.lint.isort.sections]
 "django" = ["django"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+banned-module-level-imports = [
+    "idna", # IO hit
+    "weasyprint",  # IO hit
+]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"logging".msg = "Use `structlog.stdlib.get_logger(__name__)` instead of the stdlib logging module."

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -56,6 +56,7 @@ django-privates
 django-redis
 django-simple-certmanager
 django-solo
+django-structlog
 django-tinymce
 django-treebeard
 django-upgrade-check

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,9 @@ ape-pie==0.1.0
     #   -r requirements/base.in
     #   zgw-consumers
 asgiref==3.7.2
-    # via django
+    # via
+    #   django
+    #   django-structlog
 asn1crypto==1.5.1
     # via webauthn
 attrs==23.2.0
@@ -115,6 +117,7 @@ django==4.2.20
     #   django-setup-configuration
     #   django-simple-certmanager
     #   django-solo
+    #   django-structlog
     #   django-timeline-logger
     #   django-tinymce
     #   django-treebeard
@@ -170,8 +173,10 @@ django-hijack==3.4.1
     # via -r requirements/base.in
 django-import-export==3.3.7
     # via -r requirements/base.in
-django-ipware==5.0.0
-    # via django-axes
+django-ipware==7.0.1
+    # via
+    #   django-axes
+    #   django-structlog
 django-jsonform==2.21.2
     # via
     #   -r requirements/base.in
@@ -217,6 +222,8 @@ django-solo==2.3.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
+django-structlog==9.1.1
+    # via -r requirements/base.in
 django-timeline-logger==4.0.0
     # via -r requirements/base.in
 django-tinymce==4.1.0
@@ -415,6 +422,8 @@ python-dotenv==1.0.1
     # via
     #   -r requirements/base.in
     #   pydantic-settings
+python-ipware==3.0.0
+    # via django-ipware
 python-magic==0.4.27
     # via -r requirements/base.in
 pytz==2024.1
@@ -509,6 +518,8 @@ sqlparse==0.5.0
     # via django
 stringcase==1.2.0
     # via o365
+structlog==25.2.0
+    # via django-structlog
 tablib==3.5.0
     # via
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,6 +22,7 @@ asgiref==3.7.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django
+    #   django-structlog
 asn1crypto==1.5.1
     # via
     #   -c requirements/base.txt
@@ -192,6 +193,7 @@ django==4.2.20
     #   django-setup-configuration
     #   django-simple-certmanager
     #   django-solo
+    #   django-structlog
     #   django-timeline-logger
     #   django-tinymce
     #   django-treebeard
@@ -283,10 +285,11 @@ django-import-export==3.3.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-ipware==5.0.0
+django-ipware==7.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-structlog
 django-jsonform==2.21.2
     # via
     #   -c requirements/base.txt
@@ -359,6 +362,10 @@ django-solo==2.3.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
+django-structlog==9.1.1
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-timeline-logger==4.0.0
     # via
     #   -c requirements/base.txt
@@ -776,6 +783,11 @@ python-dotenv==1.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   pydantic-settings
+python-ipware==3.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-ipware
 python-magic==0.4.27
     # via
     #   -c requirements/base.txt
@@ -971,6 +983,11 @@ stringcase==1.2.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   o365
+structlog==25.2.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-structlog
 tablib==3.5.0
     # via
     #   -c requirements/base.txt
@@ -983,8 +1000,6 @@ tabulate==0.8.9
 tblib==1.7.0
     # via -r requirements/test-tools.in
 tenacity==8.2.3
-    # via -r requirements/test-tools.in
-testfixtures==6.17.1
     # via -r requirements/test-tools.in
 tinycss2==1.1.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,6 +27,7 @@ asgiref==3.7.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django
+    #   django-structlog
 asn1crypto==1.5.1
     # via
     #   -c requirements/ci.txt
@@ -219,6 +220,7 @@ django==4.2.20
     #   django-silk
     #   django-simple-certmanager
     #   django-solo
+    #   django-structlog
     #   django-timeline-logger
     #   django-tinymce
     #   django-treebeard
@@ -314,10 +316,11 @@ django-import-export==3.3.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-ipware==5.0.0
+django-ipware==7.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-structlog
 django-jsonform==2.21.2
     # via
     #   -c requirements/ci.txt
@@ -393,6 +396,10 @@ django-solo==2.3.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
+django-structlog==9.1.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-timeline-logger==4.0.0
     # via
     #   -c requirements/ci.txt
@@ -866,6 +873,11 @@ python-dotenv==1.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pydantic-settings
+python-ipware==3.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-ipware
 python-magic==0.4.27
     # via
     #   -c requirements/ci.txt
@@ -1111,6 +1123,11 @@ stringcase==1.2.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   o365
+structlog==25.2.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-structlog
 tablib==3.5.0
     # via
     #   -c requirements/ci.txt
@@ -1125,10 +1142,6 @@ tblib==1.7.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
 tenacity==8.2.3
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-testfixtures==6.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -20,6 +20,7 @@ asgiref==3.7.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django
+    #   django-structlog
 asn1crypto==1.5.1
     # via
     #   -c requirements/base.txt
@@ -182,6 +183,7 @@ django==4.2.20
     #   django-setup-configuration
     #   django-simple-certmanager
     #   django-solo
+    #   django-structlog
     #   django-timeline-logger
     #   django-tinymce
     #   django-treebeard
@@ -275,10 +277,11 @@ django-import-export==3.3.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-ipware==5.0.0
+django-ipware==7.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-structlog
 django-jsonform==2.21.2
     # via
     #   -c requirements/base.txt
@@ -350,6 +353,10 @@ django-solo==2.3.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
+django-structlog==9.1.1
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-timeline-logger==4.0.0
     # via
     #   -c requirements/base.txt
@@ -729,6 +736,11 @@ python-dotenv==1.0.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   pydantic-settings
+python-ipware==3.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-ipware
 python-magic==0.4.27
     # via
     #   -c requirements/base.txt
@@ -882,6 +894,11 @@ stringcase==1.2.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   o365
+structlog==25.2.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-structlog
 tablib==3.5.0
     # via
     #   -c requirements/base.txt

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -12,7 +12,6 @@ pyquery  # integrates with webtest
 requests-mock
 tenacity
 tblib
-testfixtures
 hypothesis  # property-based testing
 vcrpy  # record HTTP fixtures
 zgw-consumers[testutils]

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -25,6 +25,7 @@ asgiref==3.7.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django
+    #   django-structlog
     #   django-stubs
 asn1crypto==1.5.1
     # via
@@ -204,6 +205,7 @@ django==4.2.20
     #   django-setup-configuration
     #   django-simple-certmanager
     #   django-solo
+    #   django-structlog
     #   django-stubs
     #   django-stubs-ext
     #   django-timeline-logger
@@ -297,10 +299,11 @@ django-import-export==3.3.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-ipware==5.0.0
+django-ipware==7.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-structlog
 django-jsonform==2.21.2
     # via
     #   -c requirements/ci.txt
@@ -372,6 +375,10 @@ django-solo==2.3.0
     #   django-log-outgoing-requests
     #   mozilla-django-oidc-db
     #   zgw-consumers
+django-structlog==9.1.1
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-stubs==5.0.2
     # via
     #   -r requirements/type-checking.in
@@ -829,6 +836,11 @@ python-dotenv==1.0.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pydantic-settings
+python-ipware==3.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-ipware
 python-magic==0.4.27
     # via
     #   -c requirements/ci.txt
@@ -1060,6 +1072,11 @@ stringcase==1.2.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   o365
+structlog==25.2.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-structlog
 tablib==3.5.0
     # via
     #   -c requirements/ci.txt
@@ -1074,10 +1091,6 @@ tblib==1.7.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
 tenacity==8.2.3
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-testfixtures==6.17.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/csp_post_processor/drf/fields.py
+++ b/src/csp_post_processor/drf/fields.py
@@ -2,13 +2,12 @@
 Django Rest Framework integration to apply post processing for serializer fields.
 """
 
-import logging
-
+import structlog
 from rest_framework import fields
 
 from ..processor import post_process_html
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class CSPPostProcessedHTMLField(fields.CharField):
@@ -27,10 +26,7 @@ class CSPPostProcessedHTMLField(fields.CharField):
         # the request from the context is required for post-processing, but there is no
         # guarantee this is always present!
         if not (request := self.parent.context.get("request")):
-            logger.warning(
-                "Cannot CSP post-process value, there is no valid request in the "
-                "serializer context. Returning original version."
-            )
+            logger.warning("skip_processing", reason="no_request_in_context")
             return str_value
 
         return post_process_html(str_value, request)

--- a/src/csp_post_processor/drf/spectacular.py
+++ b/src/csp_post_processor/drf/spectacular.py
@@ -2,10 +2,9 @@
 API schema generation extension using drf-spectacular.
 """
 
-import logging
-
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from drf_spectacular.extensions import OpenApiViewExtension
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import force_instance, is_list_serializer
@@ -17,7 +16,7 @@ from rest_framework.viewsets import ViewSetMixin
 from ..constants import NONCE_HTTP_HEADER
 from .fields import CSPPostProcessedHTMLField
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 NONCE_PARAMETER = OpenApiParameter(
     name=NONCE_HTTP_HEADER,
@@ -76,7 +75,9 @@ def _get_serializer_class(view_cls: type[APIView]):
             try:
                 view.get_serializer_class()
             except AssertionError:  # view without serializer class, ignore
-                logger.warning("Could not determine view %r serializer class", view_cls)
+                logger.warning(
+                    "failed_to_determine_view_serializer_class", view=view_cls
+                )
                 return None
 
     serializer = auto_schema.get_response_serializers()

--- a/src/csp_post_processor/processor.py
+++ b/src/csp_post_processor/processor.py
@@ -1,5 +1,4 @@
 import hashlib
-import logging
 
 from django.http import HttpRequest
 from django.utils.safestring import SafeString, mark_safe
@@ -7,6 +6,7 @@ from django.utils.safestring import SafeString, mark_safe
 import bleach
 import html5lib
 import lxml.html
+import structlog
 import tinycss2
 from bleach import css_sanitizer
 from lxml import etree
@@ -14,7 +14,7 @@ from rest_framework.request import Request
 
 from .constants import NONCE_HTTP_HEADER
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 wysiwyg_allowed_protocols = ["http", "https", "mailto", "data"]
 
@@ -129,7 +129,7 @@ def post_process_html(
         return html
 
     if not (csp_nonce := request.headers.get(NONCE_HTTP_HEADER)):
-        logger.info("No nonce available on the request, returning html unmodified.")
+        logger.info("skip_processing", reason="nonce_not_found")
         return html
 
     lxml_etree_document = html5lib.parse(

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -21,9 +20,6 @@ from .tokens import submission_appointment_token_generator
 
 class EmptyOptions(JsonSchemaSerializerMixin, serializers.Serializer):
     pass
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass()

--- a/src/openforms/appointments/tests/test_api_cancel_appointment.py
+++ b/src/openforms/appointments/tests/test_api_cancel_appointment.py
@@ -1,0 +1,66 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from openforms.appointments.tests.factories import AppointmentInfoFactory
+from openforms.logging.models import TimelineLogProxy
+from openforms.submissions.tests.mixins import SubmissionsMixin
+
+from ..models import AppointmentsConfig
+from .factories import AppointmentFactory
+
+
+class CancelAppointmentTests(SubmissionsMixin, APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        config = AppointmentsConfig.get_solo()
+        config.plugin = "demo"
+        config.save()
+
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(AppointmentsConfig.clear_cache)
+
+    def test_invalid_body_posted(self):
+        appointment_info = AppointmentInfoFactory.create(registration_ok=True)
+        submission = appointment_info.submission
+        AppointmentFactory.create(submission=submission)
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:appointments-cancel",
+            kwargs={"submission_uuid": submission.uuid},
+        )
+
+        response = self.client.post(endpoint, data={})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = response.json()["invalidParams"][0]
+        self.assertEqual(error["name"], "email")
+        logs = TimelineLogProxy.objects.for_object(submission).filter_event(
+            "appointment_cancel_failure"
+        )
+        self.assertEqual(logs.count(), 1)
+
+    def test_invalid_email_provided(self):
+        appointment_info = AppointmentInfoFactory.create(registration_ok=True)
+        submission = appointment_info.submission
+        AppointmentFactory.create(
+            submission=submission,
+            contact_details_meta=[{"type": "email", "key": "email"}],
+            contact_details={"email": "correct@example.com"},
+        )
+        self._add_submission_to_session(submission)
+        endpoint = reverse(
+            "api:appointments-cancel",
+            kwargs={"submission_uuid": submission.uuid},
+        )
+
+        response = self.client.post(endpoint, data={"email": "wrong@example.com"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        logs = TimelineLogProxy.objects.for_object(submission).filter_event(
+            "appointment_cancel_failure"
+        )
+        self.assertEqual(logs.count(), 1)

--- a/src/openforms/appointments/views.py
+++ b/src/openforms/appointments/views.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.views.generic import RedirectView
 
 from openforms.frontend import get_frontend_redirect_url
@@ -7,8 +5,6 @@ from openforms.submissions.models import Submission
 from openforms.submissions.views import ResumeFormMixin
 
 from .tokens import submission_appointment_token_generator
-
-logger = logging.getLogger(__name__)
 
 
 class VerifyCancelAppointmentLinkView(ResumeFormMixin, RedirectView):

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/views.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.http import HttpRequest
 
 from digid_eherkenning.oidc.models import BaseConfig
@@ -25,8 +23,6 @@ from .models import (
     OFEHerkenningBewindvoeringConfig,
     OFEHerkenningConfig,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class OIDCAuthenticationCallbackView(_OIDCAuthenticationCallbackView):

--- a/src/openforms/authentication/contrib/eherkenning/tests/utils.py
+++ b/src/openforms/authentication/contrib/eherkenning/tests/utils.py
@@ -1,3 +1,66 @@
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
+from unittest.mock import patch
+
+from onelogin.saml2.errors import OneLogin_Saml2_ValidationError
 
 TEST_FILES = Path(__file__).parent.resolve() / "data"
+
+
+@contextmanager
+def mock_saml2_return_flow(
+    mock_saml_art_verification: bool = False,
+    verify_error: OneLogin_Saml2_ValidationError | None = None,
+    get_attributes_error: OneLogin_Saml2_ValidationError | None = None,
+):
+    """
+    Apply mocks in various stages of the SAMLv2 flow.
+
+    Our SAMLv2 client performs some checks via the python3-saml library and additional
+    extra security checks via django-digid-eherkenning. The nature of these checks is
+    non-deterministic: random ID generation, IP addresses, timestamps.
+
+    This mock helper pins certain aspects or bypasses checks entirely for the sake of
+    being able to test our client usage.
+    """
+    mock_xml_validation = patch(
+        "onelogin.saml2.xml_utils.OneLogin_Saml2_XML.validate_xml", return_value=True
+    )
+    mock_unique_id = patch(
+        "onelogin.saml2.utils.OneLogin_Saml2_Utils.generate_unique_id",
+        return_value="_1330416516",
+    )
+    mock_response_validation = (
+        patch(
+            "onelogin.saml2.response.OneLogin_Saml2_Response.is_valid",
+            return_value=True,
+        )
+        if mock_saml_art_verification
+        else nullcontext()
+    )
+    mock_saml_response_validation = (
+        patch(
+            "digid_eherkenning.saml2.base.BaseSaml2Client.verify_saml2_response",
+            return_value=True,
+            side_effect=verify_error,
+        )
+        if (mock_saml_art_verification or verify_error)
+        else nullcontext()
+    )
+    mock_get_attributes = (
+        patch(
+            "onelogin.saml2.response.OneLogin_Saml2_Response.get_attributes",
+            side_effect=get_attributes_error,
+        )
+        if get_attributes_error
+        else nullcontext()
+    )
+
+    with (
+        mock_xml_validation,
+        mock_unique_id,
+        mock_response_validation,
+        mock_saml_response_validation,
+        mock_get_attributes,
+    ):
+        yield

--- a/src/openforms/authentication/contrib/eherkenning/views.py
+++ b/src/openforms/authentication/contrib/eherkenning/views.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Any
 
 from django.http import HttpResponseRedirect
 from django.urls import resolve
 from django.utils.translation import gettext as _
 
+import structlog
 from digid_eherkenning.backends import BaseSaml2Backend
 from digid_eherkenning.saml2.eherkenning import eHerkenningClient
 from digid_eherkenning.views import (
@@ -20,7 +20,7 @@ from .constants import (
     EIDAS_AUTH_SESSION_KEY,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class ExpectedIdNotPresentError(Exception):
@@ -87,24 +87,26 @@ class eHerkenningAssertionConsumerServiceView(
 
         client = eHerkenningClient()
         try:
-            response = client.artifact_resolve(request, saml_art)
-            logger.debug(response.pretty_print())
+            saml_response = client.artifact_resolve(request, saml_art)
+            logger.debug(
+                "saml_artifact_resolved", saml_response=saml_response.pretty_print()
+            )
         except OneLogin_Saml2_ValidationError as exc:
             if exc.code == OneLogin_Saml2_ValidationError.STATUS_CODE_AUTHNFAILED:
                 failure_url = self.get_failure_url(
                     MESSAGE_PARAMETER % {"plugin_id": plugin_id}, LOGIN_CANCELLED
                 )
             else:
-                logger.error(exc)
+                logger.error("artifact_resolution_failure", exc_info=exc)
                 failure_url = self.get_failure_url(
                     MESSAGE_PARAMETER % {"plugin_id": plugin_id}, GENERIC_LOGIN_ERROR
                 )
             return HttpResponseRedirect(failure_url)
 
         try:
-            attributes = response.get_attributes()
+            attributes = saml_response.get_attributes()
         except OneLogin_Saml2_ValidationError as exc:
-            logger.error(exc)
+            logger.error("artifact_resolution_failure", exc_info=exc)
             failure_url = self.get_failure_url(
                 MESSAGE_PARAMETER % {"plugin_id": plugin_id}, GENERIC_LOGIN_ERROR
             )
@@ -129,6 +131,6 @@ class eHerkenningAssertionConsumerServiceView(
         # store the authn contexts so the plugin can check persmission when
         # accessing/creating an object
         request.session[EHERKENNING_AUTH_SESSION_AUTHN_CONTEXTS] = (
-            response.get_authn_contexts()
+            saml_response.get_authn_contexts()
         )
         return HttpResponseRedirect(self.get_success_url())

--- a/src/openforms/authentication/models.py
+++ b/src/openforms/authentication/models.py
@@ -1,10 +1,11 @@
-import logging
 from collections.abc import Collection
 
 from django.contrib.auth.hashers import make_password as get_salted_hash
 from django.db import models
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
+
+import structlog
 
 from openforms.contrib.kvk.validators import validate_kvk
 from openforms.utils.validators import validate_bsn
@@ -23,7 +24,7 @@ from .types import (
     EmployeeContext,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class BaseAuthInfo(models.Model):
@@ -258,11 +259,7 @@ class AuthInfo(BaseAuthInfo):
         | EmployeeContext
     ):
         if self.attribute_hashed:
-            logger.debug(
-                "Authentication attributes are (already) hashed, using these values "
-                "can lead to unexpected results.",
-                extra={"auth_info": self.pk},
-            )
+            logger.debug("detected_hashed_authentication_attributes", auth_info=self.pk)
 
         match (self.attribute, self.legal_subject_identifier_type):
             # DigiD without machtigen/mandate

--- a/src/openforms/authentication/registry.py
+++ b/src/openforms/authentication/registry.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Iterator
 
+import structlog
 from rest_framework.request import Request
 
 from openforms.plugins.registry import BaseRegistry
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
     from .base import BasePlugin, LoginInfo  # noqa: F401
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def _iter_plugin_ids(form: Form | None, registry: Registry) -> Iterator[str]:
@@ -46,9 +46,9 @@ class Registry(BaseRegistry["BasePlugin"]):
         for plugin_id in _iter_plugin_ids(form, self):
             if plugin_id not in self._registry:
                 logger.warning(
-                    "Plugin %s not found in registry, ignoring it.",
-                    plugin_id,
-                    extra={"plugin_id": plugin_id, "form": form.pk if form else None},
+                    "ignore_unknown_plugin",
+                    plugin_id=plugin_id,
+                    form_uuid=str(form.uuid) if form else None,
                 )
                 continue
             plugin = self._registry[plugin_id]

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1,11 +1,13 @@
 import json
 import os
+from pathlib import Path
 
 # Django-hijack (and Django-hijack-admin)
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
 import sentry_sdk
+import structlog
 from celery.schedules import crontab
 from corsheaders.defaults import default_headers as default_cors_headers
 from log_outgoing_requests.datastructures import ContentType
@@ -18,13 +20,9 @@ from csp_post_processor.constants import NONCE_HTTP_HEADER
 from .utils import Filesize, config, get_sentry_integrations
 
 # Build paths inside the project, so further paths can be defined relative to
-# the code root.
-DJANGO_PROJECT_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), os.path.pardir)
-)
-BASE_DIR = os.path.abspath(
-    os.path.join(DJANGO_PROJECT_DIR, os.path.pardir, os.path.pardir)
-)
+# the code root. Gets the abspath to src/openforms
+DJANGO_PROJECT_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = DJANGO_PROJECT_DIR.parent.parent
 
 #
 # Core Django settings
@@ -158,6 +156,7 @@ INSTALLED_APPS = [
     "colorfield",
     "cookie_consent",
     "corsheaders",
+    "django_structlog",
     "django_jsonform",  # django_better_admin_arrayfield replacement
     "django_yubin",
     "hijack",
@@ -259,6 +258,15 @@ INSTALLED_APPS = [
     "openforms.authentication.static_variables.apps.AuthStaticVariables",
 ]
 
+_log_requests_via_middleware = config("LOG_REQUESTS", default=True)
+_structlog_middleware = (
+    [
+        "django_structlog.middlewares.RequestMiddleware",
+    ]
+    if _log_requests_via_middleware
+    else []
+)
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -268,6 +276,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "openforms.middleware.CsrfTokenMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    *_structlog_middleware,
     # must come after django's locale middleware so that we can override the result
     # from django and after the authentication middleware so we can check request.user
     "openforms.translations.middleware.AdminLocaleMiddleware",
@@ -288,9 +297,7 @@ ROOT_URLCONF = "openforms.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [
-            os.path.join(DJANGO_PROJECT_DIR, "templates"),
-        ],
+        "DIRS": [DJANGO_PROJECT_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -309,8 +316,8 @@ WSGI_APPLICATION = "openforms.wsgi.application"
 
 # Translations
 LOCALE_PATHS = (
-    os.path.join(DJANGO_PROJECT_DIR, "conf", "locale"),
-    os.path.join(DJANGO_PROJECT_DIR, "conf", "locale_extensions"),
+    DJANGO_PROJECT_DIR / "conf" / "locale",
+    DJANGO_PROJECT_DIR / "conf" / "locale_extensions",
 )
 
 #
@@ -319,17 +326,15 @@ LOCALE_PATHS = (
 
 STATIC_URL = "/static/"
 
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_ROOT = BASE_DIR / "static"
 
 # Additional locations of static files
 STATICFILES_DIRS = [
-    os.path.join(DJANGO_PROJECT_DIR, "static"),
+    DJANGO_PROJECT_DIR / "static",
     # font-awesome fonts
     (
         "fonts",
-        os.path.join(
-            BASE_DIR, "node_modules", "@fortawesome", "fontawesome-free", "webfonts"
-        ),
+        BASE_DIR / "node_modules" / "@fortawesome" / "fontawesome-free" / "webfonts",
     ),
 ]
 
@@ -340,11 +345,11 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MEDIA_ROOT = BASE_DIR / "media"
 
 MEDIA_URL = "/media/"
 
-PRIVATE_MEDIA_ROOT = os.path.join(BASE_DIR, "private_media")
+PRIVATE_MEDIA_ROOT = BASE_DIR / "private_media"
 
 PRIVATE_MEDIA_URL = "/private-media/"
 
@@ -373,71 +378,81 @@ DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", "openforms@example.com")
 # LOGGING
 #
 LOG_STDOUT = config("LOG_STDOUT", default=False)
-LOG_REQUESTS = config("LOG_REQUESTS", default=True)
+LOG_OUTGOING_REQUESTS = config("LOG_OUTGOING_REQUESTS", default=True)
 
-LOGGING_DIR = os.path.join(BASE_DIR, "log")
+LOGGING_DIR = BASE_DIR / "log"
 
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "verbose": {
-            "format": "%(asctime)s %(levelname)s %(name)s %(module)s P%(process)d/T%(thread)d |  %(message)s"
+        # structlog - foreign_pre_chain handles logs coming from stdlib logging module,
+        # while the `structlog.configure` call handles everything coming from structlog.
+        # They are mutually exclusive.
+        "json": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+            "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.stdlib.add_logger_name,
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+            ],
         },
-        "timestamped": {"format": "%(asctime)s %(levelname)s %(name)s  %(message)s"},
-        "simple": {"format": "%(levelname)s  %(message)s"},
+        "plain_console": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(),
+            "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.stdlib.add_logger_name,
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+            ],
+        },
+        # legacy
         "outgoing_requests": {"()": HttpFormatter},
         "flaky_tests_github_actions": {
             "format": """{"msg": "%(message)s", "file": "%(file)s", "line": %(line)d}"""
         },
     },
-    "filters": {
-        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
-    },
+    "filters": {},
     "handlers": {
-        "mail_admins": {
-            "level": "ERROR",
-            "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
-        },
-        "null": {
+        "null": {  # used by the ``mute_logging`` util
             "level": "DEBUG",
             "class": "logging.NullHandler",
         },
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
-            "formatter": config("LOG_FORMAT_CONSOLE", default="timestamped"),
+            "formatter": config("LOG_FORMAT_CONSOLE", default="json"),
         },
-        "django": {
+        # replaces the "django" and "project" handlers - in containerized applications
+        # the best practices is to log to stdout (use the console handler).
+        "json_file": {
             "level": "DEBUG",
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(LOGGING_DIR, "django.log"),
-            "formatter": "verbose",
-            "maxBytes": 1024 * 1024 * 10,  # 10 MB
-            "backupCount": 10,
-        },
-        "project": {
-            "level": "DEBUG",
-            "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(LOGGING_DIR, "openforms.log"),
-            "formatter": "verbose",
+            "filename": LOGGING_DIR / "application.jsonl",
+            "formatter": "json",
             "maxBytes": 1024 * 1024 * 10,  # 10 MB
             "backupCount": 10,
         },
         "log_outgoing_requests": {
             "level": "DEBUG",
-            "formatter": "outgoing_requests",
             "class": "logging.StreamHandler",
+            # TODO: use nicer formatter, OIP has something?
+            "formatter": "outgoing_requests",
         },
         "save_outgoing_requests": {
             "level": "DEBUG",
             "class": "log_outgoing_requests.handlers.DatabaseOutgoingRequestsHandler",
         },
+        # TODO: properly convert to structlog and we'll get JSON logs for free :)
         "flaky_tests": {
             "level": "INFO",
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(LOGGING_DIR, "flaky.jsonl"),
+            "filename": LOGGING_DIR / "flaky.jsonl",
             "formatter": "flaky_tests_github_actions",
             "maxBytes": 1024 * 1024 * 10,  # 10 MB
             "backupCount": 10,
@@ -445,19 +460,26 @@ LOGGING = {
     },
     "loggers": {
         "openforms": {
-            "handlers": ["project"] if not LOG_STDOUT else ["console"],
+            "handlers": ["json_file"] if not LOG_STDOUT else ["console"],
             "level": "INFO",
             "propagate": True,
         },
         "stuf": {
-            "handlers": ["project"] if not LOG_STDOUT else ["console"],
+            "handlers": ["json_file"] if not LOG_STDOUT else ["console"],
             "level": "DEBUG",
             "propagate": True,
         },
         "django.request": {
-            "handlers": ["django"] if not LOG_STDOUT else ["console"],
+            "handlers": ["json_file"] if not LOG_STDOUT else ["console"],
             "level": "ERROR",
-            "propagate": True,
+            "propagate": False,
+        },
+        # suppress django.server request logs because those are already emitted by
+        # django-structlog middleware
+        "django.server": {
+            "handlers": ["console"],
+            "level": "WARNING" if _log_requests_via_middleware else "INFO",
+            "propagate": False,
         },
         "django.template": {
             "handlers": ["console"],
@@ -465,17 +487,22 @@ LOGGING = {
             "propagate": True,
         },
         "mozilla_django_oidc": {
-            "handlers": ["project"] if not LOG_STDOUT else ["console"],
+            "handlers": ["json_file"] if not LOG_STDOUT else ["console"],
             "level": "INFO",
         },
         "log_outgoing_requests": {
             "handlers": (
                 ["log_outgoing_requests", "save_outgoing_requests"]
-                if LOG_REQUESTS
+                if LOG_OUTGOING_REQUESTS
                 else []
             ),
             "level": "DEBUG",
             "propagate": True,
+        },
+        "django_structlog": {
+            "handlers": ["json_file"] if not LOG_STDOUT else ["console"],
+            "level": "INFO",
+            "propagate": False,
         },
         "flaky_tests": {
             "handlers": ["flaky_tests"],
@@ -484,6 +511,24 @@ LOGGING = {
         },
     },
 }
+
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.filter_by_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+        # structlog.processors.ExceptionPrettyPrinter(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)
 
 #
 # AUTH settings - user accounts, passwords, backends...
@@ -551,7 +596,7 @@ TEST_RUNNER = "openforms.tests.runner.RandomStateRunner"
 # FIXTURES
 #
 
-FIXTURE_DIRS = (os.path.join(DJANGO_PROJECT_DIR, "fixtures"),)
+FIXTURE_DIRS = (DJANGO_PROJECT_DIR / "fixtures",)
 
 #
 # Custom settings
@@ -568,7 +613,7 @@ SHOW_ENVIRONMENT = config("SHOW_ENVIRONMENT", default=True)
 if "GIT_SHA" in os.environ:
     GIT_SHA = config("GIT_SHA", "")
 # in docker (build) context, there is no .git directory
-elif os.path.exists(os.path.join(BASE_DIR, ".git")):
+elif (BASE_DIR / ".git").exists():
     try:
         import git
     except ImportError:
@@ -581,9 +626,7 @@ else:
 
 RELEASE = config("RELEASE", GIT_SHA)
 
-with open(os.path.join(BASE_DIR, ".sdk-release"), "r") as sdk_release_file:
-    sdk_release_default = sdk_release_file.read().strip()
-
+sdk_release_default = (BASE_DIR / ".sdk-release").read_text().strip()
 SDK_RELEASE = config("SDK_RELEASE", default=sdk_release_default)
 
 NUM_PROXIES = config(
@@ -728,11 +771,12 @@ CELERY_TASK_SOFT_TIME_LIMIT = config(
 )  # soft
 
 
+# https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#crontab-schedules
 CELERY_BEAT_SCHEDULE = {
     "clear-session-store": {
-        "task": "openforms.utils.tasks.clear_session_store",
-        # https://docs.celeryproject.org/en/v4.4.7/userguide/periodic-tasks.html#crontab-schedules
+        "task": "openforms.utils.tasks.run_management_command",
         "schedule": crontab(minute=0, hour=0),
+        "kwargs": {"command": "clearsessions"},
     },
     "retry-submissions-processing": {
         "task": "openforms.submissions.tasks.retry_processing_submissions",
@@ -755,12 +799,14 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute=45, hour=4),
     },
     "cleanup_csp_reports": {
-        "task": "openforms.utils.tasks.cleanup_csp_reports",
+        "task": "openforms.utils.tasks.run_management_command",
         "schedule": crontab(hour=4),
+        "kwargs": {"command": "clean_cspreports"},
     },
     "clear-forms-exports": {
-        "task": "openforms.forms.admin.tasks.clear_forms_export",
+        "task": "openforms.utils.tasks.run_management_command",
         "schedule": crontab(hour=0, minute=0, day_of_week="sunday"),
+        "kwargs": {"command": "delete_export_files"},
     },
     "activate-forms": {
         "task": "openforms.forms.tasks.activate_forms",
@@ -1004,11 +1050,14 @@ SPECTACULAR_SETTINGS = {
 # ZGW Consumers
 #
 ZGW_CONSUMERS_TEST_SCHEMA_DIRS = [
-    os.path.join(BASE_DIR, "src/openforms/registrations/contrib/zgw_apis/tests/files"),
-    os.path.join(
-        BASE_DIR, "src/openforms/registrations/contrib/objects_api/tests/files"
-    ),
-    os.path.join(BASE_DIR, "src/openforms/contrib/haal_centraal/tests/files"),
+    DJANGO_PROJECT_DIR / "registrations" / "contrib" / "zgw_apis" / "tests" / "files",
+    DJANGO_PROJECT_DIR
+    / "registrations"
+    / "contrib"
+    / "objects_api"
+    / "tests"
+    / "files",
+    DJANGO_PROJECT_DIR / "contrib" / "haal_centraal" / "tests" / "files",
 ]
 
 ZGW_CONSUMERS_IGNORE_OAS_FIELDS = True
@@ -1022,9 +1071,7 @@ SOLO_CACHE_TIMEOUT = 60 * 5  # 5 minutes
 #
 # Self-Certifi
 #
-SELF_CERTIFI_DIR = config(
-    "SELF_CERTIFI_DIR", os.path.join(BASE_DIR, "certifi_ca_bundle")
-)
+SELF_CERTIFI_DIR = config("SELF_CERTIFI_DIR", str(BASE_DIR / "certifi_ca_bundle"))
 
 #
 # Django Cookie-Consent
@@ -1148,7 +1195,7 @@ CSP_REPORTS_FILTER_FUNCTION = "cspreports.filters.filter_browser_extensions"
 #
 # Tiny MCE default settings
 #
-with open(os.path.join(os.path.dirname(__file__), "tinymce_config.json")) as f:
+with (Path(__file__).parent / "tinymce_config.json").open("r") as f:
     # NOTE django-tinymce will add locale/language settings automatically
     TINYMCE_DEFAULT_CONFIG = json.load(f)
 
@@ -1230,6 +1277,11 @@ UPGRADE_CHECK_PATHS: UpgradePaths = {
     "3.2.0": UpgradeCheck(VersionRange(minimum="3.0.1")),
 }
 UPGRADE_CHECK_STRICT = False
+
+#
+# DJANGO-STRUCTLOG
+#
+DJANGO_STRUCTLOG_IP_LOGGING_ENABLED = False
 
 #
 # Open Forms extensions

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -16,6 +16,7 @@ from upgrade_check import UpgradeCheck, VersionRange
 from upgrade_check.constraints import UpgradePaths
 
 from csp_post_processor.constants import NONCE_HTTP_HEADER
+from openforms.logging.processors import drop_user_agent_in_dev
 
 from .utils import Filesize, config, get_sentry_integrations
 
@@ -397,6 +398,7 @@ LOGGING = {
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
+                drop_user_agent_in_dev,
                 structlog.stdlib.PositionalArgumentsFormatter(),
             ],
         },
@@ -408,6 +410,7 @@ LOGGING = {
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
+                drop_user_agent_in_dev,
                 structlog.stdlib.PositionalArgumentsFormatter(),
             ],
         },
@@ -519,6 +522,7 @@ structlog.configure(
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
+        drop_user_agent_in_dev,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,

--- a/src/openforms/conf/ci.py
+++ b/src/openforms/conf/ci.py
@@ -3,7 +3,7 @@
 """
 Continuous integration settings module.
 """
-# ruff: noqa: F405
+# ruff: noqa: F401 F405 TID253
 
 import os
 import warnings
@@ -11,10 +11,10 @@ import warnings
 # Importing the idna module has an IO side-effect to load the data, which is a rather
 # big file. Pre-loading this in the settings file populates the python module cache,
 # preventing flakiness in hypothesis tests that hit this code path.
-import idna  # noqa: F401
+import idna
 
 # Heavy imports, can interfere with some tests making use of hypothesis' deadline:
-import weasyprint  # noqa: F401
+import weasyprint
 
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
@@ -25,7 +25,7 @@ os.environ.setdefault("SENDFILE_BACKEND", "django_sendfile.backends.development"
 # * overhead making tests slower
 # * it conflicts with SimpleTestCase in some cases when the run-time configuration is
 #   looked up from the django-solo model
-os.environ.setdefault("LOG_REQUESTS", "no")
+os.environ.setdefault("LOG_OUTGOING_REQUESTS", "no")
 
 from .base import *  # noqa isort:skip
 from .utils import mute_logging  # noqa isort:skip

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -25,8 +25,9 @@ os.environ.setdefault("RELEASE", "dev")
 os.environ.setdefault("SDK_RELEASE", "latest")
 # otherwise the test suite is flaky due to logging config lookups to the DB in
 # non-DB test cases
-os.environ.setdefault("LOG_REQUESTS", "no")
+os.environ.setdefault("LOG_OUTGOING_REQUESTS", "no")
 os.environ.setdefault("LOG_STDOUT", "1")
+os.environ.setdefault("LOG_FORMAT_CONSOLE", "plain_console")
 os.environ.setdefault("VCR_RECORD_MODE", "once")
 
 os.environ.setdefault("SENDFILE_BACKEND", "django_sendfile.backends.development")
@@ -51,7 +52,7 @@ LOGGING["loggers"].update(
             "propagate": False,
         },
         "django.db.backends": {
-            "handlers": ["django"],
+            "handlers": ["json_file"],
             "level": "INFO",
             "propagate": False,
         },
@@ -60,7 +61,7 @@ LOGGING["loggers"].update(
         # Autoreload logs excessively, turn it down a bit.
         #
         "django.utils.autoreload": {
-            "handlers": ["django"],
+            "handlers": ["console"],
             "level": "INFO",
             "propagate": False,
         },

--- a/src/openforms/conf/docker.py
+++ b/src/openforms/conf/docker.py
@@ -7,6 +7,7 @@ os.environ.setdefault("DB_HOST", os.getenv("DATABASE_HOST", "db"))
 
 os.environ.setdefault("ENVIRONMENT", "docker")
 os.environ.setdefault("LOG_STDOUT", "yes")
+os.environ.setdefault("LOG_FORMAT_CONSOLE", "json")
 os.environ.setdefault("CACHE_DEFAULT", "redis:6379/0")
 os.environ.setdefault("CACHE_AXES", "redis:6379/0")
 os.environ.setdefault("CACHE_PORTALOCKER", "redis:6379/0")

--- a/src/openforms/config/models/config.py
+++ b/src/openforms/config/models/config.py
@@ -1,4 +1,3 @@
-import logging
 from functools import partial
 
 from django.core.exceptions import ValidationError
@@ -31,8 +30,6 @@ from openforms.utils.translations import runtime_gettext
 from ..constants import UploadFileType
 from ..utils import verify_clamav_connection
 from .theme import Theme
-
-logger = logging.getLogger(__name__)
 
 
 @ensure_default_language()

--- a/src/openforms/contrib/brk/client.py
+++ b/src/openforms/contrib/brk/client.py
@@ -1,7 +1,7 @@
-import logging
 from typing import NotRequired, TypedDict
 
 import requests
+import structlog
 from zgw_consumers.client import build_client
 
 from openforms.pre_requests.clients import PreRequestClientContext, PreRequestMixin
@@ -10,7 +10,7 @@ from openforms.submissions.models import Submission
 from ..hal_client import HALClient
 from .models import BRKConfig
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class NoServiceConfigured(RuntimeError):
@@ -52,7 +52,7 @@ class BRKClient(PreRequestMixin, HALClient):
             )
             response.raise_for_status()
         except requests.RequestException as exc:
-            logger.exception("exception while making BRK request", exc_info=exc)
+            logger.exception("brk_request_failure", exc_info=exc)
             raise exc
 
         return response.json()
@@ -69,7 +69,7 @@ class BRKClient(PreRequestMixin, HALClient):
             )
             response.raise_for_status()
         except requests.RequestException as exc:
-            logger.exception("exception while making BRK request", exc_info=exc)
+            logger.exception("brk_request_failure", exc_info=exc)
             raise exc
 
         return response.json()

--- a/src/openforms/contrib/client.py
+++ b/src/openforms/contrib/client.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING
+
+import structlog
+from ape_pie import APIClient
+
+if TYPE_CHECKING:
+    Base = APIClient
+else:
+    Base = object
+
+
+class LoggingMixin(Base):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        structlog.contextvars.bind_contextvars(base_url=self.base_url, client=self)
+
+    def request(self, method: str | bytes, url: str | bytes, *args, **kwargs):
+        structlog.contextvars.bind_contextvars(method=method, endpoint=url)
+        return super().request(method, url, *args, **kwargs)
+
+    def __exit__(self, *args):
+        structlog.contextvars.unbind_contextvars(
+            "base_url", "client", "method", "endpoint"
+        )
+        return super().__exit__(self, *args)
+
+
+class LoggingClient(LoggingMixin, APIClient):
+    pass

--- a/src/openforms/contrib/hal_client.py
+++ b/src/openforms/contrib/hal_client.py
@@ -1,4 +1,4 @@
-from ape_pie import APIClient
+from .client import LoggingClient
 
 HAL_CONTENT_TYPE = "application/hal+json"
 
@@ -14,5 +14,5 @@ class HALMixin:
         )
 
 
-class HALClient(HALMixin, APIClient):
+class HALClient(HALMixin, LoggingClient):
     pass

--- a/src/openforms/contrib/kadaster/api/views.py
+++ b/src/openforms/contrib/kadaster/api/views.py
@@ -1,4 +1,3 @@
-import logging
 from functools import partial
 
 from django.core.cache import cache
@@ -24,9 +23,6 @@ from .serializers import (
     LatLngSearchInputSerializer,
     LatLngSearchResultSerializer,
 )
-
-logger = logging.getLogger(__name__)
-
 
 ADDRESS_AUTOCOMPLETE_CACHE_TIMEOUT = (
     60 * 60 * 24

--- a/src/openforms/contrib/kadaster/clients/bag.py
+++ b/src/openforms/contrib/kadaster/clients/bag.py
@@ -1,13 +1,13 @@
-import logging
 from dataclasses import dataclass
 
 import elasticapm
 import requests
+import structlog
 
 from openforms.contrib.hal_client import HALClient
 from openforms.formio.components.utils import salt_location_message
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @dataclass
@@ -44,9 +44,7 @@ class BAGClient(HALClient):
         except requests.RequestException as exc:
             if reraise_errors:
                 raise exc
-            logger.exception(
-                "Could not retrieve address details from the BAG API", exc_info=exc
-            )
+            logger.exception("bag_request_failure", exc_info=exc)
             return self.build_address_result(postcode, house_number)
 
         response_data = response.json()

--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -7,6 +7,7 @@ from flags.state import flag_enabled
 from requests import Response
 from zgw_consumers.nlx import NLXClient
 
+from openforms.contrib.client import LoggingMixin
 from openforms.utils.api_clients import PaginatedResponseData, pagination_helper
 
 from ..exceptions import StandardViolation
@@ -136,7 +137,7 @@ class RoleTypeListParams(TypedDict, total=False):
     page: int
 
 
-class CatalogiClient(NLXClient):
+class CatalogiClient(LoggingMixin, NLXClient):
     _api_version: CatalogiAPIVersion | None = None
 
     @property

--- a/src/openforms/contrib/zgw/clients/documenten.py
+++ b/src/openforms/contrib/zgw/clients/documenten.py
@@ -5,6 +5,7 @@ from django.core.files.base import ContentFile
 
 from zgw_consumers.nlx import NLXClient
 
+from openforms.contrib.client import LoggingMixin
 from openforms.translations.utils import to_iso639_2b
 from openforms.utils.date import get_today
 
@@ -16,7 +17,7 @@ DocumentStatus: TypeAlias = Literal[
 ]
 
 
-class DocumentenClient(NLXClient):
+class DocumentenClient(LoggingMixin, NLXClient):
     def create_document(
         self,
         informatieobjecttype: str,

--- a/src/openforms/contrib/zgw/clients/zaken.py
+++ b/src/openforms/contrib/zgw/clients/zaken.py
@@ -1,20 +1,20 @@
-import logging
-
 from django.utils import timezone
 
+import structlog
 from furl import furl
 from zgw_consumers.nlx import NLXClient
 
+from openforms.contrib.client import LoggingMixin
 from openforms.utils.date import get_today
 
 from .catalogi import CatalogiClient
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 CRS_HEADERS = {"Content-Crs": "EPSG:4326", "Accept-Crs": "EPSG:4326"}
 
 
-class ZakenClient(NLXClient):
+class ZakenClient(LoggingMixin, NLXClient):
     def create_zaak(
         self,
         zaaktype: str,
@@ -113,10 +113,7 @@ class ZakenClient(NLXClient):
             }
             rol_typen = catalogi_client.list_roltypen(**roltypen_kwargs)
             if not rol_typen:
-                logger.warning(
-                    "No matching roltype found in the zaaktype.",
-                    extra=roltypen_kwargs,
-                )
+                logger.warning("no_roltypen_found", **roltypen_kwargs)
                 return None
             roltype = rol_typen[0]["url"]
 

--- a/src/openforms/contrib/zgw/service.py
+++ b/src/openforms/contrib/zgw/service.py
@@ -1,12 +1,9 @@
-import logging
 from io import BytesIO
 from typing import Literal, NotRequired, TypeAlias, TypedDict
 
 from openforms.submissions.models import SubmissionFileAttachment, SubmissionReport
 
 from .clients.documenten import DocumentenClient
-
-logger = logging.getLogger(__name__)
 
 SupportedLanguage: TypeAlias = Literal["nl", "en"]
 

--- a/src/openforms/dmn/contrib/camunda/tests/test_plugin.py
+++ b/src/openforms/dmn/contrib/camunda/tests/test_plugin.py
@@ -14,7 +14,6 @@ You can also point to a different host/URL and/or credentials through environmen
 variables, see :mod:`openforms.contrib.camunda.tests.utils`.
 """
 
-import logging
 from functools import partial
 from unittest.mock import patch
 
@@ -22,7 +21,6 @@ from django.test import TestCase
 
 import requests_mock
 from lxml import etree
-from testfixtures import LogCapture
 
 from openforms.contrib.camunda.tests.utils import get_camunda_client, require_camunda
 
@@ -101,22 +99,12 @@ class CamundaDMNTests(TestCase):
 
     def test_evaluation_bad_input(self):
         with self.subTest("Camunda 500"):
-            with LogCapture(
-                level=logging.ERROR, names="openforms.dmn.contrib.camunda.plugin"
-            ) as capture:
-                result = _evaluate_dmn(
-                    "invoiceClassification",
-                    # invoiceCategory value is missing
-                    input_values={"amount": 30.0},
-                )
+            # invoiceCategory value is missing
+            result = _evaluate_dmn(
+                "invoiceClassification", input_values={"amount": 30.0}
+            )
 
             self.assertEqual(result, {})
-
-            self.assertEqual(len(capture.records), 2)
-            self.assertEqual(
-                capture.records[0].msg, "Error occurred while calling Camunda API"
-            )
-            self.assertRegex(capture.records[1].msg, r"^Camunda error information: .*")
 
         with (
             self.subTest("Mocked 500 without JSON response body"),
@@ -132,25 +120,12 @@ class CamundaDMNTests(TestCase):
                 text="errored",
             )
 
-            with LogCapture(
-                level=logging.ERROR, names="openforms.dmn.contrib.camunda.plugin"
-            ) as capture:
-                result = _evaluate_dmn(
-                    "invoiceClassification",
-                    # invoiceCategory value is missing
-                    input_values={"amount": 30.0},
-                )
+            # invoiceCategory value is missing
+            result = _evaluate_dmn(
+                "invoiceClassification", input_values={"amount": 30.0}
+            )
 
             self.assertEqual(result, {})
-
-            self.assertEqual(len(capture.records), 2)
-            self.assertEqual(
-                capture.records[0].msg, "Error occurred while calling Camunda API"
-            )
-            self.assertEqual(
-                capture.records[1].msg,
-                "Could not decode JSON data in error response body",
-            )
 
     def test_get_inputs_outputs(self):
         params = plugin.get_decision_definition_parameters(

--- a/src/openforms/emails/confirmation_emails.py
+++ b/src/openforms/emails/confirmation_emails.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 from django.template.defaultfilters import date as date_filter
@@ -16,9 +15,6 @@ from .models import ConfirmationEmailTemplate
 
 if TYPE_CHECKING:
     from openforms.submissions.models import Submission  # pragma: nocover
-
-
-logger = logging.getLogger(__name__)
 
 
 def get_confirmation_email_templates(submission: Submission) -> tuple[str, str]:

--- a/src/openforms/emails/tests/test_digest_functions.py
+++ b/src/openforms/emails/tests/test_digest_functions.py
@@ -800,7 +800,7 @@ class InvalidLogicRulesTests(TestCase):
         self.assertEqual(len(invalid_logic_rules), 0)
         self.assertFalse(logs_exist)
 
-    def test_invalid_logic_rules_with_nested_key_are_only_logged(self):
+    def test_invalid_logic_rules_with_nested_key_are_not_reported(self):
         form = FormFactory.create()
         FormVariableFactory.create(
             form=form,
@@ -828,24 +828,9 @@ class InvalidLogicRulesTests(TestCase):
             ],
         )
 
-        with self.assertLogs() as logs:
-            collect_invalid_logic_rules()
+        invalid_logic_rules = collect_invalid_logic_rules()
 
-        logs_messages = [log.getMessage() for log in logs.records]
-
-        self.assertEqual(len(logs.records), 3)
-        self.assertIn(
-            f"possible invalid variable reference (foo.wrong) in logic of form {form.admin_name}",
-            logs_messages,
-        )
-        self.assertIn(
-            f"possible invalid variable reference (foo.bar) in logic of form {form.admin_name}",
-            logs_messages,
-        )
-        self.assertIn(
-            f"possible invalid variable reference (foo.0.bar) in logic of form {form.admin_name}",
-            logs_messages,
-        )
+        self.assertEqual(invalid_logic_rules, [])
 
     def test_invalid_logic_rules_are_collected_and_not_logged(self):
         form = FormFactory.create()
@@ -939,7 +924,7 @@ class InvalidLogicRulesTests(TestCase):
         )
 
     @tag("gh-4400")
-    def test_invalid_logic_rules_with_exceptions_are_both_reported_and_logged(self):
+    def test_invalid_logic_rules_with_exceptions_are_reported(self):
         form = FormFactory.create()
         FormLogicFactory(
             form=form,
@@ -947,16 +932,8 @@ class InvalidLogicRulesTests(TestCase):
             actions=[],
         )
 
-        with self.assertLogs() as logs:
-            invalid_logic_rules = collect_invalid_logic_rules()
+        invalid_logic_rules = collect_invalid_logic_rules()
 
-        logs_messages = [log.getMessage() for log in logs.records]
-
-        self.assertEqual(len(logs.records), 1)
-        self.assertIn(
-            f"malformed/unsupported JsonLogic expression in form {form.admin_name}: {{'custom_operator': [5, 3]}}",
-            logs_messages,
-        )
         self.assertEqual(len(invalid_logic_rules), 1)
         self.assertIn(
             InvalidLogicRule(
@@ -970,7 +947,7 @@ class InvalidLogicRulesTests(TestCase):
         )
 
     @tag("gh-4400")
-    def test_invalid_logic_actions_with_exceptions_are_both_reported_and_logged(self):
+    def test_invalid_logic_actions_with_exceptions_are_reported(self):
         form = FormFactory.create()
         FormVariableFactory.create(
             form=form,
@@ -995,16 +972,8 @@ class InvalidLogicRulesTests(TestCase):
             ],
         )
 
-        with self.assertLogs() as logs:
-            invalid_logic_rules = collect_invalid_logic_rules()
+        invalid_logic_rules = collect_invalid_logic_rules()
 
-        logs_messages = [log.getMessage() for log in logs.records]
-
-        self.assertEqual(len(logs.records), 1)
-        self.assertIn(
-            f"malformed/unsupported JsonLogic expression in form {form.admin_name}: {{'custom_operator': [5, 3]}}",
-            logs_messages,
-        )
         self.assertEqual(len(invalid_logic_rules), 1)
         self.assertIn(
             InvalidLogicRule(

--- a/src/openforms/emails/utils.py
+++ b/src/openforms/emails/utils.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from typing import Any, Sequence
 from urllib.parse import urlsplit
@@ -14,8 +13,6 @@ from openforms.config.models import GlobalConfiguration, Theme
 from openforms.template import openforms_backend, render_from_string
 
 from .context import get_wrapper_context
-
-logger = logging.getLogger(__name__)
 
 MESSAGE_SIZE_LIMIT = 2 * 1024 * 1024
 

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from datetime import datetime
 from typing import Protocol
@@ -9,6 +8,7 @@ from django.utils.crypto import constant_time_compare
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
+import structlog
 from glom import glom
 from rest_framework import ISO_8601, serializers
 from rest_framework.request import Request
@@ -51,7 +51,7 @@ from .np_family_members.models import FamilyMembersTypeConfig
 from .np_family_members.stuf_bg import get_np_family_members_stuf_bg
 from .utils import _normalize_pattern, salt_location_message
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 GEO_JSON_TYPE_TO_INTERACTION = {
@@ -298,9 +298,13 @@ class Postcode(BasePlugin[Component]):
 
         try:
             return conform_to_mask(value, input_mask)
-        except ValueError:
+        except ValueError as exc:
             logger.warning(
-                "Could not conform value '%s' to input mask '%s', returning original value."
+                "formio.postcode_to_mask_failure",
+                input_mask=input_mask,
+                value=value,
+                component=component,
+                exc_info=exc,
             )
             return value
 

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -5,7 +5,6 @@ Custom component types (defined by us or third parties) need to be organized in 
 adjacent custom.py module.
 """
 
-import logging
 from collections.abc import Mapping
 from datetime import time
 from typing import TYPE_CHECKING, Any
@@ -20,6 +19,7 @@ from django.core.validators import (
 )
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from glom import glom
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @register("default")
@@ -284,8 +284,13 @@ class Time(BasePlugin[Component]):
                         time.fromisoformat(max_time),
                     )
                 )
-            case _:
-                logger.warning("Got unexpected min/max time in component %r", component)
+            case _:  # pragma: no cover
+                logger.warning(
+                    "formio.unexpected_min_max_time",
+                    component=component,
+                    min_time=min_time,
+                    max_time=max_time,
+                )
 
         base = FormioTimeField(
             required=required,

--- a/src/openforms/formio/formatters/formio.py
+++ b/src/openforms/formio/formatters/formio.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from typing import Any
 
@@ -8,6 +7,7 @@ from django.utils.formats import number_format
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext, gettext_lazy as _
 
+import structlog
 from glom import glom
 
 from ..typing import (
@@ -19,7 +19,7 @@ from ..typing import (
 )
 from .base import FormatterBase
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def get_value_label(possible_values: list[OptionDict], value: int | str) -> str:
@@ -34,9 +34,9 @@ def get_value_label(possible_values: list[OptionDict], value: int | str) -> str:
     if not isinstance(value, str):
         value = str(value)
         logger.info(
-            "Casted original value %r to string value %s for option comparison",
-            _original,
-            value,
+            "formio.formatter_cast_to_string",
+            original=_original,
+            value=value,
         )
 
     for possible_value in possible_values:

--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -6,9 +6,9 @@ component definitions are rewritten to be compatible with the current code.
 """
 
 import json
-import logging
 from typing import Protocol, cast
 
+import structlog
 from glom import assign, glom
 
 from openforms.formio.constants import DataSrcOptions
@@ -19,7 +19,7 @@ from .datastructures import FormioConfigurationWrapper
 from .typing import AddressNLComponent, Component, MapComponent
 from .utils import get_component_empty_value
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class ComponentConverter(Protocol):
@@ -244,9 +244,9 @@ def convert_simple_conditionals(configuration: JSONObject) -> bool:
 
         if comparison_component_key not in config:
             logger.warning(
-                "Couldn't locate component with key %s in configuration %r",
-                comparison_component_key,
-                configuration,
+                "component_not_found",
+                key=comparison_component_key,
+                configuration=configuration,
             )
             continue
 

--- a/src/openforms/formio/serializers.py
+++ b/src/openforms/formio/serializers.py
@@ -8,9 +8,9 @@ https://github.com/formio/formio.js/blob/4.13.x/src/validator/Validator.js.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, TypeAlias
 
+import structlog
 from glom import assign, glom
 from rest_framework import serializers
 
@@ -23,6 +23,7 @@ from .utils import is_layout_component, iter_components
 if TYPE_CHECKING:
     from .registry import ComponentRegistry
 
+logger = structlog.stdlib.get_logger(__name__)
 
 FieldOrNestedFields: TypeAlias = serializers.Field | dict[str, "FieldOrNestedFields"]
 
@@ -101,12 +102,10 @@ class StepDataSerializer(serializers.Serializer):
         return any(field.required for field in self.fields.values())
 
     def _set_required(self, value: bool) -> None:
-        # we need a setter because the serializers.Field.__init__ sets the initival
+        # we need a setter because the serializers.Field.__init__ sets the initial
         # value, but we actually derive the value via :meth:`_get_required` above
         # dynamically based on the children, so we just ignore it.
-        logging.debug(
-            "Setting the serializer required property has no effect. This is deliberate"
-        )
+        logger.debug("disabled_setter_call")
 
     required = property(_get_required, _set_required)  # type:ignore
 

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeAlias
 
 import elasticapm
+import structlog
 from glom import Coalesce, Path, glom
 from typing_extensions import TypeIs
 
@@ -17,7 +17,7 @@ from .typing import Column, ColumnsComponent, Component, FormioConfiguration
 if TYPE_CHECKING:
     from .datastructures import FormioData
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 # XXX: we should probably be able to narrow this in Python 3.11 with non-total typed
 # dicts.

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -1,7 +1,8 @@
-import logging
 from typing import Iterator
 
 from django.template import TemplateSyntaxError
+
+import structlog
 
 from openforms.template import parse, render_from_string
 from openforms.typing import JSONObject, JSONValue
@@ -10,7 +11,7 @@ from .datastructures import FormioConfigurationWrapper, FormioData
 from .typing import Component
 from .utils import flatten_by_path, recursive_apply
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 SUPPORTED_TEMPLATE_PROPERTIES = (
     "label",
@@ -96,7 +97,8 @@ def inject_variables(
                 templated_value = render(property_value, values.data)
             except TemplateSyntaxError as exc:
                 logger.debug(
-                    "Error during formio configuration 'template' rendering",
+                    "formio.template_evaluation_failure",
+                    template=property_value,
                     exc_info=exc,
                 )
                 # keep the original value on error

--- a/src/openforms/forms/admin/tasks.py
+++ b/src/openforms/forms/admin/tasks.py
@@ -7,7 +7,6 @@ from zipfile import ZipFile
 
 from django.conf import settings
 from django.core.files import File
-from django.core.management import call_command
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -96,9 +95,3 @@ def process_forms_import(import_file: str, user_id: int) -> None:
 
     logevent.bulk_forms_imported(user=user, failed_files=failed_files)
     private_media_storage.delete(import_file)
-
-
-@app.task
-def clear_forms_export():
-    logger.debug("Clearing old export files")
-    call_command("delete_export_files")

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -1,4 +1,3 @@
-import logging
 import uuid as _uuid
 from collections.abc import Iterator
 from contextlib import suppress
@@ -16,6 +15,7 @@ from django.utils.formats import localize
 from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _, override
 
+import structlog
 from autoslug import AutoSlugField
 from privates.fields import PrivateMediaFileField
 from rest_framework.reverse import reverse
@@ -40,7 +40,7 @@ from ..constants import StatementCheckboxChoices, SubmissionAllowedChoices
 from .utils import literal_getter
 
 User = get_user_model()
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class FormQuerySet(models.QuerySet):
@@ -668,14 +668,14 @@ class Form(models.Model):
     def activate(self):
         self.active = True
         self.activate_on = None
-        logger.debug("Activating form %s", self.admin_name)
         self.save(update_fields=["active", "activate_on"])
+        logger.debug("forms.form_activated", id=self.pk, name=self.admin_name)
 
     def deactivate(self):
         self.active = False
         self.deactivate_on = None
-        logger.debug("Deactivating form %s", self.admin_name)
         self.save(update_fields=["active", "deactivate_on"])
+        logger.debug("forms.form_deactivated", id=self.pk, name=self.admin_name)
 
 
 class FormsExportQuerySet(DeleteFilesQuerySetMixin, models.QuerySet):

--- a/src/openforms/forms/views/form.py
+++ b/src/openforms/forms/views/form.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -13,8 +11,6 @@ from openforms.utils.decorators import conditional_search_engine_index
 from openforms.utils.mixins import UserIsStaffMixin
 
 from ..models import Form
-
-logger = logging.getLogger(__name__)
 
 
 class FormListView(ListView):

--- a/src/openforms/logging/logevent.py
+++ b/src/openforms/logging/logevent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from collections.abc import Sequence
 from functools import partial
 from typing import TYPE_CHECKING
@@ -26,8 +25,6 @@ if TYPE_CHECKING:
     from stuf.models import StufService
 
     from .models import TimelineLogProxy
-
-logger = logging.getLogger(__name__)
 
 
 def _create_log(
@@ -71,7 +68,6 @@ def _create_log(
         extra_data=extra_data,
         user=user,
     )
-    # logger.debug('Logged event in %s %s %s', event, object._meta.object_name, object.pk)
     return log_entry
 
 

--- a/src/openforms/logging/processors.py
+++ b/src/openforms/logging/processors.py
@@ -1,0 +1,15 @@
+"""
+Custom structlog processors.
+"""
+
+from django.conf import settings
+
+from structlog.typing import EventDict, WrappedLogger
+
+
+def drop_user_agent_in_dev(
+    logger: WrappedLogger, method_name: str, event_dict: EventDict
+):
+    if settings.DEBUG and "user_agent" in event_dict:
+        del event_dict["user_agent"]
+    return event_dict

--- a/src/openforms/prefill/co_sign.py
+++ b/src/openforms/prefill/co_sign.py
@@ -7,7 +7,7 @@ done by amending the co-sign data on a submission when the co-sign auth event is
 received, see the :mod:`signals` module.
 """
 
-import logging
+import structlog
 
 from openforms.authentication.service import AuthAttribute
 from openforms.submissions.cosigning import CosignV1Data
@@ -16,7 +16,7 @@ from openforms.submissions.models import Submission
 from .models import PrefillConfig
 from .registry import register
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 AUTH_ATTRIBUTE_TO_CONFIG_FIELD = {
@@ -31,35 +31,37 @@ def get_default_plugin_for_auth_attribute(
     if not auth_attribute or not (
         config_field := AUTH_ATTRIBUTE_TO_CONFIG_FIELD.get(auth_attribute)
     ):
-        logger.info("Unsupported auth_attribute '%s'", auth_attribute)
+        logger.info(
+            "unsupported_auth_attribute_provided", auth_attribute=auth_attribute
+        )
         return
 
     config = PrefillConfig.get_solo()
     default_plugin = getattr(config, config_field)
     if not default_plugin:
-        logger.info(
-            "Prefill config is missing a value for '%s', aborting.", config_field
-        )
+        logger.info("missing_prefill_config", field=config_field)
     return default_plugin
 
 
 def add_co_sign_representation(
     submission: Submission, auth_attribute: AuthAttribute | None
 ):
+    log = logger.bind(
+        action="prefill.add_co_sign_representation",
+        submission_uuid=str(submission.uuid),
+    )
     default_plugin = get_default_plugin_for_auth_attribute(auth_attribute)
     # configuration may be incomplete, do nothing in that case!
     if not default_plugin:
+        log.debug("no_lookup_plugin")
         return
 
     plugin = register[default_plugin]
-    logger.debug(
-        "Fetching co-sign representation data for submission %s using plugin %r",
-        submission.uuid,
-        plugin,
-    )
+    log = log.bind(plugin=plugin)
 
     _cosign_data: CosignV1Data = submission.co_sign_data.copy()
 
+    log.debug("retrieving_cosign_representation")
     values, representation = plugin.get_co_sign_values(
         submission, _cosign_data["identifier"]
     )
@@ -71,3 +73,4 @@ def add_co_sign_representation(
     )
     submission.co_sign_data.update(_cosign_data)
     submission.save(update_fields=["co_sign_data"])
+    log.debug("cosign_data_updated")

--- a/src/openforms/prefill/contrib/kvk/plugin.py
+++ b/src/openforms/prefill/contrib/kvk/plugin.py
@@ -1,9 +1,9 @@
-import logging
 from typing import Any
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from glom import GlomError, glom
 from requests import RequestException
 
@@ -19,7 +19,7 @@ from ...constants import IdentifierRoles
 from ...registry import register
 from .constants import Attributes
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def _select_address(items, type_):
@@ -78,9 +78,9 @@ class KVK_KVKNumberPrefill(BasePlugin):
         for attr in attributes:
             try:
                 values[attr] = glom(result, attr)
-            except GlomError:
+            except GlomError as exc:
                 logger.warning(
-                    f"missing expected attribute '{attr}' in backend response"
+                    "missing_attribute_in_response", attribute=attr, exc_info=exc
                 )
         return values
 

--- a/src/openforms/prefill/contrib/kvk/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/kvk/tests/test_plugin.py
@@ -31,7 +31,11 @@ class KVKPrefillTests(KVKTestMixin, TestCase):
         )
         values = plugin.get_prefill_values(
             submission,
-            [Attributes.bezoekadres_straatnaam, Attributes.kvkNummer],
+            [
+                Attributes.bezoekadres_straatnaam,
+                Attributes.kvkNummer,
+                "invalidAttribute",
+            ],
         )
         expected = {
             "bezoekadres.straatnaam": "Abebe Bikilalaan",

--- a/src/openforms/prefill/contrib/objects_api/plugin.py
+++ b/src/openforms/prefill/contrib/objects_api/plugin.py
@@ -1,8 +1,7 @@
-import logging
-
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from glom import Path, PathAccessError, glom
 
 from openforms.contrib.objects_api.checks import check_config
@@ -17,7 +16,7 @@ from ...registry import register
 from .api.serializers import ObjectsAPIOptionsSerializer
 from .typing import ObjectsAPIOptions
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 PLUGIN_IDENTIFIER = "objects_api"
@@ -32,7 +31,11 @@ class ObjectsAPIPrefill(BasePlugin[ObjectsAPIOptions]):
         self, submission: Submission, prefill_options: ObjectsAPIOptions
     ) -> None:
         if prefill_options["skip_ownership_check"]:
-            logger.info("Skipping ownership check for submission %r.", submission.uuid)
+            logger.info(
+                "skip_ownership_check",
+                submission_uuid=str(submission.uuid),
+                plugin=self,
+            )
             return
 
         assert submission.initial_data_reference

--- a/src/openforms/prefill/contrib/stufbg/plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/plugin.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Any
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 import requests
+import structlog
 from glom import T as Target, glom
 from lxml import etree
 
@@ -20,7 +20,7 @@ from ...base import BasePlugin
 from ...constants import IdentifierRoles
 from ...registry import register
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 """
@@ -165,7 +165,11 @@ class StufBgPrefill(BasePlugin):
     ) -> dict[str, Any]:
         if not (bsn_value := cls.get_identifier_value(submission, identifier_role)):
             #  If there is no bsn we can't prefill any values so just return
-            logger.info("No BSN associated with submission, cannot prefill.")
+            logger.info(
+                "lookup_identifier_absent",
+                submission_uuid=str(submission.uuid),
+                plugin=cls,
+            )
             return {}
 
         return cls._get_values_for_bsn(bsn_value, attributes)

--- a/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/stufbg/tests/test_plugin.py
@@ -138,21 +138,10 @@ class StufBgPrefillTests(TestCase):
     def test_get_available_attributes_when_error_occurs(self):
         client_patcher = mock_stufbg_client("StufBgErrorResponse.xml")
         self.addCleanup(client_patcher.stop)
-
         attributes = [c.value for c in FieldChoices]
 
-        with self.assertLogs() as logs:
-            with self.assertRaises(ValueError):
-                self.plugin.get_prefill_values(self.submission, attributes)
-
-            self.assertEqual(logs.records[0].fault["faultcode"], "soapenv:Server")
-            self.assertEqual(logs.records[0].fault["faultstring"], "Policy Falsified")
-            self.assertEqual(
-                logs.records[0].fault["detail"][
-                    "http://www.layer7tech.com/ws/policy/fault:policyResult"
-                ]["@status"],
-                "Error in Assertion Processing",
-            )
+        with self.assertRaises(ValueError):
+            self.plugin.get_prefill_values(self.submission, attributes)
 
     def test_get_available_attributes_when_no_answer_is_returned(self):
         client_patcher = mock_stufbg_client("StufBgNoAnswerResponse.xml")
@@ -172,13 +161,8 @@ class StufBgPrefillTests(TestCase):
         self.addCleanup(client_patcher.stop)
         attributes = [c.value for c in FieldChoices]
 
-        with self.assertLogs() as logs:
-            with self.assertRaises(ValueError):
-                self.plugin.get_prefill_values(self.submission, attributes)
-
-            self.assertEqual(
-                logs.records[0].fault, {"faultstring": "Object niet gevonden"}
-            )
+        with self.assertRaises(ValueError):
+            self.plugin.get_prefill_values(self.submission, attributes)
 
     def test_get_available_attributes_when_empty_reponse_is_returned(self):
         client_patcher = mock_stufbg_client("StufBgNoObjectResponse.xml")

--- a/src/openforms/prefill/contrib/suwinet/plugin.py
+++ b/src/openforms/prefill/contrib/suwinet/plugin.py
@@ -1,7 +1,7 @@
-import logging
-
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+
+import structlog
 
 from openforms.authentication.service import AuthAttribute
 from openforms.plugins.exceptions import InvalidPluginConfiguration
@@ -15,14 +15,14 @@ from ...base import BasePlugin
 from ...constants import IdentifierRoles
 from ...registry import register
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def _get_client() -> SuwinetClient | None:
     try:
         return get_client()
     except NoServiceConfigured:
-        logger.warning("No service defined for Suwinet.")
+        logger.warning("suwinet_service_not_configured")
     return None
 
 
@@ -64,10 +64,9 @@ class SuwinetPrefill(BasePlugin):
                 return perform_soap_call(bsn)
             except Exception:
                 logger.exception(
-                    "Suwinet operation '%s' on service '%s' failed.",
-                    operation,
-                    service_name,
-                    extra={"service": service_name, "operation": operation},
+                    "prefill.suwinet.operation_failed",
+                    operation=operation,
+                    service=service_name,
                 )
                 return None
 

--- a/src/openforms/prefill/contrib/suwinet/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/suwinet/tests/test_plugin.py
@@ -170,14 +170,8 @@ class SuwinetPrefillTests(SuwinetTestCase):
         plugin = SuwinetPrefill(identifier="suwinet")
         submission = SubmissionFactory.create(auth_info__value="444444440")
 
-        with self.assertLogs("openforms.prefill.contrib.suwinet.plugin") as logged:
-            values = plugin.get_prefill_values(
-                submission, ["UWVWbDossierPersoonGSD.UwvWbPersoonsInfo"]
-            )
-
-        self.assertIn(
-            "Suwinet operation 'UwvWbPersoonsInfo' on service 'UWVWbDossierPersoonGSD' failed.",
-            logged.output[0],
+        values = plugin.get_prefill_values(
+            submission, ["UWVWbDossierPersoonGSD.UwvWbPersoonsInfo"]
         )
 
         # still returns empty values

--- a/src/openforms/prefill/service.py
+++ b/src/openforms/prefill/service.py
@@ -34,10 +34,10 @@ So, to recap:
    form field default values.
 """
 
-import logging
 from collections import defaultdict
 
 import elasticapm
+import structlog
 
 from openforms.formio.service import (
     FormioConfigurationWrapper,
@@ -56,7 +56,7 @@ from .sources import (
     fetch_prefill_values_from_options,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def inject_prefill(
@@ -97,8 +97,11 @@ def inject_prefill(
 
         if prefill_value != default_value and default_value is not None:
             logger.info(
-                "Overwriting non-null default value for component %r",
-                component,
+                "prefill.overwrite_non_null_default_value",
+                submission_uuid=str(submission.uuid),
+                component_type=component["type"],
+                default_value=default_value,
+                component_id=component.get("id"),
             )
         component["defaultValue"] = prefill_value
 

--- a/src/openforms/prefill/signals.py
+++ b/src/openforms/prefill/signals.py
@@ -1,7 +1,7 @@
-import logging
-
 from django.dispatch import receiver
 from django.http import HttpRequest
+
+import structlog
 
 from openforms.authentication.base import BasePlugin
 from openforms.authentication.signals import co_sign_authentication_success
@@ -9,7 +9,7 @@ from openforms.submissions.models import Submission
 
 from .co_sign import add_co_sign_representation as _add_co_sign_representation
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @receiver(
@@ -19,17 +19,13 @@ logger = logging.getLogger(__name__)
 def add_co_sign_representation(
     sender, request: HttpRequest, plugin: BasePlugin, submission: Submission, **kwargs
 ) -> None:
-    logger.debug(
-        "Handling co-sign event for submisssion %s, plugin auth type: %s",
-        submission.uuid,
-        plugin.provides_auth,
+    log = logger.bind(
+        action="prefill.add_co_sign_representation",
+        submission_uuid=str(submission.uuid),
     )
-
+    log.debug("cosign", plugin_auth_type=plugin.provides_auth)
     if not submission.co_sign_data or not submission.co_sign_data["identifier"]:
-        logger.warning(
-            "Submission co sign data is missing or incomplete (submission %s), aborting",
-            submission.uuid,
-        )
+        log.warning("cosign_data_missing_or_incomplete", outcome="skip")
         return
 
     _add_co_sign_representation(submission, plugin.provides_auth)

--- a/src/openforms/prefill/tests/test_prefill_hook.py
+++ b/src/openforms/prefill/tests/test_prefill_hook.py
@@ -1,4 +1,3 @@
-import logging
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -374,14 +373,11 @@ class PrefillHookTests(TransactionTestCase):
             def get_prefill_values(*args, **kwargs):
                 raise Exception("boo")
 
-        with self.assertLogs(level=logging.ERROR) as log:
-            new_configuration = apply_prefill(
-                configuration=configuration,
-                submission=submission,
-                register=register,
-            )
-
-        self.assertIn("boo", log.output[0])
+        new_configuration = apply_prefill(
+            configuration=configuration,
+            submission=submission,
+            register=register,
+        )
 
         field = new_configuration["components"][0]
         self.assertIsNone(field["defaultValue"])

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any, override
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+
+import structlog
 
 from openforms.config.data import Action
 from openforms.contrib.objects_api.checks import check_config
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 
 PLUGIN_IDENTIFIER = "objects_api"
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @register(PLUGIN_IDENTIFIER)

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import re
 from dataclasses import dataclass
 from functools import partial
@@ -9,6 +8,7 @@ from typing import TYPE_CHECKING, Any, override
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from json_logic.typing import Primitive
 
 from openforms.plugins.exceptions import InvalidPluginConfiguration
@@ -44,7 +44,7 @@ from .utils import flatten_data
 if TYPE_CHECKING:
     from openforms.forms.models import FormVariable
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 PLUGIN_IDENTIFIER = "stuf-zds-create-zaak"
 

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -1,4 +1,3 @@
-import logging
 import warnings
 from datetime import datetime
 from functools import partial, wraps
@@ -9,6 +8,7 @@ from django.utils.text import Truncator
 from django.utils.translation import gettext, gettext_lazy as _
 
 import requests
+import structlog
 from furl import furl
 from glom import assign
 
@@ -43,7 +43,7 @@ from .options import ZaakOptionsSerializer
 from .typing import CatalogueOption, RegistrationOptions
 from .utils import process_according_to_eigenschap_format
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class VariablesProperties(TypedDict):

--- a/src/openforms/registrations/service.py
+++ b/src/openforms/registrations/service.py
@@ -1,5 +1,3 @@
-import logging
-
 from openforms.submissions.models import Submission
 
 from .base import BasePlugin
@@ -7,8 +5,6 @@ from .base import BasePlugin
 __all__ = [
     "get_registration_plugin",
 ]
-
-logger = logging.getLogger(__name__)
 
 
 def get_registration_plugin(submission: Submission) -> BasePlugin | None:

--- a/src/openforms/setup.py
+++ b/src/openforms/setup.py
@@ -10,7 +10,6 @@ they are available for Django settings initialization.
     before Django is initialized.
 """
 
-import logging
 import mimetypes
 import os
 import sys
@@ -23,13 +22,14 @@ from django.conf import settings
 import defusedxml
 import portalocker
 import redis
+import structlog
 from django_redis import get_redis_connection
 from dotenv import load_dotenv
 from mozilla_django_oidc import views
 from requests import Session
 from self_certifi import load_self_signed_certs as _load_self_signed_certs
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 mimetypes.init()
 

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TypedDict
@@ -10,6 +9,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 import elasticapm
+import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -42,7 +42,7 @@ from .fields import (
 )
 from .validators import FormMaintenanceModeValidator, ValidatePrefillData
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class NestedSubmissionStepSerializer(NestedHyperlinkedModelSerializer):

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -1,11 +1,11 @@
 import contextlib
-import logging
 from uuid import UUID
 
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
@@ -67,7 +67,7 @@ from .serializers import (
 )
 from .validation import SubmissionCompletionSerializer
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @contextlib.contextmanager

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -1,4 +1,3 @@
-import logging
 import os.path
 import pathlib
 import re
@@ -15,6 +14,7 @@ from django.urls import Resolver404, resolve
 from django.utils.translation import gettext as _
 
 import PIL
+import structlog
 from glom import Path, glom
 from PIL import Image
 
@@ -32,7 +32,7 @@ from openforms.template import render_from_string, sandbox_backend
 from openforms.typing import JSONObject
 from openforms.utils.glom import _glom_path_to_str
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 DEFAULT_IMAGE_MAX_SIZE = (10000, 10000)
 

--- a/src/openforms/submissions/logic/log_utils.py
+++ b/src/openforms/submissions/logic/log_utils.py
@@ -1,18 +1,20 @@
 import contextlib
-import logging
 from typing import Iterator
+
+import structlog
 
 from openforms.forms.models import FormLogic
 from openforms.typing import JSONObject
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @contextlib.contextmanager
 def log_errors(logic: JSONObject, rule: FormLogic) -> Iterator[None]:
+    log = logger.bind(rule_id=rule.pk)
     try:
         yield
     except Exception as error:
-        logger.error(
-            "Error in rule %s: evaluation of %s failed.", rule.pk, logic, exc_info=error
+        log.error(
+            "submissions.logic_rule_evaluation_failure", logic=logic, exc_info=error
         )

--- a/src/openforms/submissions/models/submission_files.py
+++ b/src/openforms/submissions/models/submission_files.py
@@ -1,5 +1,4 @@
 import hashlib
-import logging
 import os.path
 import uuid
 from collections import defaultdict
@@ -11,6 +10,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+import structlog
 from glom import glom
 from privates.fields import PrivateMediaFileField
 
@@ -23,7 +23,7 @@ from .submission_step import SubmissionStep
 if TYPE_CHECKING:
     from .submission_value_variable import SubmissionValueVariable
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def fmt_upload_to(prefix, instance, filename):

--- a/src/openforms/submissions/rendering/nodes.py
+++ b/src/openforms/submissions/rendering/nodes.py
@@ -1,6 +1,7 @@
-import logging
 from dataclasses import dataclass
 from typing import Iterator
+
+import structlog
 
 from openforms.formio.rendering.nodes import FormioNode
 
@@ -8,7 +9,7 @@ from ..models import SubmissionStep
 from .base import Node
 from .constants import RenderModes
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class FormNode(Node):
@@ -57,12 +58,12 @@ class SubmissionStepNode(Node):
         # applicable because of form logic.
         logic_evaluated = getattr(self.step, "_form_logic_evaluated", False)
         if not logic_evaluated:
+            # logic should really be evaluated before rendering steps!
             logger.warning(
-                "You should ensure that the form logic is evaluated before rendering "
-                "steps! Submission ID: %s, renderer: %r, step ID: %s",
-                self.step.submission.uuid,
-                self.renderer,
-                self.step.uuid,
+                "submissions.rendering.logic_not_evaluated",
+                submission_uuid=str(self.step.submission.uuid),
+                renderer=self.renderer,
+                step_uuid=str(self.step.uuid),
             )
         return self.step.is_applicable
 

--- a/src/openforms/submissions/report.py
+++ b/src/openforms/submissions/report.py
@@ -4,7 +4,6 @@ Utility classes for the submission report rendering.
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import cast
 
@@ -12,13 +11,15 @@ from django.utils.html import format_html
 from django.utils.safestring import SafeString
 from django.utils.translation import gettext_lazy as _
 
+import structlog
+
 from openforms.authentication.service import AuthAttribute
 from openforms.forms.models import Form
 
 from .cosigning import CosignV1Data
 from .models import Submission
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @dataclass
@@ -70,7 +71,8 @@ class Report:
 
         if not representation:
             logger.warning(
-                "Incomplete co-sign data for submission %s", self.submission.uuid
+                "incomplete_co_sign_data_detected",
+                submission_uuid=str(self.submission.uuid),
             )
 
         return _("{representation} ({auth_attribute}: {identifier})").format(

--- a/src/openforms/submissions/signals.py
+++ b/src/openforms/submissions/signals.py
@@ -1,9 +1,9 @@
-import logging
-
 from django.db import transaction
 from django.db.models import F
 from django.db.models.signals import post_delete
 from django.dispatch import Signal, receiver
+
+import structlog
 
 from openforms.submissions.models import (
     Submission,
@@ -12,7 +12,7 @@ from openforms.submissions.models import (
 )
 from openforms.utils.files import _delete_obj_files, get_file_field_names
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 # custom signal to decouple actions done by feature modules - this avoids having to
@@ -74,7 +74,9 @@ def delete_obj_files(
 def delete_submission_report_files(
     sender: type[SubmissionReport], instance: SubmissionReport, **kwargs
 ) -> None:
-    logger.debug("Deleting file %r", instance.content.name)
+    logger.debug(
+        "submissions.delete_submission_report_pdf", filename=instance.content.name
+    )
 
     instance.content.delete(save=False)
 

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -4,7 +4,6 @@ import requests_mock
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory, APITestCase
-from testfixtures import LogCapture
 from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.accounts.tests.factories import SuperUserFactory
@@ -222,62 +221,27 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
         )
         self._add_submission_to_session(submission)
 
-        with (
-            self.subTest("Invalid time with good format"),
-            LogCapture() as log_capture,
-        ):
-            self.client.post(endpoint, data={"data": {"time": "25:00"}})
+        with self.subTest("Invalid time with good format"):
+            response = self.client.post(endpoint, data={"data": {"time": "25:00"}})
 
-            log_capture.check_present(
-                (
-                    "openforms.utils.date",
-                    "INFO",
-                    "Invalid time '25:00', falling back to 'None' instead.",
-                )
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        with (
-            self.subTest("Invalid time with bad format"),
-            LogCapture() as log_capture,
-        ):
-            self.client.post(endpoint, data={"data": {"time": "Invalid"}})
+        with self.subTest("Invalid time with bad format"):
+            response = self.client.post(endpoint, data={"data": {"time": "Invalid"}})
 
-            log_capture.check_present(
-                (
-                    "openforms.utils.date",
-                    "INFO",
-                    "Badly formatted time 'Invalid', falling back to 'None' instead.",
-                )
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        with self.subTest("Invalid date"), LogCapture() as log_capture:
-            self.client.post(endpoint, data={"data": {"date": "2020-13-46"}})
+        with self.subTest("Invalid date"):
+            response = self.client.post(endpoint, data={"data": {"date": "2020-13-46"}})
 
-            log_capture.check_present(
-                (
-                    "openforms.utils.date",
-                    "INFO",
-                    "Can't format date '2020-13-46', falling back to an empty string.",
-                ),
-                (
-                    "openforms.utils.date",
-                    "INFO",
-                    "Badly formatted datetime '2020-13-46', falling back to 'None' instead.",
-                ),
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        with self.subTest("Invalid datetime"), LogCapture() as log_capture:
-            self.client.post(
+        with self.subTest("Invalid datetime"):
+            response = self.client.post(
                 endpoint, data={"data": {"datetime": "2022-13-46T00:00:00+02:00"}}
             )
 
-            log_capture.check_present(
-                (
-                    "openforms.utils.date",
-                    "INFO",
-                    "Can't parse datetime '2022-13-46T00:00:00+02:00', falling back to 'None' instead.",
-                )
-            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_handling_none_values_in_logic(self):
         submission = SubmissionFactory.from_components(

--- a/src/openforms/submissions/tests/test_session_update_concurrency.py
+++ b/src/openforms/submissions/tests/test_session_update_concurrency.py
@@ -1,0 +1,26 @@
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import TestCase
+
+from ..utils import append_to_session_list
+
+
+class SessionUpdateTests(TestCase):
+    def test_just_in_time_refresh(self):
+        session = SessionStore()
+        session["some-list"] = ["initial"]
+        session.save()
+        session_key = session.session_key
+
+        def _race():
+            session = SessionStore(session_key)
+            session["some-list"] = ["initial", "second"]
+            session.save()  # close_db_connections()
+
+        # other key gets modified and runs in its own thread, but crucially *after*
+        # we instantiated and loaded our own session
+        _race()
+
+        append_to_session_list(session, "some-list", "third")
+
+        session.load()
+        self.assertEqual(session["some-list"], ["initial", "second", "third"])

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from freezegun import freeze_time
 from privates.test import temp_private_root
 from pyquery import PyQuery as pq
-from testfixtures import LogCapture
 
 from openforms.config.models import GlobalConfiguration
 from openforms.formio.constants import DataSrcOptions
@@ -75,10 +74,8 @@ class SubmissionReportGenerationTests(TestCase):
         """
         report = SubmissionReportFactory.create(content="", submission__completed=True)
 
-        with LogCapture(level=logging.ERROR) as capture:
+        with self.assertNoLogs(level=logging.ERROR):
             report.generate_submission_report_pdf()
-
-        capture.check()
 
     def test_hidden_output_not_included(self):
         """

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -1,4 +1,5 @@
-import logging
+import logging  # noqa TID251 -- used only for the log level
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings, tag
 from django.utils.html import format_html
@@ -8,6 +9,7 @@ from freezegun import freeze_time
 from privates.test import temp_private_root
 from pyquery import PyQuery as pq
 
+from openforms.logging.models import TimelineLogProxy
 from openforms.config.models import GlobalConfiguration
 from openforms.formio.constants import DataSrcOptions
 from openforms.forms.tests.factories import FormLogicFactory
@@ -652,6 +654,24 @@ class SubmissionReportGenerationTests(TestCase):
             """,
         )
         self.assertInHTML(expected, html, count=1)
+
+    def test_pdf_generation_failure_is_logged(self):
+        submission = SubmissionFactory.create(completed=True, with_report=False)
+        generate_submission_report.request.id = "some-id"
+
+        with (
+            patch(
+                "openforms.submissions.tasks.pdf.SubmissionReport.generate_submission_report_pdf",
+                side_effect=IOError("storage full"),
+            ),
+            self.assertRaises(IOError),
+        ):
+            generate_submission_report.run(submission.id)
+
+        logs = TimelineLogProxy.objects.for_object(submission).filter_event(
+            "pdf_generation_failure"
+        )
+        self.assertEqual(logs.count(), 1)
 
 
 @temp_private_root()

--- a/src/openforms/tests/test_celery_beat.py
+++ b/src/openforms/tests/test_celery_beat.py
@@ -1,3 +1,5 @@
+import inspect
+
 from django.conf import settings
 from django.test import SimpleTestCase
 from django.utils.module_loading import import_string
@@ -21,5 +23,17 @@ class BeatConfigTests(SimpleTestCase):
                     # its is important the full path is used or beat won't be able to find the task
                     if task.name != task_path:
                         self.fail(
-                            f"Task '{task_path}' in settings.CELERY_BEAT_SCHEDULE should be registered with it's full import path, eg: '{task.name}'"
+                            f"Task '{task_path}' in settings.CELERY_BEAT_SCHEDULE should be "
+                            f"registered with it's full import path, eg: '{task.name}'"
                         )
+
+                # verify the args/kwargs against the signature
+                task_signature = inspect.signature(task)
+                task_args = entry.get("args") or ()
+                task_kwargs = entry.get("kwargs") or {}
+                try:
+                    task_signature.bind(*task_args, **task_kwargs)
+                except TypeError as exc:
+                    raise self.failureException(
+                        "invalid task args/kwargs specified in schedule"
+                    ) from exc

--- a/src/openforms/tests/utils.py
+++ b/src/openforms/tests/utils.py
@@ -1,7 +1,6 @@
 import contextlib
 import cProfile
 import io
-import logging
 import os
 import pstats
 import socket
@@ -12,12 +11,14 @@ from pstats import SortKey
 
 from django.conf import settings
 
+import structlog
+
 NOOP_CACHES = {
     name: {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}
     for name in settings.CACHES.keys()
 }
 
-flaky_test_logger = logging.getLogger("flaky_tests")
+flaky_test_logger = structlog.stdlib.get_logger("flaky_tests")
 
 
 def can_connect(hostname: str):
@@ -100,6 +101,7 @@ def log_flaky():
     )
     frame_info = getframeinfo(frame.f_back)
     relative_path = Path(frame_info.filename).relative_to(Path(settings.BASE_DIR))
+    # TODO: convert to structlog events
     flaky_test_logger.warning(
         "Flaky test: %s",
         frame_info.function,

--- a/src/openforms/translations/middleware.py
+++ b/src/openforms/translations/middleware.py
@@ -1,13 +1,13 @@
-import logging
-
 from django.conf import settings
 from django.http import HttpRequest
 from django.utils import translation
 
+import structlog
+
 from openforms.typing import RequestHandler
 from openforms.utils.urls import is_admin_request
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def _remove_language_cookie_from_request(request: HttpRequest) -> None:
@@ -16,19 +16,11 @@ def _remove_language_cookie_from_request(request: HttpRequest) -> None:
 
     settings.LANGUAGE_COOKIE_NAME
     """
-    logger.debug(
-        "Removing the language cookie (if present) from request %r",
-        request,
-        extra={"request": request},
-    )
     cookie_name = settings.LANGUAGE_COOKIE_NAME
-    if cookie_name in request.COOKIES:
+    cookie_present = cookie_name in request.COOKIES
+    if cookie_present:
         del request.COOKIES[cookie_name]
-        logger.debug(
-            "Cookie %s was present but is now ignored.",
-            cookie_name,
-            extra={"request": request},
-        )
+    logger.debug("language_cookie_removal", was_present=cookie_present)
 
 
 class AdminLocaleMiddleware:

--- a/src/openforms/upgrades/script_checks.py
+++ b/src/openforms/upgrades/script_checks.py
@@ -1,14 +1,14 @@
 import contextlib
-import logging
 import sys
 from pathlib import Path
 
 from django.conf import settings
 from django.utils.module_loading import import_string
 
+import structlog
 from upgrade_check.constraints import CodeCheck
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @contextlib.contextmanager
@@ -41,7 +41,7 @@ class BinScriptCheck(CodeCheck):
             try:
                 result = main_func(skip_setup=True)
             except Exception as exc:
-                logger.error("Script check errored", exc_info=exc)
+                logger.error("script_check_error", exc_info=exc)
                 result = False
         del main_func  # reduce memory usage
         return True if result is None else result

--- a/src/openforms/upgrades/upgrade_paths.py
+++ b/src/openforms/upgrades/upgrade_paths.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,13 +8,14 @@ from django.conf import settings
 from django.core.management import CommandError, call_command
 from django.utils.module_loading import import_string
 
+import structlog
 from semantic_version import SimpleSpec, Version
 
 from .models import VERSION_DEV
 
 __all__ = ["check_upgrade_path"]
 
-logger = logging.getLogger(__name__)
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class VersionParseError(Exception):
@@ -64,7 +64,7 @@ class UpgradeConstraint:
             try:
                 result = main_func(skip_setup=True)
             except Exception as exc:
-                logger.error("Script check errored", exc_info=exc)
+                logger.error("script_check_error", exc_info=exc)
                 result = False
             if result is False:
                 checks_pass = False

--- a/src/openforms/utils/tests/logging.py
+++ b/src/openforms/utils/tests/logging.py
@@ -1,6 +1,4 @@
-import logging
-from contextlib import contextmanager
-from typing import Iterator
+import logging  # noqa: TID251 -- structlog uses the same level constants
 
 from django.test.utils import TestContextDecorator
 
@@ -11,23 +9,3 @@ class disable_logging(TestContextDecorator):
 
     def disable(self):
         logging.disable(logging.NOTSET)
-
-
-@contextmanager
-def ensure_logger_level(level: str = "INFO", name="openforms") -> Iterator[None]:
-    """
-    Set the (minimum) level for a given logger.
-
-    Base or individual settings may tweak the log level to reduce the overload for the
-    developer, but this affects tests that verify that log records are "written" by
-    application code for a certain log level.
-
-    This context manager allows you to pin the log level for a given text, irrespective
-    of individual preferences/developer settings.
-    """
-    logger = logging.getLogger(name)
-    original_level = logger.getEffectiveLevel()
-
-    logger.setLevel(logging._nameToLevel[level])
-    yield
-    logger.setLevel(original_level)

--- a/src/openforms/utils/tests/test_tasks.py
+++ b/src/openforms/utils/tests/test_tasks.py
@@ -1,0 +1,16 @@
+from django.contrib.sessions.models import Session
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from ..tasks import run_management_command
+
+
+class RunManagementCommandTaskTests(TestCase):
+    @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.db")
+    def test_clearsessions(self):
+        # create an expired session
+        Session.objects.create(session_key="dummy", expire_date=timezone.now())
+
+        run_management_command(command="clearsessions")
+
+        self.assertFalse(Session.objects.exists())


### PR DESCRIPTION
Closes #5285 (partly)

[skip: e2e]

**Changes**

* Added django-structlog
* Configured stdout logs to be JSON formatted (or dev-friendly format in dev)
* Disabled default django server logs, django_structlog takes care of that
* Ensure that context vars are sent in logs originating from stdlib logging
* Replaced all stdlib logging calls with appropriate structlog calls
* Set up necessary events/context using structlog for better logging

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
