### PR TITLE
:green_heart: Fix e2e test on Webkit

### DIFF
--- a/src/openforms/payments/tests/test_e2e.py
+++ b/src/openforms/payments/tests/test_e2e.py
@@ -9,6 +9,7 @@ from furl import furl
 from playwright.async_api import Route, expect
 from rest_framework.test import APIRequestFactory
 
+from openforms.forms.constants import StatementCheckboxChoices
 from openforms.forms.tests.factories import FormFactory
 from openforms.submissions.constants import ProcessingStatuses
 from openforms.submissions.models import Submission
@@ -30,6 +31,8 @@ class PaymentFlowTests(E2ETestCase):
             formstep__form_definition__slug="first-step",
             payment_backend="demo",
             product__price=Decimal("11.35"),
+            ask_privacy_consent=StatementCheckboxChoices.disabled,
+            ask_statement_of_truth=StatementCheckboxChoices.disabled,
         )
 
         return form
@@ -83,7 +86,6 @@ class PaymentFlowTests(E2ETestCase):
 
                 await page.get_by_role("button", name="Formulier starten").click()
                 await page.get_by_role("button", name="Volgende").click()
-                await page.get_by_role("checkbox").click()  # Privacy checkbox
                 await page.get_by_role("button", name="Verzenden").click()
                 await page.get_by_role("button", name="Betalen").click()
 


### PR DESCRIPTION
In CI, there appears to be some label-overlap check with the checkbox sudo for the webkit browsers, which supposedly captures the click.

Verified against the webkit browser 'Browser' on Arch that clicks do properly propagate. There may be some minor overlap because the label sits flush against the border of the checkbox, while the checkbox has a padding of 2px to the right that may trigger this overlap detection.

Either way, the label is associated with the input, so that clicking the label actually toggles the checkbox anyway.