### PR TITLE
#5813 document component pre-registration hook and tasks

### DIFF
--- a/docs/developers/backend/core/formio.rst
+++ b/docs/developers/backend/core/formio.rst
@@ -138,12 +138,13 @@ Pre-registration of components
 ------------------------------
 
 Some component types have specific logic which should be executed after the form is submitted,
-for example updating external service with the submission information.
+for example updating an external service using the submission data.
 
 This logic can be implemented in the :meth:`openforms.formio.registry.BasePlugin.pre_registration_hook`.
 
-This method is called for all components between pre-pregistration and registration steps, so the
-submission reference ID is already generated and can be used.
+This method is called for all components during the
+:meth:`openforms.submissions.tasks.on_post_submission_event` proces, between the pre-pregistration
+and registration steps, so the submission reference ID is already generated and can be used.
 
 For an example of a custom field type, see :class:`openforms.formio.components.custom.CustomerProfile`.
 

--- a/docs/developers/backend/core/submissions.rst
+++ b/docs/developers/backend/core/submissions.rst
@@ -21,9 +21,9 @@ Globally, the various actions and plugin categories are processed in order:
 #. Pre-registration step. Each :ref:`registration plugin <developers_registration_plugins>` can perform
    pre-registration task, like for example generating and setting a submission reference ID. If no registration backend
    is configured, then an internal ID is generated and set on the submission.
-#. Component pre-registration step. A group of tasks run in parallel for all components that have
+#. Component pre-registration step. A group of tasks run in parallel for all components that implement the
    :ref:`pre-registration hook <developers_backend_core_formio_pre_registration>`. The results are processed
-   after all component tasks are completed.
+   after all component pre-registration tasks are completed.
 #. A PDF is created that the user can download.
    This PDF is also uploaded to most
    :ref:`registration backends <developers_registration_plugins>`, depending
@@ -56,10 +56,12 @@ This method schedules the following tasks/chains:
 
   - :meth:`openforms.appointments.tasks.maybe_register_appointment`
   - :meth:`openforms.registrations.tasks.pre_registration`
-  - group :meth:`openforms.registrations.tasks.execute_component_pre_registration_group`, which run the
+  - :meth:`openforms.registrations.tasks.execute_component_pre_registration_group` which runs the
     following tasks in parallel:
 
-    - :meth:`openforms.registrations.tasks.execute_component_pre_registration`
+    - :meth:`openforms.registrations.tasks.execute_component_pre_registration`, one for each
+      component implementing
+      :ref:`pre-registration hook <developers_backend_core_formio_pre_registration>`
 
   - :meth:`openforms.registrations.tasks.process_component_pre_registration`
   - :meth:`openforms.submissions.tasks.pdf.generate_report_task`


### PR DESCRIPTION
Closes #5813
[skip: e2e]

**Changes**

* [x] add component pre-registration tasks to submission processing documentation
* [x] add pre-registration hook to formio integration documentation

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
