### PR TITLE
:mute: [#5285] Silence log events in Sentry

### DIFF
--- a/src/openforms/conf/utils.py
+++ b/src/openforms/conf/utils.py
@@ -1,8 +1,10 @@
+import logging  # noqa: TID251 - only used for the log levels
 import re
 from typing import Any
 
 from decouple import Csv, config as _config, undefined
 from sentry_sdk.integrations import DidNotEnable, django, redis
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 S_SI = {
     "B": lambda val: val,
@@ -100,6 +102,12 @@ def get_sentry_integrations() -> list:
     """
     default = [
         django.DjangoIntegration(),
+        LoggingIntegration(
+            level=logging.INFO,  # breadcrumbs
+            # do not send any logs as event to Sentry at all - these must be scraped by
+            # the (container) infrastructure instead.
+            event_level=None,
+        ),
         redis.RedisIntegration(),
     ]
     extra = []


### PR DESCRIPTION
Closes #5285

**Changes**

Disable sending log events to Sentry, but keep the breadcrumbs from logging calls that lead to an exception.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
