### PR TITLE
[#5733] fix outgoing request logging

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -189,7 +189,7 @@ django-jsonform==2.21.2
     # via
     #   -r requirements/base.in
     #   mozilla-django-oidc-db
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.7.1
     # via -r requirements/base.in
 django-modeltranslation==0.19.4
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -301,7 +301,7 @@ django-jsonform==2.21.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.7.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -330,7 +330,7 @@ django-jsonform==2.21.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -290,7 +290,7 @@ django-jsonform==2.21.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.7.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -313,7 +313,7 @@ django-jsonform==2.21.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
-django-log-outgoing-requests==0.6.1
+django-log-outgoing-requests==0.7.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #5733 

**Changes**

Updates django-log-outgoing-requests to the latest bug fix release so that outgoing requests are shown again in the admin whenever requests are done by the generic json registration plugin.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
