### PR TITLE
Determine input/output variables and steps of logic rules

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -86,6 +86,8 @@ include = [
     "src/openforms/submissions/metrics.py",
     "src/openforms/submissions/query.py",
     "src/openforms/submissions/report.py",
+    "src/openforms/submissions/tests/form_logic/test_rule_analysis.py",
+    "src/openforms/submissions/logic/actions.py",
     # our own template app/package on top of Django
     "src/openforms/template",
     # generic typing helpers

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -142,6 +142,21 @@ class FormioConfigurationWrapper:
             nodes.append(component)
         return all(is_visible_in_frontend(node, values) for node in nodes)
 
+    def get_child_component_keys(self, key: str) -> set[str]:
+        """
+        Get all child component keys for an arbitrary component key.
+
+        :param key: The component key.
+        :returns: A set of children component keys. Will be an empty set if the
+          component does not contain any children.
+        """
+        return {
+            child["key"]
+            for child in iter_components(
+                self.component_map[key], recursive=True, recurse_into_editgrid=False
+            )
+        }
+
 
 class FormioData(UserDict):
     """

--- a/src/openforms/forms/models/logic.py
+++ b/src/openforms/forms/models/logic.py
@@ -89,7 +89,10 @@ class FormLogic(OrderedModel):
         from openforms.submissions.logic.actions import PropertyAction
 
         for action in self.action_operations:
-            if not isinstance(action, PropertyAction) or action.property != "hidden":
+            if (
+                not isinstance(action, PropertyAction)
+                or action.property_name != "hidden"
+            ):
                 continue
             yield action
 

--- a/src/openforms/forms/models/logic.py
+++ b/src/openforms/forms/models/logic.py
@@ -1,10 +1,15 @@
 import uuid as _uuid
+from collections.abc import Collection
 
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from ordered_model.models import OrderedModel
+
+from openforms.forms.models import FormStep
+from openforms.utils.json_logic import introspect_json_logic
+from openforms.variables.service import resolve_key
 
 
 class FormLogic(OrderedModel):
@@ -49,6 +54,7 @@ class FormLogic(OrderedModel):
     )
 
     order_with_respect_to = "form"
+    _steps: set[FormStep] | None = None
 
     class Meta(OrderedModel.Meta):
         verbose_name = _("form logic")
@@ -91,3 +97,58 @@ class FormLogic(OrderedModel):
     def components_in_hidden_actions(self) -> set[str]:
         """Set of components for which an action changes the "hidden" property."""
         return {action.component for action in self.hidden_actions}
+
+    @property
+    def unresolved_input_variables_from_trigger(self) -> set[str]:
+        """Set of unresolved input variables from the JSON logic trigger."""
+        return {
+            var.key
+            for var in introspect_json_logic(self.json_logic_trigger).get_input_keys()
+        }
+
+    @property
+    def steps(self) -> set[FormStep]:
+        """
+        Set of steps (determined by the actions) on which this rule should be executed.
+        """
+        if self._steps is not None:
+            return self._steps
+
+        self._steps = set()
+        for action in self.action_operations:
+            self._steps |= action.steps
+
+        return self._steps
+
+    @property
+    def input_variable_keys(self) -> Collection[str]:
+        """
+        Set of input form variable keys, determined from the JSON logic trigger and all
+        actions.
+        """
+        raw_input_keys = self.unresolved_input_variables_from_trigger
+        for action in self.action_operations:
+            raw_input_keys |= action.unresolved_input_variables
+
+        return {
+            resolved_key
+            for key in raw_input_keys
+            if (resolved_key := resolve_key(key, self.form.all_form_variable_keys))
+            is not None
+        }
+
+    @property
+    def output_variable_keys(self) -> Collection[str]:
+        """Set of output form variable keys, determined from all actions."""
+        raw_output_keys = set()
+        for action in self.action_operations:
+            raw_output_keys |= action.unresolved_output_variables
+
+        # Resolving the key here should not be necessary, as we do not support changing
+        # values inside editgrid items (and also selectboxes, partners, children), so
+        # it should already be the top-level key. We do need to do the check on all
+        # form variables, as they might still include components for which we don't have
+        # a variable (e.g. layout components).
+        return {
+            key for key in raw_output_keys if key in self.form.all_form_variable_keys
+        }

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -254,16 +254,14 @@ class StepNotApplicableAction(ActionOperation):
         # anyway if it was marked at not applicable.
         # Together with detecting "self cycles" in the dependency graph, though, we can
         # detect if the rule uses a field from the current step as input, which would be
-        # weird to do.
+        # a weird thing to do.
         form_step = self.rule.form.formstep_set.get(uuid=self.form_step_identifier)
         configuration = form_step.form_definition.configuration_wrapper
         return set(configuration.component_map.keys())
 
     @property
     def steps(self) -> set[FormStep]:
-        steps = self._get_steps(self.rule.unresolved_input_variables_from_trigger)
-        # Return last step to make sure all data will be available.
-        return {max(steps, key=lambda step: step.order)} if steps else steps
+        return self._get_steps(self.rule.unresolved_input_variables_from_trigger)
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -303,16 +301,14 @@ class StepApplicableAction(ActionOperation):
         # submission data.
         # Together with detecting "self cycles" in the dependency graph, though, we can
         # detect if the rule uses a field from the current step as input, which would be
-        # weird to do.
+        # a weird thing to do.
         form_step = self.rule.form.formstep_set.get(uuid=self.form_step_identifier)
         configuration = form_step.form_definition.configuration_wrapper
         return set(configuration.component_map.keys())
 
     @property
     def steps(self) -> set[FormStep]:
-        steps = self._get_steps(self.rule.unresolved_input_variables_from_trigger)
-        # Return last step to make sure all data will be available.
-        return {max(steps, key=lambda step: step.order)} if steps else steps
+        return self._get_steps(self.rule.unresolved_input_variables_from_trigger)
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -356,12 +352,10 @@ class VariableAction(ActionOperation):
 
         # If we cannot resolve a step from the output variables (we are setting a value
         # on a user-defined variable), try to resolve it from the input variables.
-        # Select the last step to make sure we have all data.
-        steps = self._get_steps(
+        return self._get_steps(
             self.rule.unresolved_input_variables_from_trigger
             | self.unresolved_input_variables
         )
-        return {max(steps, key=lambda step: step.order)} if steps else steps
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -545,12 +539,10 @@ class ServiceFetchAction(ActionOperation):
 
         # If we cannot resolve a step from the output variables (we are setting a value
         # on a user-defined variable), try to resolve it from the input variables.
-        # Select the last step to make sure we have all data.
-        steps = self._get_steps(
+        return self._get_steps(
             self.rule.unresolved_input_variables_from_trigger
             | self.unresolved_input_variables
         )
-        return {max(steps, key=lambda step: step.order)} if steps else steps
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -608,12 +600,10 @@ class EvaluateDMNAction(ActionOperation):
 
         # If we cannot resolve a step from the output variables (we are setting a value
         # on a user-defined variable), try to resolve it from the input variables.
-        # Select the last step to make sure we have all data
-        steps = self._get_steps(
+        return self._get_steps(
             self.rule.unresolved_input_variables_from_trigger
             | self.unresolved_input_variables
         )
-        return {max(steps, key=lambda step: step.order)} if steps else steps
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -147,21 +147,21 @@ class ActionOperation:
 @dataclass
 class PropertyAction(ActionOperation):
     component: str
-    property: str
+    property_name: str
     value: Any
 
-    @builtins.property
+    @property
     def unresolved_input_variables(self) -> set[str]:
         return set()
 
-    @builtins.property
+    @property
     def unresolved_output_variables(self) -> set[str]:
         # Also need to include children, as it might be a layout component.
         return {self.component} | self.rule.form.get_child_component_keys(
             self.component
         )
 
-    @builtins.property
+    @property
     def steps(self) -> set[FormStep]:
         return self._get_steps(self.unresolved_output_variables)
 
@@ -169,7 +169,7 @@ class PropertyAction(ActionOperation):
     def from_action(cls, action: ActionDict) -> Self:
         return cls(
             component=action["component"],
-            property=action["action"]["property"]["value"],
+            property_name=action["action"]["property"]["value"],
             value=action["action"]["state"],
         )
 
@@ -179,7 +179,7 @@ class PropertyAction(ActionOperation):
         if self.component not in configuration:
             return None
         component = configuration[self.component]
-        assign(component, self.property, self.value, missing=dict)
+        assign(component, self.property_name, self.value, missing=dict)
 
     def eval(
         self,
@@ -189,7 +189,7 @@ class PropertyAction(ActionOperation):
     ) -> DataMapping | None:
         # To avoid doing unnecessary work, only apply clear-on-hide logic for components
         # for which their action sets the "hidden" property to True.
-        if not (self.property == "hidden" and self.value):
+        if not (self.property_name == "hidden" and self.value):
             return None
 
         # Note that this can happen when the action applies to a component of a

--- a/src/openforms/submissions/tests/form_logic/test_rule_analysis.py
+++ b/src/openforms/submissions/tests/form_logic/test_rule_analysis.py
@@ -1,0 +1,847 @@
+from django.test import TestCase
+
+from openforms.forms.constants import LogicActionTypes
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormStepFactory,
+    FormVariableFactory,
+)
+from openforms.variables.constants import FormVariableDataTypes
+from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
+
+
+class DetermineVariablesAndStepTests(TestCase):
+    def test_property_action(self):
+        form = FormFactory.create()
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "key": "select.boxes",
+                        "type": "selectboxes",
+                        "label": "Selectboxes",
+                        "values": [
+                            {"label": "A", "value": "a"},
+                            {"label": "B", "value": "b"},
+                        ],
+                    },
+                    {
+                        "key": "partners",
+                        "type": "partners",
+                        "label": "Partners",
+                    },
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                    },
+                    {
+                        "key": "fieldset",
+                        "type": "fieldset",
+                        "label": "Fieldset",
+                        "components": [
+                            {
+                                "key": "textfieldInFieldset",
+                                "type": "textfield",
+                                "label": "Textfield in fieldset",
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {"==": [{"var": "checkbox"}, True]},
+                    {"==": [{"var": "select.boxes.a"}, True]},
+                    {"==": [{"var": "partners.0.firstNames"}, "Hans"]},
+                ]
+            },
+            actions=[
+                {
+                    "component": "textfield",
+                    "action": {
+                        "name": "Hide textfield",
+                        "type": LogicActionTypes.property,
+                        "property": {"value": "hidden", "type": "bool"},
+                        "state": True,
+                    },
+                }
+            ],
+        )
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "component": "textfieldInFieldset",
+                    "action": {
+                        "name": "Hide textfieldInFieldset",
+                        "type": LogicActionTypes.property,
+                        "property": {"value": "hidden", "type": "bool"},
+                        "state": True,
+                    },
+                }
+            ],
+        )
+
+        with self.subTest("Ensure step of output variable is set"):
+            self.assertEqual(rule_1.steps, {step_2})
+            self.assertEqual(
+                rule_1.input_variable_keys, {"checkbox", "select.boxes", "partners"}
+            )
+            self.assertEqual(rule_1.output_variable_keys, {"textfield"})
+
+        with self.subTest(
+            "Ensure step of output variable is set (component is in a fieldset)"
+        ):
+            self.assertEqual(rule_2.steps, {step_2})
+            self.assertEqual(rule_2.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule_2.output_variable_keys, {"textfieldInFieldset"})
+
+    def test_disable_next(self):
+        form = FormFactory.create()
+        step_1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox2",
+                        "type": "checkbox",
+                        "label": "Checkbox 2",
+                    }
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+        )
+
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {"==": [{"var": "checkbox"}, True]},
+                    {"==": [{"var": "checkbox2"}, True]},
+                ]
+            },
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.disable_next},
+                    "form_step_uuid": str(step_2.uuid),
+                }
+            ],
+        )
+
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "user_defined"}, "foo"]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.disable_next},
+                    "form_step_uuid": str(step_1.uuid),
+                },
+                {
+                    "action": {"type": LogicActionTypes.disable_next},
+                    "form_step_uuid": str(step_2.uuid),
+                },
+            ],
+        )
+
+        with self.subTest("The specified step is set"):
+            self.assertEqual(rule_1.steps, {step_2})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox", "checkbox2"})
+            self.assertEqual(rule_1.output_variable_keys, set())
+
+        with self.subTest("User-defined variable and two actions with different steps"):
+            self.assertEqual(rule_2.steps, {step_1, step_2})
+            self.assertEqual(rule_2.input_variable_keys, {"user_defined"})
+            self.assertEqual(rule_2.output_variable_keys, set())
+
+    def test_step_applicable(self):
+        form = FormFactory.create()
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox2",
+                        "type": "checkbox",
+                        "label": "Checkbox 2",
+                    }
+                ]
+            },
+        )
+        step_3 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+        )
+
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {"==": [{"var": "checkbox"}, True]},
+                    {"==": [{"var": "checkbox2"}, True]},
+                ]
+            },
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_applicable},
+                    "form_step_uuid": str(step_3.uuid),
+                }
+            ],
+        )
+
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "user_defined"}, "foo"]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_applicable},
+                    "form_step_uuid": str(step_3.uuid),
+                }
+            ],
+        )
+
+        with self.subTest("Last step of input variables is set"):
+            self.assertEqual(rule_1.steps, {step_2})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox", "checkbox2"})
+            self.assertEqual(rule_1.output_variable_keys, {"textfield"})
+
+        with self.subTest("No step if trigger includes user-defined variable"):
+            self.assertEqual(rule_2.steps, set())
+            self.assertEqual(rule_2.input_variable_keys, {"user_defined"})
+            self.assertEqual(rule_2.output_variable_keys, {"textfield"})
+
+    def test_step_not_applicable(self):
+        form = FormFactory.create()
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox2",
+                        "type": "checkbox",
+                        "label": "Checkbox 2",
+                    }
+                ]
+            },
+        )
+        step_3 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+        )
+
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {"==": [{"var": "checkbox"}, True]},
+                    {"==": [{"var": "checkbox2"}, True]},
+                ]
+            },
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_not_applicable},
+                    "form_step_uuid": str(step_3.uuid),
+                }
+            ],
+        )
+
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "user_defined"}, "foo"]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_not_applicable},
+                    "form_step_uuid": str(step_3.uuid),
+                }
+            ],
+        )
+
+        with self.subTest("Last step of input variables is set"):
+            self.assertEqual(rule_1.steps, {step_2})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox", "checkbox2"})
+            self.assertEqual(rule_1.output_variable_keys, {"textfield"})
+
+        with self.subTest("No step if trigger includes user-defined variable"):
+            self.assertEqual(rule_2.steps, set())
+            self.assertEqual(rule_2.input_variable_keys, {"user_defined"})
+            self.assertEqual(rule_2.output_variable_keys, {"textfield"})
+
+    def test_variable_action(self):
+        form = FormFactory.create()
+        step_1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                    },
+                    {
+                        "key": "fieldset",
+                        "type": "fieldset",
+                        "label": "Fieldset",
+                        "components": [
+                            {
+                                "key": "textfieldInFieldset",
+                                "type": "textfield",
+                                "label": "Textfield in fieldset",
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+        )
+
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {
+                        "name": "Set textfield",
+                        "type": LogicActionTypes.variable,
+                        "value": "foo",
+                    },
+                    "variable": "textfield",
+                }
+            ],
+        )
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {
+                        "name": "Set textfieldInFieldset",
+                        "type": LogicActionTypes.variable,
+                        "value": "foo",
+                    },
+                    "variable": "textfieldInFieldset",
+                }
+            ],
+        )
+        rule_3 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {
+                        "name": "Set user_defined",
+                        "type": LogicActionTypes.variable,
+                        "value": "foo",
+                    },
+                    "variable": "user_defined",
+                }
+            ],
+        )
+        rule_4 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "name": "Set user_defined",
+                        "type": LogicActionTypes.variable,
+                        "value": "foo",
+                    },
+                    "variable": "user_defined",
+                }
+            ],
+        )
+        rule_5 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "name": "Set user_defined from textfieldInFieldset",
+                        "type": LogicActionTypes.variable,
+                        "value": {"var": "textfieldInFieldset"},
+                    },
+                    "variable": "user_defined",
+                }
+            ],
+        )
+
+        with self.subTest("Ensure step of output variable is set"):
+            self.assertEqual(rule_1.steps, {step_2})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule_1.output_variable_keys, {"textfield"})
+
+        with self.subTest(
+            "Ensure step of output variable is set (component is in a fieldset)"
+        ):
+            self.assertEqual(rule_2.steps, {step_2})
+            self.assertEqual(rule_2.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule_2.output_variable_keys, {"textfieldInFieldset"})
+
+        with self.subTest(
+            "Ensure last step of input variables is set when output variable is "
+            "user-defined."
+        ):
+            self.assertEqual(rule_3.steps, {step_1})
+            self.assertEqual(rule_3.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule_3.output_variable_keys, {"user_defined"})
+
+        with self.subTest(
+            "Ensure no step when we have no input variables, and output variable is "
+            "user-defined"
+        ):
+            self.assertEqual(rule_4.steps, set())
+            self.assertEqual(rule_4.input_variable_keys, set())
+            self.assertEqual(rule_4.output_variable_keys, {"user_defined"})
+
+        with self.subTest(
+            "Ensure last step of input variables from json logic value is set"
+        ):
+            self.assertEqual(rule_5.steps, {step_2})
+            self.assertEqual(rule_5.input_variable_keys, {"textfieldInFieldset"})
+            self.assertEqual(rule_5.output_variable_keys, {"user_defined"})
+
+    def test_synchronize_variables(self):
+        form = FormFactory.create()
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "type": "children",
+                        "key": "children",
+                        "label": "Children",
+                    },
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "editgrid",
+                        "key": "editgrid",
+                        "label": "Editgrid",
+                        "components": [
+                            {"type": "bsn", "key": "bsn", "label": "BSN"},
+                            {"type": "textfield", "key": "childName", "label": "Name"},
+                        ],
+                    }
+                ]
+            },
+        )
+        rule = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {
+                        "type": LogicActionTypes.synchronize_variables,
+                        "config": {
+                            "source_variable": "children",
+                            "destination_variable": "editgrid",
+                            "identifier_variable": "bsn",
+                            "data_mappings": [
+                                {
+                                    "property": "bsn",
+                                    "component_key": "bsn",
+                                },
+                                {
+                                    "property": "firstNames",
+                                    "component_key": "childName",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+        )
+
+        with self.subTest("Ensure step of output variable is set"):
+            self.assertEqual(rule.steps, {step_2})
+            self.assertEqual(rule.input_variable_keys, {"checkbox", "children"})
+            self.assertEqual(rule.output_variable_keys, {"editgrid"})
+
+    def test_service_fetch(self):
+        form = FormFactory.create()
+        step_1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                    },
+                    {
+                        "type": "date",
+                        "key": "date",
+                        "label": "Date",
+                    },
+                    {
+                        "type": "currency",
+                        "key": "currency",
+                        "label": "Currency",
+                    },
+                    {
+                        "type": "number",
+                        "key": "number",
+                        "label": "Number",
+                    },
+                ]
+            },
+        )
+        # Add service fetch configuration
+        var = form.formvariable_set.get(key="textfield")
+        var.service_fetch_configuration = ServiceFetchConfigurationFactory.create(
+            name="Get something",
+            headers={"X-Header": "foo"},
+            query_params={"X-Param": ["bar", "baz"]},
+        )
+        var.save()
+        # Add user-defined variables
+        FormVariableFactory.create(
+            form=form,
+            name="test_case",
+            key="test_case",
+            data_type=FormVariableDataTypes.boolean,
+            user_defined=True,
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+            service_fetch_configuration=ServiceFetchConfigurationFactory.create(
+                name="Get something",
+                headers={"X-Header": "foo"},
+                query_params={"X-Param": ["bar", "baz"]},
+            ),
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined_with_template",
+            key="user_defined_with_template",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+            service_fetch_configuration=ServiceFetchConfigurationFactory.create(
+                name="Get something",
+                path="https://example.com/something/{% if test_case %}{{number}}{% endif %}",
+                # The date field value is a date object, so it can be formatted
+                headers={"X-Header": "{{date|date:'Y-m-d'}}"},
+                query_params={"X-Param": "{{currency}}"},
+            ),
+        )
+
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.fetch_from_service},
+                    "variable": "textfield",
+                }
+            ],
+        )
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.fetch_from_service},
+                    "variable": "user_defined",
+                }
+            ],
+        )
+        rule_3 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.fetch_from_service},
+                    "variable": "user_defined",
+                }
+            ],
+        )
+
+        rule_4 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.fetch_from_service},
+                    "variable": "user_defined_with_template",
+                }
+            ],
+        )
+
+        with self.subTest("Ensure step of output variable is set"):
+            self.assertEqual(rule_1.steps, {step_2})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule_1.output_variable_keys, {"textfield"})
+
+        with self.subTest(
+            "Ensure last step of input variables is set when output variable is "
+            "user-defined."
+        ):
+            self.assertEqual(rule_2.steps, {step_1})
+            self.assertEqual(rule_2.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule_2.output_variable_keys, {"user_defined"})
+
+        with self.subTest(
+            "Ensure no step when we have no input variables, and output variable is "
+            "user-defined"
+        ):
+            self.assertEqual(rule_3.steps, set())
+            self.assertEqual(rule_3.input_variable_keys, set())
+            self.assertEqual(rule_3.output_variable_keys, {"user_defined"})
+
+        with self.subTest(
+            "Ensure last step of the input variables from template(s) in path, header, "
+            "and query parameters values is set"
+        ):
+            self.assertEqual(rule_4.steps, {step_2})
+            self.assertEqual(
+                rule_4.input_variable_keys, {"currency", "date", "number", "test_case"}
+            )
+            self.assertEqual(
+                rule_4.output_variable_keys, {"user_defined_with_template"}
+            )
+
+    def test_evaluate_dmn(self):
+        form = FormFactory.create()
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "type": "date",
+                        "key": "date",
+                        "label": "date",
+                    },
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                    },
+                ]
+            },
+        )
+        step_3 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "email",
+                        "key": "email",
+                        "label": "Email",
+                    },
+                ]
+            },
+        )
+        rule = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {
+                        "type": LogicActionTypes.evaluate_dmn,
+                        "config": {
+                            "plugin_id": "camunda",
+                            "decision_definition_id": "some-id",
+                            "decision_definition_version": "1",
+                            "input_mapping": [
+                                {"form_variable": "date", "dmn_variable": "dateDMN"},
+                            ],
+                            "output_mapping": [
+                                {
+                                    "form_variable": "textfield",
+                                    "dmn_variable": "textfieldDMN",
+                                },
+                                {
+                                    "form_variable": "email",
+                                    "dmn_variable": "emailDMN",
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
+        )
+
+        with self.subTest("Ensure steps of output variables are set"):
+            self.assertEqual(rule.steps, {step_2, step_3})
+            self.assertEqual(rule.input_variable_keys, {"checkbox", "date"})
+            self.assertEqual(rule.output_variable_keys, {"textfield", "email"})
+
+    def test_set_registration_backend(self):
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        rule = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {
+                        "name": "Set registration backend",
+                        "type": LogicActionTypes.set_registration_backend,
+                        "value": "some_backend",
+                    }
+                }
+            ],
+        )
+
+        with self.subTest("Ensure step of input variable is set"):
+            self.assertEqual(rule.steps, {step})
+            self.assertEqual(rule.input_variable_keys, {"checkbox"})
+            self.assertEqual(rule.output_variable_keys, set())

--- a/src/openforms/template/__init__.py
+++ b/src/openforms/template/__init__.py
@@ -22,7 +22,13 @@ from django.utils.safestring import SafeString
 
 from .backends.sandboxed_django import backend as sandbox_backend, openforms_backend
 
-__all__ = ["render_from_string", "parse", "sandbox_backend", "openforms_backend"]
+__all__ = [
+    "render_from_string",
+    "parse",
+    "sandbox_backend",
+    "openforms_backend",
+    "extract_variables_used",
+]
 
 
 def parse(source: str, backend=sandbox_backend) -> DjangoTemplate:


### PR DESCRIPTION
Partly closes #2409

[skip: e2e]

**Changes**

Added functionality to analyze logic rules with their actions, and determine input/output variables and steps

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
