### PR TITLE
:technologist: Suppress parser warning in test

### DIFF
--- a/src/openforms/payments/contrib/worldline/tests/test_plugin.py
+++ b/src/openforms/payments/contrib/worldline/tests/test_plugin.py
@@ -122,7 +122,7 @@ class WorldlinePluginTests(OFVCRMixin, WebTest):
             "Parse the payment URL from within the initial Worldline page"
         ):
             response = requests.get(data["url"])
-            soup = BeautifulSoup(response.content)
+            soup = BeautifulSoup(response.content, features="lxml")
             form = soup.select_one("form[name=redirectForm]")
 
             self.assertIsInstance(form, Tag)
@@ -216,7 +216,7 @@ class WorldlinePluginTests(OFVCRMixin, WebTest):
             "Parse the payment URL from within the initial Worldline page"
         ):
             response = requests.get(data["url"])
-            soup = BeautifulSoup(response.content)
+            soup = BeautifulSoup(response.content, features="lxml")
             form = soup.select_one("form[name=redirectForm]")
 
             self.assertIsInstance(form, Tag)
@@ -297,7 +297,7 @@ class WorldlinePluginTests(OFVCRMixin, WebTest):
             "Parse the payment URL from within the initial Worldline page"
         ):
             response = requests.get(data["url"])
-            soup = BeautifulSoup(response.content)
+            soup = BeautifulSoup(response.content, features="lxml")
             form = soup.select_one("form[name=redirectForm]")
 
             self.assertIsInstance(form, Tag)


### PR DESCRIPTION
It's annoying :)

Closes -

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
