### PR TITLE
[#5407] Add migration notice for 3.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -272,16 +272,15 @@ This contains the changes from the alpha and fixes applied until the stable vers
 BEFORE upgrading to 3.1.0, please read the release notes carefully and review the
 following instructions.
 
+Upgrade procedure
+-----------------
+
 .. warning:: Upgrade notice
 
     [:backend:`4931`] introduced a migration which processes log records and therefore
     could take a long time to complete. Make sure to verify the amount of log records
     before applying the migration to see if the longer processing time is relevant for
     the upgrade.
-
-
-Upgrade procedure
------------------
 
 To upgrade to 3.1, please:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -275,16 +275,13 @@ following instructions.
 Upgrade procedure
 -----------------
 
-.. warning:: Upgrade notice
-
-    [:backend:`4931`] introduced a migration which processes log records and therefore
-    could take a long time to complete. Make sure to verify the amount of log records
-    before applying the migration to see if the longer processing time is relevant for
-    the upgrade.
-
 To upgrade to 3.1, please:
 
 * ⚠️ Ensure you upgrade to Open Forms 3.0.1 before upgrading to the 3.1 release series.
+
+* ⚠️ Verify the amount of log records before applying the upgrade. [:backend:`4931`]
+  introduced a migration which processes log records and therefore could take a
+  long time to complete.
 
 * We recommend running the ``bin/report_component_problems.py`` and
   ``bin/report_form_registration_problems.py`` scripts to diagnose any problems in

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -272,6 +272,14 @@ This contains the changes from the alpha and fixes applied until the stable vers
 BEFORE upgrading to 3.1.0, please read the release notes carefully and review the
 following instructions.
 
+.. warning:: Upgrade notice
+
+    [:backend:`4931`] introduced a migration which processes log records and therefore
+    could take a long time to complete. Make sure to verify the amount of log records
+    before applying the migration to see if the longer processing time is relevant for
+    the upgrade.
+
+
 Upgrade procedure
 -----------------
 


### PR DESCRIPTION
Closes #5407 

**Changes**

Adds a warning notice for the 3.1.0 release regarding the possibility of a longer processing time when upgrading.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
