### PR TITLE
Support and document Highly Available Redis options

### DIFF
--- a/docker/docker-compose.redis-sentinel.yml
+++ b/docker/docker-compose.redis-sentinel.yml
@@ -1,0 +1,85 @@
+---
+#
+# DISCLAIMER: failover will not actually work properly in this setup - see
+# https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#sentinel-docker-nat-and-possible-issues
+#
+# This docker-compose only exists to verify/test that a local setup can work with
+# Redis Sentinels, it does NOT cover the actual failover scenario.
+#
+# Redis config file references:
+# * https://raw.githubusercontent.com/redis/redis/8.0/redis.conf
+# * https://raw.githubusercontent.com/redis/redis/8.0/redis-full.conf
+#
+# Docs:
+# * https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/
+# * https://www.squash.io/tutorial-on-redis-sentinel-a-deep-look/
+
+services:
+  # https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#testing-the-failover
+  # To 'kill' the primary, you can run:
+  #
+  #   docker compose -f docker-compose.redis-sentinel.yml exec redis-primary \
+  #     redis-cli -p 6380 DEBUG sleep 60
+  #
+
+  redis-primary:
+    image: redis:8
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    volumes:
+      - ./redis/sentinel.primary.conf:/usr/local/etc/redis/redis.conf:ro
+      - data-primary:/data
+    network_mode: host
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a insecure-supersecret ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  redis-replica-0:
+    image: redis:8
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    volumes:
+      - ./redis/sentinel.replica.conf:/usr/local/etc/redis/redis.conf:ro
+      - data-replica-0:/data
+    network_mode: host
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a insecure-supersecret ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+    depends_on:
+      - redis-primary
+
+  redis-sentinel-0: &redis-sentinel
+    image: redis:8
+    command:
+      - sh
+      - -c
+      - |
+        mkdir -p /usr/local/etc/redis/
+        cp /tmp/sentinel.conf /usr/local/etc/redis/sentinel.conf
+        exec redis-sentinel /usr/local/etc/redis/sentinel.conf --port $${REDIS_PORT}
+    volumes:
+      - ./redis/sentinel.conf:/tmp/sentinel.conf:ro
+    environment:
+      - REDIS_PORT=26379
+    network_mode: host
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli --port 26379 ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  redis-sentinel-1:
+    <<: *redis-sentinel
+    environment:
+      - REDIS_PORT=26380
+
+  redis-sentinel-2:
+    <<: *redis-sentinel
+    environment:
+      - REDIS_PORT=26381
+
+volumes:
+  data-primary:
+  data-replica-0:

--- a/docker/redis/sentinel.conf
+++ b/docker/redis/sentinel.conf
@@ -1,0 +1,12 @@
+daemonize no
+logfile ""
+
+sentinel resolve-hostnames yes
+# Give name 'broker' to the master set to monitor, point to primary by host name and
+# port (in docker-compose) and require a quorum of 2 sentinels to agree that the master
+# is down.
+sentinel monitor broker 127.0.0.1 6380 2
+sentinel auth-pass broker insecure-supersecret
+sentinel down-after-milliseconds broker 5000
+sentinel failover-timeout broker 60000
+sentinel parallel-syncs broker 1

--- a/docker/redis/sentinel.primary.conf
+++ b/docker/redis/sentinel.primary.conf
@@ -1,0 +1,9 @@
+port 6380
+appendonly yes
+appendfsync everysec
+# disable RDB; rely on AOF
+save ""
+
+requirepass insecure-supersecret
+# harmless on primary; needed for seamless promotion
+masterauth insecure-supersecret

--- a/docker/redis/sentinel.replica.conf
+++ b/docker/redis/sentinel.replica.conf
@@ -1,0 +1,11 @@
+port 6381
+appendonly yes
+appendfsync everysec
+# disable RDB; rely on AOF
+save ""
+
+requirepass insecure-supersecret
+# harmless on primary; needed for seamless promotion
+masterauth insecure-supersecret
+
+replicaof 127.0.0.1 6380

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -64,6 +64,9 @@ Common settings
 * ``CELERY_RESULT_BACKEND``: URL for the Redis result broker for Celery.
   Defaults to ``redis://127.0.0.1:6379/1``.
 
+.. seealso:: For advanced Celery broker/result backend configurations, see
+   :ref:`installation_redis`.
+
 .. _email-settings:
 
 Email settings

--- a/docs/installation/redis.rst
+++ b/docs/installation/redis.rst
@@ -6,71 +6,427 @@ Redis configuration
 
 .. note:: The intended audience for this documentation is DevOps engineers
 
-In Open-Forms, `Redis`_ is used as cache, as message broker (for Celery) and as a backend for Celery to store the results
-of the tasks.
+.. contents:: Jump to
+    :local:
+    :backlinks: none
 
-Redis is an in-memory data-store, which means that it is susceptible to data loss in the event of abrupt termination or
-power failures unless the default configuration is modified [#]_.
+Introduction
+============
+
+`Redis`_ is an advanced key-value store and in-memory database. Open Forms uses Redis in
+its architecture for distinct features:
+
+* as a cache backend
+* as message broker for asynchronous task processing (using Celery)
+* as a result backend to store the outcome of the asynchronous task processing (Celery again)
+* for distributed locks, required for the async task scheduling
+
+Redis being an in-memory data store makes it susceptible to data loss in the event of
+abrupt termination or power failures unless the default configuration is modified [#]_.
+
+This section of the documentation offers solutions for a robust Redis infrastructure,
+but first we need to identify the risks that need to be mitigated.
 
 .. _Redis: https://redis.io/
 .. [#] https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#redis
 
-Configuring Redis as robust message broker
-==========================================
+The table below provides a summary and the sections below elaborate on each feature.
 
-By default, Redis runs with snapshotting enabled.
-This means that Redis saves the DB (database) to disk if a certain number of write operations have been performed in a
-certain period of time. By default, Redis will save the DB (see the default `redis.conf file`_ for more details):
+================= ========================= =================== ==========================
+Purpose           Description               Failure mode        Why it's bad
+================= ========================= =================== ==========================
+Cache backend     Improve performance       Data loss           Need to re-calculate results
+Cache backend     Session store             Unavailability      Cannot login, cannot
+                                                                start/fill out forms
+Message broker    Coordinate tasks for      Data loss,          Scheduled tasks can be lost,
+                  background workers        Unavailability      Cannot schedule new tasks
+Result backend    Store background job      Data loss,          Submission confirmation
+                  metadata and outcome      Unavailability      may not reach end user.
+Distributed locks Prevent race conditions   Data loss           Identical tasks may be
+                                                                scheduled multiple times
+Distributed locks Prevent race conditions   Unavailability      Task doesn't get scheduled
+================= ========================= =================== ==========================
+
+Cache backend
+-------------
+
+The primary purpose of caches is improving performance by storing pre-computed results
+for a set time so that re-calculation and/or re-fetching data can be avoided, which is
+usually more expensive than reading from the cache.
+
+Data loss in the cache layer is annoying, but not fatal, since it will automatically
+rebuild over time when the Redis instance is available again. There may be temporary
+degraded performance and users may have to log in again.
+
+Message broker
+--------------
+
+The application schedules tasks to be executed by background workers. This stores task
+metadata in Redis like which tasks and what arguments to apply for the task. Scheduled
+tasks are removed when a worker executes it and confirms that the task has been
+processed. Until a worker picks up the task, it only exists in Redis.
+
+Data loss in the message broker is fatal - the scheduled task will be lost forever if
+the Redis storage configuration is not tuned.
+
+Result backend
+--------------
+
+A subset of background tasks are configured to store their result and execution progress
+in the result backend. This is used to be able to poll the execution status from the
+web application.
+
+Data loss in the result backend is annoying, but not fatal. The crucial mutations applied
+in tasks are persisted in the Postgres database. Error monitoring in task failures is
+available via Sentry - losing tracebacks of failed tasks is not a major concern.
+Additionally, we don't have complex workflows that rely on the task results to continue execution.
+
+Distributed locks
+-----------------
+
+The following background tasks use a lock in Redis to prevent the same task from being
+scheduled multiple times:
+
+* Submission registration
+* Updating the submission payment status in the registration backend
+* Registering the appointment with the appointment backend
+
+Data loss in the Redis instance that manages the lock(s) could lead to the same task
+being scheduled multiple times. This is already exceptional, as the application needs to
+be suffering from a race condition in the first place - the locking is a defense-in-depth
+mechanism. Another failure mode is that difference processes see a different lock state,
+e.g. because of replication lag.
+
+Furthermore, the background tasks are built to be idempotent - executing a task again
+after it was already completed is not supposed to produce a different result. There is
+only a risk for such a situation if multiple workers are executing the same task at the
+same time, creating another race condition.
+
+Finally, if the Redis instance used for locks is not available, scheduling the task will
+fail and show up in Sentry error monitoring. The tasks can be manually scheduled again,
+and operations will continue as usual.
+
+Conclusion
+----------
+
+The primary focus of attention is on the message broker for which durability is the
+most important aspect. A highly available (HA) setup further increases robustness and
+reduces the likelihood of tasks being dropped or lost, promoting self-healing
+characteristics.
+
+Cache backends benefit from a HA infrastructure by minimizing the risk of Redis not
+being available or limiting the impact when a failure happens. Similarly, the result
+backend can benefit from HA configurations.
+
+For distributed locks, preventing data loss by tuning persistence configuration should
+be sufficient.
+
+Redis persistence
+=================
+
+By default, Redis has snapshotting enabled. This means that Redis saves the database
+(DB) to disk if a certain number of write operations have been performed in a certain
+period of time. Unless configured otherwise, Redis will save the DB (see the default
+`redis.conf file`_ for more details):
 
 * After 3600 seconds (an hour) if at least 1 change was performed
 * After 300 seconds (5 minutes) if at least 100 changes were performed
-* After 60 seconds if at least 10000 changes were performed
+* After 60 seconds if at least 10K changes were performed
+
+If Redis is abruptly terminated and any changes have not been written to the DB, the
+data will be lost. For Open-Forms, this means that Celery tasks that have been queued
+and have not yet been picked up by a worker might be lost, locks no longer exists,
+background tasks results are lost and cached data is lost.
+
+.. warning::
+
+    Ensure that you always have persistent volume mounts configured in container
+    environments (like Kubernetes and Docker), otherwise container restarts will also
+    lead to data loss, even if persistence is configured!
+
+    The default Redis container images have a working directory of ``/data`` - you'll
+    want to mount volumes there.
+
+Enable Append Only File (`AOF`_)
+--------------------------------
+
+The Redis AOF persistence option is similar to Write Ahead Logs (WAL) in other databases.
+
+    AOF persistence logs every write operation received by the server. These operations
+    can then be replayed again at server startup, reconstructing the original dataset.
+    Commands are logged using the same format as the Redis protocol itself.
+
+    -- Redis documentation
+
+By default, changes are persisted every second, reducing the window for data loss to
+one second.
+
+.. tip:: Enabling AOF is particularly beneficial if you're running a single instance
+   without any HA configuration.
+
+Recommended persistence mechanism
+---------------------------------
+
+The table below lists the recommended persistence mechanism.
+
+================== ====== =============
+Feature            AOF    RDB snapshots
+================== ====== =============
+cache                     ✅
+message broker     ✅     ❌
+result backend     ✅     ✅
+distributed locks  ✅     ❌
+================== ====== =============
+
+Legend:
+
+* ✅: suitable
+* ❌: avoid, if possible
+* blank: neutral
+
+.. seealso:: See the `upstream <https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/>`_
+   documentation for more options.
+
+Relation to HA configurations
+-----------------------------
+
+Redis has some options for highly-available setups, which can help reduce the impact of
+failures with data loss in the master(s). Ultimately, all options come down to
+replication in terms of persistence robustness.
+
+Each master node (handling writes) can be replicated by one or more replicas. Replication_
+is asynchronous, but this can help reduce the data loss interval from 1-15 minutes to a
+couple of seconds (depending on the replication lag). This means that data lost in the
+master may have been replicated to a replica already, and recovery is possible.
+
+`Redis Sentinel`_ relies on replication for the failover mechanism.
+
+`Redis cluster`_ also relies on replication to be able to promote a replica to master
+during failover.
+
+It is still recommended to tune the persistence in the master and replica nodes
+accordingly.
+
+Other options
+-------------
+
+In theory, you can avoid the Redis persistence challenge entirely by using a
+`different broker`_, for example RabbitMQ (see ``CELERY_BROKER_URL`` in the
+:ref:`installation_environment_config`). However, this has not been tested by the Open
+Forms development team and may bring other challenges.
 
 .. _redis.conf file: https://redis.io/docs/latest/operate/oss_and_stack/management/config-file/
-
-If Redis is abruptly terminated and any changes have not been written to the DB, the data will be lost. For Open-Forms,
-this means that Celery tasks that have been queued and have not yet been picked up by a worker might be lost.
-
-The easiest workaround for this problem is to enable `AOF`_ (Append Only File) persistence in Redis. From the Redis
-documentation:
-
-
-    AOF persistence logs every write operation received by the server. These operations can then be replayed again at
-    server startup, reconstructing the original dataset. Commands are logged using the same format as the Redis protocol
-    itself.
-
-By default, changes are persisted every second. This means that the window for data loss is reduced to 1 s.
-
-Other (more complex) solutions are also possible, but out-of-scope for this documentation. For example:
-
-* Run HA (High Availability) with `Redis sentinel`_.
-* Run a `Redis cluster`_ instead of a single node.
-* Run Redis with `replication`_.
-* Run Celery with a `different broker`_, for example RabbitMQ (see ``CELERY_BROKER_URL``
-  in the :ref:`installation_environment_config`).
-
-
-.. _Redis sentinel: https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/
 .. _AOF: https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/
+.. _Replication: https://redis.io/docs/latest/operate/oss_and_stack/management/replication/
+.. _Redis sentinel: https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/
 .. _Redis cluster: https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/
-.. _replication: https://redis.io/docs/latest/operate/oss_and_stack/management/replication/
 .. _different broker: https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#configuration
 
-Deploying multiple Redis instances
-==================================
+Deployment strategies
+=====================
 
-By default, Open-Forms uses a single Redis instance that is shared for cache, Celery message broker and Celery backend
-for storing results.
+You can employ one or multiple strategies to achieve a robust and performant setup.
+Strategies are not mutually exclusive - you can combine ideas of one with principles of
+another one.
 
-By adding AOF persistence for the message broker, it is possible that the performance of the cache or results
-backend degrades. This may be because the cache/results backend may lead to many writes to the append-only file.
+In general, each strategy comes with a tradeoff between operational complexity and
+impact in the event of failure.
 
-If you observe this problem, you may consider deploying a Redis instance for each individual use case (cache,
-message broker, results backend). These can be configured through the environment variables
-``CACHE_<suffix>``, ``CELERY_BROKER_URL`` and ``CELERY_RESULT_BACKEND`` (see :ref:`installation_environment_config`
-for more details on these environment variables). Using this strategy, different Redis configuration files can be
-used for each instance to tune them for the intended usage:
+Single master
+--------------
 
-* cache: default snapshotting is okay, cache data loss is not an issue
-* message broker: AOF-configuration recommended
-* result store: AOF-configuration recommended
+The default example configuration uses a single Redis instance (example in
+``docker-compose.yml``) to illustrate the machinery. At the minimum, you should
+enable ``appendonly`` in such situations.
+
+The big advantage is the simplicity of the setup - there is no Redis cluster to monitor
+and manage. It is very well suited if you're deploying an Open Forms instance on a single
+physical machine (VPS, VM or dedicated server), since hardware failures that would bring
+down Redis will most likely also bring down the actual application and background
+workers, beating the point of a HA Redis setup.
+
+The major drawback is that you *do* have a single point of failure. In particular on
+Kubernetes it is very simple to horizontally scale application and background workers
+across multiple (hardware) nodes.
+
+Run multiple Redis masters
+--------------------------
+
+Instead of sending everything to the same Redis instance, you can also opt to dedicate
+a master for each individual aspect. Open Forms supports this by having separate
+:ref:`environment variables <installation_environment_config>`.
+
+This allows you to tune Redis configuration for each usage profile.
+
+**Caches**
+
+``CACHE_DEFAULT``
+    The default cache, used for the majority of cache-related operations. E.g. a master
+    with RDB snapshots.
+
+``CACHE_AXES``
+    Cache backend for brute forcing login attempts throttling. E.g. a master with RDB
+    snapshots.
+
+``CACHE_PORTALOCKER``
+    Cache backend used for startup-phase locks. E.g. a master with no persistence
+    configured at all.
+
+**Message broker**
+
+``CELERY_BROKER_URL``
+    The message broker backend to use. You can also specify Redis Sentinels here. Here
+    you really want an instance with AOF enabled.
+
+**Result backend**
+
+``CELERY_RESULT_BACKEND``
+    The result backend to use. You can also specify Redis Sentinels here. E.g. a master
+    or cluster with RDB snapshots.
+
+**Distributed locks**
+
+``CELERY_ONCE_REDIS_URL``
+    Used for the distributed locks to avoid the same task being scheduled multiple
+    times. By default, it falls back to ``CELERY_BROKER_URL``.
+
+Deploy a HA-setup
+-----------------
+
+See :ref:`installation_redis_ha` below for the available options.
+
+.. _installation_redis_ha:
+
+High availability strategy
+==========================
+
+In highly available Redis setups you typically aim for:
+
+* minimize downtime
+* minimize data loss potential
+* self-healing / automatic failover
+
+Configuring and deploying such setups is outside of the scope of this documentation. We
+do provide a reference Docker Compose setup in the repository for testing purposes - see
+the ``docker`` subdirectory. On Kubernetes, we recommend using an operator to manage
+your Redis cluster.
+
+There seem to be essentially two available options:
+
+* `Redis Sentinel`_ - a single master with one or more replicas and sentinel instances
+  that monitor and manage the failover.
+* `Redis cluster`_ - a multi-master solution with each master having one or more
+  replicas. Data is sharded and the cluster manages failover.
+
+More exotic setups with a proxy exposing a single entrypoint or commercial offerings by
+cloud providers have not been explored.
+
+Of the two options, Redis Sentinel is best supported and Redis Cluster has known
+limitations difficulties. Open Forms therefore only officially supports Redis Sentinel.
+Additionally, not all components of Open Forms have support for Sentinel.
+
+================== ======== =======
+Feature support    Sentinel Cluster
+================== ======== =======
+cache              ❌       ❌
+message broker     ✅       ❌
+result backend     ✅       ❌
+distributed locks  ❌       ❌
+================== ======== =======
+
+.. note:: Sentinel support for cache may be added in the future.
+
+Redis Sentinel
+--------------
+
+`Redis Sentinel`_ allows for automatic failover in case of a master failure and informs
+clients of the failure. It is particularly suited for the message broker and result
+backend use cases. When a replica is promoted to master, the sentinels will
+automatically relay the new master address to Celery.
+
+An outage at the Redis level should then not lead to service interruptions in Open Forms,
+if the failover goes well.
+
+To use Sentinel with Open Forms, you must configure a number of environment variables
+correctly.
+
+**Broker**
+
+``CELERY_BROKER_URL``
+    The sentinel protocol must be used instead of the Redis protocol. You should include
+    the addresses of the sentinel instances, e.g.:
+
+    .. code-block:: bash
+
+       CELERY_BROKER_URL="sentinel://localhost:26379;sentinel://localhost:23680;sentinel://localhost:23681"
+
+``REDIS_BROKER_SENTINEL_MASTER``
+    Sentinels can monitor multiple masters and handle their failovers. You must specify
+    the name of the ``master`` being used for the broker. Example:
+
+    .. code-block:: bash
+
+        REDIS_BROKER_SENTINEL_MASTER=broker
+
+``CELERY_ONCE_REDIS_URL``
+    Because this envvar defaults to the value of ``CELERY_BROKER_URL`` and sentinel is
+    not supported for the distributed locks, you must set this to a fixed master instance:
+
+    .. code-block:: bash
+
+        CELERY_ONCE_REDIS_URL=redis://some-master-instance:6379/0
+
+Optional environment variables are:
+
+``REDIS_BROKER_SENTINEL_PASSWORD``
+    Optional authentication password for the sentinel instances.
+
+``REDIS_BROKER_SENTINEL_USERNAME``
+    Optional authentication username for the sentinel instances.
+
+**Result backend**
+
+``CELERY_RESULT_BACKEND``
+    The sentinel protocol must be used instead of the Redis protocol. You should include
+    the addresses of the sentinel instances, e.g.:
+
+    .. code-block:: bash
+
+       CELERY_RESULT_BACKEND="sentinel://localhost:26379;sentinel://localhost:23680;sentinel://localhost:23681"
+
+``REDIS_RESULT_BACKEND_SENTINEL_MASTER``
+    Sentinels can monitor multiple masters and handle their failovers. You must specify
+    the name of the ``master`` being used for the result backend. Example:
+
+    .. code-block:: bash
+
+        REDIS_RESULT_BACKEND_SENTINEL_MASTER=celeryresults
+
+Optional environment variables are:
+
+``REDIS_RESULT_BACKEND_SENTINEL_PASSWORD``
+    Optional authentication password for the sentinel instances.
+
+``REDIS_RESULT_BACKEND_SENTINEL_USERNAME``
+    Optional authentication username for the sentinel instances.
+
+Redis cluster
+-------------
+
+Redis cluster is currently not officially supported. Our sentiment is also that cluster
+is more aimed at scaling and performance rather than being highly available.
+
+Workarounds exist to make Celery work with Redis cluster, but ultimately they lead to
+Celery workloads always being sent to the same instance in the cluster, creating a false
+sense of security.
+
+.. warning:: Some (managed) cloud offerings use cluster under the hood and may cause
+   issues.
+
+.. seealso:: Upstream references for issues/workarounds with Redis cluster:
+
+    * https://github.com/celery/celery/issues/8276
+    * https://github.com/celery/celery/issues/9436
+    * https://github.com/celery/celery/issues/8968
+    * https://github.com/celery/kombu/pull/1021
+    * https://github.com/rcpch/national-paediatric-diabetes-audit/pull/714/files

--- a/src/openforms/celery.py
+++ b/src/openforms/celery.py
@@ -19,6 +19,29 @@ app = Celery("open-forms")
 assert app.steps is not None
 app.steps["worker"].add(DjangoStructLogInitStep)
 app.config_from_object("django.conf:settings", namespace="CELERY")
+
+app.conf.broker_transport_options = {
+    # only used when the broker uses redis sentinel. Failing to specify a master name
+    # when the broker is configured with sentinel will trigger a `ValueError` in workers.
+    "master_name": config("REDIS_BROKER_SENTINEL_MASTER", default="") or None,
+    # Optional authentication parameters
+    "sentinel_kwargs": {
+        "password": config("REDIS_BROKER_SENTINEL_PASSWORD", default="") or None,
+        "username": config("REDIS_BROKER_SENTINEL_USERNAME", default="") or None,
+    },
+}
+app.conf.result_backend_transport_options = {
+    # only used when the broker uses redis sentinel. Failing to specify a master name
+    # when the broker is configured with sentinel will trigger a `ValueError` in workers.
+    "master_name": config("REDIS_RESULT_BACKEND_SENTINEL_MASTER", default="") or None,
+    # Optional authentication parameters
+    "sentinel_kwargs": {
+        "password": config("REDIS_RESULT_BACKEND_SENTINEL_PASSWORD", default="")
+        or None,
+        "username": config("REDIS_RESULT_BACKEND_SENTINEL_USERNAME", default="")
+        or None,
+    },
+}
 app.conf.ONCE = {
     "backend": "celery_once.backends.Redis",
     "settings": {

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -765,8 +765,10 @@ MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = [
 #
 # CELERY - async task queue
 #
-CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+CELERY_BROKER_URL = config("CELERY_BROKER_URL", default="redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = config(
+    "CELERY_RESULT_BACKEND", default="redis://localhost:6379/0"
+)
 
 # Add (by default) 5 (soft), 15 (hard) minute timeouts to all Celery tasks.
 CELERY_TASK_TIME_LIMIT = config("CELERY_TASK_HARD_TIME_LIMIT", default=15 * 60)  # hard


### PR DESCRIPTION
Closes #5060

**Changes**

* Added sample docker compose for Redis Sentinel setup with 1 master and 1 replica
* Added code support for Sentinel to Celery broker and result backend configuration
* Updated the Redis documentation - restructured + added new information
  - Restructured persistence configuration docs
  - Added information about HA setup options

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]