### PR TITLE
Add more default map tile layers

### DIFF
--- a/src/openforms/config/apps.py
+++ b/src/openforms/config/apps.py
@@ -3,14 +3,15 @@ from io import StringIO
 from django.apps import AppConfig
 from django.core.management import call_command
 from django.db.models.signals import post_migrate
-from django.dispatch import receiver
 
 
 class OpenFormsConfigConfig(AppConfig):
     name = "openforms.config"
     verbose_name = "Configuration"
 
+    def ready(self):
+        post_migrate.connect(update_map_tile_layers, sender=self)
 
-@receiver(post_migrate, dispatch_uid="load_default_map_tile_layers")
+
 def update_map_tile_layers(sender, **kwargs):
     call_command("loaddata", "default_map_tile_layers", verbosity=0, stdout=StringIO())

--- a/src/openforms/fixtures/default_map_tile_layers.json
+++ b/src/openforms/fixtures/default_map_tile_layers.json
@@ -1,18 +1,42 @@
 [
-{
-    "model": "config.maptilelayer",
-    "fields": {
-        "identifier": "brt",
-        "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png",
-        "label": "BRT"
+    {
+        "model": "config.maptilelayer",
+        "fields": {
+            "identifier": "brt",
+            "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png",
+            "label": "BRT"
+        }
+    },
+    {
+        "model": "config.maptilelayer",
+        "fields": {
+            "identifier": "brt-grijs",
+            "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/grijs/EPSG:28992/{z}/{x}/{y}.png",
+            "label": "BRT (grijs)"
+        }
+    },
+    {
+        "model": "config.maptilelayer",
+        "fields": {
+            "identifier": "brt-pastel",
+            "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/pastel/EPSG:28992/{z}/{x}/{y}.png",
+            "label": "BRT (pastel)"
+        }
+    },
+    {
+        "model": "config.maptilelayer",
+        "fields": {
+            "identifier": "brt-water",
+            "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/water/EPSG:28992/{z}/{x}/{y}.png",
+            "label": "BRT (water)"
+        }
+    },
+    {
+        "model": "config.maptilelayer",
+        "fields": {
+            "identifier": "luchtfoto",
+            "url": "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0/Actueel_orthoHR/EPSG:28992/{z}/{x}/{y}.png",
+            "label": "Luchtfoto"
+        }
     }
-},
-{
-    "model": "config.maptilelayer",
-    "fields": {
-        "identifier": "luchtfoto",
-        "url": "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0/Actueel_orthoHR/EPSG:28992/{z}/{x}/{y}.png",
-        "label": "Luchtfoto"
-    }
-}
 ]


### PR DESCRIPTION
Closes #5253 

[skip: e2e]

**Changes**

- Added more default map tile layers
- Ensured the fixtures are only loaded once when migrating the config app

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
