### PR TITLE
Replace OAS steps in CI with re-usable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,16 +110,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Generate OAS
-        run: ./bin/generate_oas.sh openapi.yaml
-
-      - name: Store generated OAS
-        uses: actions/upload-artifact@v4
-        with:
-          name: open-forms-oas
-          path: openapi.yaml
-          retention-days: 1
-
   tests-reverse:
     name: Run the Django test suite in reverse
     runs-on: ubuntu-latest
@@ -475,104 +465,21 @@ jobs:
           # ensure local image gets used
           TAG: ${{ needs.docker_build_setup.outputs.version }}
 
-  oas-up-to-date:
-    needs: tests
-    name: Check for unexepected OAS changes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download generated OAS
-        uses: actions/download-artifact@v4
-        with:
-          name: open-forms-oas
-      - name: Check for OAS changes
-        run: |
-          diff openapi.yaml src/openapi.yaml
-      - name: Write failure markdown
-        if: ${{ failure() }}
-        run: |
-          echo 'Run the following command locally and commit the changes' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo './bin/generate_oas.sh' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-  oas-lint:
-    needs: oas-up-to-date
-    name: Validate OAS
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download generated OAS
-        uses: actions/download-artifact@v4
-        with:
-          name: open-forms-oas
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install spectral
-        run: npm install -g @stoplight/spectral@5.9.2
-      - name: Run OAS linter
-        run: spectral lint ./openapi.yaml
-
-  oas-postman:
-    needs: oas-up-to-date
-    name: Generate Postman collection from OAS
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download generated OAS
-        uses: actions/download-artifact@v4
-        with:
-          name: open-forms-oas
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install dependencies
-        run: npm install -g openapi-to-postmanv2
-      - name: Create tests folder
-        run: mkdir -p ./tests/postman
-      - name: Generate Postman collection
-        run: openapi2postmanv2 -s ./openapi.yaml -o ./tests/postman/collection.json --pretty
-
-  oas-generate-sdks:
-    needs: oas-up-to-date
-    name: Generate SDKs from OAS
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download generated OAS
-        uses: actions/download-artifact@v4
-        with:
-          name: open-forms-oas
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install dependencies
-        run: npm install -g @openapitools/openapi-generator-cli@2.4.2
-      - name: Validate schema
-        run: openapi-generator-cli validate -i ./openapi.yaml
-      - name: Generate Java client
-        run:
-          openapi-generator-cli generate -i ./openapi.yaml
-          --global-property=modelTests=false,apiTests=false,modelDocs=false,apiDocs=false \ -o
-          ./sdks/java -g java
-          --additional-properties=dateLibrary=java8,java8=true,optionalProjectFile=false,optionalAssemblyInfo=false
-      - name: Generate .NET Full Framework client
-        run:
-          openapi-generator-cli generate -i ./openapi.yaml
-          --global-property=modelTests=false,apiTests=false,modelDocs=false,apiDocs=false \ -o
-          ./sdks/net -g csharp
-          --additional-properties=optionalProjectFile=false,optionalAssemblyInfo=false
-      - name: Generate Python client
-        run:
-          openapi-generator-cli generate -i ./openapi.yaml
-          --global-property=modelTests=false,apiTests=false,modelDocs=false,apiDocs=false \ -o
-          ./sdks/python -g python
-          --additional-properties=optionalProjectFile=false,optionalAssemblyInfo=false+
+  oas:
+    name: OAS
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@v5
+    with:
+      python-version: '3.12'
+      apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
+      django-settings-module: openforms.conf.ci
+      oas-generate-command: ./bin/generate_oas.sh
+      schema-path: src/openapi.yaml
+      oas-artifact-name: open-forms-oas
+      node-version-file: '.nvmrc'
+      spectral-version: '^6.15.0'
+      openapi-to-postman-version: '^5.0.0'
+      postman-artifact-name: open-forms-postman-collection
+      openapi-generator-version: '^2.20.0'
 
   docker_push:
     needs:
@@ -580,9 +487,7 @@ jobs:
       - e2etests
       - docker_build_setup
       - docker_build
-      - oas-lint
-      - oas-postman
-      - oas-generate-sdks
+      - oas
 
     name: Push Docker image
     runs-on: ubuntu-latest

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,7 +1,0 @@
-{
-    "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-    "spaces": 2,
-    "generator-cli": {
-        "version": "7.0.0"
-    }
-}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3291,7 +3291,6 @@ paths:
         schema:
           type: string
           format: uri
-          default: ''
         description: Filter document types against this catalogue URL.
       - in: query
         name: objects_api_group
@@ -4093,7 +4092,6 @@ paths:
         schema:
           type: string
           format: uri
-          default: ''
         description: Filter document types against this catalogue URL.
       - in: query
         name: zgw_api_group

--- a/src/openforms/api/drf_spectacular/hooks.py
+++ b/src/openforms/api/drf_spectacular/hooks.py
@@ -1,3 +1,5 @@
+import itertools
+
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
@@ -124,5 +126,72 @@ def add_unsafe_methods_parameter(result, generator, request, public):
 
             operation.setdefault("parameters", [])
             operation["parameters"].append(CSRF_TOKEN_PARAMETER)
+
+    return result
+
+
+def remove_invalid_url_defaults(result, generator, **kwargs):  # pragma: no cover
+    """
+    Fix ``URLField(default="")`` schema generation.
+
+    An empty string does not satisfy the `format: uri` validation, and schema validation
+    tools can trip on this.
+
+    The majority of the code here is inspired by the built in postprocess_schema_enums
+    hook.
+
+    TODO: contribute upstream patch
+    """
+    schemas = result.get("components", {}).get("schemas", {})
+
+    def iter_prop_containers(schema):
+        match schema:
+            case {"properties": props}:
+                yield props
+            case {"oneOf": nested} | {"allOf": nested} | {"anyOf": nested}:
+                yield from iter_prop_containers(nested)
+            case list():
+                for item in schema:
+                    yield from iter_prop_containers(item)
+            case dict():
+                for nested in schema.values():
+                    yield from iter_prop_containers(nested)
+
+    def iter_parameter_schemas():
+        for path in result.get("paths", {}).values():
+            for operation in path.values():
+                if not (parameters := operation.get("parameters")):
+                    continue
+                for parameter in parameters:
+                    yield parameter["schema"]
+
+    schemas_iterator = itertools.chain(
+        iter_parameter_schemas(),
+        (
+            schema
+            for props in iter_prop_containers(schemas)
+            for schema in props.values()
+        ),
+    )
+
+    # find all string (with format uri) properties that have an invalid default
+    for prop_schema in schemas_iterator:
+        if prop_schema.get("type") == "array":
+            prop_schema = prop_schema.get("items", {})
+
+        # only consider string types
+        match prop_schema:
+            case {"type": "string"}:
+                pass
+            case {"type": list() as types} if "string" in types:
+                pass
+            case _:
+                continue
+
+        match prop_schema:
+            case {"format": "uri", "default": ""}:
+                del prop_schema["default"]
+            case _:
+                continue
 
     return result

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1007,6 +1007,7 @@ SPECTACULAR_SETTINGS = {
         "drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields",
         "openforms.api.drf_spectacular.hooks.add_middleware_headers",
         "openforms.api.drf_spectacular.hooks.add_unsafe_methods_parameter",
+        "openforms.api.drf_spectacular.hooks.remove_invalid_url_defaults",
     ],
     "TOS": None,
     # Optional: MAY contain "name", "url", "email"


### PR DESCRIPTION
The generation and linting of the OpenAPI spec can be replaced with a single re-usable workflow, while keeping the dependencies of the CI workflow to not push docker images until it's confirmed the API spec is valid.

[skip: e2e]