### PR TITLE
Ensure the endpoints exist for the SDK

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3019,6 +3019,34 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+  /api/v2/i18n/compiled-messages/{language_code}.json:
+    get:
+      operationId: i18n_compiled_messages_.json_retrieve
+      summary: Get customized (compiled) translations
+      parameters:
+      - in: path
+        name: language_code
+        schema:
+          type: string
+        required: true
+      tags:
+      - translations
+      security:
+      - tokenAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          description: No response body
+          headers:
+            X-Session-Expires-In:
+              $ref: '#/components/headers/X-Session-Expires-In'
+            X-CSRFToken:
+              $ref: '#/components/headers/X-CSRFToken'
+            X-Is-Form-Designer:
+              $ref: '#/components/headers/X-Is-Form-Designer'
+            Content-Language:
+              $ref: '#/components/headers/Content-Language'
   /api/v2/i18n/formio/{language}:
     get:
       operationId: i18n_formio_retrieve

--- a/src/openforms/translations/api/urls.py
+++ b/src/openforms/translations/api/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from .views import FormioTranslationsView, LanguageInfoView, SetLanguageView
+from .views import (
+    CustomizedCompiledTranslations,
+    FormioTranslationsView,
+    LanguageInfoView,
+    SetLanguageView,
+)
 
 app_name = "i18n"
 
@@ -11,5 +16,10 @@ urlpatterns = [
         "formio/<str:language>",
         FormioTranslationsView.as_view(),
         name="formio-translations",
+    ),
+    path(
+        "compiled-messages/<str:language_code>.json",
+        CustomizedCompiledTranslations.as_view(),
+        name="customized-translations",
     ),
 ]

--- a/src/openforms/translations/api/views.py
+++ b/src/openforms/translations/api/views.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 
 from django.conf import settings
-from django.http import FileResponse
+from django.http import FileResponse, JsonResponse
 from django.utils.translation import activate, get_language, gettext_lazy as _
 
-from drf_spectacular.plumbing import build_object_type
+from drf_spectacular.plumbing import build_basic_type, build_object_type
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema
 from rest_framework import permissions, status
 from rest_framework.exceptions import NotFound
@@ -126,3 +127,15 @@ class FormioTranslationsView(APIView):
             / f"{language}.json"
         )
         return FileResponse(filepath.open("rb"))
+
+
+@extend_schema(
+    summary=_("Get customized (compiled) translations"),
+    tags=["translations"],
+    # FIXME: this doesn't document the `null` -> better to make the SDK deal with empty
+    # responses than use 'null'.
+    responses={"200": build_basic_type(OpenApiTypes.NONE)},
+)
+class CustomizedCompiledTranslations(APIView):
+    def get(self, request: Request, *args, **kwargs):
+        return JsonResponse(data=None, safe=False)

--- a/src/openforms/translations/tests/test_views.py
+++ b/src/openforms/translations/tests/test_views.py
@@ -44,3 +44,15 @@ class FormioTranslationsEndpointTests(APITestCase):
                 response = self.client.get(endpoint)
 
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class CustomizedCompiledTranslationsTests(APITestCase):
+    def test_returns_null_response_body(self):
+        endpoint = reverse(
+            "api:i18n:customized-translations", kwargs={"language_code": "nl"}
+        )
+
+        response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), None)


### PR DESCRIPTION
The endpoints throwing a 404 crashes the SDK right now. We add temporary endpoints that return 'null' in the body.

Note that we bypass DRF Response here, because passing Response(None) results in no response body being
returned at all rather than the literal 'null' JSON.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
