### PR TITLE
Add support for sending e-mail via the Office365 Graph API

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -72,6 +72,13 @@ Common settings
 Email settings
 --------------
 
+* ``MAILER_USE_BACKEND``: Configure the e-mail backend. Defaults to ``django.core.mail.backends.smtp.EmailBackend``. Set to ``django_o365mail.EmailBackend`` for sending via the Office365 Graph API.
+
+* ``DEFAULT_FROM_EMAIL``: The email address to use a default sender. Defaults
+  to ``openforms@example.com``.
+
+**SMTP**
+
 * ``EMAIL_HOST``: Email server host. Defaults to ``localhost``.
 
 * ``EMAIL_PORT``: Email server port. Defaults to ``25``.
@@ -83,10 +90,21 @@ Email settings
 * ``EMAIL_USE_TLS``: Indicates whether the email server uses TLS. Defaults to
   ``False``.
 
-* ``DEFAULT_FROM_EMAIL``: The email address to use a default sender. Defaults
-  to ``openforms@example.com``.
-
 * ``EMAIL_TIMEOUT``: How long to wait for blocking operations like the connection attempt, in seconds. Defaults to ``10``.
+
+**Office365 Graph API**
+
+* ``O365_MAIL_CLIENT_ID``: Application client ID for Office365 Graph API authentication. Defaults to ``""``.
+
+* ``O365_MAIL_CLIENT_SECRET``: Application client secret for Office365 Graph API authentication. Defaults to ``""``.
+
+* ``O365_MAIL_TENANT_ID``: Tenant ID where the application is registered. Defaults to ``""``.
+
+* ``O365_MAIL_RESOURCE``: The email address/mailbox resource to use for sending emails. Optional - if not specified, the default mailbox for the authenticated user will be used. Defaults to ``""``.
+
+* ``O365_MAIL_SAVE_TO_SENT``: Whether to save sent emails. Defaults to ``False``.
+
+* ``O365_ACTUALLY_SEND_IN_DEBUG``: Whether to actually send emails when ``DEBUG`` is enabled. Defaults to ``False``.
 
 .. _installation_config_cors:
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -58,6 +58,7 @@ django-import-export
 django-jsonform
 django-log-outgoing-requests
 django-modeltranslation
+django-o365mail
 django-ordered-model
 django-privates
 django-redis

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -195,6 +195,8 @@ django-log-outgoing-requests==0.7.1
     # via -r requirements/base.in
 django-modeltranslation==0.19.4
     # via -r requirements/base.in
+django-o365mail==1.1.0
+    # via -r requirements/base.in
 django-ordered-model==3.6
     # via
     #   -r requirements/base.in
@@ -375,7 +377,9 @@ nh3==0.3.2
 numpy==2.3.3
     # via shapely
 o365==2.0.31
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   django-o365mail
 oauthlib==3.2.2
     # via requests-oauthlib
 odfpy==1.4.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -311,6 +311,10 @@ django-modeltranslation==0.19.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+django-o365mail==1.1.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-ordered-model==3.6
     # via
     #   -c requirements/base.txt
@@ -668,6 +672,7 @@ o365==2.0.31
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-o365mail
 oauthlib==3.2.2
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -340,6 +340,10 @@ django-modeltranslation==0.19.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+django-o365mail==1.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-ordered-model==3.6
     # via
     #   -c requirements/ci.txt
@@ -735,6 +739,7 @@ o365==2.0.31
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-o365mail
 oauthlib==3.2.2
     # via
     #   -c requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -300,6 +300,10 @@ django-modeltranslation==0.19.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+django-o365mail==1.1.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-ordered-model==3.6
     # via
     #   -c requirements/base.txt
@@ -622,6 +626,7 @@ o365==2.0.31
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   django-o365mail
 oauthlib==3.2.2
     # via
     #   -c requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -327,6 +327,10 @@ django-modeltranslation==0.19.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+django-o365mail==1.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-ordered-model==3.6
     # via
     #   -c requirements/ci.txt
@@ -718,6 +722,7 @@ o365==2.0.31
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   django-o365mail
 oauthlib==3.2.2
     # via
     #   -c requirements/ci.txt

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1392,3 +1392,29 @@ OPEN_FORMS_EXTENSIONS = config("OPEN_FORMS_EXTENSIONS", split=True, default=[])
 
 if OPEN_FORMS_EXTENSIONS:
     INSTALLED_APPS += OPEN_FORMS_EXTENSIONS
+
+#
+# django-yubin
+#
+
+MAILER_USE_BACKEND = config(
+    "MAILER_USE_BACKEND",
+    default="django.core.mail.backends.smtp.EmailBackend",  # or django_o365mail.EmailBackend for sending via the Office365 Graph API
+)
+
+#
+# django-o365mail for sending mail via the Office365 Graph API
+#
+
+O365_MAIL_CLIENT_ID = config("O365_MAIL_CLIENT_ID", default="")
+O365_MAIL_CLIENT_SECRET = config("O365_MAIL_CLIENT_SECRET", default="")
+O365_MAIL_TENANT_ID = config("O365_MAIL_TENANT_ID", default="")
+O365_MAIL_SAVE_TO_SENT = config("O365_MAIL_SAVE_TO_SENT", default=False)
+O365_ACTUALLY_SEND_IN_DEBUG = config("O365_ACTUALLY_SEND_IN_DEBUG", default=False)
+O365_MAIL_ACCOUNT_KWARGS: dict[str, str] = {
+    "token_backend": "O365.utils.token.EnvTokenBackend"
+}
+O365_MAIL_RESOURCE = config("O365_MAIL_RESOURCE", default="")
+
+if O365_MAIL_RESOURCE:
+    O365_MAIL_MAILBOX_KWARGS: dict[str, str] = {"resource": O365_MAIL_RESOURCE}


### PR DESCRIPTION
Closes #5972 

**Changes**

This pull request adds support for sending emails via the Microsoft Office365 Graph API by introducing the `django-o365mail` backend. It updates configuration options, documentation, and dependencies to enable this feature.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
