### PR TITLE
[#4879] save merchant reference

### DIFF
--- a/src/openforms/payments/contrib/worldline/plugin.py
+++ b/src/openforms/payments/contrib/worldline/plugin.py
@@ -139,7 +139,12 @@ class WorldlinePaymentPlugin(BasePlugin[PaymentOptions]):
 
         payment.plugin_options = option_serializer.data
         payment.provider_payment_id = checkout_response.merchant_reference or ""
-        payment.save(update_fields=("plugin_options",))
+        payment.save(
+            update_fields=(
+                "plugin_options",
+                "provider_payment_id",
+            )
+        )
 
         return PaymentInfo(
             type=PaymentRequestType.get,

--- a/src/openforms/payments/contrib/worldline/tests/test_plugin.py
+++ b/src/openforms/payments/contrib/worldline/tests/test_plugin.py
@@ -336,7 +336,7 @@ class WorldlinePluginTests(OFVCRMixin, WebTest):
         submission.refresh_from_db()
         payment.refresh_from_db()
         self.assertEqual(payment.status, PaymentStatus.started)
-        self.assertEqual(payment.provider_payment_id, "")
+        self.assertTrue(payment.provider_payment_id)
         self.assertEqual(submission.payment_user_has_paid, False)
 
     def test_no_redirect_url(self):


### PR DESCRIPTION
Fixes the merchant reference not being saved after receiving the checkout status. Not sure how this got past[ this test though ](https://github.com/open-formulieren/open-forms/blob/master/src/openforms/payments/contrib/worldline/tests/test_plugin.py#L161):thinking:.

[skip: e2e]