### PR TITLE
Rename metrics with proper naming conventions

### DIFF
--- a/docs/installation/observability/metrics.rst
+++ b/docs/installation/observability/metrics.rst
@@ -40,10 +40,15 @@ Generic
 Application specific
 ====================
 
+.. versionchanged:: 3.4.0
+
+    The metrics names have all been prefixed with the ``openforms`` namespace, and some
+    metrics have some more renames to be better comply with the OTel naming conventions.
+
 Accounts
 --------
 
-``user_count``
+``openforms.auth.user_count``
     Reports the number of users in the database. This is a global metric, you must take
     care in de-duplicating results. Additional attributes are:
 
@@ -59,14 +64,14 @@ Accounts
           [1m]
         ))
 
-``auth.login_failures``
+``openforms.auth.login_failures``
     A counter incremented every time a user login fails (typically because of invalid
     credentials). Does not include the second factor, if enabled. Additional attributes:
 
     - ``http_target`` - the request path where the login failure occurred, if this
       happened in a request context.
 
-``auth.user_lockouts``
+``openforms.auth.user_lockouts``
     A counter incremented every time a user is locked out because they reached the
     maximum number of failed attempts. Additional attributes:
 
@@ -74,14 +79,14 @@ Accounts
       happened in a request context.
     - ``username`` - username of the user trying to log in.
 
-``auth.logins``
+``openforms.auth.logins``
     Counter incrementing on every successful login by a user. Additional attributes:
 
     - ``http_target`` - the request path where the login failure occurred, if this
       happened in a request context.
     - ``username`` - username of the user trying to log in.
 
-``auth.logouts``
+``openforms.auth.logouts``
     Counter incrementing every time a user logs out. Additional attributes:
 
     - ``username`` - username of the user who logged out.
@@ -92,7 +97,7 @@ Forms
 Form metrics describe the forms defined by the organization. For submission statistics,
 see the :ref:`Submission <installation_observability_metrics_submissions>` metrics.
 
-``form_count``
+``openforms.form_count``
     The total count of forms defined in the database, ignoring forms that have been
     moved into the trash. Additional attributes are:
 
@@ -100,14 +105,14 @@ see the :ref:`Submission <installation_observability_metrics_submissions>` metri
     - ``type`` - one of ``total``, ``live``, ``translation_enabled``, ``is_appointment``
       or ``trash``. For all but ``trash`` the forms in the trash are excluded.
 
-``form_component_count``
+``openforms.form_component_count``
     Keeps track of how often a Formio component type is used in a form. This is only
     reported for live, non-appointment forms. Additional attributes are:
 
     - ``scope`` - fixed, set to ``global`` to enable de-duplication.
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form.
-    - ``type`` - the Formio component type, e.g. ``textfield``, ``email``,
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form.
+    - ``openforms.component.type`` - the Formio component type, e.g. ``textfield``, ``email``,
       ``selectboxes``...
 
 .. _installation_observability_metrics_submissions:
@@ -115,47 +120,47 @@ see the :ref:`Submission <installation_observability_metrics_submissions>` metri
 Submissions
 -----------
 
-``submission.starts``
+``openforms.submission.starts``
     Counts the number of submissions started by end-users. Additional attributes are:
 
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form that was submitted.
-    - ``auth.logged_in`` - ``true/false``, indicates if the user was logged in when
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form that was submitted.
+    - ``openforms.auth.logged_in`` - ``true/false``, indicates if the user was logged in when
       starting the submission.
-    - ``auth.plugin`` - if logged in, the ID of the plugin that the user was logged in
+    - ``openforms.auth.plugin`` - if logged in, the ID of the plugin that the user was logged in
       with.
 
-``submission.completions``
+``openforms.submission.completions``
     Counts the number of form submissions completed by end-users. Additional attributes
     are:
 
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form that was submitted.
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form that was submitted.
 
-``submission.suspensions``
+``openforms.submission.suspensions``
     Counts the number of submissions suspended/paused by end-users. Additional
     attributes are:
 
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form that was submitted.
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form that was submitted.
 
-``submission.step_saves``
+``openforms.submission.step_saves``
     Counts the number times a submission step is saved (i.e. the user submits and goes
     to the next step). Additional attributes are:
 
-    - ``step.name`` - the name of the step that was saved.
-    - ``step.number`` - the step sequence, starting at 1 for the first step.
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form that was submitted.
+    - ``openforms.step.name`` - the name of the step that was saved.
+    - ``openforms.step.number`` - the step sequence, starting at 1 for the first step.
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form that was submitted.
     - ``type`` - ``create`` or ``update``. Users can go back to a step and modify
       details, which results in an update.
 
-``submissions``
+``openforms.submission_count``
     The total count of submissions in the database. This is a global metric, you must
     take care in de-duplicating results. Additional attributes are:
 
     - ``scope`` - fixed, set to ``global`` to enable de-duplication.
-    - ``form.name`` - the name of the form that the submission belongs to.
+    - ``openforms.openforms.form.name`` - the name of the form that the submission belongs to.
     - ``type`` - the kind of submission, possible values are ``successful``,
       ``incomplete``, ``errored``,  ``other`` which maps to the associated retention
       periods.
@@ -171,37 +176,37 @@ Submissions
           )
         )
 
-``attachment.file_size``
+``openforms.attachment_upload.file_size``
     A histogram of submission attachments, with buckets covering file upload sizes from
     0 bytes to 1 GiB (Open Forms by default limits uploads to 50 MB). Additional
     attributes are:
 
-    - ``step.name`` - the name of the step that was saved.
-    - ``step.number`` - the step sequence, starting at 1 for the first step.
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form that was submitted.
+    - ``openforms.step.name`` - the name of the step that was saved.
+    - ``openforms.step.number`` - the step sequence, starting at 1 for the first step.
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form that was submitted.
     - ``content_type`` - the file type of the attachment.
 
-``submission.attachments_per_submission``
+``openforms.submission.attachments_per_submission``
     A histogram counting the amount of attachments within a submission. Additional
     attributes are:
 
-    - ``form.uuid`` - the unique database ID of the form.
-    - ``form.name`` - the name of the form that was submitted.
+    - ``openforms.form.uuid`` - the unique database ID of the form.
+    - ``openforms.form.name`` - the name of the form that was submitted.
 
 Plugins
 -------
 
-``plugin_usage_count``
+``openforms.plugin.usage_count``
     A gauge reporting how many times each (installed) plugin is used in an instance.
     This is a global metric, you must take care in de-duplicating results. Additional
     attributes are:
 
     - ``scope`` - fixed, set to ``global`` to enable de-duplication.
-    - ``plugin.module`` - the feature module the plugin/metric belongs to, such as
+    - ``openforms.plugin.module`` - the feature module the plugin/metric belongs to, such as
       ``registrations``, ``prefill``, ``authentication``...
-    - ``plugin.identifier`` - the unique identifier for a plugin. The combination of
+    - ``openforms.plugin.identifier`` - the unique identifier for a plugin. The combination of
       ``(module, identifier)`` is guaranteed to be unique.
-    - ``plugin.is_enabled`` - flag to indicate whether the plugin is enabled or not.
+    - ``openforms.plugin.is_enabled`` - flag to indicate whether the plugin is enabled or not.
       Disabled plugin metrics should have a value of ``0`` during normal operation.
-    - ``plugin.is_demo`` - flag that marks demo plugins only available for testing.
+    - ``openforms.plugin.is_demo`` - flag that marks demo plugins only available for testing.

--- a/src/openforms/accounts/metrics.py
+++ b/src/openforms/accounts/metrics.py
@@ -32,32 +32,32 @@ def count_users(options: metrics.CallbackOptions) -> Collection[metrics.Observat
 
 
 meter.create_observable_gauge(
-    name="user_count",
+    name="openforms.auth.user_count",
     description="The number of application users in the database.",
-    unit="",  # no unit so that the _ratio suffix is not added
+    unit=r"{user}",  # no unit so that the _ratio suffix is not added
     callbacks=[count_users],
 )
 
 logins = meter.create_counter(
-    "auth.logins",
+    "openforms.auth.logins",
     unit="1",  # unitless count
     description="The number of successful user logins.",
 )
 
 logouts = meter.create_counter(
-    "auth.logouts",
+    "openforms.auth.logouts",
     unit="1",  # unitless count
     description="The number of user logouts.",
 )
 
 login_failures = meter.create_counter(
-    "auth.login_failures",
+    "openforms.auth.login_failures",
     unit="1",  # unitless count
     description="The number of failed logins by users, including the admin.",
 )
 
 user_lockouts = meter.create_counter(
-    "auth.user_lockouts",
+    "openforms.auth.user_lockouts",
     unit="1",  # unitless count
     description="The number of user lockouts because of failed logins.",
 )

--- a/src/openforms/forms/metrics.py
+++ b/src/openforms/forms/metrics.py
@@ -34,7 +34,7 @@ def count_forms(options: metrics.CallbackOptions) -> Collection[metrics.Observat
 
 
 meter.create_observable_gauge(
-    name="form_count",
+    name="openforms.form_count",
     description="The number of forms in the database.",
     unit="",  # no unit so that the _ratio suffix is not added
     callbacks=[count_forms],
@@ -75,9 +75,9 @@ def count_component_usage(
             amount,
             attributes={
                 "scope": "global",
-                "form.uuid": str(form_uuid),
-                "form.name": uuid_to_name_map[form_uuid],
-                "type": component_type,
+                "openforms.form.uuid": str(form_uuid),
+                "openforms.form.name": uuid_to_name_map[form_uuid],
+                "openforms.component.type": component_type,
             },
         )
         for (form_uuid, component_type), amount in counter.items()
@@ -85,7 +85,7 @@ def count_component_usage(
 
 
 meter.create_observable_gauge(
-    name="form_component_count",
+    name="openforms.form_component_count",
     description="The number of forms in the database.",
     unit="",  # no unit so that the _ratio suffix is not added
     callbacks=[count_component_usage],

--- a/src/openforms/forms/tests/test_metrics.py
+++ b/src/openforms/forms/tests/test_metrics.py
@@ -92,7 +92,7 @@ class FormComponentCountMetricTests(MetricsAssertMixin, TestCase):
         self.assertMarkedGlobal(result)
 
         with self.subTest("counts by form"):
-            counts_by_form = self._group_observations_by(result, "form.name")
+            counts_by_form = self._group_observations_by(result, "openforms.form.name")
 
             expected = {
                 form_1.name: 4 + 1,  # components of fd1 and fd2
@@ -101,7 +101,9 @@ class FormComponentCountMetricTests(MetricsAssertMixin, TestCase):
             self.assertEqual(counts_by_form, expected)
 
         with self.subTest("counts by type"):
-            counts_by_type = self._group_observations_by(result, "type")
+            counts_by_type = self._group_observations_by(
+                result, "openforms.component.type"
+            )
 
             expected = {
                 "textfield": 2,  # fd1 is used once

--- a/src/openforms/plugins/registry.py
+++ b/src/openforms/plugins/registry.py
@@ -133,16 +133,16 @@ def record_plugin_usage(
                 value=times_used,
                 attributes={
                     "scope": "global",
-                    "plugin.module": module,
-                    "plugin.identifier": plugin.identifier,
-                    "plugin.is_enabled": plugin.is_enabled,
-                    "plugin.is_demo": plugin.is_demo_plugin,
+                    "openforms.plugin.module": module,
+                    "openforms.plugin.identifier": plugin.identifier,
+                    "openforms.plugin.is_enabled": plugin.is_enabled,
+                    "openforms.plugin.is_demo": plugin.is_demo_plugin,
                 },
             )
 
 
 meter.create_observable_gauge(
-    name="plugin_usage_count",
+    name="openforms.plugin.usage_count",
     description="The usage counts of module plugins.",
     unit="",  # no unit so that the _ratio suffix is not added
     callbacks=[record_plugin_usage],

--- a/src/openforms/plugins/tests/test_metrics.py
+++ b/src/openforms/plugins/tests/test_metrics.py
@@ -16,7 +16,7 @@ class PluginRegistryMetricTests(MetricsAssertMixin, TestCase):
 
         with self.subTest("modules reported"):
             modules = {
-                observation.attributes["plugin.module"]
+                observation.attributes["openforms.plugin.module"]
                 for observation in result
                 if observation.attributes
             }
@@ -38,8 +38,8 @@ class PluginRegistryMetricTests(MetricsAssertMixin, TestCase):
             assert observation.attributes
             with self.subTest(
                 "zero counts reported",
-                module=observation.attributes["plugin.module"],
-                plugin=observation.attributes["plugin.identifier"],
+                module=observation.attributes["openforms.plugin.module"],
+                plugin=observation.attributes["openforms.plugin.identifier"],
             ):
                 self.assertEqual(observation.value, 0)
 

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -182,10 +182,12 @@ class SubmissionViewSet(
         start_counter.add(
             1,
             attributes={
-                "form.name": form.name,
-                "form.uuid": str(form.uuid),
-                "auth.logged_in": logged_in,
-                "auth.plugin": submission.auth_info.plugin if logged_in else "",
+                "openforms.form.name": form.name,
+                "openforms.form.uuid": str(form.uuid),
+                "openforms.auth.logged_in": logged_in,
+                "openforms.auth.plugin": submission.auth_info.plugin
+                if logged_in
+                else "",
             },
         )
 
@@ -442,8 +444,8 @@ class SubmissionViewSet(
         suspension_counter.add(
             1,
             attributes={
-                "form.name": submission.form.name,
-                "form.uuid": str(submission.form.uuid),
+                "openforms.form.name": submission.form.name,
+                "openforms.form.uuid": str(submission.form.uuid),
             },
         )
 
@@ -616,11 +618,11 @@ class SubmissionStepViewSet(
         step_saved_counter.add(
             1,
             attributes={
-                "step.name": instance.form_step.form_definition.name,
-                "step.number": current_step_index + 1,
+                "openforms.step.name": instance.form_step.form_definition.name,
+                "openforms.step.number": current_step_index + 1,
                 "type": "create" if create else "update",
-                "form.name": submission.form.name,
-                "form.uuid": str(submission.form.uuid),
+                "openforms.form.name": submission.form.name,
+                "openforms.form.uuid": str(submission.form.uuid),
             },
         )
 

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -218,10 +218,10 @@ def attach_uploads_to_submission_step(
         upload_file_size.record(
             attachment.content.size,
             attributes={
-                "form.name": submission_step.submission.form.name,
-                "form.uuid": str(submission_step.submission.form.uuid),
-                "step.name": submission_step.form_step.form_definition.name,
-                "step.number": current_step_index + 1,
+                "openforms.form.name": submission_step.submission.form.name,
+                "openforms.form.uuid": str(submission_step.submission.form.uuid),
+                "openforms.step.name": submission_step.form_step.form_definition.name,
+                "openforms.step.number": current_step_index + 1,
                 "content_type": attachment.content_type,
             },
         )

--- a/src/openforms/submissions/metrics.py
+++ b/src/openforms/submissions/metrics.py
@@ -9,25 +9,25 @@ from .models import Submission
 meter = metrics.get_meter("openforms.submissions")
 
 start_counter = meter.create_counter(
-    "submission.starts",
+    "openforms.submission.starts",
     description="Amount of form submissions started (via the API).",
     unit="1",  # unitless count
 )
 
 suspension_counter = meter.create_counter(
-    "submission.supensions",
+    "openforms.submission.supensions",
     description="Amount of form submissions suspended/paused.",
     unit="1",  # unitless count
 )
 
 completion_counter = meter.create_counter(
-    "submission.completions",
+    "openforms.submission.completions",
     unit="1",  # unitless count
     description="The number of form submissions completed by end users.",
 )
 
 step_saved_counter = meter.create_counter(
-    "submission.step_saves",
+    "openforms.submission.step_saves",
     unit="1",  # unitless count
     description="The number of steps saved to the database.",
 )
@@ -45,7 +45,7 @@ def count_submissions(
         metrics.Observation(
             value=agg["count"],
             attributes={
-                "form.name": agg["form__name"],
+                "openforms.form.name": agg["form__name"],
                 "type": agg["stage"],
                 "scope": "global",
             },
@@ -55,14 +55,14 @@ def count_submissions(
 
 
 meter.create_observable_gauge(
-    name="submission_count",
+    name="openforms.submission_count",
     description="The number of submissions.",
     unit="",  # no unit so that the _ratio suffix is not added
     callbacks=[count_submissions],
 )
 
 upload_file_size = meter.create_histogram(
-    name="attachment.file_size",
+    name="openforms.attachment_upload.file_size",
     unit="bytes",
     description="Size of a single uploaded attachment.",
     explicit_bucket_boundaries_advisory=(
@@ -77,7 +77,7 @@ upload_file_size = meter.create_histogram(
 )
 
 attachments_per_submission = meter.create_histogram(
-    name="submission.attachments_per_submission",
+    name="openforms.submission.attachments_per_submission",
     unit="1",
     description="Number of attachments per completed form submission.",
     explicit_bucket_boundaries_advisory=(0, 5, 10, 20, 50, 100),

--- a/src/openforms/submissions/tests/test_metrics.py
+++ b/src/openforms/submissions/tests/test_metrics.py
@@ -42,7 +42,7 @@ class SubmissionCountMetricTests(MetricsAssertMixin, TestCase):
             self.assertEqual(total, 6 + 2 + 3)
 
         with self.subTest(aggregation="by form"):
-            by_form = self._group_observations_by(result, "form.name")
+            by_form = self._group_observations_by(result, "openforms.form.name")
 
             self.assertEqual(
                 by_form,


### PR DESCRIPTION
OTel prescribes naming conventions: https://opentelemetry.io/docs/specs/semconv/general/naming/ and we were not following those yet.

Now that we're still in the early stages, we can still get away with this kind of breaking change.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
