### PR TITLE
Refactor handling of prefill data

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -32,7 +32,7 @@ from openforms.prefill.contrib.family_members.plugin import (
 )
 from openforms.submissions.models import Submission
 from openforms.typing import JSONObject
-from openforms.utils.date import TIMEZONE_AMS, datetime_in_amsterdam, format_date_value
+from openforms.utils.date import TIMEZONE_AMS, datetime_in_amsterdam
 from openforms.utils.json_schema import GEO_JSON_COORDINATE_SCHEMAS, to_multiple
 from openforms.utils.validators import BSNValidator, IBANValidator
 from openforms.validations.service import PluginValidator
@@ -96,10 +96,6 @@ class FormioDateField(serializers.DateField):
 @register("date")
 class Date(BasePlugin[DateComponent]):
     formatter = DateFormatter
-
-    @staticmethod
-    def normalizer(component: DateComponent, value: str) -> str:
-        return format_date_value(value)
 
     def mutate_config_dynamically(
         self, component: DateComponent, submission: Submission, data: FormioData

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -737,7 +737,8 @@ class PartnerListField(serializers.Field):
     def validate_list(self, partners):
         component_key = self.component["key"]
         submission = self.context["submission"]
-        prefill_data = submission.get_prefilled_data()
+        state = submission.load_submission_value_variables_state()
+        prefill_data = state.get_prefilled_data()
 
         fm_immutable_variable = FormVariable.objects.filter(
             source=FormVariableSources.user_defined,
@@ -860,7 +861,8 @@ class ChildListField(serializers.Field):
     def validate_list(self, children):
         component_key = self.component["key"]
         submission = self.context["submission"]
-        prefill_data = submission.get_prefilled_data()
+        state = submission.load_submission_value_variables_state()
+        prefill_data = state.get_prefilled_data()
 
         fm_immutable_variable = FormVariable.objects.filter(
             source=FormVariableSources.user_defined,

--- a/src/openforms/prefill/contrib/family_members/plugin.py
+++ b/src/openforms/prefill/contrib/family_members/plugin.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from typing import Protocol, assert_never
 
 from django.urls import reverse
@@ -88,7 +89,7 @@ class FamilyMembersPrefill(BasePlugin[FamilyMemberOptions]):
         # prefill configuration and the mutable one) with the data that we have retrieved
         return {
             initial_data_form_variable: results,
-            form_variable_to_update: results,
+            form_variable_to_update: deepcopy(results),
         }
 
     def check_config(self):

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -23,6 +23,7 @@ from openforms.logging.tests.utils import disable_timelinelog
 from openforms.prefill.service import prefill_variables
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.utils.tests.vcr import OFVCRMixin
+from openforms.variables.constants import FormVariableDataTypes
 from stuf.constants import EndpointType
 from stuf.stuf_bg.models import StufBGConfig
 from stuf.tests.factories import StufServiceFactory
@@ -84,6 +85,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             key="hc_prefill_partners_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "type": "partners",
@@ -131,6 +133,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             key="hc_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "mutable_data_form_variable": "hc_prefill_children_mutable",
@@ -205,6 +208,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             key="hc_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "mutable_data_form_variable": "hc_prefill_children_mutable",
@@ -254,6 +258,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             key="hc_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "mutable_data_form_variable": "hc_prefill_children_mutable",
@@ -394,6 +399,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             key="stuf_bg_partners_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "type": "partners",
@@ -455,6 +461,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             key="stuf_bg_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "type": "children",
@@ -540,6 +547,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             key="stuf_bg_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "type": "children",
@@ -625,6 +633,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             key="stuf_bg_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "type": "children",
@@ -692,10 +701,15 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
         ]
 
         self.assertEqual(
-            state.variables["stuf_bg_prefill_children_mutable"].value, expected_data
-        )
-        self.assertEqual(
             state.variables["stuf_bg_prefill_children_immutable"].value, expected_data
+        )
+
+        # Partial dates will be converted to empty strings for the partner component.
+        expected_data[1]["dateOfBirth"] = ""
+        expected_data[2]["dateOfBirth"] = ""
+
+        self.assertEqual(
+            state.variables["stuf_bg_prefill_children_mutable"].value, expected_data
         )
 
     def test_children_with_incomplete_dateOfBirth_are_not_shown_when_filter(self):
@@ -719,6 +733,7 @@ class FamilyMembersPrefillPluginStufBgTests(TestCase):
             key="stuf_bg_prefill_children_immutable",
             form=submission.form,
             user_defined=True,
+            data_type=FormVariableDataTypes.array,
             prefill_plugin=PLUGIN_IDENTIFIER,
             prefill_options={
                 "type": "children",

--- a/src/openforms/prefill/service.py
+++ b/src/openforms/prefill/service.py
@@ -34,14 +34,12 @@ So, to recap:
    form field default values.
 """
 
-from collections import defaultdict
-
 import elasticapm
 import structlog
 
 from openforms.formio.service import (
     FormioConfigurationWrapper,
-    normalize_value_for_component,
+    FormioData,
 )
 from openforms.submissions.models import Submission
 from openforms.submissions.models.submission_value_variable import (
@@ -108,75 +106,54 @@ def inject_prefill(
 
 @elasticapm.capture_span(span_type="app.prefill")
 def prefill_variables(submission: Submission, register: Registry | None = None) -> None:
-    """Update the submission variables state with the fetched attribute values.
+    """
+    Update the submission variables state with the fetched attribute values.
 
-    For each submission value variable that need to be prefilled, the according plugin will
-    be used to fetch the value. If ``register`` is not specified, the default registry instance
-    will be used.
+    For each submission value variable that needs to be prefilled, the according plugin
+    will be used to fetch the value. If ``register`` is not specified, the default
+    registry instance will be used.
     """
     register = register or default_register
 
     state = submission.load_submission_value_variables_state()
-    variables_to_prefill = state.get_prefill_variables()
-
-    key_source_mappings: defaultdict[str, str] = defaultdict()
-    if state.variables:
-        for variable_key, variable in state.variables.items():
-            assert variable.form_variable is not None
-            key_source_mappings[variable_key] = variable.form_variable.source
 
     variables_with_attribute: list[SubmissionValueVariable] = []
     variables_with_options: list[SubmissionValueVariable] = []
-    prefill_data: defaultdict[str, JSONEncodable] = defaultdict(dict)
+    prefill_data: dict[str, JSONEncodable] = {}
 
-    for variable in variables_to_prefill:
-        assert variable.form_variable is not None
-        key_source_mappings[variable.form_variable.key] = variable.form_variable.source
+    for variable in state.prefilled_variables.values():
+        form_variable = variable.form_variable
+        assert form_variable is not None
         # variables which have prefill enabled via the component's configuration
         if (
-            variable.form_variable.source == FormVariableSources.component
-            and variable.form_variable.prefill_plugin
-            and variable.form_variable.prefill_attribute
+            form_variable.source == FormVariableSources.component
+            and form_variable.prefill_plugin
+            and form_variable.prefill_attribute
         ):
             variables_with_attribute.append(variable)
+            continue
 
-        if variable.form_variable.source == FormVariableSources.user_defined:
-            # variables which have prefill enabled via the variables tab and define prefill options
-            if (
-                variable.form_variable.prefill_plugin
-                and variable.form_variable.prefill_options
-            ):
+        if form_variable.source == FormVariableSources.user_defined:
+            # variables which have prefill enabled via the variables tab and define
+            # prefill options
+            if form_variable.prefill_plugin and form_variable.prefill_options:
                 variables_with_options.append(variable)
 
-            # variables which have prefill enabled via the variables tab and define prefill attribute
-            if (
-                variable.form_variable.prefill_plugin
-                and variable.form_variable.prefill_attribute
-            ):
+            # variables which have prefill enabled via the variables tab and define
+            # prefill attribute
+            if form_variable.prefill_plugin and form_variable.prefill_attribute:
                 variables_with_attribute.append(variable)
 
-    if variables_with_attribute and (
-        results_from_attribute := fetch_prefill_values_from_attribute(
+    if variables_with_attribute:
+        results_from_attribute = fetch_prefill_values_from_attribute(
             submission, register, variables_with_attribute
         )
-    ):
         prefill_data.update(**results_from_attribute)
-    if variables_with_options and (
-        results_from_options := fetch_prefill_values_from_options(
+
+    if variables_with_options:
+        results_from_options = fetch_prefill_values_from_options(
             submission, register, variables_with_options
         )
-    ):
         prefill_data.update(**results_from_options)
 
-    total_config_wrapper = submission.total_configuration_wrapper
-    for variable_key, prefill_value in prefill_data.items():
-        if key_source_mappings[variable_key] == FormVariableSources.component:
-            component = total_config_wrapper[variable_key]
-            normalized_prefill_value = normalize_value_for_component(
-                component, prefill_value
-            )
-            prefill_value = normalized_prefill_value
-
-        prefill_data[variable_key] = prefill_value
-
-    state.save_prefill_data(prefill_data)
+    state.save_prefill_data(FormioData(prefill_data))

--- a/src/openforms/prefill/tests/test_prefill_variables.py
+++ b/src/openforms/prefill/tests/test_prefill_variables.py
@@ -222,7 +222,7 @@ class PrefillVariablesTests(TestCase):
 
         FormVariable.objects.all().delete()
 
-        prefill_variables = submission_value_variables_state.get_prefill_variables()
+        prefill_variables = submission_value_variables_state.prefilled_variables
         self.assertEqual(2, len(prefill_variables))
 
 

--- a/src/openforms/prefill/tests/test_prefill_variables.py
+++ b/src/openforms/prefill/tests/test_prefill_variables.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import patch
 
 from django.core.exceptions import PermissionDenied
@@ -126,7 +127,11 @@ class PrefillVariablesTests(TestCase):
 
     @patch(
         "openforms.prefill.service.fetch_prefill_values_from_attribute",
-        return_value={"postcode": "1015CJ", "birthDate": "19990615"},
+        return_value={
+            "postcode": "1015CJ",
+            "birthDate": "19990615",
+            "user_defined": "20000101",
+        },
     )
     def test_normalization_applied(self, m_prefill):
         form = FormFactory.create()
@@ -162,6 +167,15 @@ class PrefillVariablesTests(TestCase):
                     }
                 ]
             },
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            data_type=FormVariableDataTypes.date,
+            user_defined=True,
+            prefill_plugin="birthDate",
+            prefill_attribute="static",
         )
         submission = SubmissionFactory.create(form=form)
         submission_step1 = SubmissionStepFactory.create(
@@ -202,11 +216,15 @@ class PrefillVariablesTests(TestCase):
         assert "defaultValue" in component_date
         self.assertEqual(component_date["defaultValue"], "1999-06-15")
 
-        variable_postcode = submission.submissionvaluevariable_set.get(key="postcode")
-        variable_date = submission.submissionvaluevariable_set.get(key="birthDate")
-
-        self.assertEqual(variable_postcode.value, "1015 CJ")
-        self.assertEqual(variable_date.value, "1999-06-15")
+        state = submission.load_submission_value_variables_state()
+        self.assertEqual(
+            state.get_prefilled_data().data,
+            {
+                "birthDate": date(1999, 6, 15),
+                "postcode": "1015 CJ",
+                "user_defined": date(2000, 1, 1),
+            },
+        )
 
     def test_prefill_variables_are_retrieved_when_form_variables_deleted(self):
         form_step = FormStepFactory.create(form_definition__configuration=CONFIGURATION)

--- a/src/openforms/submissions/api/validators.py
+++ b/src/openforms/submissions/api/validators.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.serializers import JSONField
 
-from openforms.formio.service import normalize_value_for_component
+from openforms.formio.service import FormioData
 from openforms.forms.models import Form
 
 from ..exceptions import FormMaintenance
@@ -17,10 +17,11 @@ class ValidatePrefillData:
     default_message = _("The prefill data may not be altered.")
     requires_context = True
 
-    def __call__(self, data: dict, field: JSONField):
+    def __call__(self, data: FormioData, field: JSONField):
         instance: SubmissionStep = field.parent.instance
         assert instance._form_logic_evaluated, "Logic must be evaluated"
-        prefill_data = instance.submission.get_prefilled_data()
+        state = instance.submission.load_submission_value_variables_state()
+        prefilled_data = state.get_prefilled_data()
 
         errors = {}
         for component in instance.form_step.iter_components():
@@ -39,16 +40,18 @@ class ValidatePrefillData:
             if component_key not in data:
                 continue
 
-            original_prefill_value = prefill_data.get(component_key)
-            if original_prefill_value is None:
-                # the value will be `None` if there is no actual prefill data available, so there is nothing to compare to. This
-                # especially applies to test-environments without real prefill-connections.
+            prefill_value = prefilled_data.get(component_key)
+            if prefill_value is None:
+                # The value will be `None` if there is no actual prefill data available,
+                # or if the normalization has failed. E.g., if we receive a "date"
+                # '1985', conversion to a date object will result in `None`. There is
+                # no use in comparing it to the new value. This especially applies to
+                # test-environments without real prefill-connections.
                 continue
 
-            prefill_value = normalize_value_for_component(
-                component, original_prefill_value
-            )
-            new_value = data.get(component_key)
+            # Prefilled values fetched from the state are in native Python types, so
+            # we need to convert the new value before doing a comparison.
+            new_value = state.variables[component_key].to_python(data[component_key])
             if new_value != prefill_value:
                 errors[component_key] = serializers.ErrorDetail(
                     self.default_message, code=self.code

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -341,7 +341,6 @@ class Submission(models.Model):
     ] = SubmissionQuerySet.as_manager()
 
     _form_login_required: bool | None = None  # can be set via annotation
-    _prefilled_data = None
     _total_configuration_wrapper = None
 
     # type hints for (reverse) related fields
@@ -844,15 +843,6 @@ class Submission(models.Model):
             return ""
 
         return f"{self.auth_info.plugin} ({self.auth_info.attribute})"
-
-    def get_prefilled_data(self):
-        if self._prefilled_data is None:
-            values_state = self.load_submission_value_variables_state()
-            prefill_vars = values_state.get_prefill_variables()
-            self._prefilled_data = {
-                variable.key: variable.value for variable in prefill_vars
-            }
-        return self._prefilled_data
 
     @cached_property
     def cosign_state(self) -> CosignState:

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -16,7 +16,7 @@ from django.utils.translation import gettext_lazy as _
 import structlog
 from typing_extensions import deprecated
 
-from openforms.formio.service import FormioData
+from openforms.formio.service import FormioData, normalize_value_for_component
 from openforms.formio.typing import Component
 from openforms.formio.utils import (
     get_component_data_subtype,
@@ -295,19 +295,32 @@ class SubmissionValueVariablesState:
             )
         return self._static_data
 
+    def save_prefill_data(self, data: FormioData) -> None:
+        """
+        Save the prefill data to the database.
 
-    def save_prefill_data(self, data: dict[str, Any]) -> None:
-        # The way we retrieve the variables has been changed here, since
-        # the new architecture of the prefill module requires access to all the
-        # variables at this point (the previous implementation with
-        # self.get_prefill_variables() gave us access to the component variables
-        # and not the user_defined ones).
+        Note that this method does not validate whether the data are related to
+        variables that have prefill configured. This is because a configured prefill
+        on one component/variable can result in other variables being prefilled as well.
+        This means we have to check all variables, and not just the ones in
+        ``self.prefilled_variables``.
+
+        Component and data-type normalization will be applied before saving.
+        """
         variables_to_create: list[SubmissionValueVariable] = []
         for variable in self.variables.values():
-            if variable.key not in data:
+            value = data.get(variable.key, empty)
+            if value is empty:
                 continue
 
-            variable.value = data[variable.key]
+            # Apply component-specific normalization
+            if variable.form_variable.source == FormVariableSources.component:
+                value = normalize_value_for_component(variable.configuration, value)
+
+            # Perform a conversion from Python/JSON -> Python -> JSON, to ensure
+            # the type is valid and to normalize any date-related strings (also covers
+            # user-defined variables).
+            variable.value = variable.to_json(variable.to_python(value))
             variable.source = SubmissionValueVariableSources.prefill
             variables_to_create.append(variable)
 

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -84,6 +84,14 @@ class SubmissionValueVariablesState:
             and variable.form_variable.source == FormVariableSources.user_defined
         }
 
+    @property
+    def prefilled_variables(self) -> dict[str, SubmissionValueVariable]:
+        return {
+            variable.key: variable
+            for variable in self.variables.values()
+            if variable.is_initially_prefilled
+        }
+
     @deprecated("Use `state.variables[key]` instead.")
     def get_variable(self, key: str) -> SubmissionValueVariable:
         return self.variables[key]
@@ -132,6 +140,14 @@ class SubmissionValueVariablesState:
             )
 
         return data
+
+    def get_prefilled_data(self) -> FormioData:
+        """Return the values of prefilled variables in a ``FormioData`` instance."""
+        data = {
+            variable_key: variable.to_python()
+            for variable_key, variable in self.prefilled_variables.items()
+        }
+        return FormioData(data)
 
     def get_variables_in_submission_step(
         self,
@@ -279,13 +295,6 @@ class SubmissionValueVariablesState:
             )
         return self._static_data
 
-    def get_prefill_variables(self) -> list[SubmissionValueVariable]:
-        prefill_vars = []
-        for variable in self.variables.values():
-            if not variable.is_initially_prefilled:
-                continue
-            prefill_vars.append(variable)
-        return prefill_vars
 
     def save_prefill_data(self, data: dict[str, Any]) -> None:
         # The way we retrieve the variables has been changed here, since

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -229,7 +229,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                         "prefill": {"plugin": "test-prefill", "attribute": "name"},
                         "disabled": True,
                         "defaultValue": "",
-                        "hidden": False,
+                        "hidden": True,
                     },
                     {
                         "type": "textfield",
@@ -238,7 +238,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                         "prefill": {"plugin": "test-prefill", "attribute": "surname"},
                         "disabled": True,
                         "defaultValue": "",
-                        "hidden": True,
+                        "hidden": False,
                     },
                 ],
             },

--- a/src/openforms/tests/test_registrator_prefill.py
+++ b/src/openforms/tests/test_registrator_prefill.py
@@ -161,13 +161,10 @@ class OIDCRegistratorSubjectHaalCentraalPrefillIntegrationTest(
             submission = Submission.objects.get()
             state = submission.load_submission_value_variables_state()
 
-            variables = state.get_prefill_variables()
-
-            self.assertEqual(len(variables), 1)
-            self.assertEqual(variables[0].key, "voornamen")
-
+            data = state.get_prefilled_data()
+            self.assertEqual(len(data), 1)
             # check we got the name from the haalcentraal JSON mock
-            self.assertEqual(variables[0].value, "Cornelia Francisca")
+            self.assertEqual(data["voornamen"], "Cornelia Francisca")
 
             # test registrator data
             self.assertEqual(submission.auth_info.value, "999990676")

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -15,12 +15,7 @@ logger = structlog.stdlib.get_logger(__name__)
 TIMEZONE_AMS = ZoneInfo("Europe/Amsterdam")
 
 
-def format_date_value(date_value: str | date | None) -> str:
-    if date_value is None:
-        return ""
-    if isinstance(date_value, date):
-        return date_value.isoformat()
-
+def format_date_value(date_value: str) -> str:
     try:
         parsed_date = date.fromisoformat(date_value)
     except ValueError:


### PR DESCRIPTION
Closes #5902

**Changes**

* Removed date value normalizer from the date component
* Moved getting prefill data from `Submission` to `SubmissionValueVariablesState`
* Ensure values are normalized according to the relevant data types before saving prefill data to the database
* Revert implemented bandaid fix for #5885

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
