### PR TITLE
[#5268] Adapt generic JSON registration to custom children component

### DIFF
--- a/src/openforms/registrations/contrib/generic_json/plugin.py
+++ b/src/openforms/registrations/contrib/generic_json/plugin.py
@@ -194,6 +194,19 @@ class GenericJSONRegistration(BasePlugin):
                         options,
                     )
 
+            case {"type": "children"}:
+                assert isinstance(schema["items"], dict)
+                _properties = schema["items"]["properties"]
+                assert isinstance(_properties, dict)
+
+                _properties.update(
+                    {
+                        "affixes": {"type": "string"},
+                        "initials": {"type": "string"},
+                        "lastName": {"type": "string"},
+                    }
+                )
+
             case _:
                 pass
 
@@ -380,6 +393,26 @@ def process_component(
                 partner.pop("firstNames", None)
                 partner.pop("dateOfBirthPrecision", None)
                 partner.pop("__addedManually", None)
+
+        case {"type": "children"}:
+            children = values[key]
+            assert isinstance(children, list)
+
+            updated = []
+            for child in children:
+                assert isinstance(child, dict)
+                if child.get("selected") not in (None, True):
+                    continue
+
+                # not relevant properties
+                child.pop("dateOfBirthPrecision", None)
+                child.pop("__id", None)
+                child.pop("__addedManually", None)
+                child.pop("selected", None)
+
+                updated.append(child)
+
+            values[key] = updated
 
         case _:
             pass

--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_added_manually_and_selection_disabled.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_added_manually_and_selection_disabled.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '{"values": {"children": [{"bsn": "999970100", "affixes": "", "initials":
+      "O.", "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02"},
+      {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02"}], "childrenImmutable": [{"bsn":
+      "999970100", "affixes": "", "initials": "O.", "lastName": "Oostingh", "firstNames":
+      "Olle", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}, {"bsn":
+      "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh", "firstNames":
+      "Onne", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}]}, "values_schema":
+      {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object",
+      "properties": {"children": {"title": "Children", "type": "array", "items": {"type":
+      "object", "required": ["bsn"], "properties": {"bsn": {"type": "string", "pattern":
+      "^\\d{9}$", "format": "nl-bsn"}, "firstNames": {"type": "string"}, "dateOfBirth":
+      {"type": "string", "format": "date"}, "affixes": {"type": "string"}, "initials":
+      {"type": "string"}, "lastName": {"type": "string"}}, "additionalProperties":
+      false}}, "childrenImmutable": {"type": "array", "title": "Children immutable"}},
+      "required": ["children", "childrenImmutable"], "additionalProperties": false},
+      "metadata": {}, "metadata_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {}, "required": [], "additionalProperties":
+      false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTgxODAzMDYsImV4cCI6MTc1ODIyMzUwNiwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.gJ7uh6_WpXYgi-G_NdgdevlpA587-YxT_VnOddEwhzo
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1474'
+      User-Agent:
+      - python-requests/2.32.4
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"children\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"firstNames\": \"Olle\",\n          \"initials\":
+        \"O.\",\n          \"lastName\": \"Oostingh\"\n        },\n        {\n          \"affixes\":
+        \"\",\n          \"bsn\": \"999970112\",\n          \"dateOfBirth\": \"2022-02-02\",\n
+        \         \"firstNames\": \"Onne\",\n          \"initials\": \"O.\",\n          \"lastName\":
+        \"Oostingh\"\n        }\n      ],\n      \"childrenImmutable\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\":
+        \"Olle\",\n          \"initials\": \"O.\",\n          \"lastName\": \"Oostingh\"\n
+        \       },\n        {\n          \"affixes\": \"\",\n          \"bsn\": \"999970112\",\n
+        \         \"dateOfBirth\": \"2022-02-02\",\n          \"dateOfBirthPrecision\":
+        \"date\",\n          \"firstNames\": \"Onne\",\n          \"initials\": \"O.\",\n
+        \         \"lastName\": \"Oostingh\"\n        }\n      ]\n    },\n    \"values_schema\":
+        {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"children\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"affixes\": {\n                \"type\":
+        \"string\"\n              },\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"type\":
+        \"string\"\n              },\n              \"dateOfBirth\": {\n                \"format\":
+        \"date\",\n                \"type\": \"string\"\n              },\n              \"firstNames\":
+        {\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Children\",\n          \"type\":
+        \"array\"\n        },\n        \"childrenImmutable\": {\n          \"title\":
+        \"Children immutable\",\n          \"type\": \"array\"\n        }\n      },\n
+        \     \"required\": [\n        \"children\",\n        \"childrenImmutable\"\n
+        \     ],\n      \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2521'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Sep 2025 07:25:06 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_added_manually_and_selection_enabled.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_added_manually_and_selection_enabled.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: '{"values": {"children": [{"bsn": "999970100", "affixes": "", "initials":
+      "O.", "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02"}],
+      "extraChildDetails": [{"bsn": "999970100", "firstNames": "Olle"}], "childrenImmutable":
+      [{"bsn": "999970100", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Olle", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"},
+      {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}]},
+      "values_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {"children": {"title": "Children", "type": "array",
+      "items": {"type": "object", "required": ["bsn"], "properties": {"bsn": {"type":
+      "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "firstNames": {"type":
+      "string"}, "dateOfBirth": {"type": "string", "format": "date"}, "affixes": {"type":
+      "string"}, "initials": {"type": "string"}, "lastName": {"type": "string"}},
+      "additionalProperties": false}}, "extraChildDetails": {"title": "Extrachilddetails",
+      "type": "array", "items": {"type": "object", "properties": {"bsn": {"title":
+      "BSN", "type": "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "childName":
+      {"title": "Child name", "type": "string"}}, "required": ["bsn", "childName"],
+      "additionalProperties": false}}, "childrenImmutable": {"type": "array", "title":
+      "Children immutable"}}, "required": ["children", "extraChildDetails", "childrenImmutable"],
+      "additionalProperties": false}, "metadata": {}, "metadata_schema": {"$schema":
+      "https://json-schema.org/draft/2020-12/schema", "type": "object", "properties":
+      {}, "required": [], "additionalProperties": false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTgxNzk5NzcsImV4cCI6MTc1ODIyMzE3NywiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.jOgQUPigDsQs7fr9uSDnEDmNhOHgWV7LIoEuglBl8TY
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1754'
+      User-Agent:
+      - python-requests/2.32.4
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"children\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"firstNames\": \"Olle\",\n          \"initials\":
+        \"O.\",\n          \"lastName\": \"Oostingh\"\n        }\n      ],\n      \"childrenImmutable\":
+        [\n        {\n          \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n
+        \         \"dateOfBirth\": \"2022-02-02\",\n          \"dateOfBirthPrecision\":
+        \"date\",\n          \"firstNames\": \"Olle\",\n          \"initials\": \"O.\",\n
+        \         \"lastName\": \"Oostingh\"\n        },\n        {\n          \"affixes\":
+        \"\",\n          \"bsn\": \"999970112\",\n          \"dateOfBirth\": \"2022-02-02\",\n
+        \         \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\": \"Onne\",\n
+        \         \"initials\": \"O.\",\n          \"lastName\": \"Oostingh\"\n        }\n
+        \     ],\n      \"extraChildDetails\": [\n        {\n          \"bsn\": \"999970100\",\n
+        \         \"firstNames\": \"Olle\"\n        }\n      ]\n    },\n    \"values_schema\":
+        {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"children\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"affixes\": {\n                \"type\":
+        \"string\"\n              },\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"type\":
+        \"string\"\n              },\n              \"dateOfBirth\": {\n                \"format\":
+        \"date\",\n                \"type\": \"string\"\n              },\n              \"firstNames\":
+        {\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Children\",\n          \"type\":
+        \"array\"\n        },\n        \"childrenImmutable\": {\n          \"title\":
+        \"Children immutable\",\n          \"type\": \"array\"\n        },\n        \"extraChildDetails\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"title\":
+        \"BSN\",\n                \"type\": \"string\"\n              },\n              \"childName\":
+        {\n                \"title\": \"Child name\",\n                \"type\": \"string\"\n
+        \             }\n            },\n            \"required\": [\n              \"bsn\",\n
+        \             \"childName\"\n            ],\n            \"type\": \"object\"\n
+        \         },\n          \"title\": \"Extrachilddetails\",\n          \"type\":
+        \"array\"\n        }\n      },\n      \"required\": [\n        \"children\",\n
+        \       \"extraChildDetails\",\n        \"childrenImmutable\"\n      ],\n
+        \     \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3103'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Sep 2025 07:19:37 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_selection_disabled.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_selection_disabled.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '{"values": {"children": [{"bsn": "999970100", "affixes": "", "initials":
+      "O.", "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02"},
+      {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02"}], "childrenImmutable": [{"bsn":
+      "999970100", "affixes": "", "initials": "O.", "lastName": "Oostingh", "firstNames":
+      "Olle", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}, {"bsn":
+      "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh", "firstNames":
+      "Onne", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}]}, "values_schema":
+      {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object",
+      "properties": {"children": {"title": "Children", "type": "array", "items": {"type":
+      "object", "required": ["bsn"], "properties": {"bsn": {"type": "string", "pattern":
+      "^\\d{9}$", "format": "nl-bsn"}, "firstNames": {"type": "string"}, "dateOfBirth":
+      {"type": "string", "format": "date"}, "affixes": {"type": "string"}, "initials":
+      {"type": "string"}, "lastName": {"type": "string"}}, "additionalProperties":
+      false}}, "childrenImmutable": {"type": "array", "title": "Children immutable"}},
+      "required": ["children", "childrenImmutable"], "additionalProperties": false},
+      "metadata": {}, "metadata_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {}, "required": [], "additionalProperties":
+      false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTgxNzk5MzUsImV4cCI6MTc1ODIyMzEzNSwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.6c-oQt-hWHvlZrTpFrOv5MHiH7Dc3Hq3VNaWv_sumfQ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1474'
+      User-Agent:
+      - python-requests/2.32.4
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"children\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"firstNames\": \"Olle\",\n          \"initials\":
+        \"O.\",\n          \"lastName\": \"Oostingh\"\n        },\n        {\n          \"affixes\":
+        \"\",\n          \"bsn\": \"999970112\",\n          \"dateOfBirth\": \"2022-02-02\",\n
+        \         \"firstNames\": \"Onne\",\n          \"initials\": \"O.\",\n          \"lastName\":
+        \"Oostingh\"\n        }\n      ],\n      \"childrenImmutable\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\":
+        \"Olle\",\n          \"initials\": \"O.\",\n          \"lastName\": \"Oostingh\"\n
+        \       },\n        {\n          \"affixes\": \"\",\n          \"bsn\": \"999970112\",\n
+        \         \"dateOfBirth\": \"2022-02-02\",\n          \"dateOfBirthPrecision\":
+        \"date\",\n          \"firstNames\": \"Onne\",\n          \"initials\": \"O.\",\n
+        \         \"lastName\": \"Oostingh\"\n        }\n      ]\n    },\n    \"values_schema\":
+        {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"children\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"affixes\": {\n                \"type\":
+        \"string\"\n              },\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"type\":
+        \"string\"\n              },\n              \"dateOfBirth\": {\n                \"format\":
+        \"date\",\n                \"type\": \"string\"\n              },\n              \"firstNames\":
+        {\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Children\",\n          \"type\":
+        \"array\"\n        },\n        \"childrenImmutable\": {\n          \"title\":
+        \"Children immutable\",\n          \"type\": \"array\"\n        }\n      },\n
+        \     \"required\": [\n        \"children\",\n        \"childrenImmutable\"\n
+        \     ],\n      \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2521'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Sep 2025 07:18:55 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_selection_enabled.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_selection_enabled.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"values": {"children": [{"bsn": "999970100", "affixes": "", "initials":
+      "O.", "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02"}],
+      "childrenImmutable": [{"bsn": "999970100", "affixes": "", "initials": "O.",
+      "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision":
+      "date"}, {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}]},
+      "values_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {"children": {"title": "Children", "type": "array",
+      "items": {"type": "object", "required": ["bsn"], "properties": {"bsn": {"type":
+      "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "firstNames": {"type":
+      "string"}, "dateOfBirth": {"type": "string", "format": "date"}, "affixes": {"type":
+      "string"}, "initials": {"type": "string"}, "lastName": {"type": "string"}},
+      "additionalProperties": false}}, "childrenImmutable": {"type": "array", "title":
+      "Children immutable"}}, "required": ["children", "childrenImmutable"], "additionalProperties":
+      false}, "metadata": {}, "metadata_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {}, "required": [], "additionalProperties":
+      false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTgxNzk5NTYsImV4cCI6MTc1ODIyMzE1NiwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.dqcINpE78Xe4Xvo6i1LB4KLRji3KtIpFxT8Ptjqb6k4
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1344'
+      User-Agent:
+      - python-requests/2.32.4
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"children\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"firstNames\": \"Olle\",\n          \"initials\":
+        \"O.\",\n          \"lastName\": \"Oostingh\"\n        }\n      ],\n      \"childrenImmutable\":
+        [\n        {\n          \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n
+        \         \"dateOfBirth\": \"2022-02-02\",\n          \"dateOfBirthPrecision\":
+        \"date\",\n          \"firstNames\": \"Olle\",\n          \"initials\": \"O.\",\n
+        \         \"lastName\": \"Oostingh\"\n        },\n        {\n          \"affixes\":
+        \"\",\n          \"bsn\": \"999970112\",\n          \"dateOfBirth\": \"2022-02-02\",\n
+        \         \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\": \"Onne\",\n
+        \         \"initials\": \"O.\",\n          \"lastName\": \"Oostingh\"\n        }\n
+        \     ]\n    },\n    \"values_schema\": {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"children\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"affixes\": {\n                \"type\":
+        \"string\"\n              },\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"type\":
+        \"string\"\n              },\n              \"dateOfBirth\": {\n                \"format\":
+        \"date\",\n                \"type\": \"string\"\n              },\n              \"firstNames\":
+        {\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Children\",\n          \"type\":
+        \"array\"\n        },\n        \"childrenImmutable\": {\n          \"title\":
+        \"Children immutable\",\n          \"type\": \"array\"\n        }\n      },\n
+        \     \"required\": [\n        \"children\",\n        \"childrenImmutable\"\n
+        \     ],\n      \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2313'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Sep 2025 07:19:16 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_two_steps_and_selection_disabled.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_two_steps_and_selection_disabled.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"values": {"children": [{"bsn": "999970100", "affixes": "", "initials":
+      "O.", "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02"},
+      {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02"}], "extraChildDetails": [{"bsn":
+      "999970100", "firstNames": "Olle"}, {"bsn": "999970112", "firstNames": "Onne"}],
+      "childrenImmutable": [{"bsn": "999970100", "affixes": "", "initials": "O.",
+      "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision":
+      "date"}, {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}]},
+      "values_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {"children": {"title": "Children", "type": "array",
+      "items": {"type": "object", "required": ["bsn"], "properties": {"bsn": {"type":
+      "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "firstNames": {"type":
+      "string"}, "dateOfBirth": {"type": "string", "format": "date"}, "affixes": {"type":
+      "string"}, "initials": {"type": "string"}, "lastName": {"type": "string"}},
+      "additionalProperties": false}}, "extraChildDetails": {"title": "Extrachilddetails",
+      "type": "array", "items": {"type": "object", "properties": {"bsn": {"title":
+      "BSN", "type": "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "childName":
+      {"title": "Child name", "type": "string"}}, "required": ["bsn", "childName"],
+      "additionalProperties": false}}, "childrenImmutable": {"type": "array", "title":
+      "Children immutable"}}, "required": ["children", "extraChildDetails", "childrenImmutable"],
+      "additionalProperties": false}, "metadata": {}, "metadata_schema": {"$schema":
+      "https://json-schema.org/draft/2020-12/schema", "type": "object", "properties":
+      {}, "required": [], "additionalProperties": false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTgxODAzMjcsImV4cCI6MTc1ODIyMzUyNywiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.J7nmywQfG7KxLi50At-a_ofxg92uiUEMm96AQmw-Jgw
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1928'
+      User-Agent:
+      - python-requests/2.32.4
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"children\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"firstNames\": \"Olle\",\n          \"initials\":
+        \"O.\",\n          \"lastName\": \"Oostingh\"\n        },\n        {\n          \"affixes\":
+        \"\",\n          \"bsn\": \"999970112\",\n          \"dateOfBirth\": \"2022-02-02\",\n
+        \         \"firstNames\": \"Onne\",\n          \"initials\": \"O.\",\n          \"lastName\":
+        \"Oostingh\"\n        }\n      ],\n      \"childrenImmutable\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\":
+        \"Olle\",\n          \"initials\": \"O.\",\n          \"lastName\": \"Oostingh\"\n
+        \       },\n        {\n          \"affixes\": \"\",\n          \"bsn\": \"999970112\",\n
+        \         \"dateOfBirth\": \"2022-02-02\",\n          \"dateOfBirthPrecision\":
+        \"date\",\n          \"firstNames\": \"Onne\",\n          \"initials\": \"O.\",\n
+        \         \"lastName\": \"Oostingh\"\n        }\n      ],\n      \"extraChildDetails\":
+        [\n        {\n          \"bsn\": \"999970100\",\n          \"firstNames\":
+        \"Olle\"\n        },\n        {\n          \"bsn\": \"999970112\",\n          \"firstNames\":
+        \"Onne\"\n        }\n      ]\n    },\n    \"values_schema\": {\n      \"$schema\":
+        \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {\n        \"children\": {\n          \"items\":
+        {\n            \"additionalProperties\": false,\n            \"properties\":
+        {\n              \"affixes\": {\n                \"type\": \"string\"\n              },\n
+        \             \"bsn\": {\n                \"format\": \"nl-bsn\",\n                \"pattern\":
+        \"^\\\\d{9}$\",\n                \"type\": \"string\"\n              },\n
+        \             \"dateOfBirth\": {\n                \"format\": \"date\",\n
+        \               \"type\": \"string\"\n              },\n              \"firstNames\":
+        {\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Children\",\n          \"type\":
+        \"array\"\n        },\n        \"childrenImmutable\": {\n          \"title\":
+        \"Children immutable\",\n          \"type\": \"array\"\n        },\n        \"extraChildDetails\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"title\":
+        \"BSN\",\n                \"type\": \"string\"\n              },\n              \"childName\":
+        {\n                \"title\": \"Child name\",\n                \"type\": \"string\"\n
+        \             }\n            },\n            \"required\": [\n              \"bsn\",\n
+        \             \"childName\"\n            ],\n            \"type\": \"object\"\n
+        \         },\n          \"title\": \"Extrachilddetails\",\n          \"type\":
+        \"array\"\n        }\n      },\n      \"required\": [\n        \"children\",\n
+        \       \"extraChildDetails\",\n        \"childrenImmutable\"\n      ],\n
+        \     \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3393'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Sep 2025 07:25:27 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_two_steps_and_selection_enabled.yaml
+++ b/src/openforms/registrations/contrib/generic_json/tests/files/vcr_cassettes/GenericJSONBackendTests/test_children_components_schema_with_two_steps_and_selection_enabled.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: '{"values": {"children": [{"bsn": "999970100", "affixes": "", "initials":
+      "O.", "lastName": "Oostingh", "firstNames": "Olle", "dateOfBirth": "2022-02-02"}],
+      "extraChildDetails": [{"bsn": "999970100", "firstNames": "Olle"}], "childrenImmutable":
+      [{"bsn": "999970100", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Olle", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"},
+      {"bsn": "999970112", "affixes": "", "initials": "O.", "lastName": "Oostingh",
+      "firstNames": "Onne", "dateOfBirth": "2022-02-02", "dateOfBirthPrecision": "date"}]},
+      "values_schema": {"$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object", "properties": {"children": {"title": "Children", "type": "array",
+      "items": {"type": "object", "required": ["bsn"], "properties": {"bsn": {"type":
+      "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "firstNames": {"type":
+      "string"}, "dateOfBirth": {"type": "string", "format": "date"}, "affixes": {"type":
+      "string"}, "initials": {"type": "string"}, "lastName": {"type": "string"}},
+      "additionalProperties": false}}, "extraChildDetails": {"title": "Extrachilddetails",
+      "type": "array", "items": {"type": "object", "properties": {"bsn": {"title":
+      "BSN", "type": "string", "pattern": "^\\d{9}$", "format": "nl-bsn"}, "childName":
+      {"title": "Child name", "type": "string"}}, "required": ["bsn", "childName"],
+      "additionalProperties": false}}, "childrenImmutable": {"type": "array", "title":
+      "Children immutable"}}, "required": ["children", "extraChildDetails", "childrenImmutable"],
+      "additionalProperties": false}, "metadata": {}, "metadata_schema": {"$schema":
+      "https://json-schema.org/draft/2020-12/schema", "type": "object", "properties":
+      {}, "required": [], "additionalProperties": false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NTgxODAzNTUsImV4cCI6MTc1ODIyMzU1NSwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.TpaEZnYcoELSKEfUgupIfvwrosAduUfFXUCIGvKzxDs
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1754'
+      User-Agent:
+      - python-requests/2.32.4
+      content-type:
+      - application/json
+    method: POST
+    uri: http://localhost/json_plugin
+  response:
+    body:
+      string: "{\n  \"data\": {\n    \"metadata\": {},\n    \"metadata_schema\": {\n
+        \     \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n      \"additionalProperties\":
+        false,\n      \"properties\": {},\n      \"required\": [],\n      \"type\":
+        \"object\"\n    },\n    \"values\": {\n      \"children\": [\n        {\n
+        \         \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n          \"dateOfBirth\":
+        \"2022-02-02\",\n          \"firstNames\": \"Olle\",\n          \"initials\":
+        \"O.\",\n          \"lastName\": \"Oostingh\"\n        }\n      ],\n      \"childrenImmutable\":
+        [\n        {\n          \"affixes\": \"\",\n          \"bsn\": \"999970100\",\n
+        \         \"dateOfBirth\": \"2022-02-02\",\n          \"dateOfBirthPrecision\":
+        \"date\",\n          \"firstNames\": \"Olle\",\n          \"initials\": \"O.\",\n
+        \         \"lastName\": \"Oostingh\"\n        },\n        {\n          \"affixes\":
+        \"\",\n          \"bsn\": \"999970112\",\n          \"dateOfBirth\": \"2022-02-02\",\n
+        \         \"dateOfBirthPrecision\": \"date\",\n          \"firstNames\": \"Onne\",\n
+        \         \"initials\": \"O.\",\n          \"lastName\": \"Oostingh\"\n        }\n
+        \     ],\n      \"extraChildDetails\": [\n        {\n          \"bsn\": \"999970100\",\n
+        \         \"firstNames\": \"Olle\"\n        }\n      ]\n    },\n    \"values_schema\":
+        {\n      \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n
+        \     \"additionalProperties\": false,\n      \"properties\": {\n        \"children\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"affixes\": {\n                \"type\":
+        \"string\"\n              },\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"type\":
+        \"string\"\n              },\n              \"dateOfBirth\": {\n                \"format\":
+        \"date\",\n                \"type\": \"string\"\n              },\n              \"firstNames\":
+        {\n                \"type\": \"string\"\n              },\n              \"initials\":
+        {\n                \"type\": \"string\"\n              },\n              \"lastName\":
+        {\n                \"type\": \"string\"\n              }\n            },\n
+        \           \"required\": [\n              \"bsn\"\n            ],\n            \"type\":
+        \"object\"\n          },\n          \"title\": \"Children\",\n          \"type\":
+        \"array\"\n        },\n        \"childrenImmutable\": {\n          \"title\":
+        \"Children immutable\",\n          \"type\": \"array\"\n        },\n        \"extraChildDetails\":
+        {\n          \"items\": {\n            \"additionalProperties\": false,\n
+        \           \"properties\": {\n              \"bsn\": {\n                \"format\":
+        \"nl-bsn\",\n                \"pattern\": \"^\\\\d{9}$\",\n                \"title\":
+        \"BSN\",\n                \"type\": \"string\"\n              },\n              \"childName\":
+        {\n                \"title\": \"Child name\",\n                \"type\": \"string\"\n
+        \             }\n            },\n            \"required\": [\n              \"bsn\",\n
+        \             \"childName\"\n            ],\n            \"type\": \"object\"\n
+        \         },\n          \"title\": \"Extrachilddetails\",\n          \"type\":
+        \"array\"\n        }\n      },\n      \"required\": [\n        \"children\",\n
+        \       \"extraChildDetails\",\n        \"childrenImmutable\"\n      ],\n
+        \     \"type\": \"object\"\n    }\n  },\n  \"message\": \"Data received\"\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3103'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Sep 2025 07:25:55 GMT
+      Server:
+      - Werkzeug/3.1.3 Python/3.12.10
+    status:
+      code: 201
+      message: CREATED
+version: 1


### PR DESCRIPTION
Closes #5268 partly

**Changes**

- Removed unnecessary fields from the values and schema
- Added tests for both a children component and a form with 2 steps (children component and an extra step with an editgrid for the extra details)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
