### PR TITLE
Set up mechanism to serve static files via nginx instead of uwsgi

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -14,6 +14,11 @@ mountpoint=${SUBPATH:-/}
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
+# Copy static root to volume, if required
+if [ -n "$STATIC_ROOT_VOLUME" ]; then
+    cp -r /app/static/* "$STATIC_ROOT_VOLUME"
+fi
+
 # wait for required services
 ${SCRIPTPATH}/wait_for_db.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ x-app-env: &x-app-env
   - DB_NAME=openforms
   - DB_USER=openforms
   - DB_HOST=db
+  - STATIC_ROOT_VOLUME=/srv/static/
   - CACHE_DEFAULT=redis:6379/0
   - CACHE_AXES=redis:6379/0
   - CACHE_PORTALOCKER=redis:6379/0
@@ -59,6 +60,15 @@ x-app-env: &x-app-env
   - OTEL_EXPORTER_OTLP_METRICS_INSECURE=${OTEL_EXPORTER_OTLP_METRICS_INSECURE:-true}
   - OF_OTEL_ENABLE_CONTAINER_RESOURCE_DETECTOR=true
 
+x-app-volumes: &x-app-volumes
+  - static:/srv/static
+  - media:/app/media
+  - private_media:/app/private_media
+  - ./docker/setup_configuration:/app/setup_configuration
+  - log:/app/log
+  - certifi_ca_bundle:/app/certifi_ca_bundle
+  - ./bin/test_fix_scripts.sh:/app/bin/test_fix_scripts.sh
+
 services:
   db:
     image: postgres:${PG_VERSION:-15}  # Minimum required version is 12
@@ -88,10 +98,11 @@ services:
     networks:
       - open-forms-dev
 
-  busybox:
+  prepare-volumes:
     image: busybox
-    command: /bin/chown -R 1000 /private-media
+    command: /bin/chown -R 1000 /private-media /srv/static
     volumes:
+      - static:/srv/static
       - private_media:/private-media
 
   web:
@@ -102,13 +113,7 @@ services:
         SDK_RELEASE: ${SDK_TAG:-latest}
     image: openformulieren/open-forms:${TAG:-latest}
     environment: *x-app-env
-    volumes: &web_volumes
-      - media:/app/media
-      - private_media:/app/private_media
-      - ./docker/setup_configuration:/app/setup_configuration
-      - log:/app/log
-      - certifi_ca_bundle:/app/certifi_ca_bundle
-      - ./bin/test_fix_scripts.sh:/app/bin/test_fix_scripts.sh
+    volumes: *x-app-volumes
     labels:
       <<: *x-labels
       service: web
@@ -116,6 +121,7 @@ services:
     ports:
       - 8000:8000
     depends_on:
+      - prepare-volumes
       - db
       - redis
       - smtp
@@ -131,8 +137,9 @@ services:
     build: .
     environment: *x-app-env
     command: /setup_configuration.sh
-    volumes: *web_volumes
+    volumes: *x-app-volumes
     depends_on:
+      - prepare-volumes
       - db
       - redis
     networks:
@@ -142,6 +149,7 @@ services:
     image: nginx
     volumes:
       - ./docker-nginx-default.conf:/etc/nginx/conf.d/default.conf
+      - static:/static
       - private_media:/private-media
     ports:
       - '9000:80'
@@ -161,7 +169,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
-    volumes: *web_volumes
+    volumes: *x-app-volumes
     labels:
       <<: *x-labels
       service: background-tasks
@@ -203,6 +211,7 @@ services:
 
 volumes:
   db:
+  static:
   media:
   private_media:
   log:

--- a/docker-nginx-default.conf
+++ b/docker-nginx-default.conf
@@ -2,6 +2,11 @@ server {
     listen       80;
     server_name  localhost;
 
+    location /static/ {
+        expires max;
+        alias /static/;
+    }
+
     location /private-media {
         internal;
         alias /private-media;
@@ -17,4 +22,3 @@ server {
         proxy_pass   http://web:8000;
     }
 }
-


### PR DESCRIPTION
Sparked by a production incident before my vacation.

Copying the static files to a volume shared with the nginx container makes it possible for nginx to serve the static files directly.

The mechanism is opt-in so that we can keep things backwards compatible. Possibly in 4.0 we remove the uwsgi --static-map option as it could mask potential issues, but that's just a thought at this time.

The recursive copy should be sufficiently safe even with race conditions between replicas:

* we use the manifest static file storage, which appends a unique hash to each static file
* the replicas deploy the same container version and the same set of static files is included in each, so even if one overwrites the other the end-result will be the same
* we don't perform file removal at all, so old versions of static files are still present and won't cause issues if they're still being downloaded while an upgrade is taking place

So for now, any complexity with temporary directories and atomic copies is deferred until it turns out to actually be needed.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]