### PR TITLE
Ignore about:* urls when capturing requests in e2e tests

### DIFF
--- a/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
+++ b/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
@@ -94,6 +94,10 @@ class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
 
         def collect_requests(request):
             url = furl(request.url)
+            # ignore about:* URLs
+            if url.scheme == "about":
+                return
+
             try:
                 match = resolve(str(url.path))
             except Resolver404:
@@ -226,6 +230,10 @@ class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
 
         def collect_requests(request):
             url = furl(request.url)
+            # ignore about:* URLs
+            if url.scheme == "about":
+                return
+
             try:
                 match = resolve(str(url.path))
             except Resolver404:


### PR DESCRIPTION
These URLs apparently get triggered because of the WYSWIWYG editors that use a srcdoc attribute in an iframe. These must have a URL, and internally, browsers assign this the URL 'about:srcdoc' per spec.

These URLs also appear in the network calls of the browser and thus are picked up by Playwright. We are then in turn trying to resolve that URL to one of our own views, which fails of course.

These tests should no longer log that they're flaky, but let's observe for a while.