### PR TITLE
#5835 remove duplicated 'list_display' from the wordline webhook admin page

### DIFF
--- a/src/openforms/payments/contrib/worldline/admin.py
+++ b/src/openforms/payments/contrib/worldline/admin.py
@@ -35,8 +35,6 @@ class WorldlineWebhookConfigurationAdmin(admin.ModelAdmin):
         "webhook_key_secret",
         "feedback_url",
     )
-
-    list_display = ("webhook_key_id",)
     search_fields = ("webhook_key_id",)
     readonly_fields = ("feedback_url",)
 


### PR DESCRIPTION
Closes #5835

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
