### PR TITLE
:bug: Fix HTML sanitization of design tokens

### DIFF
--- a/src/openforms/ui/templatetags/style_dictionary.py
+++ b/src/openforms/ui/templatetags/style_dictionary.py
@@ -1,7 +1,7 @@
 from django import template
 from django.utils.safestring import mark_safe
 
-from openforms.typing import JSONPrimitive
+from openforms.typing import JSONPrimitive, JSONValue
 
 register = template.Library()
 
@@ -21,12 +21,13 @@ def extract_tokens(node: dict, prefix: str | None = None) -> dict[str, JSONPrimi
     # if a value is found, we have built up the entire token name and can return
     # the name + value combination
     if "value" in node:
-        # escape possible HTML tag attempts, as that could break someone out of the
-        # style tag, but leave other characters intact.
-        # TODO: this should probably be more clever by default...
-        tokens[prefix] = mark_safe(
-            node["value"].replace("<", "&lt;").replace(">", "&gt;")
-        )
+        _value: JSONValue = node["value"]
+        if isinstance(_value, str):
+            # escape possible HTML tag attempts, as that could break someone out of the
+            # style tag, but leave other characters intact.
+            # TODO: this should probably be more clever by default...
+            _value = mark_safe(_value.replace("<", "&lt;").replace(">", "&gt;"))
+        tokens[prefix] = _value
         return tokens
 
     # if nothing is found, we need to recurse and a node could contain multiple keys

--- a/src/openforms/ui/tests/test_style_dictionary.py
+++ b/src/openforms/ui/tests/test_style_dictionary.py
@@ -63,3 +63,11 @@ class StyleDictionaryTests(SimpleTestCase):
         tokens = style_dictionary(style_dict)
 
         self.assertEqual(tokens, {})
+
+    def test_non_string_value(self):
+        style_dict = {"some-width": {"value": 0}}
+
+        tokens = style_dictionary(style_dict)
+
+        expected = {"--some-width": 0}
+        self.assertEqual(tokens, expected)


### PR DESCRIPTION
The previous code assumed values were always strings, but they can technically also be numbers, null or booleans, as those are the valid JSON primitives.

Was reported via Sentry for DH.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
