### PR TITLE
[#5624] Add missing tag to the StUF-BG template for children

### DIFF
--- a/src/openforms/prefill/contrib/family_members/templates/family_members/tests/responses/stuf_bg_children.xml
+++ b/src/openforms/prefill/contrib/family_members/templates/family_members/tests/responses/stuf_bg_children.xml
@@ -1,11 +1,11 @@
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-                  xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
-                  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
     <soapenv:Header/>
     <soapenv:Body>
         <ns:npsLa01>
             <ns:stuurgegevens>
-                <StUF:berichtcode>?</StUF:berichtcode>
+                <StUF:berichtcode>La01</StUF:berichtcode>
                 <!--Optional:-->
                 <StUF:zender>
                     <!--Optional:-->
@@ -32,14 +32,12 @@
                 <StUF:tijdstipBericht>{{ tijdstip_bericht }}</StUF:tijdstipBericht>
                 <!--Optional:-->
                 <StUF:crossRefnummer>?</StUF:crossRefnummer>
-                <StUF:entiteittype>?</StUF:entiteittype>
+                <StUF:entiteittype>NPS</StUF:entiteittype>
             </ns:stuurgegevens>
             <ns:parameters>
-                <StUF:indicatorVervolgvraag>?</StUF:indicatorVervolgvraag>
+                <StUF:indicatorVervolgvraag>false</StUF:indicatorVervolgvraag>
                 <!--Optional:-->
                 <StUF:indicatorAfnemerIndicatie>false</StUF:indicatorAfnemerIndicatie>
-                <!--Optional:-->
-                <StUF:aantalVoorkomens>?</StUF:aantalVoorkomens>
             </ns:parameters>
             <!--Zero or more repetitions:-->
             <ns:melding>?</ns:melding>
@@ -60,7 +58,7 @@
                             <!--Optional:-->
                             <ns:voornamen>Bolly</ns:voornamen>
                             <!--Optional:-->
-                            <ns:geboortedatum>1999-06-15</ns:geboortedatum>
+                            <ns:geboortedatum>19990615</ns:geboortedatum>
                             <!--Optional:-->
                             <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
                             <!--Optional:-->
@@ -80,7 +78,7 @@
                             <!--Optional:-->
                             <ns:voornamen>Billy</ns:voornamen>
                             <!--Optional:-->
-                            <ns:geboortedatum>1998-07-16</ns:geboortedatum>
+                            <ns:geboortedatum>19980716</ns:geboortedatum>
                             <!--Optional:-->
                             <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
                             <!--Optional:-->
@@ -120,11 +118,11 @@
                             <!--Optional:-->
                             <ns:voornamen>Other</ns:voornamen>
                             <!--Optional:-->
-                            <ns:geboortedatum>1998-07-16</ns:geboortedatum>
+                            <ns:geboortedatum>19980716</ns:geboortedatum>
                             <!--Optional:-->
                             <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
                             <!--Optional:-->
-                            <ns:overlijdensdatum>2023-01-08</ns:overlijdensdatum>
+                            <ns:overlijdensdatum>20230108</ns:overlijdensdatum>
                         </ns:gerelateerde>
                     </ns:inp.heeftAlsKinderen>
 

--- a/src/openforms/prefill/contrib/family_members/templates/family_members/tests/responses/stuf_bg_children_incomplete_date_of_birth.xml
+++ b/src/openforms/prefill/contrib/family_members/templates/family_members/tests/responses/stuf_bg_children_incomplete_date_of_birth.xml
@@ -1,11 +1,12 @@
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-                  xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
-                  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <soapenv:Header/>
     <soapenv:Body>
         <ns:npsLa01>
             <ns:stuurgegevens>
-                <StUF:berichtcode>?</StUF:berichtcode>
+                <StUF:berichtcode>La01</StUF:berichtcode>
                 <!--Optional:-->
                 <StUF:zender>
                     <!--Optional:-->
@@ -32,14 +33,12 @@
                 <StUF:tijdstipBericht>{{ tijdstip_bericht }}</StUF:tijdstipBericht>
                 <!--Optional:-->
                 <StUF:crossRefnummer>?</StUF:crossRefnummer>
-                <StUF:entiteittype>?</StUF:entiteittype>
+                <StUF:entiteittype>NPS</StUF:entiteittype>
             </ns:stuurgegevens>
             <ns:parameters>
-                <StUF:indicatorVervolgvraag>?</StUF:indicatorVervolgvraag>
+                <StUF:indicatorVervolgvraag>false</StUF:indicatorVervolgvraag>
                 <!--Optional:-->
                 <StUF:indicatorAfnemerIndicatie>false</StUF:indicatorAfnemerIndicatie>
-                <!--Optional:-->
-                <StUF:aantalVoorkomens>?</StUF:aantalVoorkomens>
             </ns:parameters>
             <!--Zero or more repetitions:-->
             <ns:melding>?</ns:melding>
@@ -61,7 +60,7 @@
                             <ns:voornamen>Bolly</ns:voornamen>
                             <!--Optional:-->
                             <!--Complete date-->
-                            <ns:geboortedatum>1999-06-15</ns:geboortedatum>
+                            <ns:geboortedatum>19990615</ns:geboortedatum>
                             <!--Optional:-->
                             <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
                             <!--Optional:-->
@@ -82,7 +81,7 @@
                             <ns:voornamen>Billy</ns:voornamen>
                             <!--Optional:-->
                             <!--Only the year is known-->
-                            <geboortedatum StUF:indOnvolledigeDatum="M">1985</geboortedatum>
+                            <ns:geboortedatum StUF:indOnvolledigeDatum="M">1985</ns:geboortedatum>
                         </ns:gerelateerde>
                     </ns:inp.heeftAlsKinderen>
                     <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
@@ -99,7 +98,7 @@
                             <ns:voornamen>Billy</ns:voornamen>
                             <!--Optional:-->
                             <!--Year and month are known-->
-                            <geboortedatum StUF:indOnvolledigeDatum="D">1985-03</geboortedatum>
+                            <ns:geboortedatum StUF:indOnvolledigeDatum="D">198503</ns:geboortedatum>
                         </ns:gerelateerde>
                     </ns:inp.heeftAlsKinderen>
                     <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
@@ -116,7 +115,7 @@
                             <ns:voornamen>Billy</ns:voornamen>
                             <!--Optional:-->
                             <!--Date exists but no specific year, month, or day is known-->
-                            <ns:geboortedatum StUF:indOnvolledigeDatum="J"></ns:geboortedatum>
+                            <ns:geboortedatum StUF:indOnvolledigeDatum="J" xsi:nil="true"></ns:geboortedatum>
                         </ns:gerelateerde>
                     </ns:inp.heeftAlsKinderen>
 

--- a/src/openforms/prefill/contrib/family_members/templates/family_members/tests/responses/stuf_bg_one_partner.xml
+++ b/src/openforms/prefill/contrib/family_members/templates/family_members/tests/responses/stuf_bg_one_partner.xml
@@ -1,11 +1,11 @@
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-                  xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
-                  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:ns="http://www.egem.nl/StUF/sector/bg/0310" xmlns:StUF="http://www.egem.nl/StUF/StUF0301"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml">
     <soapenv:Header/>
     <soapenv:Body>
         <ns:npsLa01>
             <ns:stuurgegevens>
-                <StUF:berichtcode>?</StUF:berichtcode>
+                <StUF:berichtcode>La01</StUF:berichtcode>
                 <!--Optional:-->
                 <StUF:zender>
                     <!--Optional:-->
@@ -32,14 +32,12 @@
                 <StUF:tijdstipBericht>{{ tijdstip_bericht }}</StUF:tijdstipBericht>
                 <!--Optional:-->
                 <StUF:crossRefnummer>?</StUF:crossRefnummer>
-                <StUF:entiteittype>?</StUF:entiteittype>
+                <StUF:entiteittype>NPS</StUF:entiteittype>
             </ns:stuurgegevens>
             <ns:parameters>
-                <StUF:indicatorVervolgvraag>?</StUF:indicatorVervolgvraag>
+                <StUF:indicatorVervolgvraag>false</StUF:indicatorVervolgvraag>
                 <!--Optional:-->
                 <StUF:indicatorAfnemerIndicatie>false</StUF:indicatorAfnemerIndicatie>
-                <!--Optional:-->
-                <StUF:aantalVoorkomens>?</StUF:aantalVoorkomens>
             </ns:parameters>
             <!--Zero or more repetitions:-->
             <ns:melding>?</ns:melding>
@@ -60,7 +58,7 @@
                             <!--Optional:-->
                             <ns:voornamen>Belly</ns:voornamen>
                             <!--Optional:-->
-                            <ns:geboortedatum>1985-06-15</ns:geboortedatum>
+                            <ns:geboortedatum>19850615</ns:geboortedatum>
                             <!--Optional:-->
                             <ns:inp.geboorteplaats>Amsterdam</ns:inp.geboorteplaats>
                             <!--Optional:-->

--- a/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
@@ -21,11 +21,11 @@
             <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
                 <ns:gerelateerde StUF:entiteittype="NPS">
                     <ns:inp.bsn xsi:nil="true" />
-                    <ns:voornamen xsi:nil="true" />
-                    <ns:voorletters xsi:nil="true" />
-                    <ns:voorvoegselGeslachtsnaam xsi:nil="true" />
-                    <ns:geslachtsnaam xsi:nil="true" />
-                    <ns:geboortedatum xsi:nil="true" />
+                    <ns:geslachtsnaam xsi:nil="true"/>
+                    <ns:voorvoegselGeslachtsnaam xsi:nil="true"/>
+                    <ns:voorletters xsi:nil="true"/>
+                    <ns:voornamen xsi:nil="true"/>
+                    <ns:geboortedatum xsi:nil="true"/>
                 </ns:gerelateerde>
             </ns:inp.heeftAlsKinderen>
         </ns:object>

--- a/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
@@ -17,16 +17,17 @@
         <ns:inp.bsn>{{ bsn }}</ns:inp.bsn>
     </ns:gelijk>
     <ns:scope>
-        <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
-            <ns:gerelateerde StUF:entiteittype="NPS">
-                <ns:inp.bsn xsi:nil="true" />
-                <ns:voornamen xsi:nil="true" />
-                <ns:voorletters xsi:nil="true" />
-                <ns:voorvoegselGeslachtsnaam xsi:nil="true" />
-                <ns:geslachtsnaam xsi:nil="true" />
-                <ns:geboortedatum xsi:nil="true" />
-            </ns:gerelateerde>
-        </ns:inp.heeftAlsKinderen>
+        <ns:object StUF:entiteittype="NPS">
+            <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
+                <ns:gerelateerde StUF:entiteittype="NPS">
+                    <ns:inp.bsn xsi:nil="true" />
+                    <ns:voornamen xsi:nil="true" />
+                    <ns:voorletters xsi:nil="true" />
+                    <ns:voorvoegselGeslachtsnaam xsi:nil="true" />
+                    <ns:geslachtsnaam xsi:nil="true" />
+                    <ns:geboortedatum xsi:nil="true" />
+                </ns:gerelateerde>
+            </ns:inp.heeftAlsKinderen>
         </ns:object>
     </ns:scope>
 </ns:npsLv01>{% endblock %}

--- a/src/stuf/stuf_bg/templates/stuf_bg/PartnersStufBgRequest.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/PartnersStufBgRequest.xml
@@ -18,14 +18,15 @@
     </ns:gelijk>
     <ns:scope>
         <ns:object StUF:entiteittype="NPS">
+            <ns:inp.bsn xsi:nil="true"/>
             <ns:inp.heeftAlsEchtgenootPartner StUF:entiteittype="NPSNPSHUW">
                 <ns:gerelateerde StUF:entiteittype="NPS">
                     <ns:inp.bsn xsi:nil="true" />
-                    <ns:voornamen xsi:nil="true" />
-                    <ns:voorletters xsi:nil="true" />
-                    <ns:voorvoegselGeslachtsnaam xsi:nil="true" />
-                    <ns:geslachtsnaam xsi:nil="true" />
-                    <ns:geboortedatum xsi:nil="true" />
+                    <ns:geslachtsnaam xsi:nil="true"/>
+                    <ns:voorvoegselGeslachtsnaam xsi:nil="true"/>
+                    <ns:voorletters xsi:nil="true"/>
+                    <ns:voornamen xsi:nil="true"/>
+                    <ns:geboortedatum xsi:nil="true"/>
                 </ns:gerelateerde>
             </ns:inp.heeftAlsEchtgenootPartner>
         </ns:object>

--- a/src/stuf/stuf_bg/utils.py
+++ b/src/stuf/stuf_bg/utils.py
@@ -5,6 +5,8 @@ from django.utils import timezone
 
 from lxml.etree import XMLParser, fromstring as _fromstring
 
+from openforms.utils.date import format_date_value
+
 from .typing import StufBgIncompleteDateType
 
 TIMEZONE_AMS = ZoneInfo("Europe/Amsterdam")
@@ -24,7 +26,9 @@ def normalize_date_of_birth(date_input: str | StufBgIncompleteDateType) -> str:
     "V": full date
     """
     if isinstance(date_input, str):
-        return date_input
+        # the date coming from the stuf_bg is of type '20200909' so we have to make it an
+        # iso-8601 type
+        return format_date_value(date_input)
 
     date_text = date_input.get("#text")
     return date_text if date_text else ""


### PR DESCRIPTION
Closes #5624

**Changes**

- Added missing tag to the template of children in StUF-BG for the family members prefill plugin
- Added xsd validation to the plugin tests
- Fixed wrong mocked responses for children and partners

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
