### PR TITLE
[#5694] Add city and address to the appointments LocationSerializer

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8865,7 +8865,15 @@ components:
         name:
           type: string
           description: Location name
+        city:
+          type: string
+          description: City
+        address:
+          type: string
+          description: Address
       required:
+      - address
+      - city
       - identifier
       - name
     LogicActionPolymorphic:

--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -77,6 +77,8 @@ class LocationSerializer(serializers.Serializer):
         label=_("identifier"), help_text=_("ID of the location")
     )
     name = serializers.CharField(label=_("name"), help_text=_("Location name"))
+    city = serializers.CharField(label=_("city"), help_text=_("City"))
+    address = serializers.CharField(label=_("address"), help_text=_("Address"))
 
 
 class LocationInputSerializer(serializers.Serializer):


### PR DESCRIPTION
Closes #5694 partly

**Changes**

- City and address were added to the `LocationSerializer` of appointments for having them available on the frontend

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
