### PR TITLE
Add new delete_old_emails task that does not fetch the message data.

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -813,7 +813,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour=0, minute=0, day_of_week="*"),
     },
     "delete-old-emails": {
-        "task": "django_yubin.tasks.delete_old_emails",
+        "task": "openforms.emails.tasks.delete_old_emails",
         "schedule": crontab(hour=0, minute=0, day_of_week="*"),
     },
     "update-saml-digid-eherkenning": {

--- a/src/openforms/emails/tasks.py
+++ b/src/openforms/emails/tasks.py
@@ -76,3 +76,24 @@ def send_email_digest() -> None:
         settings.DEFAULT_FROM_EMAIL,
         recipients,
     )
+
+
+@app.task()
+def delete_old_emails(days=90):
+    """
+    Delete emails created before `days` days (default 90).
+
+    Override for django_yubin.tasks.delete_old_emails which caused memory issues while
+    using the DatabaseStorageBackend because the email data and attachments would be loaded.
+    """
+
+    from django_yubin.models import Message
+
+    cutoff_date = timezone.now() - timedelta(days)
+    deleted = (
+        Message.objects.defer("_message_data")
+        .filter(date_created__lt=cutoff_date)
+        .delete()
+    )
+
+    return deleted, cutoff_date

--- a/src/openforms/emails/tests/test_tasks_integration.py
+++ b/src/openforms/emails/tests/test_tasks_integration.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.files import File
+from django.core.mail import send_mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -35,7 +36,7 @@ from openforms.submissions.models.submission import Submission
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.utils.tests.vcr import OFVCRMixin
 
-from ..tasks import send_email_digest
+from ..tasks import delete_old_emails, send_email_digest
 
 TEST_FILES = Path(__file__).parent / "data"
 
@@ -301,6 +302,43 @@ class EmailDigestTaskIntegrationTests(TestCase):
                 f"Logic rule for variable 'foo' is invalid in form '{form.admin_name}'.",
                 sent_email.body,
             )
+
+
+@override_settings(EMAIL_BACKEND="django_yubin.backends.QueuedEmailBackend")
+class DeleteOldEmailsTaskIntegrationTests(TestCase):
+    def test_old_message_is_deleted(self):
+        with freeze_time("2021-01-01"):
+            send_mail(
+                subject="Test Subject",
+                message="This is a test message.",
+                from_email="test@example.com",
+                recipient_list=["recipient@example.com"],
+            )
+
+        self.assertEqual(Message.objects.count(), 1)
+
+        with freeze_time("2021-05-01"):
+            deleted, _ = delete_old_emails()
+        self.assertEqual(
+            deleted, (2, {"django_yubin.Log": 1, "django_yubin.Message": 1})
+        )
+        self.assertEqual(Message.objects.count(), 0)
+
+    def test_message_later_than_cutoff_date_is_not_deleted(self):
+        with freeze_time("2021-01-01"):
+            send_mail(
+                subject="Test Subject",
+                message="This is a test message.",
+                from_email="test@example.com",
+                recipient_list=["recipient@example.com"],
+            )
+
+        self.assertEqual(Message.objects.count(), 1)
+
+        with freeze_time("2021-01-05"):
+            deleted, _ = delete_old_emails(10)
+        self.assertEqual(deleted, (0, {}))
+        self.assertEqual(Message.objects.count(), 1)
 
 
 @override_settings(LANGUAGE_CODE="en")


### PR DESCRIPTION

Closes #5326

**Changes**
- added new task copied from [yubin](https://github.com/APSL/django-yubin/blob/2dcb33d08a5c8a0001e1e5a6abd0b8d940afa0b6/django_yubin/models.py#L263) with `defer` to not fetch the `_message_data` from the db.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
