### PR TITLE
[#5269] Set up logic to copy the children component data to the editgrid (next step)

### DIFF
--- a/src/openforms/forms/api/serializers/logic/action_serializers.py
+++ b/src/openforms/forms/api/serializers/logic/action_serializers.py
@@ -65,6 +65,19 @@ class LogicValueActionSerializer(serializers.Serializer):
     )
 
 
+class SynchronizeChildrenActionConfigSerializer(serializers.Serializer):
+    source_variable = FormioVariableKeyField(
+        label=_("Key of the form variable that will be used as the source."),
+    )
+    destination_variable = FormioVariableKeyField(
+        label=_("Key of the form variable that will be used as the destination."),
+    )
+
+
+class SynchronizeChildrenActionSerializer(serializers.Serializer):
+    config = SynchronizeChildrenActionConfigSerializer(label=_("Configuration"))
+
+
 class LogicFetchActionSerializer(serializers.Serializer):
     value = serializers.JSONField(
         label=_("service_fetch_configuration"),
@@ -128,6 +141,7 @@ class LogicActionPolymorphicSerializer(PolymorphicSerializer):
         str(
             LogicActionTypes.set_registration_backend
         ): LogicSetRegistrationBackendActionSerializer,
+        str(LogicActionTypes.synchronize_children): SynchronizeChildrenActionSerializer,
     }
 
 

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -21,6 +21,10 @@ class LogicActionTypes(models.TextChoices):
         _("Set the registration backend to use for the submission"),
     )
     evaluate_dmn = "evaluate-dmn", _("Evaluate DMN")
+    synchronize_children = (
+        "synchronize-children",
+        _("Synchronize the selected children with another editgrid component"),
+    )
 
     @classmethod
     def get_label(cls, value: str) -> str:

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -102,6 +102,39 @@ const ActionVariableValue = ({action, errors, onChange}) => (
   </>
 );
 
+const ActionSynchronizeChildren = ({action, errors, onChange}) => {
+  const intl = useIntl();
+
+  return (
+    <>
+      {intl.formatMessage({
+        description: 'From variable message',
+        defaultMessage: 'From variable',
+      })}
+      <DSLEditorNode errors={errors?.action?.config?.sourceVariable}>
+        <VariableSelection
+          name="action.config.sourceVariable"
+          onChange={onChange}
+          value={action?.action?.config?.sourceVariable}
+          filter={variable => variable.dataType === 'array' && variable.source === 'component'}
+        />
+      </DSLEditorNode>
+      {intl.formatMessage({
+        description: 'To variable message',
+        defaultMessage: 'To variable',
+      })}
+      <DSLEditorNode errors={errors?.action?.config?.destinationVariable}>
+        <VariableSelection
+          name="action.config.destinationVariable"
+          onChange={onChange}
+          value={action?.action?.config?.destinationVariable}
+          filter={variable => variable.dataType === 'array' && variable.source === 'component'}
+        />
+      </DSLEditorNode>
+    </>
+  );
+};
+
 const ActionFetchFromService = ({action, errors, onChange}) => {
   const intl = useIntl();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -349,6 +382,10 @@ const ActionComponent = ({action, errors, onChange}) => {
     }
     case 'evaluate-dmn': {
       Component = ActionEvaluateDMN;
+      break;
+    }
+    case 'synchronize-children': {
+      Component = ActionSynchronizeChildren;
       break;
     }
     default: {

--- a/src/openforms/js/components/admin/form_design/logic/constants.js
+++ b/src/openforms/js/components/admin/form_design/logic/constants.js
@@ -112,6 +112,13 @@ const ACTION_TYPES = [
       defaultMessage: 'Evaluate DMN',
     }),
   ],
+  [
+    'synchronize-children',
+    defineMessage({
+      description: 'action type "synchronize children" label',
+      defaultMessage: 'Synchronize children',
+    }),
+  ],
 ];
 
 // Action types that once they are selected need further configurations.

--- a/src/openforms/submissions/constants.py
+++ b/src/openforms/submissions/constants.py
@@ -5,6 +5,8 @@ SUBMISSIONS_SESSION_KEY = "form-submissions"
 
 IMAGE_COMPONENTS = ["signature"]
 
+MUTATIONS_RESTRICTIONS = ["bsn"]
+
 
 class RegistrationStatuses(models.TextChoices):
     pending = "pending", _("Pending (not registered yet)")

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -179,6 +179,40 @@ class VariableAction(ActionOperation):
             return {self.variable: jsonLogic(self.value, context.data)}
 
 
+class ChildrenConfig(TypedDict):
+    source_variable: str
+    destination_variable: str
+
+
+@dataclass
+class SynchronizeChildrenAction(ActionOperation):
+    source_variable: str
+    destination_variable: str
+
+    @classmethod
+    def from_action(cls, action: ActionDict) -> Self:
+        children_config: ChildrenConfig = action["action"]["config"]
+        return cls(**children_config)
+
+    def eval(
+        self,
+        context: FormioData,
+        submission: Submission,
+    ) -> DataMapping:
+        source_data = context.get(self.source_variable, [])
+        if not source_data:
+            return {
+                self.destination_variable: context.get(self.destination_variable, [])
+            }
+
+        updated_destination_data = []
+        for child in source_data:
+            if child["selected"] is None or child["selected"]:
+                updated_destination_data.append({"bsn": child["bsn"]})
+
+        return {self.destination_variable: updated_destination_data}
+
+
 @dataclass
 class ServiceFetchAction(ActionOperation):
     variable: str
@@ -292,6 +326,7 @@ ACTION_TYPE_MAPPING: Mapping[LogicActionTypes, type[ActionOperation]] = {
     LogicActionTypes.step_not_applicable: StepNotApplicableAction,
     LogicActionTypes.step_applicable: StepApplicableAction,
     LogicActionTypes.variable: VariableAction,
+    LogicActionTypes.synchronize_children: SynchronizeChildrenAction,
     LogicActionTypes.fetch_from_service: ServiceFetchAction,
     LogicActionTypes.evaluate_dmn: EvaluateDMNAction,
     LogicActionTypes.set_registration_backend: SetRegistrationBackendAction,

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -143,6 +143,7 @@ def iter_evaluate_rules(
                 continue
 
             for operation in rule.action_operations:
+                # breakpoint()
                 if mutations := operation.eval(data, submission=submission):
                     mutations_python = {
                         key: state.variables[key].to_python(value)

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -763,3 +763,118 @@ class VariableModificationTests(TestCase):
         variables_state = submission.load_submission_value_variables_state()
 
         self.assertEqual(str(variables_state.variables["date"].value), "2025-07-06")
+
+    def test_children_synchronization(self):
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "children",
+                        "key": "children",
+                        "enableSelection": True,
+                    },
+                ]
+            },
+        )
+        step2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "editgrid",
+                        "key": "editgrid",
+                        "components": [
+                            {"type": "bsn", "key": "bsn"},
+                        ],
+                    }
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            key="children_immutable",
+            form=form,
+            user_defined=True,
+            prefill_plugin="family_members",
+            prefill_options={
+                "type": "children",
+                "mutable_data_form_variable": "children",
+                "min_age": None,
+                "max_age": None,
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "type": "synchronize-children",
+                        "config": {
+                            "source_variable": "children",
+                            "destination_variable": "editgrid",
+                        },
+                    },
+                },
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step1,
+            data={
+                "children": [
+                    {
+                        "bsn": "999970409",
+                        "affixes": "van",
+                        "initials": "P.",
+                        "lastName": "Paassen",
+                        "firstNames": "Pero",
+                        "dateOfBirth": "2023-02-01",
+                        "dateOfBirthPrecision": "date",
+                        "selected": False,
+                        "__addedManually": False,
+                        "__id": "07375aec-739c-4aa7-bbca-083b617248de",
+                    },
+                    {
+                        "bsn": "999970161",
+                        "affixes": "van",
+                        "initials": "P.",
+                        "lastName": "Paassen",
+                        "firstNames": "Peet",
+                        "dateOfBirth": "2018-12-01",
+                        "dateOfBirthPrecision": "date",
+                        "selected": True,
+                        "__addedManually": False,
+                        "__id": "735ea17c-58a7-4676-94fc-cf2bb4263330",
+                    },
+                    {
+                        "bsn": "999970173",
+                        "affixes": "van",
+                        "initials": "P.",
+                        "lastName": "Paassen",
+                        "firstNames": "Pelle",
+                        "dateOfBirth": "2017-09-01",
+                        "dateOfBirthPrecision": "date",
+                        "selected": True,
+                        "__addedManually": False,
+                        "__id": "92188604-3924-439a-995b-6ab9c2ed77ae",
+                    },
+                ]
+            },
+        )
+        # Step being edited
+        submission_step2 = SubmissionStepFactory.build(
+            submission=submission,
+            form_step=step2,
+            data={},
+        )
+        evaluate_form_logic(submission, submission_step2, submission.data)
+
+        variables_state = submission.load_submission_value_variables_state()
+        variable = variables_state.variables["editgrid"]
+
+        self.assertEqual(variable.value, [{"bsn": "999970161"}, {"bsn": "999970173"}])


### PR DESCRIPTION
Closes #5269

**Changes**

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Release management

  - [ ] I have labelled the PR as "needs-backport" accordingly

- I have updated the translations assets (you do NOT need to provide translations)

  - [ ] Ran `./bin/makemessages_js.sh`
  - [ ] Ran `./bin/compilemessages_js.sh`

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
