### PR TITLE
Logic check returns all step data

### DIFF
--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -271,7 +271,12 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         new_configuration = evaluate_form_logic(instance.submission, instance)
         # update the config for serialization
         instance.form_step.form_definition.configuration = new_configuration
-        return super().to_representation(instance)
+        representation = super().to_representation(instance)
+
+        if self.context.get("unsaved_data_only", False):
+            representation["data"] = instance.unsaved_data
+
+        return representation
 
     def validate_data(self, data: FormioData):
         self._run_formio_validation(data)

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -691,6 +691,10 @@ class SubmissionStepViewSet(
 
         submission_state_logic_serializer = SubmissionStateLogicSerializer(
             instance=SubmissionStateLogic(submission=submission, step=submission_step),
-            context={"request": request, "current_step": submission_step},
+            context={
+                "request": request,
+                "current_step": submission_step,
+                "unsaved_data_only": True,
+            },
         )
         return Response(submission_state_logic_serializer.data)

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -202,6 +202,10 @@ class SubmissionStep(models.Model):  # noqa: DJ008
         self.save()
 
     @property
+    def unsaved_data(self) -> FormioData | None:
+        return self._unsaved_data
+
+    @property
     def data(self) -> FormioData:
         values_state = self.submission.load_submission_value_variables_state()
         step_data = values_state.get_data(submission_step=self)


### PR DESCRIPTION
Closes #5527

[skip: e2e]

**Changes**

Add flag to `SubmissionStateLogicSerializer` context to only return unsaved data

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
