### PR TITLE
[#5953] form endpoint authentication

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -6183,6 +6183,11 @@ paths:
           type: string
           format: uuid
         required: true
+      - in: header
+        name: X-CSRFToken
+        schema:
+          type: string
+        required: true
       tags:
       - forms
       requestBody:
@@ -6192,7 +6197,6 @@ paths:
               $ref: '#/components/schemas/FormV3'
         required: true
       security:
-      - tokenAuth: []
       - cookieAuth: []
       responses:
         '200':

--- a/src/openforms/forms/api/v3/viewsets.py
+++ b/src/openforms/forms/api/v3/viewsets.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -34,6 +35,7 @@ class FormViewSet(viewsets.GenericViewSet):
     lookup_field = "uuid"
     lookup_url_kwarg = "uuid"
     serializer_class = FormSerializer
+    authentication_classes = (SessionAuthentication,)
     permission_classes = (FormAPIPermissions,)
 
     def update(self, request: Request, **kwargs: Unpack[KwargsType]) -> Response:

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -442,6 +442,8 @@ class FormEndpointAccessTests(APITestCase):
         }
 
         response = self.client.put(url, data=data)
+        response_data = response.json()
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response_data["code"], "not_authenticated")
         self.assertEqual(Form.objects.count(), 0)


### PR DESCRIPTION
Closes #5953 

[skip: e2e]

**Changes**

Adds session authentication to the new form endpoint. [See this diff ](https://github.com/open-formulieren/open-forms/compare/feature/5882-new-form-endpoint..feature/5882-form-endpoint-authentication)for the changes between the initial endpoint PR and this PR.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
