### PR TITLE
[#5690] Add extra description for each selected product in appointments

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7107,8 +7107,12 @@ components:
         name:
           type: string
           description: Product name
+        description:
+          type: string
+          description: Product extra description
       required:
       - code
+      - description
       - identifier
       - name
     AttributeGroup:

--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -55,6 +55,11 @@ class ProductSerializer(serializers.Serializer):
         label=_("identifier"), help_text=_("ID of the product")
     )
     name = serializers.CharField(label=_("name"), help_text=_("Product name"))
+    description = serializers.CharField(
+        label=_("description"),
+        help_text=_("Product extra description"),
+        allow_blank=True,
+    )
 
     class Meta:
         ref_name = "AppointmentProduct"

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -28,6 +28,7 @@ class Product:
     name: str
     code: str = ""
     amount: int = 1
+    description: str = ""
 
     def __str__(self):
         return f"{self.identifier} x {self.amount}"


### PR DESCRIPTION
Closes #5690 partly

**Changes**

Added the extra field `description` for a product in appointments. Along with the selected product we show the extra description (if exists) that belongs to it.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
