### PR TITLE
Obfuscate Yivi and eIDAS claims for logging

### DIFF
--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/models.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/models.py
@@ -1,4 +1,5 @@
 import warnings
+from collections.abc import Sequence
 
 from django.conf import settings
 from django.db import models
@@ -15,6 +16,7 @@ from digid_eherkenning.oidc.models import (
 from digid_eherkenning.oidc.models.base import default_loa_choices
 from django_jsonform.models.fields import ArrayField
 from mozilla_django_oidc_db.fields import ClaimField, ClaimFieldDefault
+from mozilla_django_oidc_db.typing import ClaimPath
 
 from openforms.authentication.contrib.digid_eherkenning_oidc.choices import (
     EIDASAssuranceLevels,
@@ -174,6 +176,14 @@ class OFEIDASConfig(BaseConfig):
     def oidcdb_username_claim(self):
         return self.legal_subject_identifier_claim
 
+    @property
+    def oidcdb_sensitive_claims(self) -> Sequence[ClaimPath]:
+        return [
+            self.legal_subject_identifier_claim,
+            self.legal_subject_first_name_claim,
+            self.legal_subject_family_name_claim,
+        ]
+
     @classproperty
     def oidc_authentication_callback_url(cls) -> str:
         return "oidc_authentication_callback"
@@ -277,6 +287,15 @@ class OFEIDASCompanyConfig(BaseConfig):
     @property
     def oidcdb_username_claim(self):
         return self.legal_subject_identifier_claim
+
+    @property
+    def oidcdb_sensitive_claims(self) -> Sequence[ClaimPath]:
+        return [
+            self.legal_subject_identifier_claim,
+            self.acting_subject_identifier_claim,
+            self.acting_subject_first_name_claim,
+            self.acting_subject_family_name_claim,
+        ]
 
     @classproperty
     def oidc_authentication_callback_url(cls) -> str:

--- a/src/openforms/authentication/contrib/yivi_oidc/models.py
+++ b/src/openforms/authentication/contrib/yivi_oidc/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from copy import deepcopy
 
 from django.db import models
@@ -8,6 +9,7 @@ from digid_eherkenning.choices import AssuranceLevels, DigiDAssuranceLevels
 from digid_eherkenning.oidc.models.base import LOA_MAPPING_SCHEMA, BaseConfig
 from django_jsonform.models.fields import ArrayField, JSONField
 from mozilla_django_oidc_db.fields import ClaimField, ClaimFieldDefault
+from mozilla_django_oidc_db.typing import ClaimPath
 
 
 def get_callback_view(self):
@@ -141,6 +143,14 @@ class YiviOpenIDConnectConfig(BaseConfig):
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         verbose_name = _("Yivi (OIDC)")
+
+    @property
+    def oidcdb_sensitive_claims(self) -> Sequence[ClaimPath]:
+        return [
+            self.bsn_claim,
+            self.kvk_claim,
+            self.pseudo_claim,
+        ]
 
     @classproperty
     def oidc_authentication_callback_url(cls) -> str:

--- a/src/openforms/authentication/contrib/yivi_oidc/plugin.py
+++ b/src/openforms/authentication/contrib/yivi_oidc/plugin.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from itertools import chain
 from typing import TypedDict, assert_never, cast
 
@@ -115,6 +116,17 @@ class YiviOIDCAuthentication(OIDCAuthentication[YiviClaims, YiviOptions]):
     def strict_mode(self, request: HttpRequest) -> bool:
         # Yivi cannot be strict, as all its attributes should be optional!
         return False
+
+    def get_sensitive_claims(
+        self, options: YiviOptions, claims: JSONObject
+    ) -> Collection[str]:
+        # All claims that we receive, that where part of the Yivi additional attributes,
+        # should be marked as sensitive. As all Yivi claims *could* be sensitive, let's
+        # handle them all as such.
+        additional_claims = self.extract_additional_claims(options, claims)
+
+        # Return the `additional_claims` claim names as list
+        return list(additional_claims.keys())
 
     def failure_url_error_message(
         self, error: str, error_description: str

--- a/src/openforms/contrib/auth_oidc/plugin.py
+++ b/src/openforms/contrib/auth_oidc/plugin.py
@@ -104,6 +104,13 @@ class OIDCAuthentication[T, OptionsT](BasePlugin[OptionsT]):
     def strict_mode(self, request: HttpRequest) -> bool:
         return False
 
+    def get_sensitive_claims(self, options: OptionsT, claims: JSONObject) -> list[str]:
+        # Allow the plugin to dynamically decide which claims are sensitive. This will be
+        # used to obfuscate the claims, before logging.
+        # For statically defining the sensitive claims, ``oidcdb_sensitive_claims`` on
+        # the plugin config model should be used.
+        return []
+
     def transform_claims(self, options: OptionsT, normalized_claims: T) -> FormAuth:
         raise NotImplementedError("Subclasses must implement 'transform_claims'")
 


### PR DESCRIPTION
Closes #5430 

**Changes**

For the claims logging, we need to obfuscate all sensitive Yivi and eIDAS claims.

Yivi:
Because municipalities control which additional attributes are requested during login (which results into the claims), we cannot know which claims are and aren't sensitive. To be safe, we should handle all Yivi additional claims as sensitive. Besides that, we also handle the bsn, kvk and pseudo claims as sensitive.

eIDAS for person:
For personal eIDAS authentication, we regard the legal identifier and additional personal data (firstname and lastname) as sensitive.

eIDAS for companies:
For eIDAS authentication as a company, we regard the legal and acting identifiers as sensitive. In addition, the additional acting personal data (firstname and lastname) are also handled as sensitive.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Release management

  - [X] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [X] Ran `./bin/makemessages_js.sh`
  - [X] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
