### PR TITLE
[#5225] Add localized placeholder for formio date and datetime components

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -104,6 +104,9 @@ class Date(BasePlugin[DateComponent]):
         """
         mutate_min_max_validation(component, data)
 
+        # inject the translated placeholder for the formio DateField component
+        component["placeholder"] = _("dd-mm-yyyy")
+
     def build_serializer_field(
         self, component: DateComponent
     ) -> FormioDateField | serializers.ListField:
@@ -191,6 +194,9 @@ class Datetime(BasePlugin):
         Implement the behaviour for our custom datetime component options.
         """
         mutate_min_max_validation(component, data)
+
+        # inject the translated placeholder for the formio DateTimeField component
+        component["placeholder"] = _("dd-mm-yyyy HH:mm")
 
     def build_serializer_field(
         self, component: DateComponent

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from datetime import datetime
 
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.utils import timezone
 
 from freezegun import freeze_time
@@ -47,6 +47,18 @@ class DynamicDateConfigurationTests(TestCase):
         self.assertEqual(
             new_component["datePicker"]["maxDate"], "2022-09-08T00:00:00+02:00"
         )
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_date_placeholder(self):
+        component: DateComponent = {
+            "type": "date",
+            "key": "aDate",
+            "label": "Date",
+        }
+
+        new_component = self._get_dynamic_config(component, {})
+
+        self.assertEqual(new_component["placeholder"], "dd-mm-yyyy")
 
     def test_min_max_date_fixed_value(self):
         component: DateComponent = {

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -104,6 +104,18 @@ class DynamicDatetimeConfigurationTests(TestCase):
             "2022-09-12T16:07:00+02:00",
         )
 
+    @override_settings(LANGUAGE_CODE="en")
+    def test_datetime_placeholder(self):
+        component: DatetimeComponent = {
+            "type": "datetime",
+            "key": "aDatetime",
+            "label": "Datetime",
+        }
+
+        new_component = self._get_dynamic_config(component, {})
+
+        self.assertEqual(new_component["placeholder"], "dd-mm-yyyy HH:mm")
+
     @freeze_time("2022-10-03T12:00:00Z")
     def test_relative_to_variable_blank_delta(self):
         component: DatetimeComponent = {


### PR DESCRIPTION
Closes #5225

**Changes**

- Added localization for formio Date and Datetime components

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
