### PR TITLE
Also publish container image to github container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' # Exclude PRs
 
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     strategy:
       matrix:
         # KEEP IN SYNC WITH docker_build JOB
@@ -537,10 +543,25 @@ jobs:
         run: |
           docker image load -i image.tar
 
-      - name: Log into registry
-        run:
-          echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }}
-          --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to ghcr.io
+        run: |
+          docker tag $IMAGE_NAME:$TAG ghcr.io/open-formulieren/open-forms:$TAG
+          docker push ghcr.io/open-formulieren/open-forms:$TAG
+        env:
+          TAG: ${{ matrix.target.image_tag_prefix }}${{ needs.docker_build_setup.outputs.version }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Push the Docker image (production)
         run: docker push $IMAGE_NAME:$TAG


### PR DESCRIPTION
Should be a bit more future proof in the event of Docker Hub outages.

[skip: e2e]