### PR TITLE
[#6002] Fix `AttributeError` in authentication flow

### DIFF
--- a/src/openforms/authentication/tests/test_views.py
+++ b/src/openforms/authentication/tests/test_views.py
@@ -407,6 +407,45 @@ class CoSignAuthenticationFlowTests(SubmissionsMixin, APITestCase):
         )
         mock_add_co_sign_representation.assert_called_once_with(self.submission, "bsn")
 
+    @tag("gh-6002")
+    def test_co_sign_flow_with_HEAD_method_returns_empty_response(self):
+        self._add_submission_to_session(self.submission)
+
+        with mock_register(self.register):
+            with self.subTest("start ok"):
+                start_url = reverse(
+                    "authentication:start",
+                    kwargs={"slug": "myform", "plugin_id": "plugin1"},
+                )
+
+                response = self.client.head(
+                    start_url,
+                    {
+                        "next": self.next_url,
+                        CO_SIGN_PARAMETER: self.submission.uuid,
+                    },
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, b"")
+
+            with self.subTest("return ok"):
+                return_url = reverse(
+                    "authentication:return",
+                    kwargs={"slug": "myform", "plugin_id": "plugin1"},
+                )
+
+                response = self.client.head(
+                    return_url,
+                    {
+                        CO_SIGN_PARAMETER: self.submission.uuid,
+                        "next": self.next_url,
+                    },
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, b"")
+
     @override_settings(CORS_ALLOW_ALL_ORIGINS=True)
     def test_co_sign_flow_invalid_submission_id(self):
         """

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin, UserPassesTestMi
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.http import (
+    HttpResponse,
     HttpResponseBadRequest,
     HttpResponseBase,
     HttpResponseNotAllowed,
@@ -241,6 +242,11 @@ class AuthenticationStartView(AuthenticationFlowBaseView):
 
         return response
 
+    def head(self, request: Request, *args, **kwargs) -> HttpResponse:
+        # not really used by a user, implemented in order to handle possible requests
+        # from security scanners for example
+        return HttpResponse(status=200)
+
 
 COMMON_RETURN_RESPONSES = {
     302: None,
@@ -449,6 +455,11 @@ class AuthenticationReturnView(AuthenticationFlowBaseView):
     )
     def post(self, request, *args, **kwargs):
         return self._handle_return(request, *args, **kwargs)
+
+    def head(self, request: Request, *args, **kwargs) -> HttpResponse:
+        # not really used by a user, implemented in order to handle possible requests
+        # from security scanners for example
+        return HttpResponse(status=200)
 
     def finalize_response(self, request, response, *args, **kwargs):
         """


### PR DESCRIPTION
Closes #6002

**Changes**

The `HEAD` is not present in the request so it was causing the error. What we need is the query params in order to see if we have a co-sign flow.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
