### PR TITLE
[#5598] prevent cosigning by initial form submitter

### DIFF
--- a/src/openforms/authentication/service.py
+++ b/src/openforms/authentication/service.py
@@ -1,6 +1,7 @@
 from .constants import FORM_AUTH_SESSION_KEY, AuthAttribute
 from .typing import BaseAuth
 from .utils import (
+    check_user_is_submission_initiator,
     is_authenticated_with_an_allowed_plugin,
     is_authenticated_with_plugin,
     remove_auth_info_from_session,
@@ -11,6 +12,7 @@ __all__ = [
     "FORM_AUTH_SESSION_KEY",
     "AuthAttribute",
     "BaseAuth",
+    "check_user_is_submission_initiator",
     "store_auth_details",
     "is_authenticated_with_plugin",
     "is_authenticated_with_an_allowed_plugin",

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -21,7 +21,10 @@ from openforms.api.authentication import AnonCSRFSessionAuthentication
 from openforms.api.filters import PermissionFilterMixin
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.api.throttle_classes import PollingRateThrottle
-from openforms.authentication.service import is_authenticated_with_an_allowed_plugin
+from openforms.authentication.service import (
+    check_user_is_submission_initiator,
+    is_authenticated_with_an_allowed_plugin,
+)
 from openforms.forms.constants import SubmissionAllowedChoices
 from openforms.forms.models import Form, FormStep
 from openforms.logging import logevent
@@ -245,6 +248,10 @@ class SubmissionViewSet(
                     "You need to be logged in with one of the allowed authentication backends to co-sign the submission."
                 )
             )
+
+        assert not check_user_is_submission_initiator(request, submission), (
+            "The submission cannot be co-signed by the original submitter."
+        )
 
         serializer = CosignValidationSerializer(
             data={


### PR DESCRIPTION
Closes #5598 

**Changes**

Prevents the original form submitter from cosigning the submission.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
