### PR TITLE
[#5471] Enable advanced configuration when family members plugin

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormAdvancedConfiguration.js
+++ b/src/openforms/js/components/admin/form_design/FormAdvancedConfiguration.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import {FormContext} from 'components/admin/form_design/Context';
 import {getFormComponents} from 'components/admin/form_design/utils';
 import Field from 'components/admin/forms/Field';
 import Fieldset from 'components/admin/forms/Fieldset';
@@ -10,11 +11,17 @@ import {TextInput} from 'components/admin/forms/Inputs';
 import {COSIGN_V1_TYPE} from 'components/form/coSignOld';
 
 import TYPES from './types';
+import {VARIABLE_SOURCES} from './variables/constants';
 
 /**
  * Component to render the metadata admin form for an Open Forms form.
  */
 const FormAdvancedConfiguration = ({form, formSteps, onChange}) => {
+  const {formVariables} = useContext(FormContext);
+  const userDefinedVariables = formVariables.filter(
+    variable => variable.source === VARIABLE_SOURCES.userDefined
+  );
+
   const {brpPersonenRequestOptions} = form;
 
   const components = Object.values(getFormComponents(formSteps));
@@ -26,9 +33,14 @@ const FormAdvancedConfiguration = ({form, formSteps, onChange}) => {
   const hasNpFamilyMembers = components.some(comp => comp.type === 'npFamilyMembers');
   const hasCosign = components.some(comp => comp.type === COSIGN_V1_TYPE);
 
+  // The new Family members prefill plugin
+  const hasFamilyMembersPrefill = userDefinedVariables.some(
+    variable => variable.prefillPlugin === 'family_members'
+  );
+
   return (
     <>
-      {hasBRPPrefill || hasNpFamilyMembers || hasCosign ? (
+      {hasBRPPrefill || hasNpFamilyMembers || hasCosign || hasFamilyMembersPrefill ? (
         <Fieldset
           title={
             <FormattedMessage


### PR DESCRIPTION
Closes #5471

**Changes**

- Enable advanced configuration when there is a variable that makes use of the new familly members plugin.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
