### PR TITLE
:technologist: Force colored output in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           --concurrency=multiprocessing \
           --parallel-mode \
           src/manage.py test src \
+            --force-color \
             --parallel 4 \
             --exclude-tag=e2e \
             --verbosity 2
@@ -165,6 +166,7 @@ jobs:
           python src/manage.py compilemessages
           python src/manage.py collectstatic --noinput --link
           src/manage.py test src \
+            --force-color \
             --parallel 4 \
             --exclude-tag=e2e \
             --reverse
@@ -267,7 +269,7 @@ jobs:
         run: |
           python src/manage.py compilemessages
           python src/manage.py collectstatic --noinput --link
-          src/manage.py test src --tag=e2e
+          src/manage.py test src --force-color --tag=e2e
         env:
           DJANGO_SETTINGS_MODULE: openforms.conf.ci
           SECRET_KEY: dummy
@@ -342,6 +344,8 @@ jobs:
           make SPHINXOPTS="-W" html
           make linkcheck
         working-directory: open-forms/docs
+        env:
+          FORCE_COLOR: "1"
 
   # see https://github.com/orgs/community/discussions/26671
   docker_build_setup:


### PR DESCRIPTION
* For the docs, this highlights failed link checks
* For the django tests, this may improve parsing test failures

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
