### PR TITLE
Add missing check_requirements for Yivi auth plugin

### DIFF
--- a/src/openforms/authentication/contrib/eherkenning/constants.py
+++ b/src/openforms/authentication/contrib/eherkenning/constants.py
@@ -1,5 +1,8 @@
+from digid_eherkenning.choices import AssuranceLevels
+
 EHERKENNING_PLUGIN_ID = "eherkenning"
 EHERKENNING_AUTH_SESSION_KEY = f"{EHERKENNING_PLUGIN_ID}:kvk"
 EHERKENNING_AUTH_SESSION_AUTHN_CONTEXTS = f"{EHERKENNING_PLUGIN_ID}:authn_contexts"
+EHERKENNING_DEFAULT_LOA = AssuranceLevels.substantial
 EIDAS_AUTH_SESSION_KEY = "eidas:pseudo"
 EIDAS_AUTH_SESSION_AUTHN_CONTEXTS = "eidas:authn_contexts"


### PR DESCRIPTION
Closes #5140

**Changes**

Add ``check_requirements`` method for the Yivi auth plugin.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
