### PR TITLE
[#5942] remove `failed` status from final payment statusses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,30 @@ rules and/or form definitions when the feature flag for new logic rule analysis 
 The validation and reordering of logic rules happens on form save, so modiying indiviual logic rules might
 result in out-of-sync analysis.
 
+Upgrade procedure
+-----------------
+
+To upgrade to 3.5, please:
+
+* ⚠️ An script was created to address possible inaccurate payment statusses for
+  failed payments for the Worldline payment provider.
+
+  .. warning::
+
+      Previously it was assumed that failed payments could not have their
+      statusses changed through the webhooks mechanism. This was incorrect as this
+      is possible with the Worldline payment provider. Changes were introduced for
+      new payments but existing payments were not affected by these. The script
+      below processes all failed payments that might have a different status in the
+      Worldline API that were ignored previously. Whenever the Worldline API has a
+      different status, the current status from the Worldline API will be applied
+      to these payments.
+
+      .. code-block:: bash
+
+          # in the container via ``docker exec`` or ``kubectl exec``:
+          python /app/bin/fix_payment_status.py
+
 3.5.0-alpha.1 (2026-02-12)
 ==========================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,7 @@ RUN mkdir /app/bin /app/log /app/media /app/private_media /app/certifi_ca_bundle
 COPY \
     ./bin/report_component_problems.py \
     ./bin/fix_submission_value_variable_missing_fields.py \
+    ./bin/fix_payment_status.py \
     ./bin/check_disable_next_logic_action.py \
     ./bin/
 

--- a/bin/fix_payment_status.py
+++ b/bin/fix_payment_status.py
@@ -1,0 +1,158 @@
+# GH-5942 changed the final payment status states. The `failed` status
+# is no longer considered a final state. This allows users to retry previously failed
+# payments and complete them. Payments done before this change however are not affected
+# by this change, therefore this script was made.
+
+import sys
+from functools import partial
+from pathlib import Path
+
+import django
+
+import click
+from tabulate import tabulate
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR.resolve()))
+
+
+def _get_payment_status(submission_payment) -> str:
+    from onlinepayments.sdk.api_exception import ApiException
+
+    from openforms.payments.contrib.worldline.models import WorldlineMerchant
+
+    plugin_options = (
+        submission_payment.plugin_options if submission_payment.plugin_options else {}
+    )
+
+    if not (merchant := plugin_options.get("merchant")):
+        raise ValueError("No merchant found in plugin options")
+
+    try:
+        merchant = WorldlineMerchant.objects.get(pspid=merchant)
+    except WorldlineMerchant.DoesNotExist as e:
+        raise ValueError(f"No merchant found with pspid {merchant}") from e
+
+    merchant_client = merchant.get_merchant_client()
+    payments_client = merchant_client.payments()
+
+    try:
+        payment_response = payments_client.get_payment(
+            submission_payment.provider_payment_id
+        )
+    except ApiException as e:
+        raise ValueError("Payment was not found in the Worldline API") from e
+
+    return payment_response.status
+
+
+def _update_historically_failed_payments(dry_run: bool = False) -> bool:
+    from django.db import transaction
+
+    import structlog
+
+    from openforms.payments.constants import PaymentStatus
+    from openforms.payments.contrib.worldline.constants import (
+        StatusCategory as WorldlineStatusCategory,
+    )
+    from openforms.payments.models import SubmissionPayment
+    from openforms.submissions.constants import PostSubmissionEvents
+    from openforms.submissions.tasks import on_post_submission_event
+
+    logger = structlog.stdlib.get_logger(__name__)
+
+    submission_payments = SubmissionPayment.objects.filter(
+        status=PaymentStatus.failed, plugin_id="worldline"
+    )
+    changed_payments = []
+
+    with transaction.atomic():
+        for submission_payment in submission_payments:
+            with structlog.contextvars.bound_contextvars(
+                submission_uuid=str(submission_payment.submission.uuid),
+                payment_uuid=str(submission_payment.uuid),
+                public_order_id=submission_payment.public_order_id,
+            ):
+                try:
+                    worldline_status = _get_payment_status(submission_payment)
+                except ValueError as e:
+                    logger.error("payment_status_retrieval_failed", exc_info=e)
+                    continue
+
+                last_status_category = WorldlineStatusCategory.from_payment_status(
+                    worldline_status
+                )
+                last_status = WorldlineStatusCategory.to_of_status(last_status_category)
+
+                if (
+                    last_status == submission_payment.status
+                    or last_status != PaymentStatus.completed
+                ):
+                    continue
+
+                changed_payments.append(submission_payment)
+
+                if dry_run:
+                    continue
+
+                submission_payment.status = last_status
+                submission_payment.save()
+
+                transaction.on_commit(
+                    partial(
+                        on_post_submission_event,
+                        submission_payment.submission.pk,
+                        PostSubmissionEvents.on_payment_complete,
+                    )
+                )
+
+    if not changed_payments:
+        click.echo(click.style("No changes found for existing payments.", fg="green"))
+        return True
+
+    click.echo(click.style("Payment statusses were updated.", fg="yellow"))
+    click.echo("")
+    click.echo(
+        tabulate(
+            [
+                (
+                    submission_payment.public_order_id,
+                    submission_payment.submission.uuid,
+                    submission_payment.provider_payment_id,
+                )
+                for submission_payment in changed_payments
+            ],
+            headers=(
+                "Payment reference",
+                "Submission UUID",
+                "Provider payment ID",
+            ),
+        )
+    )
+
+    return False
+
+
+def main(skip_setup: bool = False, dry_run: bool = False, **kwargs) -> bool:
+    from openforms.setup import setup_env
+
+    if not skip_setup:
+        setup_env()
+        django.setup()
+
+    return _update_historically_failed_payments(dry_run=dry_run)
+
+
+@click.command()
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Do not perform any changes to the payment statusses.",
+)
+def cli(dry_run: bool):
+    return main(dry_run=dry_run)
+
+
+if __name__ == "__main__":
+    cli()

--- a/docs/manual/forms/basics.rst
+++ b/docs/manual/forms/basics.rst
@@ -241,6 +241,12 @@ Er zijn twee mogelijke flows om inzendingen te registreren voor formulieren waar
    wordt aangepast.
 2. De inzending wordt naar de registratiebackend gestuurd pas ná dat de betaling voltooid is.
 
+.. warning:: Afhankelijk van de betalingsprovider, kan het zijn dat de status van de betaling
+    op een later moment aangepast kan worden vanuit de betalingsprovider. Dit kan bijvoorbeeld
+    voorkomen wanneer een betaling mislukt, maar bij een volgende poging wel slaagt. De
+    status van de betaling kan in deze situatie in eerste instantie op "Geannuleerd of mislukt" staan
+    maar na een succesvolle poging op "Voltooid door gebruiker".
+
 De flow kan ingesteld worden in de **Algemene Configuratie**.
 
 Zie ook: :ref:`configuration_general_payment_flow`

--- a/src/openforms/payments/constants.py
+++ b/src/openforms/payments/constants.py
@@ -26,9 +26,9 @@ class PaymentStatus(models.TextChoices):
     # in-progress
     started = "started", _("Started by user")
     processing = "processing", _("Backend is processing")
+    failed = "failed", _("Cancelled or failed")
 
     # payment finished
-    failed = "failed", _("Cancelled or failed")
     completed = "completed", _("Completed by user")
 
     # flow done
@@ -40,7 +40,6 @@ class PaymentStatus(models.TextChoices):
 
 
 PAYMENT_STATUS_FINAL: Set[str] = {
-    PaymentStatus.failed.value,
     PaymentStatus.completed.value,
     PaymentStatus.registered.value,
 }

--- a/src/openforms/payments/tests/test_models.py
+++ b/src/openforms/payments/tests/test_models.py
@@ -91,14 +91,17 @@ class SubmissionPaymentTests(TransactionTestCase):
         self.assertEqual(payment.public_order_id, "xyz2020/OF-123456/4")
 
     def test_status_is_final(self):
-        for s in [PaymentStatus.started, PaymentStatus.processing]:
+        for s in [
+            PaymentStatus.started,
+            PaymentStatus.processing,
+            PaymentStatus.failed,
+        ]:
             with self.subTest(s):
                 self.assertNotIn(s, PAYMENT_STATUS_FINAL)
 
         for s in [
             PaymentStatus.registered,
             PaymentStatus.completed,
-            PaymentStatus.failed,
         ]:
             with self.subTest(s):
                 self.assertIn(s, PAYMENT_STATUS_FINAL)


### PR DESCRIPTION
Closes #5942

[skip: e2e]

**Changes**

Previously the `failed` state was deemed as a final payment status state whereas https://github.com/issues/assigned?issue=open-formulieren%7Copen-forms%7C5942 shows that the payment status can be updated (and succeed) whenever a payment initially fails.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
