### PR TITLE
Update mfa-related dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,6 +16,7 @@ lxml
 lxml-html-clean
 onlinepayments-sdk-python3 # Worldline SDK
 O365  # microsoft graph
+phonenumberslite
 Pillow  # handle images
 portalocker[redis]
 psycopg  # database driver
@@ -26,6 +27,7 @@ python-magic
 tablib[xlsx]
 tinycss2
 xmltodict
+qrcode
 referencing
 self-certifi
 semantic-version

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -237,7 +237,7 @@ django-tinymce==4.1.0
     # via -r requirements/base.in
 django-treebeard==4.7
     # via -r requirements/base.in
-django-two-factor-auth==1.16.0
+django-two-factor-auth==1.18.1
     # via maykin-2fa
 django-upgrade-check==1.0.0
     # via -r requirements/base.in
@@ -350,7 +350,7 @@ mail-parser==3.15.0
     # via django-yubin
 markuppy==1.14
     # via tablib
-maykin-2fa==1.0.0
+maykin-2fa==2.0.0
     # via
     #   -r requirements/base.in
     #   maykin-common
@@ -446,7 +446,7 @@ packaging==23.1
 pathable==0.4.3
     # via jsonschema-spec
 phonenumberslite==8.13.29
-    # via django-two-factor-auth
+    # via -r requirements/base.in
 pillow==10.3.0
     # via
     #   -r requirements/base.in
@@ -490,8 +490,6 @@ pyopenssl==25.0.0
     #   webauthn
 pyphen==0.14.0
     # via weasyprint
-pypng==0.20220715.0
-    # via qrcode
 pyproj==3.7.2
     # via -r requirements/base.in
 python-dateutil==2.9.0.post0
@@ -523,8 +521,10 @@ pyyaml==6.0.1
     #   jsonschema-spec
     #   pydantic-settings
     #   tablib
-qrcode==7.4.2
-    # via django-two-factor-auth
+qrcode==8.2
+    # via
+    #   -r requirements/base.in
+    #   django-two-factor-auth
 redis==4.5.4
     # via
     #   celery-once
@@ -641,7 +641,6 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pyopenssl
-    #   qrcode
     #   zgw-consumers
 tzdata==2025.2
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -385,7 +385,7 @@ django-treebeard==4.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-two-factor-auth==1.16.0
+django-two-factor-auth==1.18.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -614,7 +614,7 @@ markuppy==1.14
     #   tablib
 markupsafe==2.1.2
     # via jinja2
-maykin-2fa==1.0.0
+maykin-2fa==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -789,7 +789,6 @@ phonenumberslite==8.13.29
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-two-factor-auth
 pillow==10.3.0
     # via
     #   -c requirements/base.txt
@@ -887,11 +886,6 @@ pyphen==0.14.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
-pypng==0.20220715.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   qrcode
 pyproj==3.7.2
     # via
     #   -c requirements/base.txt
@@ -950,7 +944,7 @@ pyyaml==6.0.1
     #   vcrpy
     #   zgw-consumers
     #   zgw-consumers-oas
-qrcode==7.4.2
+qrcode==8.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1177,7 +1171,6 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyee
     #   pyopenssl
-    #   qrcode
     #   zgw-consumers
     #   zgw-consumers-oas
 tzdata==2025.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -419,7 +419,7 @@ django-treebeard==4.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-two-factor-auth==1.16.0
+django-two-factor-auth==1.18.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -682,7 +682,7 @@ markupsafe==2.1.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   jinja2
-maykin-2fa==1.0.0
+maykin-2fa==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -860,7 +860,6 @@ phonenumberslite==8.13.29
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-two-factor-auth
 pillow==10.3.0
     # via
     #   -c requirements/ci.txt
@@ -976,11 +975,6 @@ pyphen==0.14.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-pypng==0.20220715.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   qrcode
 pyproj==3.7.2
     # via
     #   -c requirements/ci.txt
@@ -1040,7 +1034,7 @@ pyyaml==6.0.1
     #   tablib
     #   vcrpy
     #   zgw-consumers-oas
-qrcode==7.4.2
+qrcode==8.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1328,7 +1322,6 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyee
     #   pyopenssl
-    #   qrcode
     #   rich-click
     #   zgw-consumers
     #   zgw-consumers-oas

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -371,7 +371,7 @@ django-treebeard==4.7
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-django-two-factor-auth==1.16.0
+django-two-factor-auth==1.18.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -572,7 +572,7 @@ markuppy==1.14
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   tablib
-maykin-2fa==1.0.0
+maykin-2fa==2.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -746,7 +746,6 @@ phonenumberslite==8.13.29
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   django-two-factor-auth
 pillow==10.3.0
     # via
     #   -c requirements/base.txt
@@ -834,11 +833,6 @@ pyphen==0.14.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   weasyprint
-pypng==0.20220715.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   qrcode
 pyproj==3.7.2
     # via
     #   -c requirements/base.txt
@@ -889,7 +883,7 @@ pyyaml==6.0.1
     #   jsonschema-spec
     #   pydantic-settings
     #   tablib
-qrcode==7.4.2
+qrcode==8.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1068,7 +1062,6 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pyopenssl
-    #   qrcode
     #   zgw-consumers
 tzdata==2025.2
     # via

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -406,7 +406,7 @@ django-treebeard==4.7
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-django-two-factor-auth==1.16.0
+django-two-factor-auth==1.18.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -655,7 +655,7 @@ markupsafe==2.1.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   jinja2
-maykin-2fa==1.0.0
+maykin-2fa==2.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -831,7 +831,6 @@ phonenumberslite==8.13.29
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   django-two-factor-auth
 pillow==10.3.0
     # via
     #   -c requirements/ci.txt
@@ -939,11 +938,6 @@ pyphen==0.14.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   weasyprint
-pypng==0.20220715.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   qrcode
 pyproj==3.7.2
     # via
     #   -c requirements/ci.txt
@@ -1003,7 +997,7 @@ pyyaml==6.0.1
     #   tablib
     #   vcrpy
     #   zgw-consumers-oas
-qrcode==7.4.2
+qrcode==8.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1290,7 +1284,6 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyee
     #   pyopenssl
-    #   qrcode
     #   types-lxml
     #   zgw-consumers
     #   zgw-consumers-oas


### PR DESCRIPTION
Upgrades maykin-2fa and implicitly django-two-factor-auth.

Added explicit qrcode and phonenumberslite dependencies, as these are direct dependencies of our codebase (they're or used to be pulled in via django-two-factor-auth).

Upgraded qrcode to the latest available version.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
