### PR TITLE
Don't sort user defined variables

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -1413,23 +1413,6 @@ export const ConfigurePrefillFamilyMembersPartners = {
           mutableDataFormVariable: 'userDefinedMutable',
         },
       },
-      {
-        form: 'http://localhost:8000/api/v2/forms/36612390',
-        formDefinition: undefined,
-        name: 'User defined 3',
-        key: 'userDefined3',
-        source: 'user_defined',
-        prefillPlugin: 'family_members',
-        dataType: 'string',
-        dataFormat: undefined,
-        isSensitiveData: false,
-        serviceFetchConfiguration: undefined,
-        initialValue: [],
-        prefillOptions: {
-          type: 'partners',
-          mutableDataFormVariable: 'userDefinedMutable',
-        },
-      },
     ],
   },
   play: async ({canvasElement, step}) => {
@@ -1441,7 +1424,7 @@ export const ConfigurePrefillFamilyMembersPartners = {
       await userEvent.click(userDefinedVarsTab);
       // open modal for configuration
       const editIcons = canvas.getAllByTitle('Prefill instellen');
-      await userEvent.click(editIcons[0]);
+      await userEvent.click(editIcons[1]);
       expect(await canvas.findByRole('dialog')).toBeVisible();
     });
 
@@ -1497,23 +1480,6 @@ export const ConfigurePrefillFamilyMembersChildren = {
           mutableDataFormVariable: 'userDefinedMutable',
         },
       },
-      {
-        form: 'http://localhost:8000/api/v2/forms/36612390',
-        formDefinition: undefined,
-        name: 'User defined 3',
-        key: 'userDefined3',
-        source: 'user_defined',
-        prefillPlugin: 'family_members',
-        dataType: 'string',
-        dataFormat: undefined,
-        isSensitiveData: false,
-        serviceFetchConfiguration: undefined,
-        initialValue: [],
-        prefillOptions: {
-          type: 'children',
-          mutableDataFormVariable: 'userDefinedMutable',
-        },
-      },
     ],
   },
   play: async ({canvasElement, step}) => {
@@ -1525,7 +1491,7 @@ export const ConfigurePrefillFamilyMembersChildren = {
       await userEvent.click(userDefinedVarsTab);
       // open modal for configuration
       const editIcons = canvas.getAllByTitle('Prefill instellen');
-      await userEvent.click(editIcons[0]);
+      await userEvent.click(editIcons[1]);
       expect(await canvas.findByRole('dialog')).toBeVisible();
     });
 

--- a/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesTable.js
@@ -259,7 +259,9 @@ const VariablesTable = ({variables, editable, onDelete, onChange, onFieldChange}
   );
 
   // first, sort the variables alphabetically
-  const sortedVariables = variables.toSorted((var1, var2) => var1.name.localeCompare(var2.name));
+  const sortedVariables = !editable
+    ? variables.toSorted((var1, var2) => var1.name.localeCompare(var2.name))
+    : variables;
   // then, group the variables by their step so that we display them grouped in the table,
   // which cuts down on the number of columns to display
   const variablesGroupedByFormStep = groupBy(


### PR DESCRIPTION
Closes #5303

**Changes**

Disable variable sorting for user defined variables, as it makes the editing experience horrible with the rows jumping around and input boxes losing focus.

I did explore disabling sorting only temporarily when the name field has/loses focus, but this has an additional annoying side effect that editing existing records suddenly jump out of order again.

I think we need a proper UI rework and code refactor before we can reliably enable sorting on user defined variables again.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]