### PR TITLE
:lock: Harden production image by removing npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && /tmp/patches/apply.sh /usr/local/lib/python3.12/site-packages
 
-# Download and install nvm:
+# Download and install nvm, but exclude npm as it's not needed in prod
 COPY .nvmrc /tmp/.nvmrc
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
     && \. "$HOME/.nvm/nvm.sh" \
     && mv /tmp/.nvmrc . \
     && nvm install \
-    && mv /bin/versions/node/*/ /tmp/node
+    && mv /bin/versions/node/*/ /tmp/node \
+    && rm -rf /tmp/node/bin/npm /tmp/node/lib/node_modules
 
 # Stage 2 - Install frontend deps and build assets
 FROM node:20-bookworm-slim AS frontend-build


### PR DESCRIPTION
The security scanner found some vulnerabilities in the npm dependencies.

The official retort is that they are not exploitable, and I *could* dismiss those alerts, but it's easier to just nuke npm entirely from the image so they don't get picked up in the first place, and that's less explaining to do towards auditors when they'll inevitably report it.

I tested in the newly built image that `formatjs` still appears to be functioning:

```bash
(open-forms) ➜  open-forms git:(security/uninstall-npm-in-prod) ✗ docker run --rm -it openformulieren/open-forms:latest bash
maykin@95a326e41832:/app$ node --version
v20.20.0
maykin@95a326e41832:/app$ /app/node_modules/.bin/formatjs --version
5.0.6
maykin@95a326e41832:/app$ 
```
[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
