### PR TITLE
[#4879] admin migrate form action

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -25,6 +25,8 @@ from .views import (
     ExportFormsForm,
     ExportFormsView,
     ImportFormsView,
+    PaymentMigrationForm,
+    PaymentMigrationView,
 )
 
 
@@ -142,6 +144,7 @@ class FormAdmin(
         "set_to_maintenance_mode",
         "remove_from_maintenance_mode",
         "export_forms",
+        "migrate_to_worldline",
     ]
     list_filter = (
         "active",
@@ -329,6 +332,11 @@ class FormAdmin(
                 self.admin_site.admin_view(ExportFormsView.as_view()),
                 name="forms_export",
             ),
+            path(
+                "worldline-migrate/",
+                self.admin_site.admin_view(PaymentMigrationView.as_view()),
+                name="forms_payment_migration",
+            ),
         ]
         return my_urls + urls
 
@@ -379,6 +387,14 @@ class FormAdmin(
                 count=count,
                 verbose_name=queryset.model._meta.verbose_name,
             ),
+        )
+
+    @admin.action(description=_("Migrate form(s) to Worldline payment provider"))
+    def migrate_to_worldline(self, request, queryset) -> TemplateResponse:
+        form = PaymentMigrationForm(initial={"forms_to_migrate": queryset})
+        context = {**self.admin_site.each_context(request), "form": form}
+        return TemplateResponse(
+            request, "admin/forms/form/migrate-payment-backend.html", context
         )
 
     def delete_model(self, request, form):

--- a/src/openforms/forms/templates/admin/forms/form/migrate-payment-backend.html
+++ b/src/openforms/forms/templates/admin/forms/form/migrate-payment-backend.html
@@ -1,0 +1,75 @@
+{% extends "admin/base_site.html" %}
+{% load static i18n django_admin_index %}
+
+{% block extrastyle %}
+    <link rel="stylesheet" href="{% static "bundles/core-css.css" %}">
+    <link rel="stylesheet" href="{% static "admin/css/admin-index.css" %}">
+    {{ block.super }}
+{% endblock %}
+
+{% block bodyclass %}ogone-migration-page{% endblock %}
+
+{% block nav-global %}
+    {% include "django_admin_index/includes/app_list.html" %}
+{% endblock nav-global %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:forms_form_changelist' %}">{% trans 'Forms' %}</a>
+        &rsaquo; {% trans 'Migrate payment backends for forms' %}
+    </div>
+{% endblock %}
+
+{% block title %} {% trans "Migrate payment backends for forms" %} {{ block.super }} {% endblock %}
+
+{% block content %}
+    <h1>{% trans 'Migrate payment backends for forms' %}</h1>
+    <div id="content-main">
+        {% if form.errors %}
+            <ul class="errorlist">
+                <li>
+                    <ul class="errorlist">
+                        {% for error in form.errors.values %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            </ul>
+
+            <a href="{% url 'admin:forms_form_changelist' %}" class="button cancel-link">
+                {% trans 'Back' %}
+            </a>
+        {% else %}
+            <div>
+                {% blocktranslate %}
+                Please confirm that the forms below should be migrated to the Worldline payment
+                provider backend:
+                {% endblocktranslate %}
+            </div>
+
+            <ul>
+                {% for value in form.initial.forms_to_migrate %}
+                    <li>{{ value.name }}</li>
+                {% endfor %}
+            </ul>
+
+            <form action="{% url 'admin:forms_payment_migration' %}" method="post">
+                <div>
+                    <fieldset class="module aligned">
+                        {% csrf_token %}
+
+                        {{ form.forms_to_migrate.as_hidden }}
+                    </fieldset>
+
+                    <div class="submit-row">
+                        <a href="{% url 'admin:forms_form_changelist' %}" class="button cancel-link">
+                            {% trans 'Back' %}
+                        </a>
+                        <input type="submit" value="{% trans 'Confirm' %}">
+                    </div>
+                </div>
+            </form>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/src/openforms/scss/components/admin/_index.scss
+++ b/src/openforms/scss/components/admin/_index.scss
@@ -49,5 +49,8 @@
 // Submission logs
 @import './logic-evaluated-table';
 
+// Ogone form migration
+@import './ogone-migration-page';
+
 // Errors
 @import './error-message';

--- a/src/openforms/scss/components/admin/_ogone-migration-page.scss
+++ b/src/openforms/scss/components/admin/_ogone-migration-page.scss
@@ -1,0 +1,18 @@
+.ogone-migration-page {
+  & form .cancel-link,
+  #content-main .cancel-link {
+    vertical-align: middle;
+    height: 0.9375rem;
+    line-height: 0.9375rem;
+    border-radius: 4px;
+    padding: 10px 15px;
+    color: var(--button-fg);
+    background: var(--close-button-bg);
+    margin: 0 5px 0 0;
+    text-decoration: none;
+
+    &:hover {
+      background: var(--close-button-hover-bg);
+    }
+  }
+}


### PR DESCRIPTION
Closes #5579 

**Changes**

Adds a form action which allows administrators to migrate forms with the Ogone payment backend to the Worldine payment backend.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]