### PR TITLE
[#5340] fix email_digest error

### DIFF
--- a/src/openforms/emails/digest.py
+++ b/src/openforms/emails/digest.py
@@ -395,6 +395,18 @@ def collect_invalid_registration_backends() -> list[InvalidRegistrationBackend]:
                     form_id=form.id,
                 )
             )
+        except Exception as exc:
+            # Catch any unexpected error, because we don't want this function to crash
+            invalid_registration_backends.append(
+                InvalidRegistrationBackend(
+                    config_name=plugin.verbose_name,
+                    exception_message=_(
+                        "Unexpected error appeared during the validation process: {exception}"
+                    ).format(exception=exc),
+                    form_name=form_name,
+                    form_id=form.id,
+                )
+            )
 
     return invalid_registration_backends
 


### PR DESCRIPTION
Closes #5340

**Changes**

* catch `StandardViolation` error during validation of `ZGWRegistration`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
