### PR TITLE
[#5820] Update Dockerfile to support formatjs during runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,12 @@ COPY ./*.json ./*.js /app/
 # install WITH dev tooling
 RUN npm ci --legacy-peer-deps
 
+# extract only @formatjs/cli subtree from node_modules (needed for the final stage)
+RUN npm --prefix node_modules/@formatjs/cli ls --all --parseable \
+  | sed 's#^/app/##' \
+  | sort -u \
+  | tar -czf /tmp/formatjs-node_modules.tgz -C /app -T -
+
 # copy source code
 COPY ./src /app/src
 
@@ -82,6 +88,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         # weasyprint deps, see https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#debian-11
         libpango-1.0-0 \
         libpangoft2-1.0-0 \
+        # needed for node
+        curl \
+        xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -118,6 +127,35 @@ COPY --from=frontend-build /app/node_modules/@fortawesome/fontawesome-free/webfo
 # Include SDK files. Collectstatic produces both the versions with and without hash
 # in the STATICFILES_ROOT
 COPY --from=sdk-image /sdk /app/src/openforms/static/sdk
+
+# the following are needed to have access to module formatjs/cli during runtime (process
+# custom translations)
+COPY --from=frontend-build /app/build /app/build
+COPY --from=frontend-build /app/node_modules/.bin /app/node_modules/.bin
+# copy only @formatjs/cli + dependencies
+COPY --from=frontend-build /tmp/formatjs-node_modules.tgz /tmp/
+
+# extract minimal node_modules subtree
+RUN tar -xzf /tmp/formatjs-node_modules.tgz -C /app \
+    && rm /tmp/formatjs-node_modules.tgz
+
+# install Node runtime matching .nvmrc
+COPY .nvmrc /tmp/.nvmrc
+RUN set -eux; \
+    MAJOR_VERSION=$(tr -d '[:space:]' < /tmp/.nvmrc); \
+    echo "Major Node version: $MAJOR_VERSION"; \
+    # fetch Node index.json and extract versions for this major
+    FULL_VERSION=$(curl -fsSL https://nodejs.org/dist/index.json \
+        | grep '"version":' \
+        | sed -n 's/.*"version": *"\(v'"$MAJOR_VERSION"'\.[0-9]\+\.[0-9]\+\)".*/\1/p' \
+        | sort -V \
+        | tail -n1); \
+    echo "Latest patch version: $FULL_VERSION"; \
+    # download and extract Node
+    curl -fsSL "https://nodejs.org/dist/$FULL_VERSION/node-$FULL_VERSION-linux-x64.tar.xz" -o /tmp/node.tar.xz; \
+    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1; \
+    rm /tmp/node.tar.xz /tmp/.nvmrc
+
 
 # copy source code
 COPY ./src /app/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         python3-dev \
         libpq-dev \
         shared-mime-info \
+        curl \
         # required for (log) routing support in uwsgi
         libpcre3 \
         libpcre3-dev \
@@ -43,6 +44,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/* \
     && /tmp/patches/apply.sh /usr/local/lib/python3.12/site-packages
+
+# Download and install nvm:
+COPY .nvmrc /tmp/.nvmrc
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+    && \. "$HOME/.nvm/nvm.sh" \
+    && mv /tmp/.nvmrc . \
+    && nvm install \
+    && mv /bin/versions/node/*/ /tmp/node
 
 # Stage 2 - Install frontend deps and build assets
 FROM node:20-bookworm-slim AS frontend-build
@@ -88,9 +97,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         # weasyprint deps, see https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#debian-11
         libpango-1.0-0 \
         libpangoft2-1.0-0 \
-        # needed for node
-        curl \
-        xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -139,23 +145,7 @@ COPY --from=frontend-build /tmp/formatjs-node_modules.tgz /tmp/
 RUN tar -xzf /tmp/formatjs-node_modules.tgz -C /app \
     && rm /tmp/formatjs-node_modules.tgz
 
-# install Node runtime matching .nvmrc
-COPY .nvmrc /tmp/.nvmrc
-RUN set -eux; \
-    MAJOR_VERSION=$(tr -d '[:space:]' < /tmp/.nvmrc); \
-    echo "Major Node version: $MAJOR_VERSION"; \
-    # fetch Node index.json and extract versions for this major
-    FULL_VERSION=$(curl -fsSL https://nodejs.org/dist/index.json \
-        | grep '"version":' \
-        | sed -n 's/.*"version": *"\(v'"$MAJOR_VERSION"'\.[0-9]\+\.[0-9]\+\)".*/\1/p' \
-        | sort -V \
-        | tail -n1); \
-    echo "Latest patch version: $FULL_VERSION"; \
-    # download and extract Node
-    curl -fsSL "https://nodejs.org/dist/$FULL_VERSION/node-$FULL_VERSION-linux-x64.tar.xz" -o /tmp/node.tar.xz; \
-    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1; \
-    rm /tmp/node.tar.xz /tmp/.nvmrc
-
+COPY --from=backend-build /tmp/node /usr/local/
 
 # copy source code
 COPY ./src /app/src

--- a/src/openforms/translations/subprocesses.py
+++ b/src/openforms/translations/subprocesses.py
@@ -2,6 +2,11 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+# make sure the right path is used for the subporcess (different paths are used based on
+# the environment)
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+FORMATJS_BIN = PROJECT_ROOT / "node_modules/.bin/formatjs"
+
 
 def compile_messages_file(input_path: str) -> tuple[bool, str]:
     """
@@ -22,8 +27,7 @@ def compile_messages_file(input_path: str) -> tuple[bool, str]:
     try:
         subprocess.run(
             [
-                "npx",
-                "formatjs",
+                str(FORMATJS_BIN),
                 "compile",
                 input_path,
                 "--ast",

--- a/src/openforms/translations/subprocesses.py
+++ b/src/openforms/translations/subprocesses.py
@@ -2,10 +2,12 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from django.conf import settings
+
 # make sure the right path is used for the subporcess (different paths are used based on
 # the environment)
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
-FORMATJS_BIN = PROJECT_ROOT / "node_modules/.bin/formatjs"
+PROJECT_ROOT = settings.DJANGO_PROJECT_DIR.parent.parent
+FORMATJS_BIN = PROJECT_ROOT / "node_modules" / ".bin" / "formatjs"
 
 
 def compile_messages_file(input_path: str) -> tuple[bool, str]:


### PR DESCRIPTION
Closes #5820 partly

**Changes**

Due to the subprocess we have for the custom translations in the backend, we have to use formatjs during runtime. This was not available in the last stage of the Dockerfile (no need for such frontend realated stuff until now).

Instead of installing everything in the last stage we only copy what we need from the frontend-build stage and in this way we can execute the binary code of the library without having to do network calls (everything needed is found in the already bin directory except for the node, which is a must).

Last needed update is the path in the subprocess because this changes depending on the environment we use.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
