### PR TITLE
Add/enable/extend OTel Tracing

### DIFF
--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -36,6 +36,37 @@ services:
     networks:
       - open-forms-dev
 
+  # Tempo runs as user 10001, and docker compose creates the volume as root.
+  # As such, we need to chown the volume in order for Tempo to start correctly.
+  tempo-init:
+    image: busybox:latest
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - ./tempo-data:/var/tempo
+    networks:
+      - open-forms-dev
+
+  # traces backend
+  # used this example - https://github.com/grafana/tempo/blob/main/example/docker-compose/otel-collector/docker-compose.yaml
+  tempo:
+    image: grafana/tempo:latest
+    command: --config.file=/etc/tempo.yaml
+    volumes:
+      - ./observability/tempo/tempo.yaml:/etc/tempo.yaml
+      - ./tempo-data:/var/tempo
+    ports:
+      - "3200:3200"  # tempo
+    depends_on:
+      tempo-init:
+        condition:
+          service_completed_successfully
+    networks:
+      - open-forms-dev
+
   # open telemetry collector, receives metrics from the application instance(s)
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.131.0

--- a/docker/observability/README.md
+++ b/docker/observability/README.md
@@ -67,4 +67,5 @@ Traces can be sent using OTLP to the collector at http://localhost:4317 (gRPC).
 The `maykin_common.otel` module takes care of setting everything up, just make sure to set the
 environment variable `OTEL_SDK_DISABLED=false` in development (it's disabled by default).
 
-The collector ingests the traces and prints them out to stdout.
+The collector ingests the traces and they are then exported to Grafana Tempo. They're also
+printed to stdout.

--- a/docker/observability/README.md
+++ b/docker/observability/README.md
@@ -67,5 +67,4 @@ Traces can be sent using OTLP to the collector at http://localhost:4317 (gRPC).
 The `maykin_common.otel` module takes care of setting everything up, just make sure to set the
 environment variable `OTEL_SDK_DISABLED=false` in development (it's disabled by default).
 
-The collector ingests the traces and they are then exported to Grafana Tempo. They're also
-printed to stdout.
+The collector ingests the traces and they are then exported to Grafana Tempo.

--- a/docker/observability/grafana/datasources/ds.yml
+++ b/docker/observability/grafana/datasources/ds.yml
@@ -26,3 +26,13 @@ datasources:
     disableRecordingRules: false
     timeInterval: 15s   # Prometheus scrape interval
     incrementalQueryOverlapWindow: 10m
+- name: Tempo
+  type: tempo
+  access: proxy
+  url: http://tempo:3200
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  jsonData:
+    httpMethod: GET

--- a/docker/observability/otel/otel-collector-config.yml
+++ b/docker/observability/otel/otel-collector-config.yml
@@ -89,7 +89,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug, otlp/tempo]
+      exporters: [otlp/tempo]
     metrics:
       receivers: [otlp, postgresql, redis, nginx, prometheus]
       processors: [memory_limiter, transform, batch]

--- a/docker/observability/otel/otel-collector-config.yml
+++ b/docker/observability/otel/otel-collector-config.yml
@@ -77,13 +77,19 @@ exporters:
     resource_to_telemetry_conversion:
       enabled: true
 
+  # traces tempo endpoint
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
 service:
   extensions: [basicauth/server]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug]
+      exporters: [debug, otlp/tempo]
     metrics:
       receivers: [otlp, postgresql, redis, nginx, prometheus]
       processors: [memory_limiter, transform, batch]

--- a/docker/observability/tempo/tempo.yaml
+++ b/docker/observability/tempo/tempo.yaml
@@ -1,0 +1,55 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+    metadata_slo:
+      duration_slo: 5s
+      throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+
+ingester:
+  max_block_duration: 5m # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h # overall Tempo trace retention. set for demo purposes
+
+#metrics_generator:
+#  registry:
+#    external_labels:
+#      source: tempo
+#      cluster: docker-compose
+#  storage:
+#    path: /var/tempo/generator/wal
+#    remote_write:
+#      - url: http://prometheus:9090/api/v1/write
+#        send_exemplars: true
+#  traces_storage:
+#    path: /var/tempo/generator/traces
+
+storage:
+  trace:
+    backend: local # backend configuration to use
+    wal:
+      path: /var/tempo/wal # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
+      generate_native_histograms: both

--- a/src/openforms/appointments/api/views.py
+++ b/src/openforms/appointments/api/views.py
@@ -8,6 +8,7 @@ import structlog
 from drf_spectacular.plumbing import build_array_type, build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from opentelemetry import trace
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import CreateAPIView, GenericAPIView
 from rest_framework.request import Request
@@ -48,6 +49,7 @@ from .serializers import (
     TimeSerializer,
 )
 
+tracer = trace.get_tracer("openforms.appointments.api.views")
 # TODO: see openforms.validations.api.serializers.ValidatorsFilterSerializer.as_openapi_params
 # and https://github.com/open-formulieren/open-forms/issues/611
 
@@ -105,6 +107,14 @@ class ProductsListView(ListMixin, APIView):
                 location_id=location_id,
                 current_products=products,
             ),
+            tracer.start_as_current_span(
+                name="get-available-products",
+                attributes={
+                    "span.type": "app",
+                    "span.subtype": "appointments",
+                    "span.action": "get_products",
+                },
+            ),
             elasticapm.capture_span(
                 name="get-available-products",
                 span_type="app.appointments.get_products",
@@ -141,6 +151,14 @@ class LocationsListView(ListMixin, APIView):
                 action="appointments.get_locations",
                 plugin=plugin,
                 products=products,
+            ),
+            tracer.start_as_current_span(
+                name="get-available-locations",
+                attributes={
+                    "span.type": "app",
+                    "span.subtype": "appointments",
+                    "span.action": "get_locations",
+                },
             ),
             elasticapm.capture_span(
                 name="get-available-locations",
@@ -184,6 +202,14 @@ class DatesListView(ListMixin, APIView):
                 plugin=plugin,
                 products=products,
                 location=location,
+            ),
+            tracer.start_as_current_span(
+                name="get-available-dates",
+                attributes={
+                    "span.type": "app",
+                    "span.subtype": "appointments",
+                    "span.action": "get_dates",
+                },
             ),
             elasticapm.capture_span(
                 name="get-available-dates", span_type="app.appointments.get_dates"
@@ -236,6 +262,14 @@ class TimesListView(ListMixin, APIView):
                 products=products,
                 location=location,
                 date=date,
+            ),
+            tracer.start_as_current_span(
+                name="get-available-times",
+                attributes={
+                    "span.type": "app",
+                    "span.subtype": "appointments",
+                    "span.action": "get_times",
+                },
             ),
             elasticapm.capture_span(
                 name="get-available-times", span_type="app.appointments.get_times"
@@ -290,6 +324,14 @@ class RequiredCustomerFieldsListView(APIView):
                 action="appointments.get_required_customer_fields",
                 plugin=plugin,
                 products=products,
+            ),
+            tracer.start_as_current_span(
+                name="get-required-customer-fields",
+                attributes={
+                    "span.type": "app",
+                    "span.subtype": "appointments",
+                    "span.action": "get_required_customer_fields",
+                },
             ),
             elasticapm.capture_span(
                 name="get-required-customer-fields",

--- a/src/openforms/contrib/kadaster/clients/bag.py
+++ b/src/openforms/contrib/kadaster/clients/bag.py
@@ -3,11 +3,13 @@ from dataclasses import dataclass
 import elasticapm
 import requests
 import structlog
+from opentelemetry import trace
 
 from openforms.contrib.hal_client import HALClient
 from openforms.formio.components.utils import salt_location_message
 
 logger = structlog.stdlib.get_logger(__name__)
+tracer = trace.get_tracer("openforms.contrib.kadaster.clients.bag")
 
 
 @dataclass
@@ -29,6 +31,10 @@ class BAGClient(HALClient):
     This client is expected to work with both v1 and v2 of the API's.
     """
 
+    @tracer.start_as_current_span(
+        name="get-address",
+        attributes={"span.type": "app", "span.subtype": "bag", "span.action": "query"},
+    )
     @elasticapm.capture_span(span_type="app.bag.query")
     def get_address(
         self, postcode: str, house_number: str, reraise_errors: bool = False

--- a/src/openforms/contrib/kvk/client.py
+++ b/src/openforms/contrib/kvk/client.py
@@ -5,6 +5,7 @@ from typing import Literal, TypedDict
 import elasticapm
 import requests
 import structlog
+from opentelemetry import trace
 from zgw_consumers.client import build_client
 
 from openforms.contrib.hal_client import HALClient
@@ -13,6 +14,7 @@ from .api_models.basisprofiel import BasisProfiel
 from .models import KVKConfig
 
 logger = structlog.stdlib.get_logger(__name__)
+tracer = trace.get_tracer("openforms.contrib.kvk.client")
 
 
 def get_kvk_profile_client() -> KVKProfileClient:
@@ -52,6 +54,9 @@ class SearchParams(TypedDict, total=False):
 
 
 class KVKProfileClient(HALClient):
+    @tracer.start_as_current_span(
+        name="get-profile", attributes={"span.type": "app", "span.subtype": "kvk"}
+    )
     @elasticapm.capture_span("app.kvk")
     def get_profile(self, kvk_nummer: str) -> BasisProfiel:
         """
@@ -74,6 +79,10 @@ class KVKProfileClient(HALClient):
 
 
 class KVKSearchClient(HALClient):
+    @tracer.start_as_current_span(
+        name="get-search-results",
+        attributes={"span.type": "app", "span.subtype": "kvk"},
+    )
     @elasticapm.capture_span("app.kvk")
     def get_search_results(self, query_params: SearchParams):
         """

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import elasticapm
+from opentelemetry import trace
 
 from openforms.typing import JSONObject
 
@@ -63,6 +64,8 @@ __all__ = [
     "get_component_empty_value",
 ]
 
+tracer = trace.get_tracer("openforms.formio.service")
+
 
 def format_value(component: Component, value: Any, *, as_html: bool = False):
     """
@@ -79,6 +82,10 @@ def normalize_value_for_component(component: Component, value: Any) -> Any:
     return register.normalize(component, value)
 
 
+@tracer.start_as_current_span(
+    name="get-dynamic-configuration",
+    attributes={"span.type": "app", "span.subtype": "formio"},
+)
 @elasticapm.capture_span(span_type="app.formio")
 def get_dynamic_configuration(
     config_wrapper: FormioConfigurationWrapper,

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import elasticapm
 import structlog
 from glom import Coalesce, Path, glom
+from opentelemetry import trace
 from typing_extensions import TypeIs
 
 from openforms.typing import JSONObject, JSONValue
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from .datastructures import FormioData
 
 logger = structlog.stdlib.get_logger(__name__)
+tracer = trace.get_tracer("openforms.formio.utils")
 
 # XXX: we should probably be able to narrow this in Python 3.11 with non-total typed
 # dicts.
@@ -31,6 +33,14 @@ def _is_column_component(component: ComponentLike) -> TypeIs[ColumnsComponent]:
     return component.get("type") == "columns"
 
 
+@tracer.start_as_current_span(
+    name="iter-components",
+    attributes={
+        "span.type": "app",
+        "span.subtype": "formio",
+        "span.action": "configuration",
+    },
+)
 @elasticapm.capture_span(span_type="app.formio.configuration")
 def iter_components(
     configuration: ComponentLike,
@@ -94,6 +104,14 @@ def iterate_components_with_configuration_path(
             )
 
 
+@tracer.start_as_current_span(
+    name="flatten-by-path",
+    attributes={
+        "span.type": "app",
+        "span.subtype": "formio",
+        "span.action": "configuration",
+    },
+)
 @elasticapm.capture_span(span_type="app.formio.configuration")
 def flatten_by_path(configuration: JSONObject) -> dict[str, Component]:
     """

--- a/src/openforms/prefill/service.py
+++ b/src/openforms/prefill/service.py
@@ -36,6 +36,7 @@ So, to recap:
 
 import elasticapm
 import structlog
+from opentelemetry import trace
 
 from openforms.formio.service import (
     FormioConfigurationWrapper,
@@ -55,6 +56,7 @@ from .sources import (
 )
 
 logger = structlog.stdlib.get_logger(__name__)
+tracer = trace.get_tracer("openforms.prefill.service")
 
 
 def inject_prefill(
@@ -107,6 +109,9 @@ def inject_prefill(
         component["defaultValue"] = variable.to_json(prefill_value)
 
 
+@tracer.start_as_current_span(
+    name="prefill-variables", attributes={"span.type": "app", "span.subtype": "prefill"}
+)
 @elasticapm.capture_span(span_type="app.prefill")
 def prefill_variables(submission: Submission, register: Registry | None = None) -> None:
     """


### PR DESCRIPTION
Closes #5450
Depends on https://github.com/maykinmedia/django-common/pull/47

**Changes**

* update `maykin_common` version
* add Open telemetry spans alongside Elastic Apm ones
* add trace backends for observability docker compose

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder (not to forget to remove git dep)

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
