### PR TITLE
[#5784] Add authorizationMode for card payments to Worldline payment plugin

### DIFF
--- a/src/openforms/payments/contrib/worldline/plugin.py
+++ b/src/openforms/payments/contrib/worldline/plugin.py
@@ -178,6 +178,7 @@ class WorldlinePaymentPlugin(BasePlugin[PaymentOptions]):
             {
                 "returnCancelState": True,
                 "hostedCheckoutSpecificInput": checkout_input,
+                "cardPaymentMethodSpecificInput": {"authorizationMode": "SALE"},
                 "order": order,
             }
         )


### PR DESCRIPTION
Closes #5784

**Changes**

Added `cardPaymentMethodSpecificInput.authorizationMode: "SALE"` which according to https://docs.direct.worldline-solutions.com/en/api-reference#tag/HostedCheckout/operation/CreateHostedCheckoutApi and https://docs.direct.worldline-solutions.com/en/integration/api-developer-guide/authorisation-and-directsale should be in the body.

Unfortunately, this cannot be tested locally (tried to write a test but this doesn't seem to be doable), so we have to wait for feedback until the real flow is used.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
