### PR TITLE
[#4879] specify correct proptypes for Worldline admin form

### DIFF
--- a/src/openforms/js/components/admin/form_design/payments/worldline/WorldlineOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/payments/worldline/WorldlineOptionsForm.js
@@ -53,14 +53,14 @@ WorldlineOptionsForm.propTypes = {
     type: PropTypes.oneOf(['object']), // it's the JSON schema root, it has to be
     properties: PropTypes.shape({
       merchant: PropTypes.shape({
-        enum: PropTypes.arrayOf(PropTypes.number),
+        enum: PropTypes.arrayOf(PropTypes.string),
         enumNames: PropTypes.arrayOf(PropTypes.string),
       }),
     }),
     required: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   formData: PropTypes.shape({
-    merchant: PropTypes.number,
+    merchant: PropTypes.string,
   }),
 };
 

--- a/src/openforms/js/components/admin/form_design/payments/worldline/fields.js
+++ b/src/openforms/js/components/admin/form_design/payments/worldline/fields.js
@@ -31,7 +31,7 @@ export const Merchant = ({options}) => (
 Merchant.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      value: PropTypes.number,
+      value: PropTypes.string,
       label: PropTypes.node.isRequired,
     })
   ).isRequired,


### PR DESCRIPTION
**Changes**

Fixes the current runtime errors the admin is generating:
```
Warning: Failed prop type: Invalid prop `schema.properties.merchant.enum[0]` of type `string` supplied to `WorldlineOptionsForm`, expected `number`.
WorldlineOptionsForm@http://127.0.0.1:8000/static/bundles/core-js.js:61357:7
PaymentFields@http://127.0.0.1:8000/static/bundles/core-js.js:52860:7
div
TabPanel
div
UncontrolledTabs@http://127.0.0.1:8000/static/bundles/core-js.js:301278:1915
Tabs@http://127.0.0.1:8000/static/bundles/core-js.js:301254:350
ValidationErrorsProvider@http://127.0.0.1:8000/static/bundles/core-js.js:77470:7
FormCreationForm@http://127.0.0.1:8000/static/bundles/core-js.js:56877:7
IntlProvider@http://127.0.0.1:8000/static/bundles/core-js.js:294367:47
```

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]