### PR TITLE
Replace bleach with nh3 sanitizer

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,6 +14,7 @@ jq
 html5lib
 lxml
 lxml-html-clean
+nh3
 onlinepayments-sdk-python3 # Worldline SDK
 O365  # microsoft graph
 phonenumberslite

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,5 @@
 # Core python libraries
 ape-pie
-bleach[css] >= 5
 celery ~= 5.0
 celery-once
 defusedxml

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,7 +10,6 @@ maykin-json-logic-py
 jsonschema
 jsonschema_specifications
 jq
-html5lib
 lxml
 lxml-html-clean
 nh3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,8 +25,6 @@ beautifulsoup4==4.10.0
     # via o365
 billiard==4.2.1
     # via celery
-bleach==5.0.1
-    # via -r requirements/base.in
 boltons==21.0.0
     # via
     #   face
@@ -612,7 +610,6 @@ simplejson==3.19.3
     # via mail-parser
 six==1.16.0
     # via
-    #   bleach
     #   click-repl
     #   furl
     #   html5lib
@@ -640,7 +637,6 @@ tabulate==0.8.9
 tinycss2==1.1.0
     # via
     #   -r requirements/base.in
-    #   bleach
     #   cssselect2
     #   weasyprint
 tornado==6.5
@@ -694,7 +690,6 @@ webauthn==2.0.0
     # via django-two-factor-auth
 webencodings==0.5.1
     # via
-    #   bleach
     #   cssselect2
     #   html5lib
     #   tinycss2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -294,9 +294,7 @@ googleapis-common-protos==1.70.0
 grpcio==1.74.0
     # via opentelemetry-exporter-otlp-proto-grpc
 html5lib==1.1
-    # via
-    #   -r requirements/base.in
-    #   weasyprint
+    # via weasyprint
 humanize==3.14.0
     # via flower
 idna==3.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -374,6 +374,8 @@ mozilla-django-oidc-db==1.1.1
     # via
     #   -r requirements/base.in
     #   django-digid-eherkenning
+nh3==0.3.2
+    # via -r requirements/base.in
 numpy==2.3.3
     # via shapely
 o365==2.0.31

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -51,10 +51,6 @@ billiard==4.2.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
-bleach==5.0.1
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
 boltons==21.0.0
     # via
     #   -c requirements/base.txt
@@ -1097,7 +1093,6 @@ six==1.16.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   bleach
     #   click-repl
     #   furl
     #   html5lib
@@ -1271,7 +1266,6 @@ webencodings==0.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   bleach
     #   cssselect2
     #   html5lib
     #   tinycss2

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -660,6 +660,10 @@ mozilla-django-oidc-db==1.1.1
     #   -r requirements/base.txt
 multidict==6.6.3
     # via yarl
+nh3==0.3.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 numpy==2.3.3
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,10 +61,6 @@ billiard==4.2.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
-bleach==5.0.1
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
 boltons==21.0.0
     # via
     #   -c requirements/ci.txt
@@ -1188,7 +1184,6 @@ six==1.16.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   bleach
     #   click-repl
     #   furl
     #   html5lib
@@ -1420,7 +1415,6 @@ webencodings==0.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   bleach
     #   cssselect2
     #   html5lib
     #   tinycss2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -727,6 +727,10 @@ multidict==6.6.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   yarl
+nh3==0.3.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 numpy==2.3.3
     # via
     #   -c requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -614,6 +614,10 @@ mozilla-django-oidc-db==1.1.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+nh3==0.3.2
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 numpy==2.3.3
     # via
     #   -c requirements/base.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -45,10 +45,6 @@ billiard==4.2.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   celery
-bleach==5.0.1
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
 boltons==21.0.0
     # via
     #   -c requirements/base.txt
@@ -1029,7 +1025,6 @@ six==1.16.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   bleach
     #   click-repl
     #   furl
     #   html5lib
@@ -1156,7 +1151,6 @@ webencodings==0.5.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   bleach
     #   cssselect2
     #   html5lib
     #   tinycss2

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -58,10 +58,6 @@ billiard==4.2.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   celery
-bleach==5.0.1
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
 boltons==21.0.0
     # via
     #   -c requirements/ci.txt
@@ -1156,7 +1152,6 @@ six==1.16.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   bleach
     #   click-repl
     #   furl
     #   html5lib
@@ -1395,7 +1390,6 @@ webencodings==0.5.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   bleach
     #   cssselect2
     #   html5lib
     #   tinycss2

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -708,6 +708,10 @@ multidict==6.6.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   yarl
+nh3==0.3.2
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 numpy==2.3.3
     # via
     #   -c requirements/ci.txt

--- a/src/csp_post_processor/__init__.py
+++ b/src/csp_post_processor/__init__.py
@@ -1,7 +1,5 @@
-from .processor import bleach_wysiwyg_content, post_process_html
+from .processor import post_process_html
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
-__all__ = ["bleach_wysiwyg_content", "post_process_html"]
-
-default_app_config = "csp_post_processor.apps.CSPPostProcessConfig"
+__all__ = ["post_process_html"]

--- a/src/csp_post_processor/processor.py
+++ b/src/csp_post_processor/processor.py
@@ -286,7 +286,7 @@ def _add_wysiwyg_style_attributes_and_tags():
     # util to limit amount of manual edited data in the allowed_attribute_map
     for tag in _TAGS_WITH_STYLE:
         # check if we forgot to add it to allowed tags
-        if tag not in WYSIWYG_ALLOWED_TAGS:
+        if tag not in WYSIWYG_ALLOWED_TAGS:  # pragma: no cover
             raise ValueError(
                 f"adding tag '{tag}' to tag_attr_map but missing from 'allowed_tags'"
             )
@@ -301,7 +301,7 @@ def _add_wysiwyg_style_attributes_and_tags():
 
     # check if tags in attr map exist in allowed tags
     for tag in WYSIWYG_TAG_ALLOWED_ATTRIBUTE_MAP.keys():
-        if tag not in WYSIWYG_ALLOWED_TAGS:
+        if tag not in WYSIWYG_ALLOWED_TAGS:  # pragma: no cover
             raise ValueError(
                 f"adding tag '{tag}' to tag_attr_map but missing from 'allowed_tags'"
             )

--- a/src/csp_post_processor/tests/mixins.py
+++ b/src/csp_post_processor/tests/mixins.py
@@ -1,15 +1,15 @@
-import html5lib
+import lxml.html
 
 
 class InlineStylesMixin:
     def _parse_html(self, html: str) -> tuple:
-        tree = html5lib.parse(html, treebuilder="lxml", namespaceHTMLElements=False)
-        root = tree.getroot()
-        # lxml/html5lib normalizes the markup and moves the inline style tag to the HEAD node
+        root = lxml.html.fromstring(html)
+        # lxml normalizes the markup and moves the inline style tag to the HEAD node
         # style tags in the <body> is technically not valid, pre HTML 5.2. See also
         # https://stackoverflow.com/a/4607092
         style_element = root.find("head").find("style")
         body = root.find("body")
+        assert body is not None
         content = body.getchildren() or body.text
         return style_element, content
 

--- a/src/openforms/config/tests/test_global_configuration.py
+++ b/src/openforms/config/tests/test_global_configuration.py
@@ -178,12 +178,9 @@ class AdminTests(WebTest):
             </g>
         </svg>
         """
-        sanitized_svg_content = b"""
+        sanitized_svg_content = """
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
             <circle cx="25" cy="25" r="25" fill="green"></circle>
-            //
-                alert("I am malicious &gt;:)")
-            //
             <g>
                 <rect x="0" y="0" width="10" height="10" fill="red"></rect>
             </g>
@@ -212,8 +209,8 @@ class AdminTests(WebTest):
         with self.subTest(part="assert favicon sanitized"):
             with config.favicon.file.open("r") as favicon_file:
                 # Assert that the logo is completely sanitized
-                decoded_logo = favicon_file.read()
-                self.assertEqual(decoded_logo, sanitized_svg_content)
+                decoded_logo = favicon_file.read().decode("utf-8")
+                self.assertHTMLEqual(decoded_logo, sanitized_svg_content)
 
 
 class GlobalConfirmationEmailTests(TestCase):

--- a/src/openforms/config/tests/test_theme.py
+++ b/src/openforms/config/tests/test_theme.py
@@ -88,12 +88,9 @@ class AdminTests(WebTest):
             </g>
         </svg>
         """
-        sanitized_svg_content = b"""
+        sanitized_svg_content = """
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
             <circle cx="25" cy="25" r="25" fill="green"></circle>
-            //
-                alert("I am malicious &gt;:)")
-            //
             <g>
                 <rect x="0" y="0" width="10" height="10" fill="red"></rect>
             </g>
@@ -121,8 +118,8 @@ class AdminTests(WebTest):
         with self.subTest(part="assert logo sanitized"):
             with theme.logo.file.open("r") as logo_file:
                 # Assert that the logo is completely sanitized
-                decoded_logo = logo_file.read()
-                self.assertEqual(decoded_logo, sanitized_svg_content)
+                decoded_logo = logo_file.read().decode("utf-8")
+                self.assertHTMLEqual(decoded_logo, sanitized_svg_content)
 
     def test_upload_png(self):
         logo = Path(settings.DJANGO_PROJECT_DIR) / "static" / "img" / "digid.png"

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -964,9 +964,9 @@ class Content(BasePlugin):
         """
         Ensure that the inline styles are made compatible with Content-Security-Policy.
 
-        .. note:: we apply Bleach and a CSS declaration allowlist as part of the
-           post-processor because content components are not purely "trusted" content
-           from form-designers, but can contain malicious user input if the form
+        .. note:: we apply HTML sanitation and a CSS declaration allowlist as part of
+           the post-processor because content components are not purely "trusted"
+           content from form-designers, but can contain malicious user input if the form
            designer uses variables inside the HTML. The form submission data is passed
            as template context to these HTML blobs, posing a potential injection
            security risk.


### PR DESCRIPTION
Closes #5922

**Changes**

* Replaced bleach usage with (nearly) equivalent `nh3` usage.
* Replaced html5lib usage with lxml

A future PR will upgrade weasyprint and then html5lib will be gone completely.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
