### PR TITLE
Fix date formats and missing keys in family members (StUF-BG)

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import Mapping
 from copy import deepcopy
-from datetime import datetime
+from datetime import date, datetime
 from typing import Protocol
 
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
@@ -747,7 +747,9 @@ class PartnerListField(serializers.Field):
             initial_value = [
                 {
                     key: (
-                        datetime.strptime(value, "%Y-%m-%d").date()
+                        # date format for StUF-BG (yyyymmdd) is different from HaalCentraal
+                        # (yyyy-MM-dd)
+                        date.fromisoformat(value)
                         if key == "dateOfBirth" and value
                         else value
                     )
@@ -869,7 +871,9 @@ class ChildListField(serializers.Field):
             initial_value = [
                 {
                     key: (
-                        datetime.strptime(value, "%Y-%m-%d").date()
+                        # date format for StUF-BG (yyyymmdd) is different from HaalCentraal
+                        # (yyyy-MM-dd)
+                        date.fromisoformat(value)
                         if key == "dateOfBirth" and value
                         else value
                     )

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -279,7 +279,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                             "prefilled": bool(submission_variable),
                         }
                     )
-                    del partner["dateOfBirthPrecision"]
+                    partner.pop("dateOfBirthPrecision", None)
         # register as extraElementen
         else:
             variables = FormVariable.objects.filter(
@@ -296,7 +296,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                 )
                 value = extra_data[from_key]
                 for item in value:
-                    del item["dateOfBirthPrecision"]
+                    item.pop("dateOfBirthPrecision", None)
 
                     item["dateOfBirth"] = item["dateOfBirth"].isoformat()
 


### PR DESCRIPTION
Sentry issues:
 - 454059
 - 454058

**Changes**

- StUF-BG has a different format for dates, it uses yyyymmdd, while HaalCentraal uses yyyy-MM-dd. This was not handled properly as it used only the yyyy-MM-dd format.
- StUF-BG does not have dateOfBirthPrecision so this was missed in some registration backends and we were trying to access it (KeyError).

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
