### PR TITLE
Bump mail cleaner to 2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -342,7 +342,7 @@ lxml==5.3.1
     #   zeep
 lxml-html-clean==0.4.1
     # via -r requirements/base.in
-mail-cleaner==1.2.0
+mail-cleaner==2.0.0
     # via -r requirements/base.in
 mail-parser==3.15.0
     # via django-yubin

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -592,7 +592,7 @@ lxml-html-clean==0.4.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-mail-cleaner==1.2.0
+mail-cleaner==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -653,7 +653,7 @@ lxml-html-clean==0.4.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-mail-cleaner==1.2.0
+mail-cleaner==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -556,7 +556,7 @@ lxml-html-clean==0.4.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-mail-cleaner==1.2.0
+mail-cleaner==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -628,7 +628,7 @@ lxml-html-clean==0.4.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-mail-cleaner==1.2.0
+mail-cleaner==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Contains a bugfix for crash in anchor text processing, see Taiga Vught #100.

The breaking changes do not affect us at all.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]