### PR TITLE
Fix summary page crashing when a date field has prefill configured 2

### DIFF
--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -412,10 +412,19 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                             "plugin": "test-prefill",
                             "attribute": "dateOfBirth",
                         },
-                    }
+                    },
+                    {
+                        "key": "date_empty",
+                        "type": "date",
+                        "label": "Date empty",
+                        "prefill": {
+                            "plugin": "test-prefill",
+                            "attribute": "dateOfBirth",
+                        },
+                    },
                 ]
             },
-            data={"date": "2000-01-01"},
+            data={"date": "2000-01-01", "date_empty": ""},
         )
         self._add_submission_to_session(submission)
 

--- a/src/openforms/utils/date.py
+++ b/src/openforms/utils/date.py
@@ -15,7 +15,9 @@ logger = structlog.stdlib.get_logger(__name__)
 TIMEZONE_AMS = ZoneInfo("Europe/Amsterdam")
 
 
-def format_date_value(date_value: str | date) -> str:
+def format_date_value(date_value: str | date | None) -> str:
+    if date_value is None:
+        return ""
     if isinstance(date_value, date):
         return date_value.isoformat()
 


### PR DESCRIPTION
Closes #5885 (for real this time)

[skip: e2e]

**Changes**

The empty date value (`None`) was missing from my earlier efforts :see_no_evil: 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
