### PR TITLE
Support multi-value `provides_auth`

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -42,6 +42,7 @@ include = [
     "src/openforms/logging/models.py",
     # Prefill
     "src/openforms/prefill/contrib/family_members",
+    "src/openforms/prefill/validators.py",
     # Registrations
     "src/openforms/registrations/tasks.py",
     "src/openforms/registrations/contrib/demo/",

--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -40,8 +40,13 @@ include = [
     # Logging
     "src/openforms/logging/logevent.py",
     "src/openforms/logging/models.py",
+    # Authentication
+    "src/openforms/authentication/contrib/digid/",
+    "src/openforms/authentication/contrib/family_members",
     # Prefill
-    "src/openforms/prefill/contrib/family_members",
+    "src/openforms/prefill/contrib/outage/",
+    "src/openforms/prefill/models.py",
+    "src/openforms/prefill/signals.py",
     "src/openforms/prefill/validators.py",
     # Registrations
     "src/openforms/registrations/tasks.py",
@@ -67,6 +72,8 @@ include = [
 ]
 exclude = [
     "**/__pycache__",
+    "src/openforms/authentication/contrib/digid/tests/test_auth_procedure.py",
+    "src/openforms/authentication/contrib/digid/tests/test_signicat_integration.py",
     "src/openforms/contrib/objects_api/tests/",
     "src/openforms/contrib/objects_api/json_schema.py",
     "src/openforms/formio/formatters/tests/",

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7010,9 +7010,12 @@ components:
           type: string
           description: The human-readable name for a plugin.
         providesAuth:
-          type: string
-          title: Provides authentication attributes
-          description: The authentication attribute provided by this plugin.
+          type: array
+          items:
+            type: string
+            title: Provides authentication attributes
+            description: The authentication attribute provided by this plugin.
+          minItems: 1
         schema:
           type: object
           additionalProperties: {}

--- a/src/openforms/authentication/api/serializers.py
+++ b/src/openforms/authentication/api/serializers.py
@@ -15,9 +15,12 @@ class TextChoiceSerializer(serializers.Serializer):
 
 class AuthPluginSerializer(PluginBaseSerializer):
     # serializer for form builder
-    provides_auth = serializers.CharField(
-        label=_("Provides authentication attributes"),
-        help_text=_("The authentication attribute provided by this plugin."),
+    provides_auth = serializers.ListField(
+        child=serializers.CharField(
+            label=_("Provides authentication attributes"),
+            help_text=_("The authentication attribute provided by this plugin."),
+        ),
+        min_length=1,
     )
     schema = serializers.DictField(
         source="configuration_options.display_as_jsonschema",

--- a/src/openforms/authentication/api/tests/test_endpoints.py
+++ b/src/openforms/authentication/api/tests/test_endpoints.py
@@ -31,18 +31,18 @@ class SingleLoAOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializ
 
 
 class SingleAuthPlugin(BasePlugin):
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     verbose_name = "SingleAuthPlugin"
 
 
 class AdditionalConfigAuthPlugin(BasePlugin):
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     verbose_name = "AdditionalConfigAuthPlugin"
     configuration_options = SingleLoAOptionsSerializer
 
 
 class DemoAuthPlugin(BasePlugin):
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     verbose_name = "DemoAuthPlugin"
     is_demo_plugin = True
 
@@ -111,13 +111,13 @@ class ResponseTests(APITestCase):
             {
                 "id": "plugin1",
                 "label": "SingleAuthPlugin",
-                "providesAuth": "bsn",
+                "providesAuth": ["bsn"],
                 "schema": None,
             },
             {
                 "id": "plugin3",
                 "label": "AdditionalConfigAuthPlugin",
-                "providesAuth": "bsn",
+                "providesAuth": ["bsn"],
                 "schema": {
                     "type": "object",
                     "properties": {
@@ -149,19 +149,19 @@ class ResponseTests(APITestCase):
             {
                 "id": "plugin1",
                 "label": "SingleAuthPlugin",
-                "providesAuth": "bsn",
+                "providesAuth": ["bsn"],
                 "schema": None,
             },
             {
                 "id": "plugin2",
                 "label": "DemoAuthPlugin",
-                "providesAuth": "bsn",
+                "providesAuth": ["bsn"],
                 "schema": None,
             },
             {
                 "id": "plugin3",
                 "label": "AdditionalConfigAuthPlugin",
-                "providesAuth": "bsn",
+                "providesAuth": ["bsn"],
                 "schema": {
                     "type": "object",
                     "properties": {
@@ -198,7 +198,7 @@ class ResponseTests(APITestCase):
             {
                 "id": "plugin3",
                 "label": "AdditionalConfigAuthPlugin",
-                "providesAuth": "bsn",
+                "providesAuth": ["bsn"],
                 "schema": {
                     "type": "object",
                     "properties": {

--- a/src/openforms/authentication/api/tests/test_logout.py
+++ b/src/openforms/authentication/api/tests/test_logout.py
@@ -50,7 +50,7 @@ class SubmissionLogoutTest(SubmissionsMixin, APITestCase):
 
         register("plugin1")(Plugin)
         plugin1 = register["plugin1"]
-        plugin1.provides_auth = AuthAttribute.bsn
+        plugin1.provides_auth = (AuthAttribute.bsn,)
         logout_mock = Mock()
         plugin1.logout = logout_mock
 

--- a/src/openforms/authentication/base.py
+++ b/src/openforms/authentication/base.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import ClassVar, TypedDict
 
 from django.http import HttpRequest, HttpResponse
 
@@ -47,7 +48,7 @@ class Options(TypedDict):
 
 
 class BasePlugin[OptionsT: Options](AbstractBasePlugin):
-    provides_auth: AuthAttribute
+    provides_auth: ClassVar[Sequence[AuthAttribute]]
     return_method = "GET"
     is_for_gemachtigde = False
 

--- a/src/openforms/authentication/contrib/demo/plugin.py
+++ b/src/openforms/authentication/contrib/demo/plugin.py
@@ -29,7 +29,7 @@ class DemoBaseForm(forms.Form):
 
 class BSNForm(DemoBaseForm):
     bsn = forms.CharField(
-        max_length=9, required=True, label=_("BSN"), validators=[BSNValidator]
+        max_length=9, required=True, label=_("BSN"), validators=[BSNValidator()]
     )
 
 
@@ -46,7 +46,6 @@ class DemoBaseAuthentication(BasePlugin):
     verbose_name = _("Demo")
     return_method = "POST"
     form_class: type = NotImplemented
-    provides_auth: str = NotImplemented
     is_demo_plugin = True
 
     def start_login(
@@ -86,8 +85,8 @@ class DemoBaseAuthentication(BasePlugin):
         if not is_co_sign:
             request.session[FORM_AUTH_SESSION_KEY] = {
                 "plugin": self.identifier,
-                "attribute": self.provides_auth,
-                "value": submitted.cleaned_data[self.provides_auth],
+                "attribute": self.provides_auth[0],
+                "value": submitted.cleaned_data[self.provides_auth[0]],
             }
 
         return HttpResponseRedirect(submitted.cleaned_data["next"])
@@ -103,7 +102,7 @@ class DemoBaseAuthentication(BasePlugin):
 class DemoBSNAuthentication(DemoBaseAuthentication):
     verbose_name = _("Demo BSN")
     form_class = BSNForm
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     form_field = "bsn"
     is_demo_plugin = True
 
@@ -112,6 +111,6 @@ class DemoBSNAuthentication(DemoBaseAuthentication):
 class DemoKVKAuthentication(DemoBaseAuthentication):
     verbose_name = _("Demo KvK number")
     form_class = KVKForm
-    provides_auth = AuthAttribute.kvk
+    provides_auth = (AuthAttribute.kvk,)
     form_field = "kvk"
     is_demo_plugin = True

--- a/src/openforms/authentication/contrib/digid/mixins.py
+++ b/src/openforms/authentication/contrib/digid/mixins.py
@@ -4,9 +4,9 @@ from furl import furl
 class AssertionConsumerServiceMixin:
     def get_failure_url(self, parameter: str, problem_code: str) -> str:
         # The success URL is composed by the DigiD plugin endpoint + a 'next' query parameter with the form URL
-        url = self.get_success_url()
+        url = self.get_success_url()  # type: ignore
         success_url = furl(url)
-        form_url = furl(success_url.args.popvalue("next"))
+        form_url = furl(success_url.args.popvalue("next"))  # type: ignore
         form_url.args[parameter] = problem_code
         success_url.args["next"] = form_url.url
         return success_url.url

--- a/src/openforms/authentication/contrib/digid/plugin.py
+++ b/src/openforms/authentication/contrib/digid/plugin.py
@@ -32,7 +32,7 @@ def loa_order(loa: str) -> int:
 @register(PLUGIN_ID)
 class DigidAuthentication(BasePlugin[DigidOptions]):
     verbose_name = _("DigiD")
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     configuration_options = DigidOptionsSerializer
 
     def start_login(
@@ -101,7 +101,7 @@ class DigidAuthentication(BasePlugin[DigidOptions]):
         return loa_order(authenticated_loa) >= loa_order(required)
 
     def get_logo(self, request) -> LoginLogo | None:
-        return LoginLogo(title=self.get_label(), **get_digid_logo(request))
+        return LoginLogo(title=str(self.get_label()), **get_digid_logo(request))
 
     def logout(self, request: HttpRequest):
         if DIGID_AUTH_SESSION_KEY in request.session:

--- a/src/openforms/authentication/contrib/digid/views.py
+++ b/src/openforms/authentication/contrib/digid/views.py
@@ -7,7 +7,7 @@ import structlog
 from digid_eherkenning.backends import BaseSaml2Backend
 from digid_eherkenning.choices import SectorType
 from digid_eherkenning.saml2.digid import DigiDClient
-from digid_eherkenning.views import (
+from digid_eherkenning.views.digid import (
     DigiDAssertionConsumerServiceView as _DigiDAssertionConsumerServiceView,
     DigiDLoginView as _DigiDLoginView,
 )
@@ -39,8 +39,9 @@ GENERIC_LOGIN_ERROR = "error"
 class DigiDLoginView(_DigiDLoginView):
     def get_level_of_assurance(self):
         # get the form_slug from /auth/{slug}/...?next=...
-        return_path = furl(self.request.GET.get("next")).path
-        _, _, kwargs = resolve(return_path)
+        next_param = self.request.GET.get("next", "")
+        return_path = furl(next_param).path
+        _, _, kwargs = resolve(str(return_path))
         form = get_object_or_404(Form, slug=kwargs.get("slug"))
 
         # called after AuthenticationStartView.get(), which already checks if there is an
@@ -93,6 +94,7 @@ class DigiDAssertionConsumerServiceView(
             )
             return HttpResponseRedirect(failure_url)
 
+        assert name_id is not None
         match name_id.split(":"):
             case [SectorType.bsn, bsn]:
                 pass

--- a/src/openforms/authentication/contrib/digid_mock/plugin.py
+++ b/src/openforms/authentication/contrib/digid_mock/plugin.py
@@ -17,7 +17,7 @@ from ...registry import register
 @register("digid-mock")
 class DigidMockAuthentication(BasePlugin):
     verbose_name = _("DigiD Mock")
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     is_demo_plugin = True
 
     def start_login(self, request: HttpRequest, form: Form, form_url: str, options):
@@ -54,7 +54,7 @@ class DigidMockAuthentication(BasePlugin):
         if CO_SIGN_PARAMETER not in request.GET:
             request.session[FORM_AUTH_SESSION_KEY] = {
                 "plugin": self.identifier,
-                "attribute": self.provides_auth,
+                "attribute": self.provides_auth[0],
                 "value": bsn,
             }
 

--- a/src/openforms/authentication/contrib/eherkenning/plugin.py
+++ b/src/openforms/authentication/contrib/eherkenning/plugin.py
@@ -99,9 +99,10 @@ class AuthenticationBasePlugin(BasePlugin):
 
         # set the session auth key only if we're not co-signing
         if identifier and CO_SIGN_PARAMETER not in request.GET:
+            assert len(self.provides_auth) == 1
             request.session[FORM_AUTH_SESSION_KEY] = {
                 "plugin": self.identifier,
-                "attribute": self.provides_auth,
+                "attribute": self.provides_auth[0],
                 "value": identifier,
                 "loa": self.get_session_loa(request.session),
             }
@@ -119,7 +120,7 @@ class AuthenticationBasePlugin(BasePlugin):
 @register("eherkenning")
 class EHerkenningAuthentication(AuthenticationBasePlugin):
     verbose_name = _("eHerkenning")
-    provides_auth = AuthAttribute.kvk
+    provides_auth = (AuthAttribute.kvk,)
     session_key = EHERKENNING_AUTH_SESSION_KEY
 
     def get_session_loa(self, session) -> str:
@@ -139,7 +140,7 @@ class EHerkenningAuthentication(AuthenticationBasePlugin):
 @register("eidas")
 class EIDASAuthentication(AuthenticationBasePlugin):
     verbose_name = _("eIDAS")
-    provides_auth = AuthAttribute.pseudo
+    provides_auth = (AuthAttribute.pseudo,)
     session_key = EIDAS_AUTH_SESSION_KEY
 
     def get_logo(self, request) -> LoginLogo | None:

--- a/src/openforms/authentication/contrib/org_oidc/plugin.py
+++ b/src/openforms/authentication/contrib/org_oidc/plugin.py
@@ -29,7 +29,7 @@ class OIDCAuthentication(BasePlugin):
     """
 
     verbose_name = _("Organization via OpenID Connect")
-    provides_auth = AuthAttribute.employee_id
+    provides_auth = (AuthAttribute.employee_id,)
 
     def start_login(self, request: HttpRequest, form: Form, form_url: str, options):
         return_url = reverse_plus(
@@ -63,7 +63,7 @@ class OIDCAuthentication(BasePlugin):
 
         request.session[FORM_AUTH_SESSION_KEY] = {
             "plugin": self.identifier,
-            "attribute": self.provides_auth,
+            "attribute": self.provides_auth[0],
             "value": request.user.employee_id or request.user.username,
         }
 
@@ -95,3 +95,6 @@ class OIDCAuthentication(BasePlugin):
             href="https://openid.net/",
             appearance=LogoAppearance.light,
         )
+
+
+assert len(OIDCAuthentication.provides_auth) == 1

--- a/src/openforms/authentication/contrib/outage/plugin.py
+++ b/src/openforms/authentication/contrib/outage/plugin.py
@@ -13,7 +13,7 @@ class OutageAuthentication(BasePlugin):
 
     verbose_name = _("Demo Outage")
     is_demo_plugin = True
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
 
     def start_login(self, request, form, form_url, options):
         raise Exception("simulated backend failure")
@@ -29,7 +29,7 @@ class BSNOutageAuthentication(OutageAuthentication):
     """
 
     verbose_name = _("BSN Outage")
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
 
 
 @register("kvk-outage")
@@ -39,4 +39,4 @@ class KVKOutageAuthentication(OutageAuthentication):
     """
 
     verbose_name = _("KvK Outage")
-    provides_auth = AuthAttribute.kvk
+    provides_auth = (AuthAttribute.kvk,)

--- a/src/openforms/authentication/tests/mocks.py
+++ b/src/openforms/authentication/tests/mocks.py
@@ -10,7 +10,7 @@ from ..registry import Registry
 
 class Plugin(BasePlugin):
     verbose_name = "some human readable label"
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
 
     def start_login(self, request, form, form_url, options):
         return HttpResponse("start")
@@ -40,7 +40,7 @@ class FailingPlugin(BasePlugin):
 
 class RequiresAdminPlugin(BasePlugin):
     verbose_name = "plugin requiring staff user session"
-    provides_auth = AuthAttribute.bsn
+    provides_auth = (AuthAttribute.bsn,)
     is_demo_plugin = True
 
     def start_login(self, request, form, form_url, options):

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -28,7 +28,7 @@ factory = APIRequestFactory()
 
 
 class ProvidesEmployeePlugin(Plugin):
-    provides_auth = AuthAttribute.employee_id
+    provides_auth = (AuthAttribute.employee_id,)
 
 
 class SetSubmissionIdentifyingAttributesTests(APITestCase):
@@ -40,7 +40,7 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
         request.session = {
             FORM_AUTH_SESSION_KEY: {
                 "plugin": "plugin1",
-                "attribute": RequiresAdminPlugin.provides_auth,
+                "attribute": RequiresAdminPlugin.provides_auth[0],
                 "value": "123",
             }
         }
@@ -72,7 +72,7 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
         request.session = {
             FORM_AUTH_SESSION_KEY: {
                 "plugin": "plugin1",
-                "attribute": RequiresAdminPlugin.provides_auth,
+                "attribute": RequiresAdminPlugin.provides_auth[0],
                 "value": "123",
             }
         }
@@ -191,7 +191,7 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
         request.session = {
             FORM_AUTH_SESSION_KEY: {
                 "plugin": "plugin1",
-                "attribute": Plugin.provides_auth,
+                "attribute": Plugin.provides_auth[0],
                 "value": "123",
             }
         }

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -386,11 +386,13 @@ class AuthenticationReturnView(AuthenticationFlowBaseView):
                 stacklevel=2,
             )
             logger.debug("handle_co_sign")
+            auth_attributes = plugin.provides_auth
+            assert len(auth_attributes) == 1
             co_sign_data: CosignData = {
                 **plugin.handle_co_sign(self.request, form),
                 "version": "v1",
                 "plugin": plugin.identifier,
-                "co_sign_auth_attribute": plugin.provides_auth,
+                "co_sign_auth_attribute": auth_attributes[0],
             }
             serializer = CoSignDataSerializer(data=co_sign_data)
             serializer.is_valid(raise_exception=True)

--- a/src/openforms/js/components/admin/form_design/AuthPluginField.js
+++ b/src/openforms/js/components/admin/form_design/AuthPluginField.js
@@ -29,11 +29,11 @@ const AuthPluginField = ({availableAuthPlugins, selectedAuthPlugins, onChange, e
             value={plugin.id}
             label={
               <>
-                {plugin.label}
+                {plugin.label}{' '}
                 <FormattedMessage
                   description="Auth plugin provided attributes suffix"
                   defaultMessage="(provides {attrs})"
-                  values={{attrs: plugin.providesAuth}}
+                  values={{attrs: plugin.providesAuth.join(', ')}}
                 />
               </>
             }

--- a/src/openforms/js/components/admin/form_design/AuthPluginOptions.js
+++ b/src/openforms/js/components/admin/form_design/AuthPluginOptions.js
@@ -5,6 +5,7 @@ import {FormattedMessage} from 'react-intl';
 import FormRow from 'components/admin/forms/FormRow';
 
 import {BACKEND_OPTIONS_FORMS} from './authentication/index';
+import TYPES from './types';
 
 const AuthPluginOptions = ({name, authBackend, availableAuthPlugins, onChange}) => {
   const plugin = availableAuthPlugins.find(authPlugin => authPlugin.id === authBackend.backend);
@@ -48,13 +49,7 @@ AuthPluginOptions.propTypes = {
     // Options configuration shape is specific to plugin
     options: PropTypes.object,
   }).isRequired,
-  availableAuthPlugins: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string,
-      label: PropTypes.string,
-      providesAuth: PropTypes.string,
-    })
-  ),
+  availableAuthPlugins: PropTypes.arrayOf(TYPES.AuthPlugin).isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/src/openforms/js/components/admin/form_design/FormConfigurationFields.js
+++ b/src/openforms/js/components/admin/form_design/FormConfigurationFields.js
@@ -12,6 +12,7 @@ import {getTranslatedChoices} from 'utils/i18n';
 import AuthPluginAutoLoginField from './AuthPluginAutoLoginField';
 import AuthPluginField from './AuthPluginField';
 import AuthPluginOptions from './AuthPluginOptions';
+import TYPES from './types';
 
 const SUMBISSION_ALLOWED_CHOICES = [
   [
@@ -737,14 +738,7 @@ FormConfigurationFields.propTypes = {
     ).isRequired,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
-  availableAuthPlugins: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string,
-      label: PropTypes.string,
-      providesAuth: PropTypes.string,
-      schema: PropTypes.object,
-    })
-  ),
+  availableAuthPlugins: PropTypes.arrayOf(TYPES.AuthPlugin).isRequired,
   selectedAuthPlugins: PropTypes.array.isRequired,
   onAuthPluginChange: PropTypes.func.isRequired,
 };

--- a/src/openforms/js/components/admin/form_design/FormConfigurationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/FormConfigurationFields.stories.js
@@ -34,7 +34,7 @@ export default {
       {
         id: 'digid',
         label: 'DigiD',
-        providesAuth: 'bsn',
+        providesAuth: ['bsn'],
         schema: {
           type: 'object',
           properties: {
@@ -57,7 +57,7 @@ export default {
       {
         id: 'eherkenning',
         label: 'eHerkenning',
-        providesAuth: 'kvk',
+        providesAuth: ['kvk'],
       },
     ],
     availableThemes: [

--- a/src/openforms/js/components/admin/form_design/PluginWarning.js
+++ b/src/openforms/js/components/admin/form_design/PluginWarning.js
@@ -35,7 +35,7 @@ const PluginWarning = ({loginRequired, configuration}) => {
       const authPlugin = availableAuthPlugins.find(plugin => plugin.id === pluginName);
       if (!authPlugin) break;
 
-      if (requiredAuthAttribute.includes(authPlugin.providesAuth)) {
+      if (requiredAuthAttribute.some(attr => authPlugin.providesAuth.includes(attr))) {
         pluginProvidesAttribute = true;
         break;
       }

--- a/src/openforms/js/components/admin/form_design/authentication/digid/DigidOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/authentication/digid/DigidOptionsForm.js
@@ -42,7 +42,7 @@ DigidOptionsForm.propType = {
   plugin: PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    providesAuth: PropTypes.oneOf(['bsn']).isRequired,
+    providesAuth: PropTypes.oneOf([['bsn']]).isRequired,
     schema: PropTypes.exact({
       type: PropTypes.oneOf(['object']).isRequired,
       properties: PropTypes.shape({

--- a/src/openforms/js/components/admin/form_design/authentication/digid/DigidOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/authentication/digid/DigidOptionsFormFields.js
@@ -32,7 +32,7 @@ DigidOptionsFormFields.propType = {
   plugin: PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    providesAuth: PropTypes.oneOf(['bsn']).isRequired,
+    providesAuth: PropTypes.oneOf([['bsn']]).isRequired,
     schema: PropTypes.exact({
       type: PropTypes.oneOf(['object']).isRequired,
       properties: PropTypes.shape({

--- a/src/openforms/js/components/admin/form_design/authentication/digid/DigidOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/authentication/digid/DigidOptionsFormFields.stories.js
@@ -17,7 +17,7 @@ export default {
     plugin: {
       id: 'digid',
       label: 'DigiD',
-      providesAuth: 'bsn',
+      providesAuth: ['bsn'],
       schema: {
         type: 'object',
         properties: {

--- a/src/openforms/js/components/admin/form_design/types/AuthPlugin.js
+++ b/src/openforms/js/components/admin/form_design/types/AuthPlugin.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 const AuthPlugin = PropTypes.shape({
   id: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
-  providesAuth: PropTypes.string,
+  providesAuth: PropTypes.arrayOf(PropTypes.string).isRequired,
   // Schema will be null for plugins that don't support additional configuration
   schema: PropTypes.object,
 });

--- a/src/openforms/prefill/models.py
+++ b/src/openforms/prefill/models.py
@@ -20,7 +20,7 @@ class PrefillConfig(SingletonModel):
         help_text=_("Default prefill plugin to use for company data"),
     )
 
-    class Meta:
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         verbose_name = _("global prefill configuration")
 
     def __str__(self):

--- a/src/openforms/prefill/signals.py
+++ b/src/openforms/prefill/signals.py
@@ -23,9 +23,10 @@ def add_co_sign_representation(
         action="prefill.add_co_sign_representation",
         submission_uuid=str(submission.uuid),
     )
-    log.debug("cosign", plugin_auth_type=plugin.provides_auth)
+    assert len(plugin.provides_auth) == 1
+    log.debug("cosign", plugin_auth_type=plugin.provides_auth[0])
     if not submission.co_sign_data or not submission.co_sign_data["identifier"]:
         log.warning("cosign_data_missing_or_incomplete", outcome="skip")
         return
 
-    _add_co_sign_representation(submission, plugin.provides_auth)
+    _add_co_sign_representation(submission, plugin.provides_auth[0])

--- a/src/openforms/prefill/validators.py
+++ b/src/openforms/prefill/validators.py
@@ -27,14 +27,16 @@ class CoSignValidator(BaseValidator):
 
         assert isinstance(auth_plugin_id, str)
         auth_plugin = auth_register[auth_plugin_id]
+        if len(auth_plugin.provides_auth) > 1:
+            raise ValidationError(
+                _("You may only select plugins that provide a single auth attribute."),
+                code="invalid",
+            )
 
-        default_plugin = get_default_plugin_for_auth_attribute(
-            auth_plugin.provides_auth
-        )
+        auth_attribute = auth_plugin.provides_auth[0]
+        default_plugin = get_default_plugin_for_auth_attribute(auth_attribute)
         if not default_plugin:
-            config_field_name = AUTH_ATTRIBUTE_TO_CONFIG_FIELD[
-                auth_plugin.provides_auth
-            ]
+            config_field_name = AUTH_ATTRIBUTE_TO_CONFIG_FIELD[auth_attribute]
             field = PrefillConfig._meta.get_field(config_field_name)
             assert isinstance(field, PrefillPluginChoiceField)
             raise ValidationError(

--- a/src/openforms/prefill/validators.py
+++ b/src/openforms/prefill/validators.py
@@ -11,6 +11,7 @@ from .co_sign import (
     PrefillConfig,
     get_default_plugin_for_auth_attribute,
 )
+from .fields import PrefillPluginChoiceField
 
 
 @register("coSign")
@@ -24,7 +25,9 @@ class CoSignValidator(BaseValidator):
                 code="invalid",
             )
 
+        assert isinstance(auth_plugin_id, str)
         auth_plugin = auth_register[auth_plugin_id]
+
         default_plugin = get_default_plugin_for_auth_attribute(
             auth_plugin.provides_auth
         )
@@ -32,14 +35,14 @@ class CoSignValidator(BaseValidator):
             config_field_name = AUTH_ATTRIBUTE_TO_CONFIG_FIELD[
                 auth_plugin.provides_auth
             ]
+            field = PrefillConfig._meta.get_field(config_field_name)
+            assert isinstance(field, PrefillPluginChoiceField)
             raise ValidationError(
                 _(
                     "The co-sign component requires the '{field_label}' "
                     "({config_verbose_name}) to be configured."
                 ).format(
-                    field_label=PrefillConfig._meta.get_field(
-                        config_field_name
-                    ).verbose_name,
+                    field_label=field.verbose_name,
                     config_verbose_name=PrefillConfig._meta.verbose_name,
                 ),
                 code="invalid",


### PR DESCRIPTION
Part of #5132

[skip: e2e]

**Changes**

Widened the type of `BasePlugin.provides_auth` to a collection of auth attributes rather than a simple scalar, to facilitate Yivi.