### PR TITLE
Fix integrity error when saving form variable

### DIFF
--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -50,6 +50,7 @@ UPSERT_ATTRIBUTES_TO_COMPARE: tuple[str, ...] = (
     "name",
     "is_sensitive_data",
     "data_type",
+    "data_subtype",
     "initial_value",
 )
 

--- a/src/openforms/forms/tests/variables/test_model.py
+++ b/src/openforms/forms/tests/variables/test_model.py
@@ -556,6 +556,12 @@ class FormVariableManagerTests(TestCase):
                         "label": "Some selectboxes",
                         "defaultValue": {"foo": True},
                     },
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                        "multiple": False,
+                    },
                 ]
             }
         )
@@ -569,7 +575,7 @@ class FormVariableManagerTests(TestCase):
             FormVariable.objects.synchronize_for(fd)
 
             form_variables = FormVariable.objects.all()
-            self.assertEqual(len(form_variables), 2 + 2)  # 2 for each form (step)
+            self.assertEqual(len(form_variables), 6)  # 2 for each form (step)
             step1_variables = {
                 variable.key: variable
                 for variable in form_variables
@@ -600,6 +606,7 @@ class FormVariableManagerTests(TestCase):
                     self.assertEqual(
                         date_variable.data_type, FormVariableDataTypes.date
                     )
+                    self.assertEqual(date_variable.data_subtype, "")
                     self.assertEqual(date_variable.data_format, "")
                     self.assertTrue(date_variable.is_sensitive_data)
                     self.assertEqual(date_variable.initial_value, "2025-01-01")
@@ -621,9 +628,32 @@ class FormVariableManagerTests(TestCase):
                     self.assertEqual(
                         date_variable.data_type, FormVariableDataTypes.object
                     )
+                    self.assertEqual(date_variable.data_subtype, "")
                     self.assertEqual(date_variable.data_format, "")
                     self.assertFalse(date_variable.is_sensitive_data)
                     self.assertEqual(date_variable.initial_value, {"foo": True})
+
+                with self.subTest("textfield variable"):
+                    textfield_variable = container["textfield"]
+                    self.assertEqual(textfield_variable.form_definition, fd)
+                    self.assertEqual(textfield_variable.name, "Textfield")
+                    self.assertEqual(
+                        textfield_variable.source, FormVariableSources.component
+                    )
+                    self.assertIsNone(textfield_variable.service_fetch_configuration)
+                    self.assertEqual(textfield_variable.prefill_plugin, "")
+                    self.assertEqual(textfield_variable.prefill_attribute, "")
+                    self.assertEqual(
+                        textfield_variable.prefill_identifier_role, IdentifierRoles.main
+                    )
+                    self.assertEqual(textfield_variable.prefill_options, {})
+                    self.assertEqual(
+                        textfield_variable.data_type, FormVariableDataTypes.string
+                    )
+                    self.assertEqual(textfield_variable.data_subtype, "")
+                    self.assertEqual(textfield_variable.data_format, "")
+                    self.assertFalse(textfield_variable.is_sensitive_data)
+                    self.assertIsNone(textfield_variable.initial_value)
 
         # update some components, remove one and add a new one
         with self.subTest("update form definition"):
@@ -651,6 +681,13 @@ class FormVariableManagerTests(TestCase):
                             },
                         ],
                     },
+                    # updated multiple property
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                        "multiple": True,
+                    },
                 ]
             }
             fd.save()
@@ -658,7 +695,7 @@ class FormVariableManagerTests(TestCase):
             FormVariable.objects.synchronize_for(fd)
 
             form_variables = FormVariable.objects.all()
-            self.assertEqual(len(form_variables), 2 + 2)  # 2 for each form (step)
+            self.assertEqual(len(form_variables), 6)  # 2 for each form (step)
             step1_variables = {
                 variable.key: variable
                 for variable in form_variables
@@ -712,3 +749,27 @@ class FormVariableManagerTests(TestCase):
                     self.assertEqual(date_variable.data_format, "")
                     self.assertFalse(date_variable.is_sensitive_data)
                     self.assertIsNone(date_variable.initial_value)
+
+                with self.subTest("textfield variable"):
+                    textfield_variable = container["textfield"]
+                    self.assertEqual(textfield_variable.form_definition, fd)
+                    self.assertEqual(textfield_variable.name, "Textfield")
+                    self.assertEqual(
+                        textfield_variable.source, FormVariableSources.component
+                    )
+                    self.assertIsNone(textfield_variable.service_fetch_configuration)
+                    self.assertEqual(textfield_variable.prefill_plugin, "")
+                    self.assertEqual(textfield_variable.prefill_attribute, "")
+                    self.assertEqual(
+                        textfield_variable.prefill_identifier_role, IdentifierRoles.main
+                    )
+                    self.assertEqual(textfield_variable.prefill_options, {})
+                    self.assertEqual(
+                        textfield_variable.data_type, FormVariableDataTypes.array
+                    )
+                    self.assertEqual(
+                        textfield_variable.data_subtype, FormVariableDataTypes.string
+                    )
+                    self.assertEqual(textfield_variable.data_format, "")
+                    self.assertFalse(textfield_variable.is_sensitive_data)
+                    self.assertEqual(textfield_variable.initial_value, [])


### PR DESCRIPTION
Closes -

[skip: e2e]

**Changes**

Added `data_subtype` to list of form variable attributes to upsert/update

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how
