### PR TITLE
Supporting multi select for the ReactSelect component

### DIFF
--- a/src/openforms/js/components/admin/forms/ReactSelect.js
+++ b/src/openforms/js/components/admin/forms/ReactSelect.js
@@ -68,6 +68,9 @@ const getValue = (options, value) => {
   return null;
 };
 
+const getValues = (options, values) =>
+  values && Array.isArray(values) ? values.map(value => getValue(options, value)) : [];
+
 export const ReactSelectContext = createContext({parentSelector: () => document.body});
 ReactSelectContext.displayName = 'ReactSelectContext';
 
@@ -126,13 +129,12 @@ const SelectWithFormik = ({name, options, className, ...props}) => {
       menuPortalTarget={parentSelector()}
       options={options}
       {...fieldProps}
-      value={getValue(options, value)}
+      value={props.isMulti ? getValues(options, value) : getValue(options, value)}
       onChange={selectedOption => {
-        // clear the value
-        if (selectedOption == null) {
-          setValue(undefined);
+        if (props.isMulti) {
+          setValue(selectedOption.map(option => option.value));
         } else {
-          setValue(selectedOption.value);
+          setValue(selectedOption == null ? undefined : selectedOption.value);
         }
       }}
       {...props}


### PR DESCRIPTION
Partly closes #5140 

**Changes**

Allowing the ReactSelect component (with the build-in Formik support) to be used as multi select.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
