### PR TITLE
[#5694] Add missing postcode to the Appointments Location serializer

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8871,11 +8871,16 @@ components:
         address:
           type: string
           description: Address
+        postalcode:
+          type: string
+          title: postal code
+          description: Postal code
       required:
       - address
       - city
       - identifier
       - name
+      - postalcode
     LogicActionPolymorphic:
       oneOf:
       - $ref: '#/components/schemas/LogicActionPolymorphicGenericObject'

--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -77,8 +77,21 @@ class LocationSerializer(serializers.Serializer):
         label=_("identifier"), help_text=_("ID of the location")
     )
     name = serializers.CharField(label=_("name"), help_text=_("Location name"))
-    city = serializers.CharField(label=_("city"), help_text=_("City"))
-    address = serializers.CharField(label=_("address"), help_text=_("Address"))
+    city = serializers.CharField(
+        label=_("city"),
+        allow_blank=True,
+        help_text=_("City"),
+    )
+    address = serializers.CharField(
+        label=_("address"),
+        allow_blank=True,
+        help_text=_("Address"),
+    )
+    postalcode = serializers.CharField(
+        label=_("postal code"),
+        allow_blank=True,
+        help_text=_("Postal code"),
+    )
 
 
 class LocationInputSerializer(serializers.Serializer):

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -37,9 +37,9 @@ class Product:
 class Location:
     identifier: str
     name: str
-    address: str | None = None
-    postalcode: str | None = None
-    city: str | None = None
+    address: str = ""
+    postalcode: str = ""
+    city: str = ""
 
     def __str__(self):
         return self.identifier


### PR DESCRIPTION
Closes #5694 partly

**Changes**

- Missed to add the postcode, we will need this on the frontend.
- Changed the `Location` dataclass definition in the appointments base file
- Updated fields properties in the `LocationSerializer`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
