### PR TITLE
[#5756] Remove max number of children in the StUF-BG request (Family members prefill)

### DIFF
--- a/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
@@ -9,7 +9,6 @@
     <ns:parameters>
         <StUF:sortering>0</StUF:sortering>
         <StUF:indicatorVervolgvraag>false</StUF:indicatorVervolgvraag>
-        <StUF:maximumAantal>1</StUF:maximumAantal>
         <StUF:indicatorAfnemerIndicatie>false</StUF:indicatorAfnemerIndicatie>
         <StUF:indicatorAantal>false</StUF:indicatorAantal>
     </ns:parameters>


### PR DESCRIPTION
Closes #5756

**Changes**

In StUF-BG request template we had the maximum amount of children set to 1. This is not the case so it has been removed (`minOccurs="0"`). For the partners component this makes sense (at least for now) and we keep it as is with maximum of 1 partner.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
