### PR TITLE
Add missing closing tag for div in children preview

### DIFF
--- a/src/openforms/js/components/formio_builder/templates/children.js
+++ b/src/openforms/js/components/formio_builder/templates/children.js
@@ -43,6 +43,7 @@ const TEMPLATE = `
     </tbody>
 
   </table>
+</div>
 `;
 
 export default TEMPLATE;


### PR DESCRIPTION
**Changes**

- Just added a missing `</div>` to the children component template in the form builder

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

