### PR TITLE
[#5879] fix handling non-dict types for errors migration cleanup

### DIFF
--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -374,7 +374,8 @@ def empty_errors_property(component: Component) -> bool:
     if "errors" not in component:
         return False
 
-    if len(component["errors"]) > 0:
+    errors = component["errors"]
+    if type(errors) is not dict or len(component["errors"]) > 0:
         component["errors"] = {}
         return True
 

--- a/src/openforms/formio/tests/test_migration_converters.py
+++ b/src/openforms/formio/tests/test_migration_converters.py
@@ -185,10 +185,27 @@ class LicensePlateTests(SimpleTestCase):
             "errors": {"foo": "bar"},
         }
 
-        changed = empty_errors_property(component)
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
 
-        self.assertTrue(changed)
-        self.assertEqual(component["errors"], {})
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
+
+        component: Component = {
+            "type": "licenseplate",
+            "key": "licensePlate",
+            "label": "Licenseplate",
+            "validate": {
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$"  # type: ignore
+            },
+            "errors": None,
+        }
+
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
+
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
 
     def test_empty_errors(self):
         component: Component = {
@@ -262,10 +279,26 @@ class PostCodeTests(SimpleTestCase):
             "errors": {"foo": "bar"},
         }
 
-        changed = empty_errors_property(component)
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
 
-        self.assertTrue(changed)
-        self.assertEqual(component["errors"], {})
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
+
+        component: Component = {
+            "type": "postcode",
+            "key": "postcode",
+            "validate": {
+                "pattern": r"^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$"  # type: ignore
+            },
+            "errors": None,
+        }
+
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
+
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
 
     def test_empty_errors(self):
         component: Component = {
@@ -540,10 +573,24 @@ class TextTests(SimpleTestCase):
             "errors": {"foo": "bar"},
         }
 
-        changed = empty_errors_property(component)
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
 
-        self.assertTrue(changed)
-        self.assertEqual(component["errors"], {})
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
+
+        component: Component = {
+            "type": "textfield",
+            "key": "textField",
+            "label": "Text field",
+            "errors": None,
+        }
+
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
+
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
 
     def test_empty_errors(self):
         component: Component = {
@@ -707,10 +754,24 @@ class EmailTests(SimpleTestCase):
             "errors": {"foo": "bar"},
         }
 
-        changed = empty_errors_property(component)
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
 
-        self.assertTrue(changed)
-        self.assertEqual(component["errors"], {})
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
+
+        component: Component = {
+            "type": "email",
+            "key": "eMailadres",
+            "label": "Emailadres",
+            "errors": None,
+        }
+
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
+
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
 
     def test_empty_errors(self):
         component: Component = {
@@ -925,10 +986,24 @@ class PhoneNumberTests(SimpleTestCase):
             "errors": {"foo": "bar"},
         }
 
-        changed = empty_errors_property(component)
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
 
-        self.assertTrue(changed)
-        self.assertEqual(component["errors"], {})
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
+
+        component: Component = {
+            "type": "phoneNumber",
+            "key": "telefoonnummer",
+            "label": "Telefoonnummer",
+            "errors": None,
+        }
+
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
+
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
 
     def test_empty_errors(self):
         component: Component = {
@@ -1518,10 +1593,29 @@ class SelectBoxTests(SimpleTestCase):
             "errors": {"foo": "bar"},
         }
 
-        changed = empty_errors_property(component)
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
 
-        self.assertTrue(changed)
-        self.assertEqual(component["errors"], {})
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
+
+        component: Component = {
+            "key": "person.pets",
+            "type": "selectboxes",
+            "label": "Pets",
+            "values": [
+                {"value": "cat", "label": "Cat"},
+                {"value": "dog", "label": "Dog"},
+                {"value": "bird", "label": "Bird"},
+            ],
+            "errors": None,
+        }
+
+        with self.subTest(component=component):
+            changed = empty_errors_property(component)
+
+            self.assertTrue(changed)
+            self.assertEqual(component["errors"], {})
 
     def test_empty_errors(self):
         component: Component = {


### PR DESCRIPTION
Fixes issues introduced through https://github.com/open-formulieren/open-forms/pull/5895#event-22216958523

**Changes**

These changes fixes the conversion of incorrect `errors` properties in the component definition.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
