### PR TITLE
[#5268] Update ObjectsAPI registration to handle partners component data

### DIFF
--- a/docker/objects-apis/fixtures/objects_api_fixtures.json
+++ b/docker/objects-apis/fixtures/objects_api_fixtures.json
@@ -45,6 +45,15 @@
     }
 },
 {
+    "model": "core.objecttype",
+    "pk": 6,
+    "fields": {
+        "service": 1,
+        "uuid": "59cdc902-576b-495f-ae63-c9c78b8afc09",
+        "_name": "Partners"
+    }
+},
+{
     "model": "token.tokenauth",
     "pk": 1,
     "fields": {
@@ -55,7 +64,8 @@
         "last_modified": "2023-10-24T08:58:51.291Z",
         "created": "2023-10-24T08:58:51.291Z",
         "application": "",
-        "administration": ""
+        "administration": "",
+        "is_superuser": false
     }
 },
 {
@@ -108,6 +118,17 @@
     "fields": {
         "token_auth": 1,
         "object_type": 5,
+        "mode": "read_and_write",
+        "use_fields": false,
+        "fields": null
+    }
+},
+{
+    "model": "token.permission",
+    "pk": 6,
+    "fields": {
+        "token_auth": 1,
+        "object_type": 6,
         "mode": "read_and_write",
         "use_fields": false,
         "fields": null

--- a/docker/objects-apis/fixtures/objecttypes_api_fixtures.json
+++ b/docker/objects-apis/fixtures/objecttypes_api_fixtures.json
@@ -138,6 +138,29 @@
     }
 },
 {
+    "model": "core.objecttype",
+    "pk": 7,
+    "fields": {
+        "uuid": "59cdc902-576b-495f-ae63-c9c78b8afc09",
+        "name": "Partners",
+        "name_plural": "Partners",
+        "description": "",
+        "data_classification": "open",
+        "maintainer_organization": "",
+        "maintainer_department": "",
+        "contact_person": "",
+        "contact_email": "",
+        "source": "",
+        "update_frequency": "unknown",
+        "provider_organization": "",
+        "documentation_url": "",
+        "labels": {},
+        "created_at": "2025-07-22",
+        "modified_at": "2025-07-22",
+        "allow_geometry": true
+    }
+},
+{
     "model": "core.objectversion",
     "pk": 1,
     "fields": {
@@ -452,6 +475,61 @@
             }
         },
         "status": "draft"
+    }
+},
+{
+    "model": "core.objectversion",
+    "pk": 10,
+    "fields": {
+        "object_type": 7,
+        "version": 1,
+        "created_at": "2025-07-22",
+        "modified_at": "2025-07-22",
+        "published_at": "2025-07-22",
+        "json_schema": {
+            "$id": "https://example.com/partners.schema.json",
+            "type": "object",
+            "title": "Partners",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "required": [
+                "partners"
+            ],
+            "properties": {
+                "partners": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "bsn"
+                        ],
+                        "properties": {
+                            "bsn": {
+                                "type": "string",
+                                "format": "nl-bsn",
+                                "pattern": "^\\d{9}$"
+                            },
+                            "affixes": {
+                                "type": "string"
+                            },
+                            "initials": {
+                                "type": "string"
+                            },
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "dateOfBirth": {
+                                "type": "string",
+                                "format": "date"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "title": "Partners"
+                }
+            },
+            "additionalProperties": false
+        },
+        "status": "published"
     }
 },
 {

--- a/src/openforms/registrations/contrib/objects_api/handlers/v2.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v2.py
@@ -155,6 +155,16 @@ def process_mapped_variable(
             assert isinstance(value, dict)
             if transform_to_list and variable_key in transform_to_list:
                 value = [option for option, is_selected in value.items() if is_selected]
+        case {"type": "partners"}:
+            assert isinstance(value, list)
+
+            for partner in value:
+                assert isinstance(partner, dict)
+
+                # these are not relevant for the object (at least for now)
+                partner.pop("firstNames", None)
+                partner.pop("dateOfBirthPrecision", None)
+                partner.pop("__addedManually", None)
 
         # not a component or standard behaviour where no transformation is necessary
         case None | _:

--- a/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendV2Tests/test_submission_with_partners_component.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/files/vcr_cassettes/ObjectsAPIBackendV2Tests/test_submission_with_partners_component.yaml
@@ -1,0 +1,142 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes
+  response:
+    body:
+      string: '{"count":7,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+        everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e","uuid":"644ab597-e88c-43c0-8321-f12113510b0e","name":"Fieldset
+        component","namePlural":"Fieldset component","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705","uuid":"f1dde4fe-b7f9-46dc-84ae-429ae49e3705","name":"Geo
+        in data","namePlural":"Geo in data","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2","uuid":"527b8408-7421-4808-a744-43ccb7bdaaa2","name":"File
+        Uploads","namePlural":"File Uploads","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/3edfdaf7-f469-470b-a391-bb7ea015bd6f","uuid":"3edfdaf7-f469-470b-a391-bb7ea015bd6f","name":"Tree","namePlural":"Trees","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/3edfdaf7-f469-470b-a391-bb7ea015bd6f/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-11-25","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/4"]}]}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4618'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Tue, 22 Jul 2025 10:00:44 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.4
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","status":"published","jsonSchema":{"$id":"https://example.com/partners.schema.json","type":"object","title":"Partners","$schema":"https://json-schema.org/draft/2020-12/schema","required":["partners"],"properties":{"partners":{"type":"array","items":{"type":"object","required":["bsn"],"properties":{"bsn":{"type":"string","format":"nl-bsn","pattern":"^\\d{9}$"},"affixes":{"type":"string"},"initials":{"type":"string"},"lastName":{"type":"string"},"dateOfBirth":{"type":"string","format":"date"}},"additionalProperties":false},"title":"Partners"}},"additionalProperties":false},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","publishedAt":"2025-07-22"}]}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '923'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Tue, 22 Jul 2025 10:00:44 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.27.4
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["000009921"],
+      "fields": ["partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3MTA4NTU2MzQsImV4cCI6MTcxMDg5ODgzNCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.t6t4_Vm4NTG31vOVdyHgoT9gnEzD4lqld4dDmB7IHQc
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.4
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"partners":[{"burgerservicenummer":"999995182","naam":{"voornamen":"Anna
+        Maria Petra","geslachtsnaam":"Jansma","voorletters":"A.M.P."},"geboorte":{"datum":{"type":"Datum","datum":"1945-04-18","langFormaat":"18
+        april 1945"}}},{"burgerservicenummer":"123456782","naam":{"voornamen":"Test
+        second partner","geslachtsnaam":"Test","voorletters":"T.s.p."},"geboorte":{"datum":{"type":"Datum","datum":"1945-04-18","langFormaat":"18
+        april 1945"}}}]}]}'
+    headers:
+      Content-Length:
+      - '497'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 22 Jul 2025 10:00:43 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Closes #5268 

**Changes**

- Added object type for partners and updated the fixture for the Objects and Objecttypes containers
- Remove unused properties from the partners' data (not relevant to the object created)
- Test for the specific component

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
