### PR TITLE
[#5643] Add `heeftAlsAanspreekpunt` to StUF-ZDS

### DIFF
--- a/src/openforms/registrations/constants.py
+++ b/src/openforms/registrations/constants.py
@@ -34,6 +34,19 @@ class RegistrationAttribute(models.TextChoices):
     )
     initiator_postcode = "initiator_postcode", _("Initiator > Postcode")
     initiator_woonplaats = "initiator_woonplaats", _("Initiator > Woonplaats")
+    # heeftAlsAanspreekpunt for Natuurlijk Persoon
+    initiator_contactpersoonNaam = (
+        "initiator_contactpersoonNaam",
+        _("Initiator > ContactpersoonNaam"),
+    )
+    initiator_telefoonnummer = (
+        "initiator_telefoonnummer",
+        _("Initiator > Telefoonnummer"),
+    )
+    initiator_emailadres = (
+        "initiator_emailadres",
+        _("Initiator > Emailadres"),
+    )
 
     # Vestiging
     initiator_handelsnaam = "initiator_handelsnaam", _("Initiator > Handelsnaam")

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -199,6 +199,10 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
         "initiator.verblijfsadres.huisnummer": RegistrationAttribute.initiator_huisnummer,
         "initiator.verblijfsadres.huisletter": RegistrationAttribute.initiator_huisletter,
         "initiator.verblijfsadres.huisnummertoevoeging": RegistrationAttribute.initiator_huisnummer_toevoeging,
+        # heeftAlsAanspreekpunt for Natuurlijk Persoon
+        "initiator.contactpersoonNaam": RegistrationAttribute.initiator_contactpersoonNaam,
+        "initiator.telefoonnummer": RegistrationAttribute.initiator_telefoonnummer,
+        "initiator.emailadres": RegistrationAttribute.initiator_emailadres,
         # Vestiging
         "initiator.vestigingsNummer": RegistrationAttribute.initiator_vestigingsnummer,
         "initiator.handelsnaam": RegistrationAttribute.initiator_handelsnaam,

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -485,6 +485,27 @@ class StufZDSPluginTests(StUFZDSTestBase):
                         "attribute": RegistrationAttribute.locatie_coordinaat,
                     },
                 },
+                {
+                    "key": "contactpersoonNaam",
+                    "type": "textfield",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_contactpersoonNaam,
+                    },
+                },
+                {
+                    "key": "telefoonnummer",
+                    "type": "phoneNumber",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_telefoonnummer,
+                    },
+                },
+                {
+                    "key": "emailadres",
+                    "type": "email",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_emailadres,
+                    },
+                },
             ],
             public_registration_reference="foo-zaak",
             registration_result={"intermediate": {"zaaknummer": "foo-zaak"}},
@@ -500,6 +521,9 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 },
                 "voorletters": "J.W.",
                 "geslachtsaanduiding": "mannelijk",
+                "contactpersoonNaam": "Naam",
+                "telefoonnummer": "0612345678",
+                "emailadres": "foo@example.com",
             },
             bsn="111222333",
             form__name="my-form",
@@ -579,6 +603,9 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:geboortedatum": "20001231",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:voorletters": "J.W.",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:geslachtsaanduiding": "M",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:heeftAlsAanspreekpunt/zkn:gerelateerde/zkn:contactpersoonNaam": "Naam",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:heeftAlsAanspreekpunt/zkn:gerelateerde/bg:telefoonnummer": "0612345678",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:heeftAlsAanspreekpunt/zkn:gerelateerde/bg:emailadres": "foo@example.com",
                 "//zkn:object/zkn:anderZaakObject/zkn:omschrijving": "coordinaat",
                 "//zkn:object/zkn:anderZaakObject/zkn:lokatie/gml:Point/gml:pos": "4.893164274470299 52.36673378967122",
                 "//zkn:isVan/zkn:gerelateerde/zkn:omschrijving": "zt-omschrijving",

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -130,6 +130,9 @@
                     {% endif %}
                 </ZKN:gerelateerde>
                 <StUF:tijdstipRegistratie>{{ tijdstip_registratie }}</StUF:tijdstipRegistratie>
+                {% if initiator.contactpersoonNaam or initiator.telefoonnummer or initiator.emailadres %}
+                    {% include "stuf_zds/soap/includes/heeftAlsAanspreekpunt.xml" %}
+                {% endif %}
             </ZKN:heeftAlsInitiator>
         {% elif not global_config.allow_empty_initiator %}
             <ZKN:heeftAlsInitiator StUF:verwerkingssoort="T" StUF:entiteittype="ZAKBTRINI">

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/heeftAlsAanspreekpunt.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/heeftAlsAanspreekpunt.xml
@@ -1,0 +1,7 @@
+<ZKN:heeftAlsAanspreekpunt StUF:verwerkingssoort="T">
+    <ZKN:gerelateerde>
+        {% if initiator.contactpersoonNaam %}<ZKN:contactpersoonNaam>{{ initiator.contactpersoonNaam }}</ZKN:contactpersoonNaam>{% endif %}
+        {% if initiator.telefoonnummer %}<BG:telefoonnummer>{{ initiator.telefoonnummer }}</BG:telefoonnummer>{% endif %}
+        {% if initiator.emailadres %}<BG:emailadres>{{ initiator.emailadres }}</BG:emailadres>{% endif %}
+    </ZKN:gerelateerde>
+</ZKN:heeftAlsAanspreekpunt>


### PR DESCRIPTION
Closes #5643

**Changes**

- Added `heeftAlsAanspreekpunt` to StUF-ZDS. If any of the   `contactpersoonNaam`, `telefoonnummer` or `emailadres` are provided for the initiator, they will be present in the xml file. 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
