### PR TITLE
#5790 Show forms in maintenance mode as not live in the admin

### DIFF
--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -272,7 +272,7 @@ class FormAdmin(
 
     @admin.display(description=_("Live"), boolean=True)
     def is_live(self, obj: Form) -> bool:
-        return obj.active and not obj._is_deleted
+        return obj.active and not obj._is_deleted and not obj.maintenance_mode
 
     def get_form(self, request, *args, **kwargs):
         # no actual changes to the fields are triggered, we're only ending up here


### PR DESCRIPTION
Closes #5790

**Changes**

* change logic for `is_live` field in the admin list view

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
