### PR TITLE
Fix failing tests in form json schema

### DIFF
--- a/src/openforms/forms/tests/test_api_form_json_schema.py
+++ b/src/openforms/forms/tests/test_api_form_json_schema.py
@@ -76,7 +76,7 @@ class FormJsonSchemaAPITests(APITestCase):
             form=form,
             options={
                 "version": 2,
-                "objects_api_group": objects_api_group.identifier,
+                "objects_api_group": objects_api_group.pk,
                 "objecttype": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
                 "objecttype_version": 3,
                 "transform_to_list": [],
@@ -154,7 +154,7 @@ class FormJsonSchemaAPITests(APITestCase):
             name="Objects API",
             backend="objects_api",
             options={
-                "objects_api_group": objects_api_group.identifier,
+                "objects_api_group": objects_api_group.pk,
                 "objecttype": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
                 "objecttype_version": 3,
             },
@@ -383,7 +383,7 @@ class FormJsonSchemaAPITests(APITestCase):
             backend="objects_api",
             form=form,
             options={
-                "objects_api_group": objects_api_group.identifier,
+                "objects_api_group": objects_api_group.pk,
                 "objecttype": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
                 "objecttype_version": 3,
                 "version": 2,


### PR DESCRIPTION
**Changes**

- Fixed a couple of failing tests in the forms concerning the json schema

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
