### PR TITLE
Bump to ClamAV 1.5 in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - open-forms-dev
 
   clamav:
-    image: clamav/clamav:1.0.0
+    image: clamav/clamav:1.5
     healthcheck:
       test: ["CMD", "clamdcheck.sh"]
       interval: 5s


### PR DESCRIPTION
The 1.0.0 tag is gone on Docker Hub - 1.0 still exists, but there is already a newer version available that should be backwards compatible.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
