### PR TITLE
[#5737] Fix `synchronize variables` logic action for fieldset

### DIFF
--- a/src/openforms/js/components/admin/form_design/logic/actions/synchronize_variable/SynchronizeVariablesConfigModal.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/synchronize_variable/SynchronizeVariablesConfigModal.js
@@ -125,7 +125,7 @@ const ManageDataMappings = ({errors}) => {
   const simpleRelevantComponents = relevantComponents.filter(
     ([, compConfig]) =>
       !['array', 'object'].includes(getComponentDatatype(compConfig)) &&
-      compConfig.type !== 'columns'
+      !['columns', 'fieldset'].includes(compConfig.type)
   );
   const editGridFakeVariables = simpleRelevantComponents.map(([_, initialCompConfig]) =>
     makeNewVariableFromComponent(initialCompConfig, undefined)


### PR DESCRIPTION
Closes #5737

**Changes**

In the data mappings for the specific type of logic action we need the simple components. We used to filter out the `columns` but `fieldset` should be too.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
