### PR TITLE
Upgrade django-privates to 3.1.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -194,7 +194,7 @@ django-otp==1.3.0
     # via django-two-factor-auth
 django-phonenumber-field==7.3.0
     # via django-two-factor-auth
-django-privates==3.0.0
+django-privates==3.1.1
     # via
     #   -r requirements/base.in
     #   django-simple-certmanager

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -318,7 +318,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-two-factor-auth
-django-privates==3.0.0
+django-privates==3.1.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -349,7 +349,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
-django-privates==3.0.0
+django-privates==3.1.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -310,7 +310,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   django-two-factor-auth
-django-privates==3.0.0
+django-privates==3.1.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -332,7 +332,7 @@ django-phonenumber-field==7.3.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   django-two-factor-auth
-django-privates==3.0.0
+django-privates==3.1.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
django privates 3.0.0 introduced a regression that breaks pickling of (affected) model instances, which in turn breaks the caching.

Closes #5394 

**Changes**

* Fixed bug in django-privates and upgraded dependency

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
