### PR TITLE
Fix results sent to the frontend in the family members prefill plugin

### DIFF
--- a/src/openforms/contrib/haal_centraal/clients/brp.py
+++ b/src/openforms/contrib/haal_centraal/clients/brp.py
@@ -174,7 +174,11 @@ class V2Client(BRPClient):
     def find_persons(
         self, bsns: Sequence[str], reraise_errors: bool = False, **kwargs
     ) -> Mapping[str, JSONObject] | None:
-        attributes: Sequence[str] = kwargs.pop("attributes")
+        attributes: Sequence[str] = [
+            "burgerservicenummer",
+            *kwargs.pop("attributes", []),
+        ]
+
         body = {
             "type": "RaadpleegMetBurgerservicenummer",
             "burgerservicenummer": bsns,

--- a/src/openforms/contrib/haal_centraal/data.py
+++ b/src/openforms/contrib/haal_centraal/data.py
@@ -1,12 +1,21 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
+from openforms.api.utils import underscore_to_camel
 from openforms.utils.date import get_today
 
 
 class NaturalPersonDetails(BaseModel):
+    # This is needed in order to have the camel case names on the frontend and snake case
+    # on the backend
+    model_config = ConfigDict(
+        alias_generator=underscore_to_camel,
+        populate_by_name=True,  # Allow using snake_case names when creating model
+        from_attributes=True,
+    )
+
     bsn: str = ""
     first_names: str = ""
     initials: str = ""

--- a/src/openforms/prefill/contrib/family_members/plugin.py
+++ b/src/openforms/prefill/contrib/family_members/plugin.py
@@ -79,9 +79,10 @@ class FamilyMembersPrefill(BasePlugin[FamilyMemberOptions]):
         bsn = submission.auth_info.value
 
         handler = get_handler()
-        results: JSONObject = {
-            str(options["type"]): [item.model_dump() for item in handler(bsn, options)]
-        }
+        results: Sequence[JSONObject] = [
+            item.model_dump(by_alias=True) for item in handler(bsn, options)
+        ]
+
         # we need to update both variables (the one that contains the initial data and the
         # prefill configuration and the mutable one) with the data that we have retrieved
         return {

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -93,19 +93,17 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         prefill_variables(submission=submission)
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "partners": [
-                {
-                    "bsn": "999970136",
-                    "first_names": "Pia",
-                    "initials": "P.",
-                    "affixes": "",
-                    "lastname": "Pauw",
-                    "date_of_birth": "1989-04-01",
-                    "date_of_birth_precision": "date",
-                }
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "999970136",
+                "firstNames": "Pia",
+                "initials": "P.",
+                "affixes": "",
+                "lastname": "Pauw",
+                "dateOfBirth": "1989-04-01",
+                "dateOfBirthPrecision": "date",
+            }
+        ]
 
         self.assertEqual(
             state.variables["hc_prefill_partners_immutable"].value, expected_data
@@ -142,46 +140,44 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         prefill_variables(submission=submission)
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "999970409",
-                    "first_names": "Pero",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2023-02-01",
-                    "date_of_birth_precision": "date",
-                },
-                {
-                    "bsn": "999970161",
-                    "first_names": "Peet",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2018-12-01",
-                    "date_of_birth_precision": "date",
-                },
-                {
-                    "bsn": "999970173",
-                    "first_names": "Pelle",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2017-09-01",
-                    "date_of_birth_precision": "date",
-                },
-                {
-                    "bsn": "999970185",
-                    "first_names": "Pep",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2016-05-01",
-                    "date_of_birth_precision": "date",
-                },
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "999970409",
+                "firstNames": "Pero",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2023-02-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970161",
+                "firstNames": "Peet",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2018-12-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970173",
+                "firstNames": "Pelle",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2017-09-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970185",
+                "firstNames": "Pep",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2016-05-01",
+                "dateOfBirthPrecision": "date",
+            },
+        ]
 
         self.assertEqual(
             state.variables["hc_prefill_children_mutable"].value, expected_data
@@ -220,19 +216,17 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
 
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "999970185",
-                    "first_names": "Pep",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2016-05-01",
-                    "date_of_birth_precision": "date",
-                }
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "999970185",
+                "firstNames": "Pep",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2016-05-01",
+                "dateOfBirthPrecision": "date",
+            }
+        ]
 
         self.assertEqual(
             state.variables["hc_prefill_children_mutable"].value, expected_data
@@ -272,37 +266,35 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
 
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "999970409",
-                    "first_names": "Pero",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2023-02-01",
-                    "date_of_birth_precision": "date",
-                },
-                {
-                    "bsn": "999970161",
-                    "first_names": "Peet",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2018-12-01",
-                    "date_of_birth_precision": "date",
-                },
-                {
-                    "bsn": "999970185",
-                    "first_names": "Pep",
-                    "initials": "P.",
-                    "affixes": "van",
-                    "lastname": "Paassen",
-                    "date_of_birth": "2016-05-01",
-                    "date_of_birth_precision": "date",
-                },
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "999970409",
+                "firstNames": "Pero",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2023-02-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970161",
+                "firstNames": "Peet",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2018-12-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970185",
+                "firstNames": "Pep",
+                "initials": "P.",
+                "affixes": "van",
+                "lastname": "Paassen",
+                "dateOfBirth": "2016-05-01",
+                "dateOfBirthPrecision": "date",
+            },
+        ]
 
         self.assertEqual(
             state.variables["hc_prefill_children_mutable"].value, expected_data
@@ -375,19 +367,17 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
 
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "partners": [
-                {
-                    "bsn": "123123123",
-                    "first_names": "Belly",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1985-06-15",
-                    "deceased": None,
-                }
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "123123123",
+                "firstNames": "Belly",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1985-06-15",
+                "deceased": None,
+            }
+        ]
 
         self.assertEqual(
             state.variables["stuf_bg_partners_mutable"].value, expected_data
@@ -433,46 +423,44 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             prefill_variables(submission=submission)
 
         state = submission.load_submission_value_variables_state()
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "456789123",
-                    "first_names": "Bolly",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1999-06-15",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "789123456",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1998-07-16",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "123456789",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "789123543",
-                    "first_names": "Other",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doens",
-                    "date_of_birth": "1998-07-16",
-                    "deceased": True,
-                },
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "456789123",
+                "firstNames": "Bolly",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1999-06-15",
+                "deceased": False,
+            },
+            {
+                "bsn": "789123456",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1998-07-16",
+                "deceased": False,
+            },
+            {
+                "bsn": "123456789",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "",
+                "deceased": False,
+            },
+            {
+                "bsn": "789123543",
+                "firstNames": "Other",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doens",
+                "dateOfBirth": "1998-07-16",
+                "deceased": True,
+            },
+        ]
 
         self.assertEqual(
             state.variables["stuf_bg_prefill_children_mutable"].value, expected_data
@@ -520,39 +508,37 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
 
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "456789123",
-                    "first_names": "Bolly",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1999-06-15",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "789123456",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1998-07-16",
-                    "deceased": False,
-                },
-                # included because no age filter boundaries are provided, so even the
-                # children without known DOB are returned
-                {
-                    "bsn": "123456789",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "",
-                    "deceased": False,
-                },
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "456789123",
+                "firstNames": "Bolly",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1999-06-15",
+                "deceased": False,
+            },
+            {
+                "bsn": "789123456",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1998-07-16",
+                "deceased": False,
+            },
+            # included because no age filter boundaries are provided, so even the
+            # children without known DOB are returned
+            {
+                "bsn": "123456789",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "",
+                "deceased": False,
+            },
+        ]
 
         self.assertEqual(
             state.variables["stuf_bg_prefill_children_mutable"].value, expected_data
@@ -561,7 +547,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             state.variables["stuf_bg_prefill_children_immutable"].value, expected_data
         )
 
-    def test_children_with_incomplete_date_of_birth_are_shown_when_no_filter(self):
+    def test_children_with_incomplete_dateOfBirth_are_shown_when_no_filter(self):
         """
         Children with incomplete data for date of birth.
         All the children should be sent to the frontend when there is no filtering on age
@@ -606,46 +592,44 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
 
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "456789123",
-                    "first_names": "Bolly",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1999-06-15",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "789123456",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1985",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "123456788",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1985-03",
-                    "deceased": False,
-                },
-                {
-                    "bsn": "167556788",
-                    "first_names": "Billy",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "",
-                    "deceased": False,
-                },
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "456789123",
+                "firstNames": "Bolly",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1999-06-15",
+                "deceased": False,
+            },
+            {
+                "bsn": "789123456",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1985",
+                "deceased": False,
+            },
+            {
+                "bsn": "123456788",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1985-03",
+                "deceased": False,
+            },
+            {
+                "bsn": "167556788",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "",
+                "deceased": False,
+            },
+        ]
 
         self.assertEqual(
             state.variables["stuf_bg_prefill_children_mutable"].value, expected_data
@@ -654,7 +638,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             state.variables["stuf_bg_prefill_children_immutable"].value, expected_data
         )
 
-    def test_children_with_incomplete_date_of_birth_are_not_shown_when_filter(self):
+    def test_children_with_incomplete_dateOfBirth_are_not_shown_when_filter(self):
         """
         Children with incomplete data for date of birth.
         Only the children that have a complete (ISO 8601) date should be filtered and sent
@@ -700,19 +684,17 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
 
         state = submission.load_submission_value_variables_state()
 
-        expected_data = {
-            "children": [
-                {
-                    "bsn": "456789123",
-                    "first_names": "Bolly",
-                    "initials": "K",
-                    "affixes": "van",
-                    "lastname": "Doe",
-                    "date_of_birth": "1999-06-15",
-                    "deceased": False,
-                },
-            ]
-        }
+        expected_data = [
+            {
+                "bsn": "456789123",
+                "firstNames": "Bolly",
+                "initials": "K",
+                "affixes": "van",
+                "lastname": "Doe",
+                "dateOfBirth": "1999-06-15",
+                "deceased": False,
+            },
+        ]
 
         self.assertEqual(
             state.variables["stuf_bg_prefill_children_mutable"].value, expected_data

--- a/src/stuf/stuf_bg/data.py
+++ b/src/stuf/stuf_bg/data.py
@@ -1,11 +1,21 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+
+from openforms.api.utils import underscore_to_camel
 
 from .utils import get_today
 
 
 class NaturalPersonDetails(BaseModel):
+    # This is needed in order to have the came case on the frontend and the snake case
+    # on the backend
+    model_config = ConfigDict(
+        alias_generator=underscore_to_camel,
+        populate_by_name=True,  # Allow using snake_case names when creating model
+        from_attributes=True,
+    )
+
     bsn: str = ""
     first_names: str = ""
     initials: str = ""


### PR DESCRIPTION
Part of #5254

**Changes**

- Added missing field
- Make snake case to camel case for the frontend

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
