### PR TITLE
Fix empty values of date related objects

### DIFF
--- a/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
+++ b/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
@@ -143,14 +143,15 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         with self.assertRaises(PermissionDenied):
             prefill_variables(submission=submission)
         state = submission.load_submission_value_variables_state()
+        data = state.get_data(include_unsaved=True)
 
         self.assertEqual(TimelineLogProxy.objects.count(), 1)
         logs = TimelineLogProxy.objects.get()
 
         self.assertEqual(logs.extra_data["log_event"], "prefill_retrieve_failure")
         self.assertEqual(logs.extra_data["plugin_id"], "objects_api")
-        self.assertIsNone(state.variables["lastName"].value)
-        self.assertIsNone(state.variables["age"].value)
+        self.assertEqual(data["lastName"], "")
+        self.assertEqual(data["age"], "")
 
     def test_prefill_values_when_reference_returns_empty_values(self):
         # We manually create the objects instance as if it was created upfront by some external party
@@ -197,6 +198,7 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
 
         prefill_variables(submission=submission)
         state = submission.load_submission_value_variables_state()
+        data = state.get_data(include_unsaved=True)
 
         self.assertEqual(TimelineLogProxy.objects.count(), 2)
         ownership_check_log, prefill_log = TimelineLogProxy.objects.all()
@@ -208,5 +210,5 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         self.assertEqual(ownership_check_log.extra_data["plugin_id"], "objects_api")
         self.assertEqual(prefill_log.extra_data["log_event"], "prefill_retrieve_empty")
         self.assertEqual(prefill_log.extra_data["plugin_id"], "objects_api")
-        self.assertIsNone(state.variables["lastName"].value)
-        self.assertIsNone(state.variables["age"].value)
+        self.assertEqual(data["lastName"], "")
+        self.assertEqual(data["age"], "")

--- a/src/openforms/prefill/tests/test_prefill_hook.py
+++ b/src/openforms/prefill/tests/test_prefill_hook.py
@@ -52,7 +52,7 @@ CONFIGURATION: FormioConfiguration = {
             "description": "",
             "placeholder": "",
             "showInEmail": False,
-            "defaultValue": None,
+            "defaultValue": "",
         }
     ],
 }
@@ -352,7 +352,7 @@ class PrefillHookTests(TransactionTestCase):
 
         field = new_configuration["components"][0]
         assert "defaultValue" in field
-        self.assertIsNone(field["defaultValue"])
+        self.assertEqual(field["defaultValue"], "")
 
     def tests_no_prefill_configured(self):
         config = deepcopy(CONFIGURATION)

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -84,7 +84,7 @@ class EmailRegistration(BasePlugin[Options]):
 
                     # do not validate that the values are emails, if they're wrong values,
                     # we want to see this in error monitoring.
-                    recipients = variable_value
+                    recipients = variable_value  # pyright: ignore[reportAssignmentType]
                     log.info("recipients_resolved", recipients=recipients)
 
         return recipients

--- a/src/openforms/registrations/contrib/objects_api/handlers/v2.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v2.py
@@ -102,10 +102,10 @@ def process_mapped_variable(
     match component:
         case {"type": "date" | "datetime" | "time", "multiple": True}:
             assert isinstance(value, list)
-            value = [v.isoformat() for v in value]  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
+            value = [v.isoformat() if value else "" for v in value]  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
         case {"type": "date" | "datetime" | "time"}:
-            assert isinstance(value, date | time | datetime)
-            value = value.isoformat()
+            assert isinstance(value, date | time | datetime | None)
+            value = value.isoformat() if value else ""
         case {"type": "addressNL"}:
             assert isinstance(value, dict)
             value = value.copy()
@@ -164,7 +164,6 @@ def process_mapped_variable(
             for partner in value:
                 assert isinstance(partner, dict)
                 assert isinstance(partner["dateOfBirth"], date)
-
                 partner["dateOfBirth"] = partner["dateOfBirth"].isoformat()
 
                 # these are not relevant for the object (at least for now)

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -177,7 +177,7 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
         "betrokkeneIdentificatie.voorvoegselGeslachtsnaam": RegistrationAttribute.initiator_tussenvoegsel,
         "betrokkeneIdentificatie.geboortedatum": FieldConf(
             RegistrationAttribute.initiator_geboortedatum,
-            transform=lambda date: date.isoformat(),
+            transform=lambda date: date.isoformat() if date else "",
         ),
         "betrokkeneIdentificatie.geslachtsaanduiding": FieldConf(
             RegistrationAttribute.initiator_geslachtsaanduiding,

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -19,6 +19,7 @@ from openforms.formio.typing import Component
 from openforms.formio.utils import (
     get_component_data_subtype,
     get_component_datatype,
+    get_component_empty_value,
     iter_components,
 )
 from openforms.forms.models.form_variable import FormVariable
@@ -174,16 +175,21 @@ class SubmissionValueVariablesState:
                 continue
 
             configuration = {}
+            initial_value = form_variable.get_initial_value()
             if form_variable.source == FormVariableSources.component:
                 configuration = form_variable.form_definition.configuration_wrapper[
                     variable_key
                 ]
+                # If it does not have an initial value, make sure to set the empty
+                # component value.
+                if initial_value is None:
+                    initial_value = get_component_empty_value(configuration)
 
             # TODO Fill source field
             unsaved_submission_var = SubmissionValueVariable(
                 submission=self.submission,
                 key=variable_key,
-                value=form_variable.get_initial_value(),
+                value=initial_value,
                 is_initially_prefilled=(form_variable.prefill_plugin != ""),
                 configuration=configuration,
                 data_type=form_variable.data_type,

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -23,7 +23,13 @@ from openforms.formio.utils import (
     iter_components,
 )
 from openforms.forms.models.form_variable import FormVariable
-from openforms.typing import JSONEncodable, JSONObject, JSONSerializable, VariableValue
+from openforms.typing import (
+    JSONEncodable,
+    JSONObject,
+    JSONSerializable,
+    JSONValue,
+    VariableValue,
+)
 from openforms.utils.date import format_date_value, parse_datetime, parse_time
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 from openforms.variables.service import VariablesRegistry, get_static_variables
@@ -423,10 +429,96 @@ class SubmissionValueVariable(models.Model):
     def __str__(self):
         return _("Submission value variable {key}").format(key=self.key)
 
+    def save(self, *args, **kwargs):
+        self.value = self.to_json(self.value)
+        super().save(*args, **kwargs)
+
+    def to_json(self, value: VariableValue | object = empty) -> JSONValue:
+        """
+        Serialize a value into the JSON type, using the data type information.
+
+        :param value: Variable value to serialize. If empty, ``self.value`` is used.
+        """
+        if value is empty:
+            value = self.value
+
+        if not self.data_subtype:
+            return self._value_to_json(value, self.data_type, self.configuration)
+        else:
+            assert self.data_type == FormVariableDataTypes.array
+            return [
+                self._value_to_json(v, self.data_subtype, self.configuration)
+                for v in value
+            ]
+
+    def _value_to_json(
+        self,
+        value: VariableValue,
+        data_type: str,
+        configuration: Component | None = None,
+    ) -> VariableValue:
+        if data_type in (
+            FormVariableDataTypes.string,
+            FormVariableDataTypes.boolean,
+            FormVariableDataTypes.object,
+            FormVariableDataTypes.int,
+            FormVariableDataTypes.float,
+            FormVariableDataTypes.array,
+        ):
+            return value
+
+        if data_type in (
+            FormVariableDataTypes.date,
+            FormVariableDataTypes.time,
+            FormVariableDataTypes.datetime,
+        ):
+            if isinstance(value, str):
+                return value
+            if value is None:
+                return ""
+            return value.isoformat()
+
+        if value and data_type == FormVariableDataTypes.partners:
+            value["dateOfBirth"] = self._value_to_json(
+                value["dateOfBirth"], FormVariableDataTypes.date
+            )
+            return value
+
+        if value and data_type == FormVariableDataTypes.children:
+            value["dateOfBirth"] = self._value_to_json(
+                value["dateOfBirth"], FormVariableDataTypes.date
+            )
+            return value
+
+        if value and data_type == FormVariableDataTypes.editgrid:
+            value = FormioData(value)
+            for child_component in iter_components(configuration):
+                child_key = child_component["key"]
+                if (child_value := value.get(child_key, empty)) is empty:
+                    continue
+
+                data_type = get_component_datatype(child_component)
+                data_subtype = get_component_data_subtype(child_component)
+
+                if not data_subtype:
+                    value[child_key] = self._value_to_json(
+                        child_value, data_type, child_component
+                    )
+                else:
+                    assert data_type == FormVariableDataTypes.array
+                    value[child_key] = [
+                        self._value_to_json(v, data_subtype, child_component)
+                        for v in child_value
+                    ]
+
+            return value.data
+
+        return value
+
     def to_python(self, value: VariableValue | object = empty) -> VariableValue:
         """
         Deserialize a value into the appropriate python type, using the data type
-        information from the related form variable.
+        information.
 
         TODO: for dates/datetimes, we rely on our django settings for timezone
         information, however - formio submission does send the user's configured
@@ -457,6 +549,9 @@ class SubmissionValueVariable(models.Model):
         data_type: str,
         configuration: Component | None = None,
     ) -> VariableValue:
+        if value is None:
+            return None
+
         if data_type in (
             FormVariableDataTypes.string,
             FormVariableDataTypes.boolean,
@@ -467,7 +562,10 @@ class SubmissionValueVariable(models.Model):
         ):
             return value
 
-        if value and data_type == FormVariableDataTypes.date:
+        if data_type == FormVariableDataTypes.date:
+            if value == "":
+                return None
+
             if isinstance(value, date):
                 return value
             formatted_date = format_date_value(value)
@@ -484,7 +582,10 @@ class SubmissionValueVariable(models.Model):
                 return maybe_naive_datetime.date()
             return timezone.make_aware(maybe_naive_datetime).date()
 
-        if value and data_type == FormVariableDataTypes.datetime:
+        if data_type == FormVariableDataTypes.datetime:
+            if value == "":
+                return None
+
             if isinstance(value, datetime):
                 return value
             maybe_naive_datetime = parse_datetime(value)
@@ -495,7 +596,10 @@ class SubmissionValueVariable(models.Model):
                 return maybe_naive_datetime
             return timezone.make_aware(maybe_naive_datetime)
 
-        if value and data_type == FormVariableDataTypes.time:
+        if data_type == FormVariableDataTypes.time:
+            if value == "":
+                return None
+
             if isinstance(value, time):
                 return value
             return parse_time(value)

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1075,7 +1075,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         # Note that this doesn't make the problem go away 100% - you will get an
         # additional check if the minute value changes, but that should settle after one
         # extra logic check.
-        self.assertEqual(new_value, "2024-03-18T07:31:00Z")
+        self.assertEqual(new_value, "2024-03-18T07:31:00+00:00")
 
     def test_component_value_set_to_today(self):
         form = FormFactory.create(

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -745,47 +745,6 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             )
 
     @tag("gh-2056")
-    def test_components_hidden_by_frontend_have_correct_empty_value(self):
-        form = FormFactory.create()
-        form_step = FormStepFactory.create(
-            form=form,
-            form_definition__configuration={
-                "components": [
-                    {
-                        "key": "radio",
-                        "type": "radio",
-                        "values": [
-                            {"label": "yes", "value": "yes"},
-                            {"label": "no", "value": "no"},
-                        ],
-                    },
-                    {
-                        "type": "file",
-                        "key": "file",
-                        "hidden": False,
-                        "conditional": {"eq": "yes", "show": True, "when": "radio"},
-                        "clearOnHide": True,
-                    },
-                ]
-            },
-        )
-
-        submission = SubmissionFactory.create(form=form)
-
-        self._add_submission_to_session(submission)
-        logic_check_endpoint = reverse(
-            "api:submission-steps-logic-check",
-            kwargs={
-                "submission_uuid": submission.uuid,
-                "step_uuid": form_step.uuid,
-            },
-        )
-        response = self.client.post(logic_check_endpoint, {"data": {"radio": "no"}})
-
-        data = response.json()
-
-        self.assertEqual([], data["step"]["data"]["file"])
-
     def test_components_hidden_by_frontend_after_filling_have_correct_empty_value(self):
         form = FormFactory.create()
         form_step = FormStepFactory.create(


### PR DESCRIPTION
Partly closes #5134

[skip: e2e]

**Changes**

* The initial value of a submission value variable is now the empty value instead of `None`, if the related form value had no initial value
* Submission value variables and `SubmissionStep.data` are now serialized to JSON manually when saving to the DB and serializing for API response (this was done exclusively by the `DjangoJSONEncoder` before)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
