### PR TITLE
:green_heart: Fix test flakiness

### DIFF
--- a/bin/check_error.py
+++ b/bin/check_error.py
@@ -1,3 +1,6 @@
+# THIS SCRIPT IS ONLY USED IN UNIT TESTS
+
+
 def main(skip_setup=False):
     raise Exception("nope")
 

--- a/bin/check_fail.py
+++ b/bin/check_fail.py
@@ -1,3 +1,4 @@
+# THIS SCRIPT IS ONLY USED IN UNIT TESTS
 import django
 
 

--- a/bin/check_pass.py
+++ b/bin/check_pass.py
@@ -1,3 +1,4 @@
+# THIS SCRIPT IS ONLY USED IN UNIT TESTS
 import django
 
 

--- a/src/openforms/upgrades/tests/test_upgrade_paths.py
+++ b/src/openforms/upgrades/tests/test_upgrade_paths.py
@@ -1,17 +1,10 @@
-import shutil
-from pathlib import Path
-
-from django.conf import settings
 from django.test import SimpleTestCase
 
 from ..script_checks import BinScriptCheck
 
-FILES_DIR = (Path(__file__).parent / "files").resolve()
-
 
 class DjangoScriptTests(SimpleTestCase):
     def test_check_script(self):
-        script_dir = Path(settings.BASE_DIR) / "bin"
         scripts = (
             ("check_pass", True),
             ("check_fail", False),
@@ -19,11 +12,6 @@ class DjangoScriptTests(SimpleTestCase):
         )
         for script, expected_outcome in scripts:
             with self.subTest(script=script):
-                src = FILES_DIR / f"{script}.py-tpl"
-                dest = script_dir / f"{script}.py"
-                shutil.copyfile(src, dest)
-                self.addCleanup(dest.unlink)
-
                 script_check = BinScriptCheck(script)
 
                 self.assertEqual(script_check.execute(), expected_outcome)


### PR DESCRIPTION
It's no longer necessary to use .py-tpl files for the check scripts, instead we can put them directly in the bin/ folder and invoke them this way.

This removes the filesystem sync/race condition that introduces test flakiness (suspected).

[skip: e2e]