### PR TITLE
Wrap label text in component preview in modal

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -128,7 +128,14 @@ div.flatpickr-calendar.open {
 .component-preview {
   .col-form-label {
     @include ellipsis;
-    max-width: 100%;
+    max-inline-size: 100%;
+
+    // don't do this in the modal preview
+    @at-root .formio-dialog.component-settings & {
+      max-inline-size: unset;
+      white-space: normal;
+      overflow: unset;
+    }
   }
 
   ul.list-group {


### PR DESCRIPTION
Closes #5429

The previous fix was for the columns preview in the formio-builder which doesn't properly vertically align if some labels wrap and others don't.

This fix is kept for the full form preview, but inside the component settings modal we can apply the regular label wrapping behaviour as the columns situation there doesn't apply.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

[skip: e2e]