### PR TITLE
:art: Remove unnecessary props

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/prefill/family_members/ChildrenFiltersFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/family_members/ChildrenFiltersFields.js
@@ -1,5 +1,4 @@
 import {useFormikContext} from 'formik';
-import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
 import Field from 'components/admin/forms/Field';
@@ -7,8 +6,8 @@ import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
 import {Checkbox, NumberInput} from 'components/admin/forms/Inputs';
 
-const ChildrenFiltersFields = ({minAge, maxAge, includeDeceased}) => {
-  const {setFieldValue} = useFormikContext();
+const ChildrenFiltersFields = () => {
+  const {getFieldProps} = useFormikContext();
 
   return (
     <Fieldset
@@ -37,12 +36,9 @@ const ChildrenFiltersFields = ({minAge, maxAge, includeDeceased}) => {
           }
         >
           <NumberInput
-            value={minAge ?? ''}
+            {...getFieldProps({name: 'options.minAge', type: 'number'})}
             min={0}
             step={1}
-            onChange={e => {
-              setFieldValue('options.minAge', e.target.value);
-            }}
           />
         </Field>
       </FormRow>
@@ -64,17 +60,15 @@ const ChildrenFiltersFields = ({minAge, maxAge, includeDeceased}) => {
           }
         >
           <NumberInput
-            value={maxAge ?? ''}
+            {...getFieldProps({name: 'options.maxAge', type: 'number'})}
             min={0}
             step={1}
-            onChange={e => {
-              setFieldValue('options.maxAge', e.target.value);
-            }}
           />
         </Field>
       </FormRow>
       <FormRow>
         <Checkbox
+          {...getFieldProps({name: 'options.includeDeceased', type: 'checkbox'})}
           name="options.includeDeceased"
           label={
             <FormattedMessage
@@ -88,20 +82,10 @@ const ChildrenFiltersFields = ({minAge, maxAge, includeDeceased}) => {
               defaultMessage={`If enabled, any deceased children will be displayed too.`}
             />
           }
-          checked={includeDeceased ?? true}
-          onChange={event => {
-            setFieldValue('options.includeDeceased', event.target.checked);
-          }}
         />
       </FormRow>
     </Fieldset>
   );
-};
-
-ChildrenFiltersFields.propTypes = {
-  minAge: PropTypes.string,
-  maxAge: PropTypes.string,
-  includeDeceased: PropTypes.bool,
 };
 
 export default ChildrenFiltersFields;

--- a/src/openforms/js/components/admin/form_design/variables/prefill/family_members/FamilyMembersFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/family_members/FamilyMembersFields.js
@@ -12,7 +12,7 @@ const FamilyMembersFields = () => {
   const {values, setFieldValue} = useFormikContext();
 
   const {
-    options: {mutableDataFormVariable, type, minAge, maxAge, includeDeceased},
+    options: {type},
   } = values;
 
   const errors = Object.fromEntries(useContext(ValidationErrorContext));
@@ -39,10 +39,8 @@ const FamilyMembersFields = () => {
 
   return (
     <ValidationErrorsProvider errors={optionsErrors}>
-      <PersonFields type={type} mutableDataFormVariable={mutableDataFormVariable} />
-      {showFilters && (
-        <ChildrenFiltersFields minAge={minAge} maxAge={maxAge} includeDeceased={includeDeceased} />
-      )}
+      <PersonFields />
+      {showFilters && <ChildrenFiltersFields />}
     </ValidationErrorsProvider>
   );
 };

--- a/src/openforms/js/components/admin/form_design/variables/prefill/family_members/PersonsFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/family_members/PersonsFields.js
@@ -1,5 +1,4 @@
 import {useFormikContext} from 'formik';
-import PropTypes from 'prop-types';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import Field from 'components/admin/forms/Field';
@@ -10,7 +9,7 @@ import VariableSelection from 'components/admin/forms/VariableSelection';
 
 import {PERSON_TYPE_CHOICES} from './constants';
 
-const PersonFields = ({type, mutableDataFormVariable}) => {
+const PersonFields = () => {
   const intl = useIntl();
   const {getFieldProps, setValues} = useFormikContext();
 
@@ -23,7 +22,7 @@ const PersonFields = ({type, mutableDataFormVariable}) => {
     <Fieldset>
       <FormRow>
         <Field
-          name="type"
+          name="options.type"
           label={
             <FormattedMessage
               description="Family members options: 'Type' label"
@@ -39,10 +38,9 @@ const PersonFields = ({type, mutableDataFormVariable}) => {
           required
         >
           <ReactSelect
-            name="type"
+            name="options.type"
             required
             options={availableOptions}
-            value={availableOptions.find(opt => opt.value === type)}
             onChange={selectedOption => {
               const newValue = selectedOption ? selectedOption.value : null;
               // make sure the options have the right values when the type changes
@@ -72,8 +70,7 @@ const PersonFields = ({type, mutableDataFormVariable}) => {
           required
         >
           <VariableSelection
-            {...getFieldProps(mutableDataFormVariable)}
-            value={mutableDataFormVariable}
+            {...getFieldProps('options.mutableDataFormVariable')}
             aria-label={
               <FormattedMessage
                 description="Family members options: accessible label for (form) variable dropdown"
@@ -86,11 +83,6 @@ const PersonFields = ({type, mutableDataFormVariable}) => {
       </FormRow>
     </Fieldset>
   );
-};
-
-PersonFields.propTypes = {
-  type: PropTypes.string,
-  mutableDataFormVariable: PropTypes.string,
 };
 
 export default PersonFields;

--- a/src/openforms/js/components/admin/forms/Inputs.js
+++ b/src/openforms/js/components/admin/forms/Inputs.js
@@ -29,7 +29,11 @@ const TextArea = ({name, rows = 5, cols = 10, ...extraProps}) => {
   return <textarea name={name} rows={rows} cols={cols} {...extraProps} />;
 };
 
-const NumberInput = props => <Input type="number" {...props} />;
+const NumberInput = ({value, ...props}) => {
+  // don't pass null or undefined values!
+  const normalizedValue = value == null ? '' : value;
+  return <Input type="number" value={normalizedValue} {...props} />;
+};
 
 const DateInput = props => <Input type="date" {...props} />;
 


### PR DESCRIPTION
Formik takes care of the form state management/values - all you ideally need to do is pass the name of the form field and initialize the form values and then it handles all the change events.

Ideally you don't need to think about value or onChange anymore, and then it simplifies the prop-drilling you otherwise typically see.

[skip: e2e]