### PR TITLE
Add default data subtype if no corresponding component was found

### DIFF
--- a/src/openforms/forms/tests/test_migrations.py
+++ b/src/openforms/forms/tests/test_migrations.py
@@ -1,0 +1,45 @@
+from openforms.utils.tests.test_migrations import TestMigrations
+
+
+class DataTypeMigrationTests(TestMigrations):
+    migrate_from = "0109_formvariable_data_type_and_data_subtype"
+    migrate_to = "0111_formvariable_form_variable_subtype_empty_iff_data_type_is_not_array_and_more"
+    app = "forms"
+
+    def setUpBeforeMigration(self, apps):
+        Form = apps.get_model("forms", "Form")
+        FormVariable = apps.get_model("forms", "FormVariable")
+        FormDefinition = apps.get_model("forms", "FormDefinition")
+
+        form = Form.objects.create(name="Form")
+        fd = FormDefinition.objects.create(
+            name="Form definition",
+            configuration={
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"}
+                ]
+            },
+        )
+        # Form variable for which the key is not present in the configuration
+        FormVariable.objects.create(
+            form=form,
+            form_definition=fd,
+            name="Non-existing key",
+            key="nonExistingKey",
+            source="component",
+            data_type="array",
+            data_subtype="",
+        )
+
+    def test_migration_with_outdated_form_variable(self):
+        """
+        Ensure that the migration succeeds when a form variable has a key that is not
+        present in the corresponding form definition configuration.
+
+        Note that this situation shouldn't occur, but *could* when someone manually
+        changes a form variable and/or form definition configuration.
+        """
+        FormVariable = self.apps.get_model("forms", "FormVariable")
+
+        variable = FormVariable.objects.get(key="nonExistingKey")
+        self.assertEqual(variable.data_subtype, "string")


### PR DESCRIPTION
[skip: e2e] 

**Changes**

Added a default data subtype (string) to the migration

If a form variable was changed manually, there is a possibility that we cannot find the corresponding component definition in the formio configuration. To avoid violating the data type constraint introduced in 0111_formvariable_form_variable_subtype_empty_iff_data_type_is_not_array_and_more, we default the data subtype to a string in these cases.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
