### PR TITLE
Reshape Yivi attributes when storing them in the auth_info

### DIFF
--- a/docs/manual/authenticatie.rst
+++ b/docs/manual/authenticatie.rst
@@ -103,10 +103,6 @@ De gebruiker bepaalt daarbij telkens zelf of deze gegevens gedeeld worden.
 
 .. note:: Na authenticatie met Yivi worden eventuele aanvullende attributen beschikbaar
    gesteld onder de :ref:`vaste variabele <manual_forms_variables_static_variables>`
-   ``auth.additional_claims``. Om de Yivi attributen beschikbaar te maken in
-   :ref:`logica <manual_logic>` en in :ref:`sjabloonfunctionaliteit <manual_templates>`,
-   worden de punten in de attribuutnamen in de variabele automatisch vervangen met
-   liggende streepjes.
-
-   Bijvoorbeeld: het Yivi attribuut ``pbdf.gemeente.personalData.over18`` kan in logica
-   als ``auth.additional_claims.pbdf_gemeente_personalData_over18`` gebruikt worden.
+   ``auth.additional_claims``. Bijvoorbeeld: het Yivi attribuut
+   ``pbdf.gemeente.personalData.over18`` kan in logica als
+   ``auth.additional_claims.pbdf.gemeente.personalData.over18`` gebruikt worden.

--- a/src/openforms/authentication/contrib/yivi_oidc/oidc_plugins/plugins.py
+++ b/src/openforms/authentication/contrib/yivi_oidc/oidc_plugins/plugins.py
@@ -268,7 +268,10 @@ class YiviPlugin(BaseOIDCPlugin, AnonymousUserOIDCPluginProtocol):
             [
                 {
                     "path_in_claim": [attribute],
-                    "processed_path": ["additional_claims", attribute],
+                    "processed_path": [
+                        "additional_claims",
+                        *attribute.split("."),
+                    ],
                 }
                 for attribute_group in additional_attributes
                 for attribute in attribute_group

--- a/src/openforms/authentication/contrib/yivi_oidc/tests/oidc_plugins/test_plugins.py
+++ b/src/openforms/authentication/contrib/yivi_oidc/tests/oidc_plugins/test_plugins.py
@@ -43,15 +43,16 @@ class ProcessClaimsYiviTest(OIDCMixin, TestCase):
             options__loa_settings__bsn_loa_claim_path=["bsn.loa"],
         )
         plugin = oidc_register[oidc_client.identifier]
-        attr_group = AttributeGroupFactory.create(
-            name="know_attributes",
-            uuid="e4bfa861-3ac0-4b9a-90ff-1bdbb3a17e09",
+        attr_group_1 = AttributeGroupFactory.create(
             attributes=["irma-demo.gemeente.personalData.familyname"],
+        )
+        attr_group_2 = AttributeGroupFactory.create(
+            attributes=["irma-demo.gemeente.personalData.givenName"],
         )
         request = self._setup_form(
             options={
                 "authentication_options": [],
-                "additional_attributes_groups": [attr_group],
+                "additional_attributes_groups": [attr_group_1, attr_group_2],
                 "bsn_loa": "",
                 "kvk_loa": "",
             }
@@ -63,6 +64,7 @@ class ProcessClaimsYiviTest(OIDCMixin, TestCase):
                 "test.attribute.bsn": "123456782",
                 "bsn.loa": "low",
                 "irma-demo.gemeente.personalData.familyname": "Doe",
+                "irma-demo.gemeente.personalData.givenName": "John",
             },
             additional_attributes,
         )
@@ -73,7 +75,14 @@ class ProcessClaimsYiviTest(OIDCMixin, TestCase):
                 "bsn_claim": "123456782",
                 "loa_claim": "low",
                 "additional_claims": {
-                    "irma-demo.gemeente.personalData.familyname": "Doe"
+                    "irma-demo": {
+                        "gemeente": {
+                            "personalData": {
+                                "familyname": "Doe",
+                                "givenName": "John",
+                            }
+                        }
+                    }
                 },
             },
         )

--- a/src/openforms/authentication/static_variables/static_variables.py
+++ b/src/openforms/authentication/static_variables/static_variables.py
@@ -16,20 +16,6 @@ if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
 
-# Jsonlogic, which we use to access the variables in the json logic and components,
-# cannot retrieve data from a key that contains periods (aka dots ".").
-# To allow these values to be targeted, we replace the period with an underscore.
-# In case of nested attributes, this replacing is done recursively.
-# https://github.com/open-formulieren/open-forms/issues/5475
-def clean_attribute_keys(attributes: dict[str, object]) -> dict[str, object]:
-    return {
-        key.replace(".", "_"): clean_attribute_keys(value)
-        if isinstance(value, dict)
-        else value
-        for key, value in attributes.items()
-    }
-
-
 @register_static_variable("submission_id")
 class SubmissionID(BaseStaticVariable):
     name = _("Internal ID")
@@ -79,9 +65,7 @@ class Auth(BaseStaticVariable):
             plugin=submission.auth_info.plugin,
             attribute=submission.auth_info.attribute,
             value=submission.auth_info.value,
-            additional_claims=clean_attribute_keys(
-                submission.auth_info.additional_claims
-            ),
+            additional_claims=submission.auth_info.additional_claims,
         )
 
         return auth_data
@@ -186,7 +170,7 @@ class AuthAdditionalClaims(BaseStaticVariable):
     def get_initial_value(self, submission: Submission | None = None):
         if submission is None or not submission.is_authenticated:
             return None
-        return clean_attribute_keys(submission.auth_info.additional_claims)
+        return submission.auth_info.additional_claims
 
     def as_json_schema(self):
         return {
@@ -206,18 +190,7 @@ class AuthContext(BaseStaticVariable):
             return None
         if not submission.is_authenticated:
             return None
-        auth_context = submission.auth_info.to_auth_context_data()
-        if auth_context.get("source") == "yivi":
-            # The `additionalInformation` for yivi authentication contains yivi
-            # attributes, which won't be accessible for jsonlogic and django templating.
-            # So we have to clean them.
-            auth_context["authorizee"]["legalSubject"]["additionalInformation"] = (
-                clean_attribute_keys(
-                    auth_context["authorizee"]["legalSubject"]["additionalInformation"]
-                )
-            )
-
-        return auth_context
+        return submission.auth_info.to_auth_context_data()
 
     def as_json_schema(self):
         # NOTE: `auth_context` includes all relevant options for the authentication

--- a/src/openforms/authentication/tests/test_static_variables.py
+++ b/src/openforms/authentication/tests/test_static_variables.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from django.test import TestCase
 
-from digid_eherkenning.choices import DigiDAssuranceLevels
 from jsonschema.validators import Draft202012Validator
 
 from openforms.authentication.constants import AuthAttribute
@@ -42,47 +41,6 @@ class TestStaticVariables(TestCase):
                 "additional_claims": {
                     "firstName": "John",
                     "familyName": "Doe",
-                },
-            },
-            "auth_bsn": "111222333",
-            "auth_kvk": "",
-            "auth_pseudo": "",
-            "auth_type": "bsn",
-        }
-
-        for variable_key, value in expected.items():
-            with self.subTest(key=variable_key, value=value):
-                self.assertIn(variable_key, static_data)
-                self.assertEqual(static_data[variable_key].initial_value, value)
-
-    def test_auth_static_data_periods_and_hyphens_in_additional_claims_claim_keys_are_replaced_with_underscores(
-        self,
-    ):
-        auth_info = AuthInfoFactory.create(
-            plugin="test-plugin",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            additional_claims={
-                "first.name": "John",
-                "family.name": "Doe",
-                "pbdf.pilot-amsterdam.passport.over18": "Yes",
-            },
-        )
-
-        static_data = {
-            variable.key: variable
-            for variable in get_static_variables(submission=auth_info.submission)
-        }
-
-        expected = {
-            "auth": {
-                "plugin": "test-plugin",
-                "attribute": AuthAttribute.bsn,
-                "value": "111222333",
-                "additional_claims": {
-                    "first_name": "John",
-                    "family_name": "Doe",
-                    "pbdf_pilot-amsterdam_passport_over18": "Yes",
                 },
             },
             "auth_bsn": "111222333",
@@ -212,76 +170,6 @@ class TestStaticVariables(TestCase):
         self.assertEqual(
             static_data["auth_additional_claims"],
             {"firstName": "John", "familyName": "Doe"},
-        )
-
-    def test_additional_claims_periods_and_hyphens_in_claim_keys_are_replaced_with_underscores(
-        self,
-    ):
-        auth_info = AuthInfoFactory.create(
-            plugin="test-plugin",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            additional_claims={
-                "first.name": "John",
-                "family.name": "Doe",
-                "pbdf.pilot-amsterdam.passport.over18": "Yes",
-                "pbdf.pilot-amsterdam": {"passport.over18": "Yes"},
-            },
-        )
-
-        static_data = {
-            variable.key: variable.initial_value
-            for variable in get_static_variables(submission=auth_info.submission)
-        }
-
-        self.assertEqual(
-            static_data["auth_additional_claims"],
-            {
-                "first_name": "John",
-                "family_name": "Doe",
-                "pbdf_pilot-amsterdam_passport_over18": "Yes",
-                "pbdf_pilot-amsterdam": {"passport_over18": "Yes"},
-            },
-        )
-
-    def test_auth_context_periods_and_hyphens_in_additional_claims_claim_keys_are_replaced_with_underscores(
-        self,
-    ):
-        auth_info = AuthInfoFactory.create(
-            plugin="yivi_oidc",
-            attribute=AuthAttribute.bsn,
-            value="111222333",
-            additional_claims={
-                "first.name": "John",
-                "family.name": "Doe",
-                "pbdf.pilot-amsterdam.passport.over18": "Yes",
-                "pbdf.pilot-amsterdam": {"passport.over18": "Yes"},
-            },
-        )
-
-        static_data = {
-            variable.key: variable.initial_value
-            for variable in get_static_variables(submission=auth_info.submission)
-        }
-
-        self.assertEqual(
-            static_data["auth_context"],
-            {
-                "source": "yivi",
-                "levelOfAssurance": DigiDAssuranceLevels.middle,
-                "authorizee": {
-                    "legalSubject": {
-                        "identifierType": "bsn",
-                        "identifier": "111222333",
-                        "additionalInformation": {
-                            "first_name": "John",
-                            "family_name": "Doe",
-                            "pbdf_pilot-amsterdam_passport_over18": "Yes",
-                            "pbdf_pilot-amsterdam": {"passport_over18": "Yes"},
-                        },
-                    }
-                },
-            },
         )
 
 

--- a/src/openforms/authentication/typing.py
+++ b/src/openforms/authentication/typing.py
@@ -17,7 +17,7 @@ class BaseAuth(TypedDict):
 
 class FormAuth(BaseAuth):
     loa: NotRequired[str]
-    additional_claims: NotRequired[dict]
+    additional_claims: NotRequired[JSONObject]
     acting_subject_identifier_type: NotRequired[str]
     acting_subject_identifier_value: NotRequired[str]
     legal_subject_identifier_type: NotRequired[str]

--- a/src/openforms/contrib/auth_oidc/utils.py
+++ b/src/openforms/contrib/auth_oidc/utils.py
@@ -139,6 +139,9 @@ def process_claims(
            "pet": "cat",
            "loa_claim": "urn:etoegang:core:assurance-class:loa1"
        }
+
+    .. todo:: this can probably benefit from building complex Glom specs instead of manually
+        processing each element individually.
     """
     processed_claims = {}
 


### PR DESCRIPTION
Closes #5419 (partly)

**Changes**

Instead of processing the attributes *after* obtaining them from Yivi by replacing <kbd>.</kbd> with <kbd>_</kbd>, we transform the attributes into a nested object where each period indicates a level.

This makes them naturally available in the DTL via `{{ foo.bar }}` and in json logic with `{"var": "foo.bar"}`.

Historical data is not being updated as the Yivi feature released in 3.2 was still quite experimental.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]