### PR TITLE
#5872 Communication preferences options: profile var is not found

### DIFF
--- a/src/openforms/prefill/contrib/customer_interactions/config.py
+++ b/src/openforms/prefill/contrib/customer_interactions/config.py
@@ -42,7 +42,7 @@ class CommunicationPreferencesSerializer(
                 raise serializers.ValidationError(
                     {
                         "profile_form_variable": _(
-                            "Form variable '{key}' is not found."
+                            "No form variable with key '{key}' exists in the form."
                         ).format(key=profile_form_variable),
                     }
                 )

--- a/src/openforms/prefill/contrib/customer_interactions/tests/test_options_validation.py
+++ b/src/openforms/prefill/contrib/customer_interactions/tests/test_options_validation.py
@@ -1,4 +1,5 @@
 from django.test import TestCase, tag
+from django.utils.translation import gettext_lazy as _
 
 from openforms.contrib.customer_interactions.tests.factories import (
     CustomerInteractionsAPIGroupConfigFactory,
@@ -42,4 +43,9 @@ class CommunicationPreferencesOptionsTests(TestCase):
 
         error = serializer.errors["profile_form_variable"][0]
         self.assertEqual(error.code, "invalid")
-        self.assertEqual(error, "Form variable 'profileOld' is not found.")
+        self.assertEqual(
+            error,
+            _("No form variable with key '{key}' exists in the form.").format(
+                key="profileOld"
+            ),
+        )


### PR DESCRIPTION
Closes #5872

**Changes**

* added validation that the profile component variable defined in the prefill configurations of the user variable should exist. If it doesn't exist the Validation error with a clear message is raised

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
