### PR TITLE
Fix partners/children component that is hidden or part of non-applicable step breaking stuf zds registration

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -318,13 +318,16 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                     variable.key,
                     variable.prefill_options["mutable_data_form_variable"],
                 )
+                extra_data.pop(from_key, None)
+                # `extra_data` only contains data that was submitted, so we should skip
+                # if the key is not available (the component was hidden or part of a
+                # non-applicable step).
+                if to_key not in extra_data:
+                    continue
                 value = extra_data[to_key]
                 for item in value:
                     item.pop("dateOfBirthPrecision", None)
                     item["dateOfBirth"] = item["dateOfBirth"].isoformat()
-
-                extra_data[to_key] = value
-                extra_data.pop(from_key, None)
 
     def process_children(
         self,
@@ -395,6 +398,12 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                     variable.key,
                     variable.prefill_options["mutable_data_form_variable"],
                 )
+                extra_data.pop(from_key, None)
+                # `extra_data` only contains data that was submitted, so we should skip
+                # if the key is not available (the component was hidden or part of a
+                # non-applicable step).
+                if to_key not in extra_data:
+                    continue
                 value = extra_data[to_key]
 
                 updated = []
@@ -407,9 +416,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
 
                         updated.append(child)
 
-                value = updated
-                extra_data[to_key] = value
-                extra_data.pop(from_key, None)
+                extra_data[to_key] = updated
 
     def register_submission(
         self, submission: Submission, options: RegistrationOptions

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_registration_as_extra_elementen_when_children_component_is_hidden.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_registration_as_extra_elementen_when_children_component_is_hidden.yaml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>94ba050c-d865-4401-9184-d196ae5a0093</StUF:referentienummer>\n<StUF:tijdstipBericht>20260127082434</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260127</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260127</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260127082434</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">nl</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"textfield\">foo</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
+      StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
+      StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
+      \               <ZKN:ingangsdatumObject>20260127</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>000009969</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           \n                            \n                            \n\n
+      \                           \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260127082434</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3640'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 27 Jan 2026 08:24:34 GMT
+      Server:
+      - Werkzeug/3.1.5 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6d315ac2-d355-4d9a-8902-732310933eba</StUF:referentienummer>\n<StUF:tijdstipBericht>20260127082434</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1347'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>1689d625deadd817</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 27 Jan 2026 08:24:34 GMT
+      Server:
+      - Werkzeug/3.1.5 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>490e7552-249e-46f1-9f79-8e38a004400c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260127082434</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>1689d625deadd817</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260127</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260127</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260127</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260127</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260127082434</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260127082434</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3029'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 27 Jan 2026 08:24:34 GMT
+      Server:
+      - Werkzeug/3.1.5 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_registration_as_extra_elementen_when_partners_component_is_hidden.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_registration_as_extra_elementen_when_partners_component_is_hidden.yaml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>287bda26-6534-4d5e-af04-dab87ae6e1b1</StUF:referentienummer>\n<StUF:tijdstipBericht>20260127082416</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
+      000</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260127</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260127</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260127082416</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">nl</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"textfield\">foo</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
+      StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
+      StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
+      \               <ZKN:ingangsdatumObject>20260127</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           \n                            \n                            \n\n
+      \                           \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260127082416</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3641'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 27 Jan 2026 08:24:16 GMT
+      Server:
+      - Werkzeug/3.1.5 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8e52f53b-2a8c-494b-81d7-e15db552e183</StUF:referentienummer>\n<StUF:tijdstipBericht>20260127082416</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1347'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>103b6563f810785e</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 27 Jan 2026 08:24:16 GMT
+      Server:
+      - Werkzeug/3.1.5 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b1e24ca0-32b7-4ccf-bc5d-d27796091d7a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260127082416</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>103b6563f810785e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260127</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260127</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260127</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260127</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260127082416</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
+      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260127082416</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3030'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Tue, 27 Jan 2026 08:24:16 GMT
+      Server:
+      - Werkzeug/3.1.5 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -4102,6 +4102,80 @@ class StufZDSPluginPartnersComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         except AttributeError as e:
             raise self.failureException("Registration failed unexpectedly") from e
 
+    @tag("gh-5827")
+    def test_registration_as_extra_elementen_when_partners_component_is_hidden(self):
+        """
+        Ensure registration as extra elementen does not crash if the component was
+        hidden or part of a non-applicable step. In both cases, the partners data is
+        initially prefilled and saved to the database, but deleted again when a logic
+        rule marks a step as not applicable or a step is submitted with the component
+        hidden.
+
+        Also ensure the prefilled form variable is not included as extra element in this
+        case.
+        """
+        submission = SubmissionFactory.from_components(
+            auth_info__value="111222333",
+            auth_info__attribute=AuthAttribute.bsn,
+            components_list=[
+                {
+                    "key": "textfield",
+                    "type": "textfield",
+                    "label": "Textfield",
+                },
+                {
+                    "key": "stuf_bg_partners_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                    "hidden": True,
+                },
+            ],
+            public_registration_reference="abc123",
+            registration_result={"zaak": "1234"},
+            submitted_data={"textfield": "foo"},
+            language_code="nl",
+            completed=True,
+        )
+
+        SubmissionValueVariableFactory.create(
+            key="stuf_bg_partners_immutable",
+            submission=submission,
+            form_variable__user_defined=True,
+            form_variable__prefill_plugin="family_members",
+            form_variable__prefill_options={
+                "type": "partners",
+                "mutable_data_form_variable": "stuf_bg_partners_mutable",
+            },
+            value=[
+                {
+                    "bsn": "123123123",
+                    "firstNames": "Belly",
+                    "initials": "K",
+                    "affixes": "van",
+                    "lastName": "Doe",
+                    "dateOfBirth": "19850615",
+                    "deceased": None,
+                }
+            ],
+        )
+
+        try:
+            self.plugin.register_submission(submission, self.options)
+        except KeyError as e:
+            raise self.failureException("Registration failed unexpectedly") from e
+
+        stuf_request = self.cassette.requests[0]
+        xml_doc = etree.fromstring(stuf_request.body)
+
+        self.assertSoapXMLCommon(xml_doc)
+        extra_elements_dict = {
+            e.attrib["naam"]: e.text
+            for e in xml_doc.xpath(".//StUF:extraElement", namespaces=xml_doc.nsmap)
+        }
+        self.assertEqual(
+            extra_elements_dict, {"textfield": "foo", "language_code": "nl"}
+        )
+
 
 class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
     VCR_TEST_FILES = TESTS_DIR / "files"
@@ -5370,6 +5444,87 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
                 "//stuf:extraElementen/stuf:extraElement[@naam='extraChildDetails.1.bsn']": "999970112",
                 "//stuf:extraElementen/stuf:extraElement[@naam='extraChildDetails.1.childName']": "Onne",
             },
+        )
+
+    @tag("gh-5827")
+    def test_registration_as_extra_elementen_when_children_component_is_hidden(self):
+        """
+        Ensure registration as extra elementen does not crash if the component was
+        hidden or part of a non-applicable step. In both cases, the children data is
+        initially prefilled and saved to the database, but deleted again when a logic
+        rule marks a step as not applicable or a step is submitted with the component
+        hidden.
+
+        Also ensure the prefilled form variable is not included as extra element in this
+        case.
+        """
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "textfield",
+                    "type": "textfield",
+                    "label": "Textfield",
+                },
+                {
+                    "key": "children",
+                    "type": "children",
+                    "label": "Children",
+                    "enableSelection": False,
+                    "hidden": True,
+                },
+            ],
+            form__name="my-form",
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__value="000009969",
+            language_code="nl",
+            public_registration_reference="abc123",
+            registration_result={"zaak": "1234"},
+            submitted_data={"textfield": "foo"},
+        )
+
+        SubmissionValueVariableFactory.create(
+            key="stuf_bg_children_immutable",
+            submission=submission,
+            form_variable__user_defined=True,
+            form_variable__prefill_plugin="family_members",
+            form_variable__prefill_options={
+                "type": "children",
+                "mutable_data_form_variable": "children",
+                "min_age": None,
+                "max_age": None,
+            },
+            value=[
+                {
+                    "bsn": "999970409",
+                    "affixes": "van",
+                    "initials": "P.",
+                    "lastName": "Paassen",
+                    "firstNames": "Pero",
+                    "dateOfBirth": "2023-02-01",
+                    "dateOfBirthPrecision": "date",
+                    # Added by the frontend
+                    "selected": None,
+                    "__id": str(uuid4()),
+                    "__addedManually": False,
+                }
+            ],
+        )
+
+        try:
+            self.plugin.register_submission(submission, self.options)
+        except KeyError as e:
+            raise self.failureException("Registration failed unexpectedly") from e
+
+        stuf_request = self.cassette.requests[0]
+        xml_doc = etree.fromstring(stuf_request.body)
+
+        self.assertSoapXMLCommon(xml_doc)
+        extra_elements_dict = {
+            e.attrib["naam"]: e.text
+            for e in xml_doc.xpath(".//StUF:extraElement", namespaces=xml_doc.nsmap)
+        }
+        self.assertEqual(
+            extra_elements_dict, {"textfield": "foo", "language_code": "nl"}
         )
 
 


### PR DESCRIPTION
Closes #5827

[skip: e2e]

**Changes**

- Ensure we exit early during partner/children processing if the key is not available

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
