### PR TITLE
Implement Yivi prefill plugin

### DIFF
--- a/docs/configuration/prefill/index.rst
+++ b/docs/configuration/prefill/index.rst
@@ -16,3 +16,4 @@ Prefill plugins
    family_members
    eidas
    eidas_company
+   yivi

--- a/docs/configuration/prefill/yivi.rst
+++ b/docs/configuration/prefill/yivi.rst
@@ -1,0 +1,40 @@
+.. _configuration_prefill_yivi:
+
+====
+Yivi
+====
+
+`Yivi`_ is a identity wallet, allowing greater control for users about which personal
+data they share with a website. The information available after Yivi authentication
+depends on the Yivi authentication plugin configuration, and the decisions of the
+authenticated user.
+
+The **Yivi** prefill plugin can be used to access this data in order to prefill personal
+or professional information of the authenticated user within a form.
+
+.. note::
+
+   The Yivi prefill plugin only works if the user logged in using the Yivi via OIDC
+   authentication plugin.
+
+
+Configuration
+=============
+
+#. First thing you need is to configure the Yivi OIDC provider and OIDC client
+   (see :ref:`configuration guide <configuration_authentication_oidc_yivi>` for details)
+#. Next step is to navigate to: **Configuration** > **General configuration** > **Plugin configuration**.
+#. Make sure the **Yivi** prefill- and authentication plugins are enabled.
+#. Click **Save**.
+#. The prefill configuration is ready.
+
+How it works
+============
+
+As mentioned above, the Yivi prefill plugin grants access to Yivi authentication data.
+
+In order to use the plugin you need to complete the configuration above. Next step is
+to enable Yivi authentication on your form, as the Yivi prefill plugin requires Yivi
+authentication to work. Finally you can add prefill with Yivi to the variables.
+
+.. _`Yivi`: https://yivi.app/

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3648,6 +3648,45 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+  /api/v2/prefill/plugins/yivi/attribute-groups:
+    get:
+      operationId: prefill_plugins_yivi_attribute_groups_list
+      description: |-
+        List all Yivi prefill attributes, based on the Yivi attribute groups.
+
+        This endpoint lists all available Yivi attribute groups, and is used for Yivi
+        authentication and prefill plugin configuration. The `prefill_attributes` and
+        `is_virtual` are solely used for the Yivi prefill plugin configuration.
+
+        `prefill_attributes` contains the attributes that are derived from the
+        attribute group.
+
+        `is_virtual` is used for attribute groups that don't actually exist. These attribute
+        groups are added to pass any additional Yivi prefill attributes to the frontend
+        (like the prefill attributes for identifier and loa values).
+      summary: List available Yivi prefill attributes
+      tags:
+      - prefill
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/YiviPrefillAttribute'
+          description: ''
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/products:
     get:
       operationId: products_list
@@ -9789,6 +9828,17 @@ components:
       required:
       - id
       - label
+    PrefillAttributeChoice:
+      type: object
+      properties:
+        label:
+          type: string
+          default: ''
+          description: Prefill attribute label
+        value:
+          type: string
+          default: ''
+          description: Prefill attribute value
     PrefillIdentifierRoleEnum:
       enum:
       - main
@@ -10807,6 +10857,29 @@ components:
       - componentKey
       - email
       - submission
+    YiviPrefillAttribute:
+      type: object
+      properties:
+        attributeGroupUuid:
+          type: string
+          format: uuid
+          description: The UUID of the related attribute group.
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PrefillAttributeChoice'
+          default: []
+          title: Prefill attributes
+          description: Prefill attributes derived from the attribute group with uuid`attribute_group_uuid`.
+            The `attributes` should only be used for prefill, ifthe corresponding
+            Yivi attribute group is used in the authenticationbackend.
+        isStatic:
+          type: boolean
+          default: false
+          description: Static prefill attributes aren't related to any attribute groups,
+            and canalways be used for Yivi prefill.
+      required:
+      - attributeGroupUuid
     _AppointmentProduct:
       type: object
       properties:

--- a/src/openforms/authentication/contrib/yivi_oidc/oidc_plugins/plugins.py
+++ b/src/openforms/authentication/contrib/yivi_oidc/oidc_plugins/plugins.py
@@ -268,7 +268,12 @@ class YiviPlugin(BaseOIDCPlugin, AnonymousUserOIDCPluginProtocol):
             [
                 {
                     "path_in_claim": [attribute],
-                    "processed_path": ["additional_claims", attribute],
+                    # Jsonlogic, which we use to access the variables in the json logic and components,
+                    # cannot retrieve data from a key that contains periods (aka dots ".").
+                    # To allow these values to be targeted, we replace the period with an underscore.
+                    # In case of nested attributes, this replacing is done recursively.
+                    # https://github.com/open-formulieren/open-forms/issues/5475
+                    "processed_path": ["additional_claims", attribute.replace(".", "_")],
                 }
                 for attribute_group in additional_attributes
                 for attribute in attribute_group

--- a/src/openforms/authentication/contrib/yivi_oidc/tests/oidc_plugins/test_plugins.py
+++ b/src/openforms/authentication/contrib/yivi_oidc/tests/oidc_plugins/test_plugins.py
@@ -73,7 +73,7 @@ class ProcessClaimsYiviTest(OIDCMixin, TestCase):
                 "bsn_claim": "123456782",
                 "loa_claim": "low",
                 "additional_claims": {
-                    "irma-demo.gemeente.personalData.familyname": "Doe"
+                    "irma-demo_gemeente_personalData_familyname": "Doe"
                 },
             },
         )

--- a/src/openforms/authentication/static_variables/static_variables.py
+++ b/src/openforms/authentication/static_variables/static_variables.py
@@ -16,20 +16,6 @@ if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
 
-# Jsonlogic, which we use to access the variables in the json logic and components,
-# cannot retrieve data from a key that contains periods (aka dots ".").
-# To allow these values to be targeted, we replace the period with an underscore.
-# In case of nested attributes, this replacing is done recursively.
-# https://github.com/open-formulieren/open-forms/issues/5475
-def clean_attribute_keys(attributes: dict[str, object]) -> dict[str, object]:
-    return {
-        key.replace(".", "_"): clean_attribute_keys(value)
-        if isinstance(value, dict)
-        else value
-        for key, value in attributes.items()
-    }
-
-
 @register_static_variable("submission_id")
 class SubmissionID(BaseStaticVariable):
     name = _("Internal ID")
@@ -79,9 +65,7 @@ class Auth(BaseStaticVariable):
             plugin=submission.auth_info.plugin,
             attribute=submission.auth_info.attribute,
             value=submission.auth_info.value,
-            additional_claims=clean_attribute_keys(
-                submission.auth_info.additional_claims
-            ),
+            additional_claims=submission.auth_info.additional_claims,
         )
 
         return auth_data
@@ -186,7 +170,7 @@ class AuthAdditionalClaims(BaseStaticVariable):
     def get_initial_value(self, submission: Submission | None = None):
         if submission is None or not submission.is_authenticated:
             return None
-        return clean_attribute_keys(submission.auth_info.additional_claims)
+        return submission.auth_info.additional_claims
 
     def as_json_schema(self):
         return {
@@ -212,9 +196,7 @@ class AuthContext(BaseStaticVariable):
             # attributes, which won't be accessible for jsonlogic and django templating.
             # So we have to clean them.
             auth_context["authorizee"]["legalSubject"]["additionalInformation"] = (
-                clean_attribute_keys(
-                    auth_context["authorizee"]["legalSubject"]["additionalInformation"]
-                )
+                auth_context["authorizee"]["legalSubject"]["additionalInformation"]
             )
 
         return auth_context

--- a/src/openforms/authentication/tests/test_static_variables.py
+++ b/src/openforms/authentication/tests/test_static_variables.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from django.test import TestCase
 
-from digid_eherkenning.choices import DigiDAssuranceLevels
 from jsonschema.validators import Draft202012Validator
 
 from openforms.authentication.constants import AuthAttribute
@@ -42,47 +41,6 @@ class TestStaticVariables(TestCase):
                 "additional_claims": {
                     "firstName": "John",
                     "familyName": "Doe",
-                },
-            },
-            "auth_bsn": "111222333",
-            "auth_kvk": "",
-            "auth_pseudo": "",
-            "auth_type": "bsn",
-        }
-
-        for variable_key, value in expected.items():
-            with self.subTest(key=variable_key, value=value):
-                self.assertIn(variable_key, static_data)
-                self.assertEqual(static_data[variable_key].initial_value, value)
-
-    def test_auth_static_data_periods_and_hyphens_in_additional_claims_claim_keys_are_replaced_with_underscores(
-        self,
-    ):
-        auth_info = AuthInfoFactory.create(
-            plugin="test-plugin",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            additional_claims={
-                "first.name": "John",
-                "family.name": "Doe",
-                "pbdf.pilot-amsterdam.passport.over18": "Yes",
-            },
-        )
-
-        static_data = {
-            variable.key: variable
-            for variable in get_static_variables(submission=auth_info.submission)
-        }
-
-        expected = {
-            "auth": {
-                "plugin": "test-plugin",
-                "attribute": AuthAttribute.bsn,
-                "value": "111222333",
-                "additional_claims": {
-                    "first_name": "John",
-                    "family_name": "Doe",
-                    "pbdf_pilot-amsterdam_passport_over18": "Yes",
                 },
             },
             "auth_bsn": "111222333",
@@ -212,76 +170,6 @@ class TestStaticVariables(TestCase):
         self.assertEqual(
             static_data["auth_additional_claims"],
             {"firstName": "John", "familyName": "Doe"},
-        )
-
-    def test_additional_claims_periods_and_hyphens_in_claim_keys_are_replaced_with_underscores(
-        self,
-    ):
-        auth_info = AuthInfoFactory.create(
-            plugin="test-plugin",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            additional_claims={
-                "first.name": "John",
-                "family.name": "Doe",
-                "pbdf.pilot-amsterdam.passport.over18": "Yes",
-                "pbdf.pilot-amsterdam": {"passport.over18": "Yes"},
-            },
-        )
-
-        static_data = {
-            variable.key: variable.initial_value
-            for variable in get_static_variables(submission=auth_info.submission)
-        }
-
-        self.assertEqual(
-            static_data["auth_additional_claims"],
-            {
-                "first_name": "John",
-                "family_name": "Doe",
-                "pbdf_pilot-amsterdam_passport_over18": "Yes",
-                "pbdf_pilot-amsterdam": {"passport_over18": "Yes"},
-            },
-        )
-
-    def test_auth_context_periods_and_hyphens_in_additional_claims_claim_keys_are_replaced_with_underscores(
-        self,
-    ):
-        auth_info = AuthInfoFactory.create(
-            plugin="yivi_oidc",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            additional_claims={
-                "first.name": "John",
-                "family.name": "Doe",
-                "pbdf.pilot-amsterdam.passport.over18": "Yes",
-                "pbdf.pilot-amsterdam": {"passport.over18": "Yes"},
-            },
-        )
-
-        static_data = {
-            variable.key: variable.initial_value
-            for variable in get_static_variables(submission=auth_info.submission)
-        }
-
-        self.assertEqual(
-            static_data["auth_context"],
-            {
-                "source": "yivi",
-                "levelOfAssurance": DigiDAssuranceLevels.middle,
-                "authorizee": {
-                    "legalSubject": {
-                        "identifierType": "bsn",
-                        "identifier": "111222333",
-                        "additionalInformation": {
-                            "first_name": "John",
-                            "family_name": "Doe",
-                            "pbdf_pilot-amsterdam_passport_over18": "Yes",
-                            "pbdf_pilot-amsterdam": {"passport_over18": "Yes"},
-                        },
-                    }
-                },
-            },
         )
 
 

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -243,6 +243,7 @@ INSTALLED_APPS = [
     "openforms.prefill.contrib.suwinet.apps.SuwinetApp",
     "openforms.prefill.contrib.objects_api.apps.ObjectsApiApp",
     "openforms.prefill.contrib.family_members.apps.FamilyMembersApp",
+    "openforms.prefill.contrib.yivi.apps.YiviApp",
     "openforms.authentication",
     "openforms.authentication.contrib.demo.apps.DemoApp",
     "openforms.authentication.contrib.outage.apps.DemoOutageApp",

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -4089,6 +4089,12 @@
       "value": "Save"
     }
   ],
+  "YS5Qye": [
+    {
+      "type": 0,
+      "value": "The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!"
+    }
+  ],
   "YSuwK2": [
     {
       "type": 0,

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -4106,6 +4106,12 @@
       "value": "Opslaan"
     }
   ],
+  "YS5Qye": [
+    {
+      "type": 0,
+      "value": "The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!"
+    }
+  ],
   "YSuwK2": [
     {
       "type": 0,

--- a/src/openforms/js/components/admin/Alert.js
+++ b/src/openforms/js/components/admin/Alert.js
@@ -1,0 +1,17 @@
+import '@utrecht/components/alert';
+import PropTypes from 'prop-types';
+
+const Alert = ({children, type}) => {
+  return (
+    <div className={`alert alert-${type}`} role="alert">
+      {children}
+    </div>
+  );
+};
+
+Alert.propTypes = {
+  type: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default Alert;

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -19,6 +19,7 @@ const FormContext = React.createContext({
   registrationPluginsVariables: [],
   registrationBackends: [],
   authBackends: [],
+  yiviPrefillAttributes: [],
   plugins: {},
   languages: [],
   translationEnabled: false,

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -18,6 +18,7 @@ const FormContext = React.createContext({
   staticVariables: [],
   registrationPluginsVariables: [],
   registrationBackends: [],
+  authBackends: [],
   plugins: {},
   languages: [],
   translationEnabled: false,

--- a/src/openforms/js/components/admin/form_design/constants.js
+++ b/src/openforms/js/components/admin/form_design/constants.js
@@ -7,6 +7,7 @@ export const REGISTRATION_OBJECTS_TARGET_PATHS =
 export const REGISTRATION_GENERIC_JSON_FIXED_METADATA_VARIABLES =
   '/api/v2/registration/plugins/generic-json/fixed-metadata-variables';
 export const AUTH_PLUGINS_ENDPOINT = '/api/v2/authentication/plugins';
+export const YIVI_PREFILL_ATTRIBUTES_ENDPOINT = '/api/v2/prefill/plugins/yivi/attribute-groups';
 export const PREFILL_PLUGINS_ENDPOINT = '/api/v2/prefill/plugins';
 export const DMN_PLUGINS_ENDPOINT = '/api/v2/dmn/plugins';
 export const PAYMENT_PLUGINS_ENDPOINT = '/api/v2/payment/plugins';

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1233,6 +1233,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
           languages: state.languageInfo.languages,
           translationEnabled: state.form.translationEnabled,
           registrationBackends: state.form.registrationBackends,
+          authBackends: state.form.authBackends,
           selectedAuthPlugins: state.selectedAuthPlugins,
         }}
       >

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -50,6 +50,7 @@ import {
   REGISTRATION_VARIABLES_ENDPOINT,
   STATIC_VARIABLES_ENDPOINT,
   THEMES_ENDPOINT,
+  YIVI_PREFILL_ATTRIBUTES_ENDPOINT,
 } from './constants';
 import {loadForm, loadFromBackend, saveCompleteForm} from './data';
 import {updateWarningsValidationError} from './logic/utils';
@@ -142,6 +143,7 @@ const initialFormState = {
   logicRules: [],
   formVariables: [],
   staticVariables: [],
+  yiviPrefillAttributes: [],
   // backend error handling
   validationErrors: [],
   tabsWithErrors: [],
@@ -919,6 +921,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
     {endpoint: PAYMENT_PLUGINS_ENDPOINT, stateVar: 'availablePaymentBackends'},
     {endpoint: REGISTRATION_BACKENDS_ENDPOINT, stateVar: 'availableRegistrationBackends'},
     {endpoint: AUTH_PLUGINS_ENDPOINT, stateVar: 'availableAuthPlugins'},
+    {endpoint: YIVI_PREFILL_ATTRIBUTES_ENDPOINT, stateVar: 'yiviPrefillAttributes'},
     {endpoint: CATEGORIES_ENDPOINT, stateVar: 'availableCategories'},
     {endpoint: THEMES_ENDPOINT, stateVar: 'availableThemes'},
     {endpoint: PREFILL_PLUGINS_ENDPOINT, stateVar: 'availablePrefillPlugins'},
@@ -1224,6 +1227,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
           formVariables: state.formVariables,
           staticVariables: state.staticVariables,
           registrationPluginsVariables: state.registrationPluginsVariables,
+          yiviPrefillAttributes: state.yiviPrefillAttributes,
           plugins: {
             availableAuthPlugins: state.availableAuthPlugins,
             selectedAuthPlugins: state.selectedAuthPlugins,

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -77,6 +77,7 @@ export const FormDecorator = (Story, {args}) => (
       formVariables: args.availableFormVariables || [],
       registrationPluginsVariables: args.registrationPluginsVariables || [],
       selectedAuthPlugins: args.selectedAuthPlugins || [],
+      yiviPrefillAttributes: args.yiviPrefillAttributes || [],
       authBackends: args.authBackends || [],
       plugins: {
         availableAuthPlugins: args.availableAuthPlugins || [],

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -77,6 +77,7 @@ export const FormDecorator = (Story, {args}) => (
       formVariables: args.availableFormVariables || [],
       registrationPluginsVariables: args.registrationPluginsVariables || [],
       selectedAuthPlugins: args.selectedAuthPlugins || [],
+      authBackends: args.authBackends || [],
       plugins: {
         availableAuthPlugins: args.availableAuthPlugins || [],
         availablePrefillPlugins: args.availablePrefillPlugins || [],

--- a/src/openforms/js/components/admin/form_design/variables/prefill/constants.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/constants.js
@@ -2,6 +2,7 @@ import DefaultFields from './default/DefaultFields';
 import FamilyMembersFields from './family_members/FamilyMembersFields';
 import ObjectsAPIFields from './objects_api/ObjectsAPIFields';
 import ToggleCopyButton from './objects_api/ToggleCopyButton';
+import YiviFields from './yivi/YiviFields';
 
 const PLUGIN_COMPONENT_MAPPING = {
   objects_api: {
@@ -10,6 +11,10 @@ const PLUGIN_COMPONENT_MAPPING = {
   },
   family_members: {
     component: FamilyMembersFields,
+    pluginFieldExtra: null,
+  },
+  yivi: {
+    component: YiviFields,
     pluginFieldExtra: null,
   },
   default: {

--- a/src/openforms/js/components/admin/form_design/variables/prefill/yivi/YiviFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/yivi/YiviFields.js
@@ -1,0 +1,80 @@
+import {useContext} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import Alert from 'components/admin/Alert';
+import {FormContext} from 'components/admin/form_design/Context';
+import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import {WarningIcon} from 'components/admin/icons';
+
+import AttributeField from '../default/AttributeField';
+import IdentifierRoleField from '../default/IdentifierRoleField';
+
+const YiviFields = () => {
+  const {authBackends, yiviPrefillAttributes} = useContext(FormContext);
+  const yiviAuthBackend = authBackends.find(authBackend => authBackend.backend === 'yivi_oidc');
+  const {
+    options: {additionalAttributesGroups},
+  } = yiviAuthBackend;
+
+  const getPrefillAttributes = expression => {
+    const attributeGroup = yiviPrefillAttributes.find(expression);
+    if (!attributeGroup || !Array.isArray(attributeGroup.attributes)) {
+      return [];
+    }
+
+    return attributeGroup.attributes.map(attribute => [attribute.value, attribute.label]);
+  };
+
+  // The virtual attributes aren't dependent on the Yivi auth backend options, so they be
+  // always added.
+  const prefillAttributes = [...getPrefillAttributes(attributeGroup => attributeGroup.isStatic)];
+  additionalAttributesGroups.forEach(groupUuid => {
+    prefillAttributes.push(
+      ...getPrefillAttributes(attributeGroup => attributeGroup.attributeGroupUuid === groupUuid)
+    );
+  });
+
+  return (
+    <Fieldset>
+      <Alert type="warning">
+        <WarningIcon asLead />
+        <FormattedMessage
+          description="Yivi prefill plugin warning message"
+          defaultMessage="The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!"
+        />
+      </Alert>
+
+      <FormRow>
+        <Field
+          name="attribute"
+          label={
+            <FormattedMessage
+              description="Variable prefill attribute label"
+              defaultMessage="Attribute"
+            />
+          }
+        >
+          <AttributeField prefillAttributes={prefillAttributes} />
+        </Field>
+      </FormRow>
+
+      <FormRow>
+        <Field
+          name="identifierRole"
+          label={
+            <FormattedMessage
+              description="Variable prefill identifier role label"
+              defaultMessage="Identifier role"
+            />
+          }
+        >
+          <IdentifierRoleField />
+        </Field>
+      </FormRow>
+    </Fieldset>
+  );
+};
+
+export default YiviFields;

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1979,6 +1979,11 @@
     "description": "Admin save submit button",
     "originalDefault": "Save"
   },
+  "YS5Qye": {
+    "defaultMessage": "The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!",
+    "description": "Yivi prefill plugin warning message",
+    "originalDefault": "The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!"
+  },
   "YbnFnL": {
     "defaultMessage": "The component \"{label}\" (with key \"{key}\"{location}) has a problem in the field \"{field}\": {error}",
     "description": "Formio configuration backend validation error for specific component property",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -2000,6 +2000,11 @@
     "description": "Admin save submit button",
     "originalDefault": "Save"
   },
+  "YS5Qye": {
+    "defaultMessage": "The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!",
+    "description": "Yivi prefill plugin warning message",
+    "originalDefault": "The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. Make sure to also configure the Yivi authentication plugin!"
+  },
   "YbnFnL": {
     "defaultMessage": "Er is een fout bij de component \"{label}\" (met sleutel \"{key}\"{location}) in het veld \"{field}\": {error}",
     "description": "Formio configuration backend validation error for specific component property",

--- a/src/openforms/prefill/api/urls.py
+++ b/src/openforms/prefill/api/urls.py
@@ -18,4 +18,8 @@ urlpatterns += [
         "plugins/objects-api/",
         include("openforms.prefill.contrib.objects_api.api.urls"),
     ),
+    path(
+        "plugins/yivi/",
+        include("openforms.prefill.contrib.yivi.api.urls"),
+    ),
 ]

--- a/src/openforms/prefill/contrib/yivi/api/serializers.py
+++ b/src/openforms/prefill/contrib/yivi/api/serializers.py
@@ -1,0 +1,57 @@
+from typing import TypedDict
+
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+
+from openforms.utils.mixins import JsonSchemaSerializerMixin
+
+
+class PrefillAttributeChoice(TypedDict):
+    label: str
+    value: str
+
+
+class YiviPrefillAttributeApiResponse(TypedDict):
+    attribute_group_uuid: str
+    attributes: list[PrefillAttributeChoice]
+    is_static: bool
+
+
+class PrefillAttributeChoiceSerializer(serializers.Serializer):
+    label = serializers.CharField(
+        label=_("Label"),
+        help_text=_("Prefill attribute label"),
+        default="",
+    )
+    value = serializers.CharField(
+        label=_("Value"),
+        help_text=_("Prefill attribute value"),
+        default="",
+    )
+
+
+class YiviPrefillAttributeSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
+    attribute_group_uuid = serializers.UUIDField(
+        label=_("Attribute group UUID"),
+        help_text=_("The UUID of the related attribute group."),
+    )
+    attributes = serializers.ListField(
+        child=PrefillAttributeChoiceSerializer(),
+        label=_("Prefill attributes"),
+        help_text=_(
+            "Prefill attributes derived from the attribute group with uuid"
+            "`attribute_group_uuid`. The `attributes` should only be used for prefill, if"
+            "the corresponding Yivi attribute group is used in the authentication"
+            "backend."
+        ),
+        default=list(),
+    )
+    is_static = serializers.BooleanField(
+        label=_("Is static"),
+        help_text=_(
+            "Static prefill attributes aren't related to any attribute groups, and can"
+            "always be used for Yivi prefill."
+        ),
+        default=False,
+    )

--- a/src/openforms/prefill/contrib/yivi/api/urls.py
+++ b/src/openforms/prefill/contrib/yivi/api/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from .views import AttributeGroupListView
+
+app_name = "prefill_yivi"
+
+urlpatterns = [
+    path(
+        "attribute-groups",
+        AttributeGroupListView.as_view(),
+        name="yivi-prefill-attributes-list",
+    ),
+]

--- a/src/openforms/prefill/contrib/yivi/api/views.py
+++ b/src/openforms/prefill/contrib/yivi/api/views.py
@@ -1,0 +1,77 @@
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import authentication, permissions, views
+
+from openforms.api.views import ListMixin
+from openforms.authentication.contrib.yivi_oidc.models import AttributeGroup
+
+from .serializers import YiviPrefillAttributeApiResponse, YiviPrefillAttributeSerializer
+
+
+@extend_schema_view(
+    get=extend_schema(summary=_("List available Yivi prefill attributes")),
+)
+class AttributeGroupListView(ListMixin, views.APIView):
+    """
+    List all Yivi prefill attributes, based on the Yivi attribute groups.
+
+    This endpoint lists all available Yivi attribute groups, and is used for Yivi
+    authentication and prefill plugin configuration. The `prefill_attributes` and
+    `is_virtual` are solely used for the Yivi prefill plugin configuration.
+
+    `prefill_attributes` contains the attributes that are derived from the
+    attribute group.
+
+    `is_virtual` is used for attribute groups that don't actually exist. These attribute
+    groups are added to pass any additional Yivi prefill attributes to the frontend
+    (like the prefill attributes for identifier and loa values).
+    """
+
+    authentication_classes = (authentication.SessionAuthentication,)
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = YiviPrefillAttributeSerializer
+
+    def _get_virtual_prefill_attribute_groups(
+        self,
+    ) -> list[YiviPrefillAttributeApiResponse]:
+        virtual_prefill_attribute_group: YiviPrefillAttributeApiResponse = {
+            "attribute_group_uuid": "00000000-0000-0000-0000-000000000000",
+            "attributes": [
+                {
+                    "label": _("Identifier"),
+                    "value": "value",
+                },
+                {
+                    "label": _("Level of Assurance"),
+                    "value": "loa",
+                },
+            ],
+            "is_static": True,
+        }
+
+        return [virtual_prefill_attribute_group]
+
+    def get_objects(self) -> list[YiviPrefillAttributeApiResponse]:
+        prefill_attribute_groups: list[YiviPrefillAttributeApiResponse] = []
+
+        for group in AttributeGroup.objects.all():
+            prefill_attribute: YiviPrefillAttributeApiResponse = {
+                "attribute_group_uuid": group.uuid,
+                "attributes": [
+                    {
+                        "label": attribute,
+                        # In the backend, the periods in Yivi attributes have been replaced
+                        # with underscores. Make sure these attributes are also updated.
+                        # https://github.com/open-formulieren/open-forms/issues/5475
+                        "value": f"additional_claims.{attribute.replace('.', '_')}",
+                    }
+                    for attribute in group.attributes
+                ],
+                "is_static": False,
+            }
+            prefill_attribute_groups.append(prefill_attribute)
+
+        print(prefill_attribute_groups)
+
+        return prefill_attribute_groups + self._get_virtual_prefill_attribute_groups()

--- a/src/openforms/prefill/contrib/yivi/api/views.py
+++ b/src/openforms/prefill/contrib/yivi/api/views.py
@@ -72,6 +72,4 @@ class AttributeGroupListView(ListMixin, views.APIView):
             }
             prefill_attribute_groups.append(prefill_attribute)
 
-        print(prefill_attribute_groups)
-
         return prefill_attribute_groups + self._get_virtual_prefill_attribute_groups()

--- a/src/openforms/prefill/contrib/yivi/apps.py
+++ b/src/openforms/prefill/contrib/yivi/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class YiviApp(AppConfig):
+    name = "openforms.prefill.contrib.yivi"
+    label = "prefill_yivi"
+    verbose_name = _("Yivi prefill plugin")
+
+    def ready(self):
+        # register the plugin
+        from . import plugin  # noqa

--- a/src/openforms/prefill/contrib/yivi/constants.py
+++ b/src/openforms/prefill/contrib/yivi/constants.py
@@ -1,0 +1,1 @@
+PLUGIN_IDENTIFIER = "yivi"

--- a/src/openforms/prefill/contrib/yivi/plugin.py
+++ b/src/openforms/prefill/contrib/yivi/plugin.py
@@ -55,8 +55,7 @@ class YiviPrefill(BasePlugin):
         # Check if the user is authenticated using the required plugin, and resulted into
         # the right auth attribute.
         if (
-            not submission.is_authenticated
-            or not cls.verify_used_auth_plugin(submission)
+            not cls.verify_used_auth_plugin(submission)
             or not (
                 cls.requires_auth
                 and submission.auth_info.attribute in cls.requires_auth

--- a/src/openforms/prefill/contrib/yivi/plugin.py
+++ b/src/openforms/prefill/contrib/yivi/plugin.py
@@ -1,0 +1,63 @@
+from django.utils.translation import gettext_lazy as _
+
+from openforms.authentication.constants import AuthAttribute
+from openforms.config.data import Action
+from openforms.prefill.base import BasePlugin
+from openforms.prefill.constants import IdentifierRoles
+from openforms.prefill.registry import register
+from openforms.submissions.models import Submission
+
+from .constants import PLUGIN_IDENTIFIER
+
+
+@register(PLUGIN_IDENTIFIER)
+class YiviPrefill(BasePlugin):
+    verbose_name = _("Yivi")
+    requires_auth = (
+        AuthAttribute.bsn,
+        AuthAttribute.kvk,
+        AuthAttribute.pseudo,
+    )
+
+    @staticmethod
+    def get_available_attributes():
+        """
+        Return an empty list, and add the Yivi prefill attributes in the frontend.
+
+        All Yivi prefill attributes are dependent on the configuration of the form:
+        which authentication identifier would be available and which additional
+        attributes are requested.
+
+        The available prefill atttributes for the Yivi prefill plugin are all the Yivi
+        attributes that are used during authentication. For this reason, we use the Yivi
+        attributegroup API as the source of the Yivi prefill plugin attributes. To also
+        include the atttributes used for fetching the authentication data (identifiers,
+        loa values, etc.), we use `virtual` attributegroups. See the attributegroup API
+        for additional information.
+        """
+        return []
+
+    @classmethod
+    def get_prefill_values(
+        cls,
+        submission: Submission,
+        attributes: list[str],
+        identifier_role: IdentifierRoles = IdentifierRoles.main,
+    ) -> dict[str, object]:
+        if not submission.is_authenticated or not (
+            cls.requires_auth and submission.auth_info.attribute in cls.requires_auth
+        ):
+            return {}
+
+        prefill_values: dict[str, object] = {}
+        for attribute in attributes:
+            # @TODO could also include auth info attributes
+            prefill_values[attribute] = submission.auth_info.additional_claims.get(
+                attribute, ""
+            )
+
+        return prefill_values
+
+    def check_config(self) -> list[Action]:
+        # @TODO
+        return []

--- a/src/openforms/prefill/contrib/yivi/tests/test_endpoints.py
+++ b/src/openforms/prefill/contrib/yivi/tests/test_endpoints.py
@@ -1,0 +1,107 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import status
+from rest_framework.reverse import reverse_lazy
+from rest_framework.test import APITestCase
+
+from openforms.accounts.tests.factories import StaffUserFactory
+from openforms.authentication.tests.factories import AttributeGroupFactory
+
+
+class YiviPrefillPluginEndpointTests(APITestCase):
+    attributes_endpoint = reverse_lazy("api:prefill_yivi:yivi-prefill-attributes-list")
+    default_attributes_endpoint = reverse_lazy(
+        "api:prefill-attribute-list", kwargs={"plugin": "yivi"}
+    )
+
+    def test_default_prefill_attributes_endpoint(self):
+        AttributeGroupFactory.create(
+            name="attribute-group1",
+            uuid="50b0c4c0-16e6-4866-8d0d-05914c2161b8",
+            attributes=[
+                "irma-demo.gemeente.personalData.fullname",
+                "irma-demo.gemeente.personalData.dateofbirth",
+            ],
+        )
+
+        staff_user = StaffUserFactory.create()
+        self.client.force_authenticate(user=staff_user)
+
+        response = self.client.get(self.default_attributes_endpoint)
+
+        # Expect that the default attributes endpoint is available, and returns an empty
+        # list
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+    def test_yivi_attributes_endpoint_auth_required(self):
+        response = self.client.get(self.attributes_endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_yivi_attributes_endpoint_response(self):
+        # Create test data
+        AttributeGroupFactory.create(
+            name="attribute-group1",
+            uuid="50b0c4c0-16e6-4866-8d0d-05914c2161b8",
+            attributes=[
+                "irma-demo.gemeente.personalData.fullname",
+                "irma-demo.gemeente.personalData.dateofbirth",
+            ],
+        )
+        AttributeGroupFactory.create(
+            name="attribute-group2",
+            uuid="9d4a3849-73bd-4915-a3ca-0607605d31cf",
+            attributes=["irma-demo.gemeente.personalData.over18"],
+        )
+
+        staff_user = StaffUserFactory.create()
+        self.client.force_authenticate(user=staff_user)
+
+        response = self.client.get(self.attributes_endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # The Yivi prefill attributes endpoint should return all defined attributeGroups,
+        # and additional static attributes for retrieving identifier and loa values.
+        expected = [
+            {
+                "attribute_group_uuid": "50b0c4c0-16e6-4866-8d0d-05914c2161b8",
+                "attributes": [
+                    {
+                        "label": "irma-demo.gemeente.personalData.fullname",
+                        "value": "additional_claims.irma-demo_gemeente_personalData_fullname",
+                    },
+                    {
+                        "label": "irma-demo.gemeente.personalData.dateofbirth",
+                        "value": "additional_claims.irma-demo_gemeente_personalData_dateofbirth",
+                    },
+                ],
+                "is_static": False,
+            },
+            {
+                "attribute_group_uuid": "9d4a3849-73bd-4915-a3ca-0607605d31cf",
+                "attributes": [
+                    {
+                        "label": "irma-demo.gemeente.personalData.over18",
+                        "value": "additional_claims.irma-demo_gemeente_personalData_over18",
+                    },
+                ],
+                "is_static": False,
+            },
+            {
+                "attribute_group_uuid": "00000000-0000-0000-0000-000000000000",
+                "attributes": [
+                    {
+                        "label": _("Identifier"),
+                        "value": "value",
+                    },
+                    {
+                        "label": _("Level of Assurance"),
+                        "value": "loa",
+                    },
+                ],
+                "is_static": True,
+            },
+        ]
+        self.assertEqual(response.data, expected)

--- a/src/openforms/prefill/contrib/yivi/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/yivi/tests/test_plugin.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+
+from privates.test import temp_private_root
+
+from openforms.authentication.service import AuthAttribute
+from openforms.submissions.tests.factories import SubmissionFactory
+
+from ..plugin import YiviPrefill
+
+
+@temp_private_root()
+class YiviPrefillTests(TestCase):
+    def test_get_prefill_values(self):
+        plugin = YiviPrefill(identifier="yivi")
+
+        submission = SubmissionFactory.create(
+            auth_info__value="111222333",
+            auth_info__plugin="yivi_oidc",
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__additional_claims={
+                "irma-demo_gemeente_personalData_firstname": "Joe",
+            },
+        )
+        values = plugin.get_prefill_values(
+            submission,
+            [
+                "value",
+                "additional_claims.irma-demo_gemeente_personalData_firstname",
+            ],
+        )
+        expected = {
+            "value": "111222333",
+            "additional_claims.irma-demo_gemeente_personalData_firstname": "Joe",
+        }
+        self.assertEqual(values, expected)
+
+    def test_get_prefill_values_not_authenticated(self):
+        plugin = YiviPrefill(identifier="yivi")
+
+        submission = SubmissionFactory.create()
+        values = plugin.get_prefill_values(
+            submission,
+            [
+                "value",
+                "additional_claims.irma-demo_gemeente_personalData_firstname",
+            ],
+        )
+        expected = {}
+        self.assertEqual(values, expected)
+
+    def test_get_prefill_values_authenticated_with_wrong_auth_plugin(self):
+        plugin = YiviPrefill(identifier="yivi")
+
+        submission = SubmissionFactory.create(
+            auth_info__value="111222333",
+            auth_info__plugin="digid_oidc",
+            auth_info__attribute=AuthAttribute.bsn,
+        )
+        values = plugin.get_prefill_values(
+            submission,
+            [
+                "value",
+            ],
+        )
+        expected = {}
+        self.assertEqual(values, expected)

--- a/src/openforms/prefill/contrib/yivi/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/yivi/tests/test_plugin.py
@@ -34,6 +34,34 @@ class YiviPrefillTests(TestCase):
         }
         self.assertEqual(values, expected)
 
+    def test_get_prefill_values_with_unknown_attribute(self):
+        plugin = YiviPrefill(identifier="yivi")
+
+        submission = SubmissionFactory.create(
+            auth_info__value="111222333",
+            auth_info__plugin="yivi_oidc",
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__additional_claims={
+                "irma-demo_gemeente_personalData_firstname": "Joe",
+            },
+        )
+
+        values = plugin.get_prefill_values(
+            submission,
+            [
+                "value",
+                "additional_claims.irma-demo_gemeente_personalData_firstname",
+                "additional_claims.irma-demo_gemeente_personalData_over18",
+            ],
+        )
+
+        # Expect the unknown attribute not to be resolved
+        expected = {
+            "value": "111222333",
+            "additional_claims.irma-demo_gemeente_personalData_firstname": "Joe",
+        }
+        self.assertEqual(values, expected)
+
     def test_get_prefill_values_not_authenticated(self):
         plugin = YiviPrefill(identifier="yivi")
 


### PR DESCRIPTION
Partly closes #5419

[skip: e2e]

~Requires #5515 (wait with merging until #5515 is in master)~

**Changes**

Added a prefill plugin specifically for Yivi authentication. It grants access to the configured Yivi additional attributes and the regular authentication identifier and LoA values.

As the Yivi prefill attributes change depending on the used form configuration, which prefill attributes are available is completely determined in the frontend. By adding a Yivi prefill plugin API endpoint we provide the frontend (i.e. form-builder) with the prefill attributes and conditions when the prefill attributes can be used.

Most of the Yivi prefill attributes should be used in conjunction with specific Yivi attribute groups. Using the `attribute_group_uuid` this relationship is defined. To also provide access to static prefill attributes (the prefill attributes for the regular authentication identifier and LoA values), a `is_static` flag is used. `is_static` is used to convey that the attributes aren't related to any attributegroups and are always available for Yivi prefill.

The changes include:

* The new prefill plugin
* New Yivi prefill API endpoint
* Custom React components for the Yivi prefill config (with a "use the Yivi auth plugin" warning)
* Updated Yivi authentication claims processing (see Important to note for further information)

**Important to note:**

The Yivi prefill plugin only works in conjunction with the Yivi authentication plugin. This is made clear in the Yivi prefill plugin documentation, and in the Yivi prefill configuration in the form-builder.

The way-of-working of the Yivi authentication plugin was also touched-up.
The Yivi attributes use periods (".") in their keys, which messes with glom and jsonLogic. The jsonLogic issue was resolved in https://github.com/open-formulieren/open-forms/issues/5475, by re-formatting the Yivi static variables. To resolve the issue with glom, and to prevent any future issues, the Yivi attributes will now be re-formatting during the processing of the authentication claims.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [X] Checked copying a form
  - [X] Checked import/export of a form
  - [X] Config checks in the configuration overview admin page
  - [X] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how
