### PR TITLE
:page_facing_up: Reflect the stakeholders in the license and readme.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Licence
 
-Copyright © Dimpact, 2021
+Copyright © "the Stakeholders" (see: STAKEHOLDERS.md), 2025
 
 Licensed under the EUPL
 

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -10,7 +10,7 @@ Open Formulieren
 
 Snel en eenvoudig slimme formulieren bouwen en publiceren. (`English version`_)
 
-Ontwikkeld door `Maykin Media B.V.`_ in opdracht van `Dimpact`_.
+Ontwikkeld door `Maykin B.V.`_, oorspronkelijk in opdracht van `Dimpact`_.
 
 
 Introductie
@@ -66,13 +66,14 @@ Links
 Licentie
 ========
 
-Copyright © `Dimpact`_, 2021
+Copyright © `"the Stakeholders`_, 2025
 
 Licensed under the `EUPL`_.
 
 .. _`English version`: README.rst
-.. _`Maykin Media B.V.`: https://www.maykinmedia.nl
+.. _`Maykin B.V.`: https://www.maykinmedia.nl
 .. _`Dimpact`: https://www.dimpact.nl
+.. _ `"the Stakeholders"`: STAKEHOLDERS.md
 .. _`EUPL`: LICENSE.md
 
 .. |build-status| image:: https://github.com/open-formulieren/open-forms/actions/workflows/ci.yml/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Open Forms
 
 Easily create and publish smart forms (`Nederlandse versie`_)
 
-Developed by `Maykin Media B.V.`_, commissioned by `Dimpact`_.
+Developed by `Maykin B.V.`_, originally commissioned by `Dimpact`_.
 
 
 Introduction
@@ -66,13 +66,14 @@ References
 Licence
 =======
 
-Copyright © `Dimpact`_, 2021
+Copyright © `"the Stakeholders`_, 2025
 
 Licensed under the `EUPL`_.
 
 .. _`Nederlandse versie`: README.NL.rst
-.. _`Maykin Media B.V.`: https://www.maykinmedia.nl
+.. _`Maykin B.V.`: https://www.maykinmedia.nl
 .. _`Dimpact`: https://www.dimpact.nl
+.. _ `"the Stakeholders"`: STAKEHOLDERS.md
 .. _`EUPL`: LICENSE.md
 
 .. |build-status| image:: https://github.com/open-formulieren/open-forms/actions/workflows/ci.yml/badge.svg

--- a/STAKEHOLDERS.md
+++ b/STAKEHOLDERS.md
@@ -1,0 +1,26 @@
+# Stakeholder Definition and Copyright Notice
+
+The financial contributions made toward the development and ongoing
+maintenance of this product are of significant importance. Without such
+support from organizations and individuals, the product could not have been
+created or sustained beyond its initial release.
+
+Parties who have provided substantial financial contributions to the
+development of this product are collectively referred to as 
+**"the Stakeholders"**, unless a separate written agreement provides otherwise.
+
+All copyrights in this product are jointly held by the Stakeholders.
+
+Contributions of code are welcome. However, making a code contribution does
+not automatically confer Stakeholder status. By submitting code contributions,
+contributors agree that the copyright in their contributions is assigned to, 
+and becomes the property of, the Stakeholders.
+
+The Stakeholders are:
+
+* Dimpact - https://www.dimpact.nl
+* Gemeente Den Haag - https://www.denhaag.nl
+* Gemeente Rotterdam - https://www.rotterdam.nl
+* Gemeente Utrecht - https://www.utrecht.nl
+* Maykin - https://www.maykinmedia.nl
+* SED organisatie - https://www.sed-organisatie.nl

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -65,8 +65,7 @@ description:
 
 legal:
   license: EUPL-1.2
-  mainCopyrightOwner: Dimpact
-  repoOwner: Maykin Media
+  repoOwner: Maykin
 
 dependsOn:
   open:
@@ -110,4 +109,4 @@ maintenance:
       website: https://www.maykinmedia.nl/
   contacts:
     - name: Joeri Bekker
-      affiliation: Maykin Media
+      affiliation: Maykin


### PR DESCRIPTION
**Changes**

The creation of Open Forms was commissioned by Dimpact. However, Dimpact was the primary point of contact but the original tender was by a collective of municipalities. In addition, after the 1.0 release, additional stakeholders - including Maykin itself - made significant contributions to Open Forms of which the intellectual property was not transfered.

Although this change does not change the license, it does broaden the copyright holders to a group of parties, namely, the Stakeholders. This reflects the principle of a community more accurately, where a group within that community (again, the Stakeholders) is responsible for the stewardship ("broncode beheer" in Dutch) of this codebase.

[skip: e2e]
