### PR TITLE
Fix nested submission data is not saved

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -5414,7 +5414,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubmissionStepSummarySerialzier'
+                  $ref: '#/components/schemas/SubmissionStepSummary'
           description: ''
           headers:
             X-Session-Expires-In:
@@ -10273,7 +10273,7 @@ components:
       - id
       - isApplicable
       - slug
-    SubmissionStepSummarySerialzier:
+    SubmissionStepSummary:
       type: object
       properties:
         slug:

--- a/src/openforms/formio/api/fields.py
+++ b/src/openforms/formio/api/fields.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
+from rest_framework.fields import DictField
 
+from ..datastructures import FormioData
 from ..validators import variable_key_validator
 
 
@@ -12,3 +14,11 @@ class FormioVariableKeyField(serializers.CharField):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.validators = [variable_key_validator, *self.validators]
+
+
+class FormioDataField(DictField):
+    """A dict field which supports nested data access via dot notation."""
+
+    def to_internal_value(self, data):
+        data = super().to_internal_value(data)
+        return FormioData(data)

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -300,7 +300,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
 
 
 class FormDataSerializer(serializers.Serializer):
-    data = serializers.DictField(
+    data = FormioDataField(
         label=_("form data"),
         required=False,
         help_text=_(

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -527,7 +527,7 @@ class SubmissionComponentSummarySerializer(serializers.Serializer):
     )
 
 
-class SubmissionStepSummarySerialzier(serializers.Serializer):
+class SubmissionStepSummarySerializer(serializers.Serializer):
     slug = serializers.SlugField(
         help_text=_("Slug of the form definition used in the form step."),
         required=True,

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -63,7 +63,7 @@ from .serializers import (
     SubmissionStateLogic,
     SubmissionStateLogicSerializer,
     SubmissionStepSerializer,
-    SubmissionStepSummarySerialzier,
+    SubmissionStepSummarySerializer,
     SubmissionSuspensionSerializer,
 )
 from .validation import SubmissionCompletionSerializer
@@ -434,7 +434,7 @@ class SubmissionViewSet(
         summary=_("Summary page data"),
         description=_("Retrieve the data to display in the submission summary page."),
         responses={
-            200: SubmissionStepSummarySerialzier(many=True),
+            200: SubmissionStepSummarySerializer(many=True),
         },
     )
     @action(detail=True, methods=["get"], url_name="summary", pagination_class=None)

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -21,7 +21,6 @@ from openforms.api.filters import PermissionFilterMixin
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.api.throttle_classes import PollingRateThrottle
 from openforms.authentication.service import is_authenticated_with_an_allowed_plugin
-from openforms.formio.service import FormioData
 from openforms.forms.constants import SubmissionAllowedChoices
 from openforms.forms.models import FormStep
 from openforms.logging import logevent
@@ -652,9 +651,7 @@ class SubmissionStepViewSet(
         form_data_serializer.is_valid(raise_exception=True)
 
         if data := form_data_serializer.validated_data["data"]:
-            new_configuration = evaluate_form_logic(
-                submission, submission_step, FormioData(data)
-            )
+            new_configuration = evaluate_form_logic(submission, submission_step, data)
             submission_step.form_step.form_definition.configuration = new_configuration
 
         submission_state_logic_serializer = SubmissionStateLogicSerializer(

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -132,7 +132,7 @@ class StepNotApplicableAction(ActionOperation):
 
         # This clears data in the database to make sure that saved steps which later become
         # not-applicable don't have old data
-        submission_step_to_modify.data = {}
+        submission_step_to_modify.data = FormioData()
         if submission_step_to_modify == step:
             step.is_applicable = False
             step.data = DirtyData(FormioData())

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -198,7 +198,7 @@ class SubmissionStep(models.Model):
         self._is_applicable = value
 
     def reset(self):
-        self.data = {}
+        self.data = FormioData()
         self.save()
 
     @property

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from openforms.formio.service import FormioData
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -103,7 +104,7 @@ class FormNodeTests(TestCase):
             ],
         )
         # set up data that marks step as not-applicable
-        self.sstep1.data = {"input1": "disabled-step-2"}
+        self.sstep1.data = FormioData({"input1": "disabled-step-2"})
         self.sstep1.save()
 
         renderer = Renderer(

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -1,5 +1,6 @@
 from rest_framework.test import APITestCase
 
+from openforms.formio.datastructures import FormioData
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -158,12 +159,14 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 3. bulk_create var3 and var4 submission value variables
         # 4. bulk_update var1 and var2 submission value variables
         with self.assertNumQueries(4):
-            submission_step.data = {
-                "var1": "test1-modified",
-                "var2": "test2-modified",
-                "var3": "test3",
-                "var4": "test4",
-            }
+            submission_step.data = FormioData(
+                {
+                    "var1": "test1-modified",
+                    "var2": "test2-modified",
+                    "var3": "test3",
+                    "var4": "test4",
+                }
+            )
 
     def test_get_step_data(self):
         form = FormFactory.create()

--- a/src/openforms/submissions/tests/test_variables/test_variable_injection.py
+++ b/src/openforms/submissions/tests/test_variables/test_variable_injection.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
+from openforms.formio.service import FormioData
 from openforms.formio.tests.assertions import FormioMixin
 from openforms.forms.tests.factories import FormFactory, FormVariableFactory
 from openforms.variables.constants import FormVariableDataTypes
@@ -133,7 +134,9 @@ class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
 
     def test_detail_endpoint_interpolates_with_submission_data(self):
         self._add_submission_to_session(self.submission)
-        self.submission_step.data = {"text1": 'First "textfield"', "checkbox1": True}
+        self.submission_step.data = FormioData(
+            {"text1": 'First "textfield"', "checkbox1": True}
+        )
         endpoint = reverse(
             "api:submission-steps-detail",
             kwargs={

--- a/src/openforms/tests/e2e/test_fill_in_form.py
+++ b/src/openforms/tests/e2e/test_fill_in_form.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+
+from asgiref.sync import sync_to_async
+from furl import furl
+from playwright.async_api import expect
+
+from openforms.forms.tests.factories import FormFactory
+
+from .base import E2ETestCase, browser_page
+
+
+class FillInFormTests(E2ETestCase):
+    async def test_normal_and_nested_data_text_fields(self):
+        @sync_to_async
+        def setUpTestData():
+            # set up a form
+            form = FormFactory.create(
+                name="Form nested data",
+                slug="form-with-nested-data",
+                generate_minimal_setup=True,
+                formstep__form_definition__name="First step",
+                formstep__form_definition__slug="first-step",
+                formstep__form_definition__configuration={
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "text.field",
+                            "label": "Text field nested",
+                        },
+                        {
+                            "type": "textfield",
+                            "key": "textfield",
+                            "label": "Text field non-nested",
+                        },
+                    ]
+                },
+                translation_enabled=False,  # force Dutch
+                ask_privacy_consent=False,
+                ask_statement_of_truth=False,
+            )
+            return form
+
+        form = await setUpTestData()
+        form_url = str(
+            furl(self.live_server_url)
+            / reverse("forms:form-detail", kwargs={"slug": form.slug})
+        )
+
+        with patch("openforms.utils.validators.allow_redirect_url", return_value=True):
+            async with browser_page() as page:
+                await page.goto(form_url)
+
+                await page.get_by_role("button", name="Formulier starten").click()
+
+                await page.get_by_label("Text field nested").fill("This is nested data")
+                await page.get_by_label("Text field non-nested").fill(
+                    "This is non-nested data"
+                )
+
+                await page.get_by_role("button", name="Volgende").click()
+
+                with self.subTest("Nested data"):
+                    await expect(
+                        page.get_by_text("This is nested data")
+                    ).to_be_visible()
+
+                with self.subTest("Non-nested data"):
+                    await expect(
+                        page.get_by_text("This is non-nested data")
+                    ).to_be_visible()


### PR DESCRIPTION
Closes #5300

**Changes**

* Change the `data` field of `SubmissionStepSerializer` and `FormDataSerializer` to a `FormioDataField`
* Added missing `FormioData` when setting data to `SubmissionStep.data`
* Fix typo in name of serializer

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
