### PR TITLE
Explicitly mark tasks to ignore results

### DIFF
--- a/src/openforms/emails/tasks.py
+++ b/src/openforms/emails/tasks.py
@@ -63,7 +63,7 @@ class Digest:
         return render_to_string("emails/admin_digest.html", context)
 
 
-@app.task
+@app.task(ignore_result=True)
 def send_email_digest() -> None:
     config = GlobalConfiguration.get_solo()
     if not (recipients := config.recipients_email_digest):

--- a/src/openforms/forms/admin/tasks.py
+++ b/src/openforms/forms/admin/tasks.py
@@ -27,7 +27,7 @@ from ..utils import export_form, import_form
 logger = structlog.stdlib.get_logger(__name__)
 
 
-@app.task
+@app.task(ignore_result=True)
 def process_forms_export(forms_uuids: list, user_id: int) -> None:
     forms = Form.objects.filter(uuid__in=forms_uuids)
 
@@ -74,7 +74,7 @@ def process_forms_export(forms_uuids: list, user_id: int) -> None:
         )
 
 
-@app.task
+@app.task(ignore_result=True)
 def process_forms_import(import_file: str, user_id: int) -> None:
     user = User.objects.get(id=user_id)
     failed_files = []

--- a/src/openforms/forms/tasks.py
+++ b/src/openforms/forms/tasks.py
@@ -12,7 +12,7 @@ from .models import Form
 logger = structlog.stdlib.get_logger(__name__)
 
 
-@app.task()
+@app.task(ignore_result=True)
 def activate_forms():
     """Activate all the forms that should be activated by the specific date and time."""
     from openforms.logging import logevent
@@ -38,7 +38,7 @@ def activate_forms():
                 transaction.on_commit(partial(logevent.form_activated, form))
 
 
-@app.task()
+@app.task(ignore_result=True)
 def deactivate_forms():
     """Deactivate all the forms that should be deactivated by the specific date and time."""
     from openforms.logging import logevent

--- a/src/openforms/registrations/tasks.py
+++ b/src/openforms/registrations/tasks.py
@@ -432,7 +432,7 @@ def update_registration_with_confirmation_email(submission_id: int) -> None:
     log.info("done")
 
 
-@app.task
+@app.task(ignore_result=True)
 def execute_component_pre_registration(
     submission_id: int, component: Component
 ) -> None:

--- a/src/openforms/submissions/tasks/emails.py
+++ b/src/openforms/submissions/tasks/emails.py
@@ -89,7 +89,7 @@ def send_confirmation_email(submission_id: int) -> None:
         on_confirmation_email_sent.delay(submission.pk)
 
 
-@app.task()
+@app.task(ignore_result=True)
 def send_email_cosigner(submission_id: int) -> None:
     submission = Submission.objects.get(id=submission_id)
 


### PR DESCRIPTION
The cleanup task takes care of explicitly forgetting them, but for all the other tasks you typically want to ignore the result if it's not accessed anywhere.

Most of our tasks are just 'fire and forget', and due to Redis keys having a TTL it won't mess up memory usage of Redis, but it's good practice to be aware of these semantics.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
