### PR TITLE
Add shims for `readonly` vs. `disabled` styling

### DIFF
--- a/src/openforms/ui/static/ui/scss/_shims.scss
+++ b/src/openforms/ui/static/ui/scss/_shims.scss
@@ -43,6 +43,17 @@
   // input-group
   --of-input-group-gap: 12px;
   --of-input-group-align-items: center;
+
+  // disabled -> readonly rework, ensure design tokens are set
+  --utrecht-textbox-read-only-background-color: var(--utrecht-textbox-disabled-background-color);
+  --utrecht-textbox-read-only-border-color: var(--utrecht-textbox-disabled-border-color);
+  --utrecht-textbox-read-only-color: var(--utrecht-textbox-disabled-color);
+
+  --utrecht-form-control-read-only-background-color: var(
+    --utrecht-form-control-disabled-background-color
+  );
+  --utrecht-form-control-read-only-border-color: var(--utrecht-form-control-disabled-border-color);
+  --utrecht-form-control-read-only-color: var(--utrecht-form-control-disabled-color);
 }
 
 // .utrecht-icon:has(.openforms-tooltip-icon) {


### PR DESCRIPTION
Closes open-formulieren/formio-renderer#138

[skip: e2e]

**Changes**

Added shims for custom themes that may not specify the required design tokens.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
