### PR TITLE
[#3544] Do not delete submissions related to valid appointments

### DIFF
--- a/src/openforms/appointments/tests/test_api_cancel_appointment.py
+++ b/src/openforms/appointments/tests/test_api_cancel_appointment.py
@@ -1,12 +1,22 @@
+from datetime import datetime
+
+import pytz
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from openforms.appointments.tests.factories import AppointmentInfoFactory
+from openforms.data_removal.constants import RemovalMethods
+from openforms.data_removal.tasks import delete_submissions
+from openforms.forms.tests.factories import FormFactory
 from openforms.logging.models import TimelineLogProxy
+from openforms.submissions.models import Submission
+from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.submissions.tests.mixins import SubmissionsMixin
 
 from ..models import AppointmentsConfig
+from ..tokens import submission_appointment_token_generator
 from .factories import AppointmentFactory
 
 
@@ -64,3 +74,104 @@ class CancelAppointmentTests(SubmissionsMixin, APITestCase):
             "appointment_cancel_failure"
         )
         self.assertEqual(logs.count(), 1)
+
+    def test_cancel_appointment_and_successful_submissions_pruning(self):
+        with freeze_time("2021-07-20T12:00:00Z"):
+            form = FormFactory.create(
+                is_appointment=True,
+                successful_submissions_removal_limit=2,
+                successful_submissions_removal_method=(
+                    RemovalMethods.delete_permanently
+                ),
+            )
+            submission = SubmissionFactory.create(form=form, registration_success=True)
+            AppointmentInfoFactory.create(
+                submission=submission,
+                registration_ok=True,
+                start_time=datetime(2021, 7, 26, 12, 00, 00, tzinfo=pytz.UTC),
+            )
+            AppointmentFactory.create(
+                submission=submission,
+                datetime=datetime(2021, 7, 26, 12, 00, 00, tzinfo=pytz.UTC),
+            )
+
+            endpoint = reverse(
+                "appointments:appointments-verify-cancel-appointment-link",
+                kwargs={
+                    "token": submission_appointment_token_generator.make_token(
+                        submission
+                    ),
+                    "submission_uuid": submission.uuid,
+                },
+            )
+
+        # appointment still valid, submission should not be deleted
+        with freeze_time("2021-07-25T12:00:00Z"):
+            self.assertEqual(Submission.objects.count(), 1)
+
+            delete_submissions()
+
+            self.assertTrue(Submission.objects.exists())
+
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+        # appointment invalid, submission should be deleted
+        with freeze_time("2021-07-27T12:00:00Z"):
+            self.assertEqual(Submission.objects.count(), 1)
+
+            delete_submissions()
+
+            self.assertFalse(Submission.objects.exists())
+
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cancel_appointment_and_all_submissions_pruning(self):
+        with freeze_time("2021-07-20T12:00:00Z"):
+            form = FormFactory.create(
+                is_appointment=True,
+                all_submissions_removal_limit=2,
+            )
+            submission = SubmissionFactory.create(form=form)
+            AppointmentInfoFactory.create(
+                submission=submission,
+                registration_ok=True,
+                start_time=datetime(2021, 7, 26, 12, 00, 00, tzinfo=pytz.UTC),
+            )
+            AppointmentFactory.create(
+                submission=submission,
+                datetime=datetime(2021, 7, 26, 12, 00, 00, tzinfo=pytz.UTC),
+            )
+
+            endpoint = reverse(
+                "appointments:appointments-verify-cancel-appointment-link",
+                kwargs={
+                    "token": submission_appointment_token_generator.make_token(
+                        submission
+                    ),
+                    "submission_uuid": submission.uuid,
+                },
+            )
+
+        # appointment still valid, submission should not be deleted
+        with freeze_time("2021-07-25T12:00:00Z"):
+            self.assertEqual(Submission.objects.count(), 1)
+
+            delete_submissions()
+
+            self.assertTrue(Submission.objects.exists())
+
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+        # appointment invalid, submission should be deleted
+        with freeze_time("2021-07-27T12:00:00Z"):
+            self.assertEqual(Submission.objects.count(), 1)
+
+            delete_submissions()
+
+            self.assertFalse(Submission.objects.exists())
+
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Closes #3544

**Changes**

- Added extra filter for appointments. When a valid appointment (date in the future) exists, its related submission cannot be deleted. This makes sure that the "cancel" endpoint is working as expected.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
