### PR TITLE
Bump zgw-consumers to v1.1.0 (oauth2 support)

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -94,7 +94,7 @@ elastic-apm  # Elastic APM integration
 flower # task monitoring
 
 # Common Ground integration
-zgw-consumers[setup-configuration]
+zgw-consumers[setup-configuration,oauth2]
 
 # Anti virus scan
 clamd

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -553,7 +553,9 @@ requests==2.32.4
 requests-file==1.5.1
     # via zeep
 requests-oauthlib==1.3.0
-    # via o365
+    # via
+    #   o365
+    #   zgw-consumers
 requests-toolbelt==1.0.0
     # via
     #   onlinepayments-sdk-python3
@@ -686,7 +688,7 @@ xmltodict==0.12.0
     # via -r requirements/base.in
 zeep==4.2.1
     # via -r requirements/base.in
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via -r requirements/base.in
 zipp==3.23.0
     # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1273,7 +1273,7 @@ zeep==4.2.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1440,7 +1440,7 @@ zeep==4.2.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -1150,7 +1150,7 @@ zeep==4.2.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -1400,7 +1400,7 @@ zeep==4.2.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-zgw-consumers==1.0.0
+zgw-consumers==1.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #5688 partly

**Changes**

- Bump version to 1.1.0 (oauth2 support)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
