### PR TITLE
Fix tests in family members prefill plugin

### DIFF
--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_children_deceased.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_children_deceased.yaml
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 04 Jun 2025 14:09:24 GMT
+      - Tue, 17 Jun 2025 12:04:20 GMT
       Server:
       - Kestrel
     status:
@@ -87,7 +87,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 04 Jun 2025 14:09:24 GMT
+      - Tue, 17 Jun 2025 12:04:20 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_children_filtered_by_age.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_children_filtered_by_age.yaml
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 04 Jun 2025 14:09:24 GMT
+      - Tue, 17 Jun 2025 12:04:21 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_children_prefill_happy_flow.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_children_prefill_happy_flow.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NDkwNDYxNjUsImV4cCI6MTc0OTA4OTM2NSwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.q1IEWS8E0h-eecS0i0LwWAc2bBNnxzox4l2BGmvH-ks
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTAxNjE4NjIsImV4cCI6MTc1MDIwNTA2MiwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.pDpO2cUoW3Ep3x7g4yqU9Jf8lyE0DDZD6g1c8NDIX8g
       Connection:
       - keep-alive
       Content-Length:
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 04 Jun 2025 14:09:24 GMT
+      - Tue, 17 Jun 2025 12:04:21 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_partners_prefill_happy_flow.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/FamilyMembersPrefillPluginHCV2Tests.test_partners_prefill_happy_flow.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NDkwNDYxNjUsImV4cCI6MTc0OTA4OTM2NSwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.q1IEWS8E0h-eecS0i0LwWAc2bBNnxzox4l2BGmvH-ks
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTAxNjE4NjIsImV4cCI6MTc1MDIwNTA2MiwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.pDpO2cUoW3Ep3x7g4yqU9Jf8lyE0DDZD6g1c8NDIX8g
       Connection:
       - keep-alive
       Content-Length:
@@ -38,7 +38,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 04 Jun 2025 14:09:24 GMT
+      - Tue, 17 Jun 2025 12:04:21 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -18,7 +18,6 @@ from openforms.prefill.service import prefill_variables
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.template import render_from_string
 from openforms.utils.tests.vcr import OFVCRMixin
-from openforms.variables.constants import FormVariableDataTypes
 from stuf.constants import EndpointType
 from stuf.stuf_bg.models import StufBGConfig
 from stuf.tests.factories import StufServiceFactory
@@ -72,13 +71,13 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="999970124",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="hc_prefill_partners_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "hc_prefill_partners_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="hc_prefill_partners_immutable",
@@ -109,23 +108,23 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         ]
 
         self.assertEqual(
-            state.variables["hc_prefill_partners_immutable"].value, expected_data
+            state.variables["hc_prefill_partners_mutable"].value, expected_data
         )
         self.assertEqual(
-            state.variables["hc_prefill_partners_mutable"].value, expected_data
+            state.variables["hc_prefill_partners_immutable"].value, expected_data
         )
 
     def test_children_prefill_happy_flow(self):
         submission = SubmissionFactory.from_components(
             auth_info__value="999970124",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="hc_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "hc_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="hc_prefill_children_immutable",
@@ -193,13 +192,13 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="999970124",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="hc_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "hc_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="hc_prefill_children_immutable",
@@ -242,13 +241,13 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="999970124",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="hc_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "hc_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="hc_prefill_children_immutable",
@@ -335,13 +334,13 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="111222333",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="stuf_bg_partners_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "stuf_bg_partners_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="stuf_bg_partners_immutable",
@@ -393,13 +392,13 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="111222333",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="stuf_bg_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "stuf_bg_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="stuf_bg_prefill_children_immutable",
@@ -476,13 +475,13 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="111222333",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="stuf_bg_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "stuf_bg_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="stuf_bg_prefill_children_immutable",
@@ -559,13 +558,13 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="111222333",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="stuf_bg_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "stuf_bg_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="stuf_bg_prefill_children_immutable",
@@ -650,13 +649,13 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
         submission = SubmissionFactory.from_components(
             auth_info__value="111222333",
             auth_info__attribute=AuthAttribute.bsn,
-            components_list=[],
-        )
-        FormVariableFactory.create(
-            key="stuf_bg_prefill_children_mutable",
-            form=submission.form,
-            user_defined=True,
-            data_type=FormVariableDataTypes.array,
+            components_list=[
+                {
+                    "key": "stuf_bg_prefill_children_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
         )
         FormVariableFactory.create(
             key="stuf_bg_prefill_children_immutable",


### PR DESCRIPTION
**Changes**

The tests were not reflecting what the family members plugin should do because they were testing the old functionality (user should add 2 user defined variables for enabling the family members plugin, but now the case is different. One user defined variable and the custom component partners are needed). See the docs for the plugin for all the instructions.

Of course, they were not failing because we can indeed prefill a user defined variable with a partner's data.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
