### PR TITLE
Update release flow documentation

### DIFF
--- a/docs/developers/releases.rst
+++ b/docs/developers/releases.rst
@@ -41,6 +41,11 @@ script that automates this as much as possible:
 This extracts the backend translations in the appropriate ``.po`` files and the
 JavaScript translations into the ``src/openforms/js/lang/[locale].json`` files.
 
+For the backend translations, you can use `Django Rosetta <https://django-rosetta.readthedocs.io/>`_,
+which is located at ``http://localhost:8000/admin/rosetta``. You can filter on untranslated labels
+and add a translation. Make sure to also filter on 'fuzzy' and check if the generated translations
+make sense. Adjust them if needed and deselect the fuzzy checkbox when they are checked.
+
 You can use the script ``python ./bin/find_untranslated_js.py`` to scan for (likely)
 missing JS translations.
 


### PR DESCRIPTION
Closes nothing

[skip: e2e]

**Changes**

Added information about Django Rosetta for backend translations to the release flow documentation.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
