### PR TITLE
:art: Simplify props/state for variables editor

### DIFF
--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1419,7 +1419,6 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
           {!isAppointment && (
             <TabPanel>
               <VariablesEditor
-                variables={state.formVariables}
                 onAdd={() => dispatch({type: 'ADD_USER_DEFINED_VARIABLE'})}
                 onDelete={key => dispatch({type: 'DELETE_USER_DEFINED_VARIABLE', payload: key})}
                 onChange={onUserDefinedVariableChange}

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.js
@@ -13,13 +13,13 @@ import VariablesTable from './VariablesTable';
 import {VARIABLE_SOURCES, VARIABLE_SOURCES_GROUP_LABELS} from './constants';
 import {variableHasErrors} from './utils';
 
-const VariablesEditor = ({variables, onAdd, onDelete, onChange, onFieldChange}) => {
+const VariablesEditor = ({onAdd, onDelete, onChange, onFieldChange}) => {
   const intl = useIntl();
-  const {staticVariables} = useContext(FormContext);
-  const userDefinedVariables = variables.filter(
+  const {staticVariables, formVariables} = useContext(FormContext);
+  const userDefinedVariables = formVariables.filter(
     variable => variable.source === VARIABLE_SOURCES.userDefined
   );
-  const componentVariables = variables.filter(
+  const componentVariables = formVariables.filter(
     variable => variable.source === VARIABLE_SOURCES.component
   );
 

--- a/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
+++ b/src/openforms/js/components/admin/form_design/variables/VariablesEditor.stories.js
@@ -122,7 +122,6 @@ export default {
   component: VariablesEditor,
   decorators: [FormDecorator],
   args: {
-    variables: VARIABLES,
     availableFormVariables: VARIABLES,
     availableStaticVariables: [
       {
@@ -409,7 +408,7 @@ export const WithObjectsAPIRegistrationBackends = {
 
 export const WithObjectsAPIRegistrationBackendsTransformToList = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
@@ -557,7 +556,7 @@ export const WithObjectsAPIRegistrationBackendsTransformToList = {
 
 export const WithObjectsAPIRegistrationBackendsGeometryField = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: 'unsaved-step',
@@ -662,7 +661,7 @@ export const EmptyUserDefinedVariableWithObjectsAPIRegistration = {
         },
       },
     ],
-    variables: [
+    availableFormVariables: [
       // add a variable as if the user clicked "add new user defined variable"
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
@@ -1046,7 +1045,7 @@ export const WithGenericJSONRegistrationBackend = {
 
 export const WithGenericJSONRegistrationBackendTransformToList = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
@@ -1384,7 +1383,7 @@ export const ConfigurePrefillObjectsAPIWithCopyButton = {
 
 export const ConfigurePrefillFamilyMembersPartners = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: undefined,
@@ -1413,20 +1412,6 @@ export const ConfigurePrefillFamilyMembersPartners = {
           type: 'partners',
           mutableDataFormVariable: 'userDefinedMutable',
         },
-      },
-    ],
-    availableFormVariables: [
-      {
-        form: 'http://localhost:8000/api/v2/forms/36612390',
-        formDefinition: undefined,
-        name: 'User defined mutable',
-        key: 'userDefinedMutable',
-        source: 'user_defined',
-        dataType: 'array',
-        dataFormat: undefined,
-        isSensitiveData: false,
-        serviceFetchConfiguration: undefined,
-        initialValue: [],
       },
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
@@ -1482,7 +1467,7 @@ export const ConfigurePrefillFamilyMembersPartners = {
 
 export const ConfigurePrefillFamilyMembersChildren = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: undefined,
@@ -1511,20 +1496,6 @@ export const ConfigurePrefillFamilyMembersChildren = {
           type: 'children',
           mutableDataFormVariable: 'userDefinedMutable',
         },
-      },
-    ],
-    availableFormVariables: [
-      {
-        form: 'http://localhost:8000/api/v2/forms/36612390',
-        formDefinition: undefined,
-        name: 'User defined mutable',
-        key: 'userDefinedMutable',
-        source: 'user_defined',
-        dataType: 'array',
-        dataFormat: undefined,
-        isSensitiveData: false,
-        serviceFetchConfiguration: undefined,
-        initialValue: [],
       },
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
@@ -1586,7 +1557,7 @@ export const ConfigurePrefillFamilyMembersChildren = {
 
 export const WithValidationErrors = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
@@ -1641,7 +1612,7 @@ export const WithValidationErrors = {
 
 export const ConfigurePrefillObjectsAPIWithValidationErrors = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: undefined,
@@ -1707,7 +1678,7 @@ export const ConfigurePrefillObjectsAPIWithValidationErrors = {
 
 export const AddressNLMappingSpecificTargetsNoDeriveAddress = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',
@@ -1835,7 +1806,7 @@ export const AddressNLMappingSpecificTargetsNoDeriveAddress = {
 
 export const AddressNLMappingSpecificTargetsDeriveAddress = {
   args: {
-    variables: [
+    availableFormVariables: [
       {
         form: 'http://localhost:8000/api/v2/forms/36612390',
         formDefinition: 'http://localhost:8000/api/v2/form-definitions/6de1ea5a',


### PR DESCRIPTION
The prop variables for the editor is not necessary once we're consuming the context anyway, and this component is only rendered within the FormContext. Relying on the context only simplifies the stories in SB because we don't have to keep multiple sources of truth in sync.

[skip: e2e]