### PR TITLE
 Add and document external container health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,12 +81,22 @@ services:
     volumes:
       - ./docker-init-db.sql:/docker-entrypoint-initdb.d/init_db.sql
       - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - open-forms-dev
 
   redis:
     image: redis:8
     command: ["redis-server", "--appendonly", "yes"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 1s
+      retries: 3
     networks:
       - open-forms-dev
     volumes:
@@ -99,6 +109,12 @@ services:
 
   clamav:
     image: clamav/clamav:1.0.0
+    healthcheck:
+      test: ["CMD", "clamdcheck.sh"]
+      interval: 5s
+      timeout: 1s
+      retries: 5
+      start_period: 6m
     networks:
       - open-forms-dev
 
@@ -159,6 +175,12 @@ services:
       - '9000:80'
     depends_on:
       - web
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:80/_healthz/livez/']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - open-forms-dev
 

--- a/docker/nginx/openforms.conf
+++ b/docker/nginx/openforms.conf
@@ -11,9 +11,34 @@ server {
     listen       80;
     server_name  localhost;
 
+    # Health checks / observability
+
     location = /_status {
         stub_status;
     }
+
+    location = /_healthz/livez/ {
+        access_log off;
+        add_header Content-Type text/plain;
+        # block outside traffic
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+        return 200 "ok\n";
+    }
+
+    # same as livez - optionally you can consider proxying to the readyz backend endpoint.
+    location = /_healthz/readyz/ {
+        access_log off;
+        add_header Content-Type text/plain;
+        # block outside traffic
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+        return 200 "ok\n";
+    }
+
+    # Static asset serving
 
     location /static/ {
         expires max;
@@ -29,6 +54,8 @@ server {
         internal;
         alias /private-media;
     }
+
+    # Proxy dynamic requests
 
     location / {
         otel_trace         on;

--- a/docs/installation/health_checks.rst
+++ b/docs/installation/health_checks.rst
@@ -1,0 +1,146 @@
+.. _installation_health_checks:
+
+=======================
+Container health checks
+=======================
+
+Open Forms is deployed as a collection of containers. Containers can be checked if
+they're running as expected, and actions can be taken by the container runtime or
+container orchestration (like Kubernetes and Docker) when that's not the case, like
+restarting the container or removing it from the pool that serves traffic.
+
+Health checks are responsible for detecting anomalies and reporting that a container is
+not running as expected. They can take different forms, for example:
+
+* running a script and checking the exit code of the process
+* making an HTTP request to an endpoint which responds with a success or error status
+  code
+* opening a TCP connection to a particular port
+
+This section of the documentation describes the recommended health checks to use that
+are provided in Open Forms, or the health checks to implement in containers of third
+party software typically used in an Open Forms deployment. You can incorporate these in
+your infrastructure code (like Helm charts).
+
+You can find code examples of these health checks in our `docker-compose.yml`_ on Github.
+
+.. _docker-compose.yml: https://github.com/open-formulieren/open-forms/blob/main/docker-compose.yml
+
+Open Forms containers
+=====================
+
+HTTP service
+------------
+
+.. todo:: TODO
+
+Celery workers
+--------------
+
+.. todo:: TODO
+
+Celery beat
+-----------
+
+.. todo:: TODO
+
+Celery flower
+-------------
+
+.. todo:: TODO
+
+Third party containers
+======================
+
+Redis/Valkey
+------------
+
+The Redis and Valkey container images include a command line utility - ``redis-cli`` and
+``valkey-cli`` which has a ``ping`` command to test connectivity to the server:
+
+.. code-block:: bash
+
+    redis-cli ping
+
+The command exits with exit code ``0`` on success and exit code ``1`` on failure.
+
+nginx
+-----
+
+nginx proxies HTTP traffic from the browser/client to the backend service. It also
+serves static assets directly. The nginx config needs to be extended with a location
+handler for the health checks. You should take care to namespace this so that you don't
+get collissions with identifiers of forms that would be masked by this path.
+
+Example nginx configuration snippet:
+
+.. code-block:: nginx
+
+    location = /_healthz/livez/ {
+        access_log off;
+        add_header Content-Type text/plain;
+        # block outside traffic
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+        return 200 "ok\n";
+    }
+
+We recommend this cheap check for both the liveness and readiness checks.
+
+You can then wire up an HTTP probe or ``curl`` script to make a ``GET`` call to
+``http://localhost:8080/_healthz/livez/``. Note the port number - often the nginx
+unprivileged image will be used, which binds to 8080 by default, but check your
+specific environment to confirm.
+
+**Smart readiness probe**
+
+You *may* want to consider proxying to the backend-service for the readiness check.
+
+.. warning:: This can lead to cascading failures where first your backend-service
+   becomes unavailable, which leads to nginx becoming unavailable and possible other
+   dependent services.
+
+.. tip:: Even if the backend is not available, nginx may still be performing useful work
+   by serving static files.
+
+Example nginx configuration snippet:
+
+.. code-block:: nginx
+
+    location = /_healthz/readyz/ {
+        access_log off;
+        # block outside traffic
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Scheme $scheme;
+        proxy_pass   http://web:8000/_health/readyz/;
+    }
+
+ClamAV
+------
+
+ClamAV includes a healthcheck definition in its container image. On Kubernetes, these
+are not used, instead probes are used.
+
+The health check is implemented in ``clamdcheck.sh``, exiting with a non-zero exit code
+when there are problems. It pings the default port (3310).
+
+.. note:: On initial deploy, ClamAV will have to download the virus definitions database,
+   which can take a long time. The built-in healthcheck only starts after 6 minutes.
+   It's recommended to configure a startup probe on Kubernetes.
+
+PostgreSQL
+----------
+
+.. warning:: Running the database as a container can bring certain scaling and disaster
+   recovery challenges. We only provide this check for completeness sake.
+
+PostgreSQL container images typically include the ``pg_isready`` binary, which tests
+the database connection (accepting traffic on the specified host and port). It has a
+non-zero exit code when the database is not ready.

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -24,6 +24,7 @@ After installation, follow the :ref:`configuration_index` instructions to enable
    docker_compose
    security
    config
+   health_checks
    observability/index
    setup_configuration
    file_uploads


### PR DESCRIPTION
Partly closes #5287
Replaces #5828

[skip: e2e]

**Changes**

* Updated docker compose with explicit health checks
* Updated documentation with extra information about health checks

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
