### PR TITLE
[#5818] Add missing bsn attribute in children template for StUF-BG

### DIFF
--- a/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
+++ b/src/stuf/stuf_bg/templates/stuf_bg/ChildrenStufBgRequest.xml
@@ -17,6 +17,7 @@
     </ns:gelijk>
     <ns:scope>
         <ns:object StUF:entiteittype="NPS">
+            <ns:inp.bsn xsi:nil="true"/>
             <ns:inp.heeftAlsKinderen StUF:entiteittype="NPSNPSKND">
                 <ns:gerelateerde StUF:entiteittype="NPS">
                     <ns:inp.bsn xsi:nil="true" />


### PR DESCRIPTION
Closes #5818 

**Changes**

- Added missing attribute for BSN in the children template.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
