### PR TITLE
🗒️ [#5283] Rename form list-view

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -122,24 +122,6 @@ class FormDeletedListFilter(admin.ListFilter):
         return [self.parameter_name]
 
 
-class IsLiveListFilter(admin.SimpleListFilter):
-    title = _("is live")
-    parameter_name = "is_live"
-
-    def lookups(self, request, model_admin):
-        return [
-            ("true", _("Live")),
-            ("false", _("Not Live")),
-        ]
-
-    def queryset(self, request, queryset):
-        if self.value() == "true":
-            return queryset.filter(active=True, _is_deleted=False)
-        elif self.value() == "false":
-            return queryset.filter(active=False, _is_deleted=False)
-        return queryset
-
-
 @admin.register(Form)
 class FormAdmin(
     FormioConfigMixin,
@@ -162,7 +144,7 @@ class FormAdmin(
         "export_forms",
     ]
     list_filter = (
-        IsLiveListFilter,
+        "active",
         "maintenance_mode",
         "translation_enabled",
         FormDeletedListFilter,
@@ -284,11 +266,9 @@ class FormAdmin(
     def anno_name(self, obj: Form) -> str:
         return obj.admin_name
 
-    @admin.display(description=_("Live"))
+    @admin.display(description=_("Live"), boolean=True)
     def is_live(self, obj: Form) -> bool:
         return obj.active and not obj._is_deleted
-
-    is_live.boolean = True
 
     def get_form(self, request, *args, **kwargs):
         # no actual changes to the fields are triggered, we're only ending up here

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -467,7 +467,7 @@ class Form(models.Model):
             for auth_backend in self.authentication_backends
         ]
 
-    get_authentication_backends_display.short_description = _("inloggen")
+    get_authentication_backends_display.short_description = _("logins")
 
     @cached_property
     def has_cosign_enabled(self) -> bool:

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -440,7 +440,7 @@ class Form(models.Model):
             or "-"
         )
 
-    get_registration_backend_display.short_description = _("registration backend(s)")
+    get_registration_backend_display.short_description = _("registrations")
 
     def get_payment_backend_display(self):
         if not self.payment_backend:
@@ -467,9 +467,7 @@ class Form(models.Model):
             for auth_backend in self.authentication_backends
         ]
 
-    get_authentication_backends_display.short_description = _(
-        "authentication backend(s)"
-    )
+    get_authentication_backends_display.short_description = _("inloggen")
 
     @cached_property
     def has_cosign_enabled(self) -> bool:


### PR DESCRIPTION
Closes #5283 

[skip: e2e]

**Changes**

Renamed and removed columns from forms list-view as follows:
Active and Maintenance mode columns removed - replaced with Live
Translation enabled column removed
Maximum allowed submissions column removed
Authentication backend(s) renamed to inloggen
Payment backend removed
Registration backend(s) renamed to registrations

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
