### PR TITLE
[#5413] Handle soft-hyphens in uploaded filenames

### DIFF
--- a/src/openforms/formio/tests/factories.py
+++ b/src/openforms/formio/tests/factories.py
@@ -27,7 +27,10 @@ class SubmittedFileFactory(factory.DictFactory):
         if extracted:
             # The temporary upload was explicitly provided, read the necessary values from there
             temporary_upload = extracted
-            obj["originalName"] = obj["data"]["name"] = temporary_upload.file_name
+            obj["data"]["name"] = kwargs.get("data_name") or temporary_upload.file_name
+            obj["originalName"] = (
+                kwargs.get("original_name") or temporary_upload.file_name
+            )
             obj["size"] = obj["data"]["size"] = temporary_upload.file_size
         else:
             create_temporary_upload = (


### PR DESCRIPTION
Closes #5413 

**Changes**

Follows FormIO behavior in the way filenames are processed. Soft hyphens are replaced with dashes in FormIO and caused the validation to fail (while comparing the actual filenames with the naked eye might look the same) in the API.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
