### PR TITLE
Optimize flower memory usage

### DIFF
--- a/bin/celery_flower.sh
+++ b/bin/celery_flower.sh
@@ -2,4 +2,10 @@
 # Set defaults for OTEL
 export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-openforms-flower}"
 
-exec celery --app openforms --workdir src flower
+# 100x less than the defaults
+export FLOWER_MAX_TASKS="${FLOWER_MAX_TASKS:-1000}"
+export FLOWER_MAX_WORKERS="${FLOWER_MAX_WORKERS:-50}"
+
+exec celery \
+    --broker "${CELERY_BROKER_URL:-redis://localhost:6379/0}" \
+    flower


### PR DESCRIPTION
(no ticket, coming from our Maykin's SAAS monitoring)

**Changes**

* Using the --broker option instead of pointing to the app avoids having to load all the application code in memory - saves about 240+ MiB on my local machine
* Use 100x lower defaults for max number of tasks and workers to keep in memory, cutting down on memory growth over time, especially on k8s where worker names can be unstable

The envvars for tasks/workers are deliberately undocumented. I suspect these new defaults are fine, but if not, then an escape hatch is available.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
