### PR TITLE
Update lazy-object-proxies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -329,7 +329,7 @@ jsonschema-specifications==2023.7.1
     #   openapi-schema-validator
 kombu==5.5.2
     # via celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.11.0
     # via openapi-spec-validator
 lxml==5.3.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -572,7 +572,7 @@ kombu==5.5.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.11.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -633,7 +633,7 @@ kombu==5.5.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.11.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -537,7 +537,7 @@ kombu==5.5.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.11.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -608,7 +608,7 @@ kombu==5.5.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.11.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Although only version `1.7.0` [is reported to be yanked](https://pypi.org/project/lazy-object-proxy/#history), version `1.9.0` does not seem to be available anymore ([builds](https://github.com/open-formulieren/open-forms/actions/runs/16878268650/job/47807778977?pr=5498#step:4:81) are failing on this specific version).

[skip: e2e]