### PR TITLE
Update references from `master` branch to `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: Run CI
 on:
   push:
     branches:
-      - master
+      - main
       - stable/*
     tags:
       - '*'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -4,7 +4,7 @@ name: Code quality checks
 on:
   push:
     branches:
-      - master
+      - main
       - stable/*
     tags:
       - '*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,7 +3,7 @@ name: 'CodeQL'
 on:
   push:
     branches:
-      - master
+      - main
       - stable/*
   schedule:
     - cron: '32 20 * * 3'

--- a/.github/workflows/fe-code-quality.yml
+++ b/.github/workflows/fe-code-quality.yml
@@ -4,7 +4,7 @@ name: Frontend code quality checks
 on:
   push:
     branches:
-      - master
+      - main
       - stable/*
     tags:
     paths:

--- a/.github/workflows/sb.yml
+++ b/.github/workflows/sb.yml
@@ -4,10 +4,10 @@ name: Build and publish storybook
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
     types:
       - opened
       - reopened
@@ -57,7 +57,7 @@ jobs:
       id-token: write
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push' # Exclude PRs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' # Exclude PRs
     needs: storybook
     steps:
       - name: Setup Pages
@@ -98,7 +98,7 @@ jobs:
         uses: chromaui/action@latest
         if: github.event.pull_request.draft == false || github.event.push
         with:
-          autoAcceptChanges: master
+          autoAcceptChanges: main
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: ./storybook-static
           onlyChanged: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,10 @@ documentation for the type you are using, a deprecation notice will be indicated
 ### Making a pull request
 
 If all changes have been committed, you can push the branch to your fork of the repository and
-create a pull request to the `master` branch of this project's repository. Your pull request will be
+create a pull request to the `main` branch of this project's repository. Your pull request will be
 reviewed, if applicable, feedback will be given and if everything is approved, it will be merged.
 
-Pull requests should always be made to the `master` branch, even if they are bugfixes for any of the
+Pull requests should always be made to the `main` branch, even if they are bugfixes for any of the
 `stable/*` branches. If they are relevant for older versions, please add the _needs-backport_ label
 to the pull request and/or issue. Release managers will then ensure the fix also lands in the
 supported older versions.

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -88,7 +88,7 @@ Licensed under the `EUPL`_.
     :target: https://open-forms.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation status
 
-.. |coverage| image:: https://codecov.io/github/open-formulieren/open-forms/branch/master/graphs/badge.svg?branch=master
+.. |coverage| image:: https://codecov.io/github/open-formulieren/open-forms/branch/main/graphs/badge.svg?branch=main
     :alt: Coverage
     :target: https://codecov.io/gh/open-formulieren/open-forms
 

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Licensed under the `EUPL`_.
     :target: https://open-forms.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation status
 
-.. |coverage| image:: https://codecov.io/github/open-formulieren/open-forms/branch/master/graphs/badge.svg?branch=master
+.. |coverage| image:: https://codecov.io/github/open-formulieren/open-forms/branch/main/graphs/badge.svg?branch=main
     :alt: Coverage
     :target: https://codecov.io/gh/open-formulieren/open-forms
 

--- a/docker/ci/config.json
+++ b/docker/ci/config.json
@@ -1,7 +1,7 @@
 {
   "supportedTags": [
     {
-      "gitRef": "master",
+      "gitRef": "main",
       "tag": "latest",
       "hasExtensionsVariant": true
     },

--- a/docker/ci/generate_dockerhub_description.py
+++ b/docker/ci/generate_dockerhub_description.py
@@ -29,8 +29,8 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 ROOT = Path(__file__).parent.resolve()
 
 GITHUB_ORG = "https://github.com/open-formulieren"
-CONFIG_FILE_MASTER = (
-    "https://raw.githubusercontent.com/open-formulieren/open-forms/master/"
+CONFIG_FILE_MAIN = (
+    "https://raw.githubusercontent.com/open-formulieren/open-forms/main/"
     "docker/ci/config.json"
 )
 STABLE_PREFIX = "stable/"
@@ -134,11 +134,11 @@ def get_available_extensions(
 
 def _get_config(current_branch: str | None):
     # no branch specified -> not on CI -> grab local config
-    if current_branch is None or current_branch == "master":
+    if current_branch is None or current_branch == "main":
         with (ROOT / "config.json").open("r") as config_file:
             return json.load(config_file)
 
-    response = requests.get(CONFIG_FILE_MASTER)
+    response = requests.get(CONFIG_FILE_MAIN)
     response.raise_for_status()
     return response.json()
 

--- a/docs/configuration/general/cms_integration.rst
+++ b/docs/configuration/general/cms_integration.rst
@@ -116,4 +116,4 @@ can do with the API token.
    security risks and can lead to submissions being exposed to the world.
 
 
-.. _`Open API Specification`: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/master/src/openapi.yaml
+.. _`Open API Specification`: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/main/src/openapi.yaml

--- a/docs/developers/extending.rst
+++ b/docs/developers/extending.rst
@@ -16,7 +16,7 @@ We support two ways to add new plugins:
 #. Adding 'external' plugins. These are extensions that are extremely specific or can't be open-sourced.
    Instructions on how to implement such 'external plugins' are described below.
 
-.. _CONTRIBUTING.md: https://github.com/open-formulieren/open-forms/blob/master/CONTRIBUTING.md
+.. _CONTRIBUTING.md: https://github.com/open-formulieren/open-forms/blob/main/CONTRIBUTING.md
 
 Creating an external plugin
 ===========================

--- a/docs/developers/releases.rst
+++ b/docs/developers/releases.rst
@@ -26,7 +26,7 @@ Preparing a release
 -------------------
 
 For new releases, a release branch is created, named: ``release/<new-version>``.
-For minor and major releases, checkout from ``master``. For patch releases, checkout
+For minor and major releases, checkout from ``main``. For patch releases, checkout
 from ``stable/<major>.<minor>.x``. All release-related actions are concentrated in this branch.
 
 **Updating translation strings**
@@ -162,7 +162,7 @@ Publishing a release
 
 Once the PR has been reviewed and approved, merge it to:
 
-* the ``master`` branch for minor and major releases
+* the ``main`` branch for minor and major releases
 * the ``stable/<major>.<minor>.x`` branch for patch releases.
 
 Then proceed to tagging the release.
@@ -195,9 +195,9 @@ entry. This ensures the changes are also visible from the Github releases page.
 
 The CI workflow will ensure that a Docker image with the same release tag is published.
 
-**Create a PR with the changelog entries for the master branch**
+**Create a PR with the changelog entries for the main branch**
 
-After publishing the release make sure to create a PR to the master branch with
+After publishing the release make sure to create a PR to the main branch with
 the newly added changelogs entries.
 
 **Announce the release in communication channels**
@@ -210,20 +210,20 @@ This is to be fleshed out more, but some existing channels are:
 
 **Forward port changelog for patch releases**
 
-For patch releases only, update the ``CHANGELOG.rst`` on the master branch with the new summary of changes.
+For patch releases only, update the ``CHANGELOG.rst`` on the main branch with the new summary of changes.
 Order the entries by date (most recent first). If multiple patch versions are done on the same day, order them by
 version (most recent first).
 
 Stable releases and on-going development
 ----------------------------------------
 
-Open Forms follows the one-flow branching model: the ``master`` branch is the main
+Open Forms follows the one-flow branching model: the ``main`` branch is the main
 branch. Features and bugfixes are developed in separate branches (e.g. ``feature/foo``
-and ``issue/bar``) with a pull request to ``master``.
+and ``issue/bar``) with a pull request to ``main``.
 
 Supported stable (and upcoming) releases have their own branch following the pattern
 ``stable/<major>.<minor>.x``. Conforming to the :ref:`developers_releases_versioning`,
-bugfixes merged into ``master`` must be backported to the respective release branch(es).
+bugfixes merged into ``main`` must be backported to the respective release branch(es).
 Pull requests with bugfixes must be tagged with the **needs-backport** label. The
 release branches are tested in CI as well.
 

--- a/docs/developers/versioning.rst
+++ b/docs/developers/versioning.rst
@@ -71,8 +71,8 @@ experimental functionality was changed.
 ==============  ==============  =============================
 Version         Release date    API specification
 ==============  ==============  =============================
-latest          n/a             `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/master/src/openapi.yaml>`__,
-                                `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/master/src/openapi.yaml>`__
+latest          n/a             `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/main/src/openapi.yaml>`__,
+                                `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/main/src/openapi.yaml>`__
 3.3.0           2025-10-02      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/3.3.0/src/openapi.yaml>`__,
                                 `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/3.3.0/src/openapi.yaml>`__
 3.2.0           2025-07-11      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-formulieren/open-forms/3.2.0/src/openapi.yaml>`__,

--- a/docs/installation/additional_scipts.rst
+++ b/docs/installation/additional_scipts.rst
@@ -12,7 +12,7 @@ container you can follow the instructions to copy it from the project source.
 
 .. code-block:: bash
 
-    $ wget https://github.com/open-formulieren/open-forms/blob/master/<name_of_the_file>
+    $ wget https://github.com/open-formulieren/open-forms/blob/main/<name_of_the_file>
 
 2.  Copy the downloaded file to the `/app/bin` folder in the container
 

--- a/docs/installation/docker_compose.rst
+++ b/docs/installation/docker_compose.rst
@@ -39,9 +39,9 @@ Getting started
 
    .. code:: bash
 
-      $ wget https://github.com/open-formulieren/open-forms/archive/refs/heads/master.zip -O
-      $ unzip master.zip
-      $ cd open-forms-master
+      $ wget https://github.com/open-formulieren/open-forms/archive/refs/heads/main.zip -O
+      $ unzip main.zip
+      $ cd open-forms-main
 
 2. Start the docker containers with ``docker compose``. If you want to run the
    containers in the background, add the ``-d`` option to the command below:
@@ -50,17 +50,17 @@ Getting started
 
       docker compose up
 
-      Creating network "open-forms-master_default" with the default driver
-      Creating volume "open-forms-master_db" with default driver
-      Creating volume "open-forms-master_private_media" with default driver
-      Creating open-forms-master_db_1 ... done
-      Creating open-forms-master_redis_1 ... done
-      Creating open-forms-master_sdk_1 ... done
-      Creating open-forms-master_web_1 ... done
-      Creating open-forms-master_nginx_1 ... done
-      Creating open-forms-master_celery_1 ... done
-      Creating open-forms-master_celery-beat_1 ... done
-      Creating open-forms-master_celery-flower_1 ... done
+      Creating network "open-forms-main_default" with the default driver
+      Creating volume "open-forms-main_db" with default driver
+      Creating volume "open-forms-main_private_media" with default driver
+      Creating open-forms-main_db_1 ... done
+      Creating open-forms-main_redis_1 ... done
+      Creating open-forms-main_sdk_1 ... done
+      Creating open-forms-main_web_1 ... done
+      Creating open-forms-main_nginx_1 ... done
+      Creating open-forms-main_celery_1 ... done
+      Creating open-forms-main_celery-beat_1 ... done
+      Creating open-forms-main_celery-flower_1 ... done
       ...
 
 3. Create a super-user.

--- a/docs/installation/observability/supporting_components.rst
+++ b/docs/installation/observability/supporting_components.rst
@@ -110,7 +110,7 @@ Traces
 nginx provides the `ngx_otel_module <https://nginx.org/en/docs/ngx_otel_module.html>`_
 for distributed tracing - which is not compiled/enabled by default. The Open Forms team
 does not publish an image with this module enabled - you can opt-into doing this
-yourself. Our `docker-compose.yml <https://github.com/open-formulieren/open-forms/tree/master/docker-compose.yml>`_ can provide inspiration.
+yourself. Our `docker-compose.yml <https://github.com/open-formulieren/open-forms/tree/main/docker-compose.yml>`_ can provide inspiration.
 
 Follow the upstream documentation on how to enable this - it should be pretty straight
 forward to send the OTLP traces to the collector receiver since this is the same

--- a/docs/introduction/open-source/index.rst
+++ b/docs/introduction/open-source/index.rst
@@ -9,7 +9,7 @@ In addition, this project makes use of various open-source `Python libraries`_
 and `npm packages`_ and `npm packages for the SDK` under the hood.
 
 
-.. _`EUPL license`: https://github.com/open-formulieren/open-forms/blob/master/LICENSE.md
-.. _`Python libraries`: https://github.com/open-formulieren/open-forms/blob/master/requirements/base.txt
-.. _`npm packages`: https://github.com/open-formulieren/open-forms/blob/master/package.json
+.. _`EUPL license`: https://github.com/open-formulieren/open-forms/blob/main/LICENSE.md
+.. _`Python libraries`: https://github.com/open-formulieren/open-forms/blob/main/requirements/base.txt
+.. _`npm packages`: https://github.com/open-formulieren/open-forms/blob/main/package.json
 .. _`npm packages for the SDK`: https://github.com/open-formulieren/open-forms-sdk/blob/main/package.json

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -9,7 +9,7 @@ url: 'http://github.com/open-formulieren/open-forms.git'
 softwareType: standalone/backend
 softwareVersion: 3.4.0-alpha.2
 releaseDate: '2022-03-10'
-logo: 'https://github.com/open-formulieren/open-forms/blob/master/docs/logo.svg'
+logo: 'https://github.com/open-formulieren/open-forms/blob/main/docs/logo.svg'
 platforms:
   - web
   - linux
@@ -22,7 +22,7 @@ description:
   nl:
     shortDescription: Formulieren bouwen en ontsluiten
     documentation: 'https://open-forms.readthedocs.io/'
-    apiDocumentation: 'https://raw.githubusercontent.com/open-formulieren/open-forms/master/src/openapi.yaml'
+    apiDocumentation: 'https://raw.githubusercontent.com/open-formulieren/open-forms/main/src/openapi.yaml'
     features:
       - Bouw slimme formulieren
       - Ontsluit formulieren via een API
@@ -44,7 +44,7 @@ description:
   en:
     shortDescription: Build end expose forms
     documentation: 'https://open-forms.readthedocs.io/'
-    apiDocumentation: 'https://raw.githubusercontent.com/open-formulieren/open-forms/master/src/openapi.yaml'
+    apiDocumentation: 'https://raw.githubusercontent.com/open-formulieren/open-forms/main/src/openapi.yaml'
     features:
       - Build smart forms
       - Expose forms via an API


### PR DESCRIPTION
For consistent default branch naming across our repositories - with many people gone for holidays, we can finally apply this.

[skip: e2e]