### PR TITLE
Fix date-related objects in service fetch configuration being converted to "None"

### DIFF
--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -13,6 +13,7 @@ from openforms.forms.tests.factories import (
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableDataTypes
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
 from ...api.viewsets import SubmissionStepViewSet
@@ -918,3 +919,112 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
         except KeyError as e:
             raise self.failureException("Check logic post failed unexpectedly") from e
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @tag("gh-5888")
+    @requests_mock.Mocker()
+    def test_date_related_vales_in_service_fetch_configuration(self, m):
+        """
+        Ensure that date-related objects are properly formatted when they are used in
+        templates in the service fetch configuration.
+        """
+        service = ServiceFactory.create(api_root="https://example.com/")
+        m.get("https://example.com/test", json="foo")
+
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "date",
+                        "key": "date",
+                        "label": "Date",
+                    },
+                    {
+                        "type": "time",
+                        "key": "time",
+                        "label": "Date",
+                    },
+                    {
+                        "type": "datetime",
+                        "key": "datetime",
+                        "label": "Datetime",
+                    },
+                    {
+                        "type": "date",
+                        "key": "date_multiple",
+                        "label": "Date multiple",
+                        "multiple": True,
+                    },
+                    {
+                        "type": "date",
+                        "key": "date_empty",
+                        "label": "Date empty",
+                    },
+                    {
+                        "type": "number",
+                        "key": "number",
+                        "label": "Number",
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="foo",
+            key="foo",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+            service_fetch_configuration=ServiceFetchConfigurationFactory.create(
+                service=service,
+                path="test",
+                query_params={
+                    "date": "{{date}}",
+                    "time": "{{time}}",
+                    "datetime": "{{datetime}}",
+                    "date_multiple": "{{date_multiple}}",
+                    "date_single_value_from_multiple": "{{date_multiple.1}}",
+                    "date_empty": "{{date_empty}}",
+                    "number": "{{number}}",
+                },
+            ),
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[{"action": {"type": "fetch-from-service"}, "variable": "foo"}],
+        )
+        submission = SubmissionFactory.create(form=form)
+
+        # Perform logic check
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        response = self.client.post(
+            endpoint,
+            data={
+                "data": {
+                    "date": "2026-01-13",
+                    "time": "12:34:56",
+                    "datetime": "2026-01-13T12:34:56+01:00",
+                    "date_multiple": ["2026-01-13", "2026-01-15"],
+                    "date_empty": "",
+                    "number": None,
+                }
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            m.request_history[-1].url,
+            "https://example.com/test?"
+            "date=2026-01-13&"
+            "time=12%3A34%3A56&"
+            "number=None&"
+            "datetime=2026-01-13+12%3A34%3A56%2B01%3A00&"
+            "date_empty=&"
+            "date_multiple=%5B%272026-01-13%27%2C+%272026-01-15%27%5D&"
+            "date_single_value_from_multiple=2026-01-15",
+        )

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -1022,8 +1022,8 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
             "https://example.com/test?"
             "date=2026-01-13&"
             "time=12%3A34%3A56&"
-            "number=None&"
-            "datetime=2026-01-13+12%3A34%3A56%2B01%3A00&"
+            "number=&"
+            "datetime=2026-01-13T12%3A34%3A56%2B01%3A00&"
             "date_empty=&"
             "date_multiple=%5B%272026-01-13%27%2C+%272026-01-15%27%5D&"
             "date_single_value_from_multiple=2026-01-15",

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
@@ -15,6 +15,7 @@ from openforms.formio.service import FormioData
 from openforms.forms.tests.factories import FormVariableFactory
 from openforms.utils.tests.nlx import DisableNLXRewritingMixin
 from openforms.variables.constants import DataMappingTypes
+from openforms.variables.models import _convert_to_string
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 from openforms.variables.validators import HeaderValidator, ValidationError
 
@@ -178,9 +179,7 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
         # https://swagger.io/docs/specification/serialization/
         ...
 
-    @given(
-        field_value=data_mapping_values(),
-    )
+    @given(field_value=data_mapping_values())
     def test_it_can_construct_simple_query_parameters(self, field_value):
         # https://swagger.io/docs/specification/describing-parameters/#query-parameters
         context = FormioData({"some_field": field_value})
@@ -196,7 +195,7 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
         with requests_mock.Mocker(case_sensitive=True) as m:
             m.get(
                 furl("https://httpbin.org/response-headers")
-                .set({"freeform": field_value})
+                .set({"freeform": _convert_to_string(field_value)})
                 .url,
                 json={},
             )
@@ -230,7 +229,7 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
         with requests_mock.Mocker(case_sensitive=True) as m:
             m.get(
                 furl("https://httpbin.org/redirect-to")
-                .set({"url": some_text, "status_code": some_value})
+                .set({"url": some_text, "status_code": _convert_to_string(some_value)})
                 .url,
                 json={},
             )


### PR DESCRIPTION
Closes #5888

[skip: e2e]

**Changes**

Added conversion of `None` to empty string, and explicit conversion to ISO strings of date-related objects to the service fetch configuration (headers and query parameter template context)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
