### PR TITLE
Make partners serializer fields more specific

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -654,25 +654,21 @@ class PartnerSerializer(serializers.Serializer):
     initials = serializers.CharField(
         label=_("initials"),
         help_text=_("The initials of the partner"),
-        required=False,
         allow_blank=True,
     )
     affixes = serializers.CharField(
         label=_("affixes"),
         help_text=_("The affixes of the partner"),
-        required=False,
         allow_blank=True,
     )
     lastName = serializers.CharField(
         label=_("last name"),
         help_text=_("The last name of the partner"),
-        required=False,
         allow_blank=True,
     )
-    dateOfBirth = serializers.DateField(
+    dateOfBirth = FormioDateField(
         label=_("date of birth"),
         help_text=_("The date of birth of the partner"),
-        required=False,
     )
 
     def __init__(self, **kwargs):
@@ -721,7 +717,7 @@ class PartnerListField(serializers.Field):
                 {
                     key: (
                         datetime.strptime(value, "%Y-%m-%d").date()
-                        if key == "dateOfBirth"
+                        if key == "dateOfBirth" and value
                         else value
                     )
                     for key, value in partner.items()

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_children_deceased.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_children_deceased.yaml
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 30 Jun 2025 15:12:43 GMT
+      - Fri, 01 Aug 2025 12:45:24 GMT
       Server:
       - Kestrel
     status:
@@ -87,7 +87,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 30 Jun 2025 15:12:43 GMT
+      - Fri, 01 Aug 2025 12:45:24 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_children_filtered_by_age.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_children_filtered_by_age.yaml
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 30 Jun 2025 15:12:43 GMT
+      - Fri, 01 Aug 2025 12:45:24 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_children_prefill_happy_flow.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_children_prefill_happy_flow.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTEyOTYzNjQsImV4cCI6MTc1MTMzOTU2NCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.hwqPaGJ6re5DV1LKp1wSDi-_QTfoMrmwzR4pdYt3rEo
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTQwNTIzMjQsImV4cCI6MTc1NDA5NTUyNCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.jwVScixzzbOlqo4k4nb8V-81vOtvx_dAQO2dwWe1VmU
       Connection:
       - keep-alive
       Content-Length:
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 30 Jun 2025 15:12:43 GMT
+      - Fri, 01 Aug 2025 12:45:24 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_partners_prefill_happy_flow.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/files/vcr_cassettes/FamilyMembersPrefillPluginHCV2Tests/test_partners_prefill_happy_flow.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate, br
       Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTEyOTYzNjQsImV4cCI6MTc1MTMzOTU2NCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.hwqPaGJ6re5DV1LKp1wSDi-_QTfoMrmwzR4pdYt3rEo
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTQwNTIzMjQsImV4cCI6MTc1NDA5NTUyNCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.jwVScixzzbOlqo4k4nb8V-81vOtvx_dAQO2dwWe1VmU
       Connection:
       - keep-alive
       Content-Length:
@@ -38,7 +38,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 30 Jun 2025 15:12:43 GMT
+      - Fri, 01 Aug 2025 12:45:24 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -121,8 +121,8 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             components_list=[
                 {
                     "key": "hc_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )
@@ -195,8 +195,8 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             components_list=[
                 {
                     "key": "hc_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )
@@ -244,8 +244,8 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             components_list=[
                 {
                     "key": "hc_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )
@@ -395,8 +395,8 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             components_list=[
                 {
                     "key": "stuf_bg_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )
@@ -478,8 +478,8 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             components_list=[
                 {
                     "key": "stuf_bg_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )
@@ -561,8 +561,8 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             components_list=[
                 {
                     "key": "stuf_bg_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )
@@ -652,8 +652,8 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             components_list=[
                 {
                     "key": "stuf_bg_prefill_children_mutable",
-                    "type": "partners",
-                    "label": "Partners",
+                    "type": "children",
+                    "label": "Children",
                 },
             ],
         )


### PR DESCRIPTION
**Changes**

- Found out that the serializer fields do not adhere to the data that we build in the `get_family_members` (BRP), so updated these to be required.
- Fixed some tests that didn't have the right component (partners)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Release management

  - [x] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [x] Ran `./bin/makemessages_js.sh`
  - [x] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
