### PR TITLE
[OF-SDK#871] Add missing formio translations

### DIFF
--- a/src/openforms/js/lang/formio/en.json
+++ b/src/openforms/js/lang/formio/en.json
@@ -42,5 +42,7 @@
   "You must select at least {{minCount}} items.": "Ensure this field has at least {{minCount}} checked options.",
   "Empty fields": "Fields without a value",
   "Invalid Postcode": "The submitted value does not match the postcode pattern: 1234 AB",
+  "Multiple children share the same BSN number": "Multiple children share the same BSN number",
+  "Are you sure you want to remove child with BSN: '{{bsn}}'?": "Are you sure you want to remove child with BSN: '{{bsn}}'?",
   "": ""
 }

--- a/src/openforms/js/lang/formio/nl.json
+++ b/src/openforms/js/lang/formio/nl.json
@@ -415,5 +415,7 @@
   "Lastname": "Achternaam",
   "Children": "Kinderen",
   "Partners": "Partners",
+  "Multiple children share the same BSN number": "Er zijn meerdere kinderen met hetzelfde BSN. Zorg dt deze uniek zijn.",
+  "Are you sure you want to remove child with BSN: '{{bsn}}'?": "Ben je zeker dat je het kind met BSN '{{ bsn }}' wil verwijderen?",
   "": ""
 }


### PR DESCRIPTION
Closes open-formulieren/open-forms-sdk#871 partly

**Changes**

- Added missing translations for the custom formio component (`children`)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
