### PR TITLE
[#5268] Test generic JSON registration with custom partners component

### DIFF
--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/GenericJSONBackendTests.test_partners_components_schema.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/GenericJSONBackendTests.test_partners_components_schema.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: '{"values": {"partners": [{"bsn": "999970136", "affixes": "", "initials":
+      "P.", "lastName": "Pauw", "firstNames": "Pia", "dateOfBirth": "1989-04-01",
+      "dateOfBirthPrecision": "date"}]}, "values_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {"partners": {"title": "Partners", "type": "array",
+      "items": {"type": "object", "required": ["bsn"], "properties": {"bsn": {"type":
+      "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "initials": {"type": "string"},
+      "affixes": {"type": "string"}, "lastName": {"type": "string"}, "dateOfBirth":
+      {"type": "string", "format": "date"}}, "additionalProperties": false}}}, "required":
+      ["partners"], "additionalProperties": false}, "metadata": {}, "metadata_schema":
+      {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object",
+      "properties": {}, "required": [], "additionalProperties": false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTAzMjMxOTEsImV4cCI6MTc1MDM2NjM5MSwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.g5Rl_pS5IJcpmOiTz3iG2Rk9x9ricrcnjMwKPByRLfQ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '898'
+      User-Agent:
+      - python-requests/2.32.2
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"partners\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970136\",\n          \"dateOfBirth\":
+        \"1989-04-01\",\n          \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\":
+        \"Pia\",\n          \"initials\": \"P.\",\n          \"lastName\": \"Pauw\"\n
+        \       }\n      ]\n    },\n    \"values_schema\": {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"partners\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"affixes\": {\n                \"type\":
+        \"string\"\n              },\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"type\":
+        \"string\"\n              },\n              \"dateOfBirth\": {\n                \"format\":
+        \"date\",\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Partners\",\n          \"type\":
+        \"array\"\n        }\n      },\n      \"required\": [\n        \"partners\"\n
+        \     ],\n      \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1595'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 19 Jun 2025 08:53:11 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1


### PR DESCRIPTION
Closes #5268 partly

**Changes**

- Make sure custom partners component schema and values are correct in the Generic JSON registration

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
