### PR TITLE
Fix date fields with prefill configuation breaking the submission summary page

### DIFF
--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -395,3 +395,31 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
         data = response.json()
 
         self.assertEqual(2, len(data))
+
+    @tag("gh-5885")
+    def test_summary_with_date_prefill(self):
+        form = FormFactory.create()
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "date",
+                        "type": "date",
+                        "label": "Date",
+                        "prefill": {
+                            "plugin": "test-prefill",
+                            "attribute": "dateOfBirth",
+                        },
+                    }
+                ]
+            },
+            data={"date": "2000-01-01"},
+        )
+        self._add_submission_to_session(submission)
+
+        url = reverse("api:submission-summary", kwargs={"uuid": submission.uuid})
+        response = self.client.get(url)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -15,7 +15,10 @@ logger = structlog.stdlib.get_logger(__name__)
 TIMEZONE_AMS = ZoneInfo("Europe/Amsterdam")
 
 
-def format_date_value(date_value: str) -> str:
+def format_date_value(date_value: str | date) -> str:
+    if isinstance(date_value, date):
+        return date_value.isoformat()
+
     try:
         parsed_date = date.fromisoformat(date_value)
     except ValueError:


### PR DESCRIPTION
Closes #5885

[skip: e2e]

**Changes**

Added a bandaid fix which ensures `format_date_value` can also handle date. See commit message for more details

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
