### PR TITLE
Add span/trace IDs to log events for correlation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ local.py
 /log/nginx/*.log*
 /.env
 /docker/.env
+/docker/tempo-data
 /private_media/
 /celerybeat
 /tmp/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@
 # https://open-forms.readthedocs.io/en/latest/installation/config.html
 #
 x-labels: &x-labels
-  client: dev
-  target: test
+  client: of
+  target: docker-compose
   app: openforms
 
 x-app-env: &x-app-env

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -51,12 +51,11 @@ services:
       - open-forms-dev
 
   # traces backend
-  # used this example - https://github.com/grafana/tempo/blob/main/example/docker-compose/otel-collector/docker-compose.yaml
   tempo:
-    image: grafana/tempo:latest
-    command: --config.file=/etc/tempo.yaml
+    image: grafana/tempo:2.10.0
+    command: --config.file=/etc/tempo.yml
     volumes:
-      - ./observability/tempo/tempo.yaml:/etc/tempo.yaml
+      - ./observability/tempo/tempo.yml:/etc/tempo.yml
       - ./tempo-data:/var/tempo
     ports:
       - "3200:3200"  # tempo
@@ -70,9 +69,9 @@ services:
   # open telemetry collector, receives metrics from the application instance(s)
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.131.0
-    command: --config=/etc/otel-collector-config.yaml
+    command: --config=/etc/otel-collector-config.yml
     volumes:
-      - ./observability/otel/otel-collector-config.yml:/etc/otel-collector-config.yaml
+      - ./observability/otel/otel-collector-config.yml:/etc/otel-collector-config.yml
     ports:
       - 4317:4317
       - 4318:4318

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -8,7 +8,9 @@ services:
     image: grafana/loki:latest
     ports:
       - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yml
+    volumes:
+      - ./observability/loki/local-config.yml:/etc/loki/local-config.yml
     networks:
       - open-forms-dev
 

--- a/docker/observability/grafana/datasources/ds.yml
+++ b/docker/observability/grafana/datasources/ds.yml
@@ -3,15 +3,25 @@
 apiVersion: 1
 
 datasources:
+
 - name: Loki
   type: loki
   access: proxy
   orgId: 1
   url: http://loki:3100
+  uid: loki
   basicAuth: false
   isDefault: true
   version: 1
   editable: false
+  jsonData:
+    derivedFields:
+      - name: Trace ID
+        datasourceUid: tempo
+        matcherRegex: "\"trace_id\"\\s*:\\s*\"(\\w+)\""
+        url: '$${__value.raw}'
+        urlDisplayLabel: 'View Trace'
+
 - name: Prometheus
   type: prometheus
   access: proxy
@@ -26,10 +36,12 @@ datasources:
     disableRecordingRules: false
     timeInterval: 15s   # Prometheus scrape interval
     incrementalQueryOverlapWindow: 10m
+
 - name: Tempo
   type: tempo
   access: proxy
   url: http://tempo:3200
+  uid: tempo
   basicAuth: false
   isDefault: false
   version: 1

--- a/docker/observability/grafana/datasources/ds.yml
+++ b/docker/observability/grafana/datasources/ds.yml
@@ -48,3 +48,14 @@ datasources:
   editable: false
   jsonData:
     httpMethod: GET
+    tracesToLogsV2:
+      # Field with an internal link pointing to a logs data source in Grafana.
+      # datasourceUid value must match the uid value of the logs data source.
+      datasourceUid: loki
+      spanStartTimeShift: '-1h'
+      spanEndTimeShift: '1h'
+      tags: []
+      filterByTraceID: false
+      filterBySpanID: false
+      customQuery: true
+      query: '{app=~".+"} | trace_id="$${__trace.traceId}"'

--- a/docker/observability/loki/local-config.yml
+++ b/docker/observability/loki/local-config.yml
@@ -1,0 +1,47 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+  retention_period: 672h # 28 days retention

--- a/docker/observability/promtail/config.yml
+++ b/docker/observability/promtail/config.yml
@@ -49,7 +49,18 @@ scrape_configs:
         action: drop
         regex: promtail
     pipeline_stages:
-    - docker: {}
-    - static_labels:
-        job: docker
-        instance: docker.host.internal
+      - docker: {}
+      - static_labels:
+          job: docker
+          instance: docker.host.internal
+      - json:
+          drop_malformed: false
+          expressions:
+            event: event
+            level: level
+            trace_id: trace_id
+            span_id: span_id
+      - labels:
+          event:
+          level:
+

--- a/docker/observability/promtail/config.yml
+++ b/docker/observability/promtail/config.yml
@@ -66,7 +66,6 @@ scrape_configs:
       - labels:
           event:
           level:
-      # requires config changes in loki to actually accept this!
       - structured_metadata:
           trace_id:
           span_id:

--- a/docker/observability/promtail/config.yml
+++ b/docker/observability/promtail/config.yml
@@ -60,7 +60,16 @@ scrape_configs:
             level: level
             trace_id: trace_id
             span_id: span_id
+            logger: logger
+            request: request
+            request_id: request_id
       - labels:
           event:
           level:
-
+      # requires config changes in loki to actually accept this!
+      - structured_metadata:
+          trace_id:
+          span_id:
+          logger:
+          request:
+          request_id:

--- a/docker/observability/tempo/tempo.yml
+++ b/docker/observability/tempo/tempo.yml
@@ -1,3 +1,5 @@
+---
+
 stream_over_http_enabled: true
 server:
   http_listen_port: 3200

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -21,7 +21,10 @@ from upgrade_check.constraints import UpgradePaths
 
 from csp_post_processor.constants import NONCE_HTTP_HEADER
 from openforms.logging.adapter import from_structlog
-from openforms.logging.processors import drop_user_agent_in_dev
+from openforms.logging.processors import (
+    add_open_telemetry_spans,
+    drop_user_agent_in_dev,
+)
 
 from .utils import Filesize, get_sentry_integrations
 
@@ -419,6 +422,7 @@ LOGGING = {
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
                 drop_user_agent_in_dev,
+                add_open_telemetry_spans,
                 structlog.stdlib.PositionalArgumentsFormatter(),
             ],
         },
@@ -431,6 +435,7 @@ LOGGING = {
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
                 drop_user_agent_in_dev,
+                add_open_telemetry_spans,
                 structlog.stdlib.PositionalArgumentsFormatter(),
             ],
         },
@@ -540,6 +545,7 @@ structlog.configure(
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         drop_user_agent_in_dev,
+        add_open_telemetry_spans,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,

--- a/src/openforms/logging/processors.py
+++ b/src/openforms/logging/processors.py
@@ -4,6 +4,7 @@ Custom structlog processors.
 
 from django.conf import settings
 
+from opentelemetry import trace
 from structlog.typing import EventDict, WrappedLogger
 
 
@@ -12,4 +13,37 @@ def drop_user_agent_in_dev(
 ):
     if settings.DEBUG and "user_agent" in event_dict:
         del event_dict["user_agent"]
+    return event_dict
+
+
+def add_open_telemetry_spans(
+    logger: WrappedLogger, method_name: str, event_dict: EventDict
+):  # pragma: no cover
+    """
+    Add trace and span IDs to the structlog event dict when tracing is active.
+
+    Note that tracing is not active/recording when OTEL_SDK_DISABLED=true is set,
+    which is why coverage reporting is disabled on this processor.
+
+    Implementation adapted from the docs:
+    https://www.structlog.org/en/stable/frameworks.html#opentelemetry
+    """
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return event_dict
+
+    ctx = span.get_span_context()
+    parent = getattr(span, "parent", None)
+
+    # emit the attributes as top-level key, see the OTel data model:
+    # https://opentelemetry.io/docs/concepts/signals/logs/#log-record
+    event_dict.update(
+        {
+            "span_id": format(ctx.span_id, "016x"),
+            "trace_id": format(ctx.trace_id, "032x"),
+        }
+    )
+    if parent:
+        event_dict["parent_span_id"] = format(parent.span_id, "016x")
+
     return event_dict


### PR DESCRIPTION
Partly closes #5358

**Changes**

If OTel tracing is enabled, add the span and trace IDs so that logs and traces can be correlated. The actual correlation mechanics depend on Grafana data source configuration and some Promtail/Alloy configuration.

We can't really (unit) test this, as `OTEL_SDK_DISABLED=false` is required to get real recording spans, but then we have to bring up the whole collector/tempo/prometheus stack too... So this was verified locally with the docker compose setup and confirmed to function as intended.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
