### PR TITLE
[#3640] Allow suspending submission only when not completed

### DIFF
--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -428,7 +428,7 @@ class SubmissionViewSet(
         """
         submission = self.get_object()
 
-        if not submission.form.suspension_allowed:
+        if not submission.suspension_allowed:
             raise PermissionDenied(_("Suspending this form is not allowed."))
 
         serializer = SubmissionSuspensionSerializer(

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -503,6 +503,10 @@ class Submission(models.Model):
         # success is set if it succeeded or there was no registration backend configured
         return self.registration_status == RegistrationStatuses.success
 
+    @property
+    def suspension_allowed(self) -> bool:
+        return self.form.suspension_allowed and not self.is_completed
+
     @transaction.atomic()
     def remove_sensitive_data(self):
         from .submission_files import SubmissionFileAttachment


### PR DESCRIPTION
Closes #3640

**Changes**

- Added extra validation for allowing submission to be suspended if this is allowed in the form level and if the submission is not completed.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
