### PR TITLE
:arrow_up: Bump to latest django-timeline-logger

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -230,7 +230,7 @@ django-solo==2.3.0
     #   zgw-consumers
 django-structlog==9.1.1
     # via -r requirements/base.in
-django-timeline-logger==4.0.0
+django-timeline-logger==5.0.0
     # via -r requirements/base.in
 django-tinymce==4.1.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -370,7 +370,7 @@ django-structlog==9.1.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-timeline-logger==4.0.0
+django-timeline-logger==5.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -402,7 +402,7 @@ django-structlog==9.1.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-timeline-logger==4.0.0
+django-timeline-logger==5.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -358,7 +358,7 @@ django-structlog==9.1.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-timeline-logger==4.0.0
+django-timeline-logger==5.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -389,7 +389,7 @@ django-stubs-ext==5.0.2
     # via
     #   -r requirements/type-checking.in
     #   django-stubs
-django-timeline-logger==4.0.0
+django-timeline-logger==5.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Upgraded to latest timeline logger, which includes the management command to prune old log entries.

[skip: e2e]