### PR TITLE
:ambulance: Hotfix multiple rules having similar visibility actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Changelog
 
     The Dutch version of this changelog can be found :ref:`here <changelog-nl>`.
 
+3.4.3 (2026-02-26)
+==================
+
+Hotfix release.
+
+* [:backend:`6005`] Fixed input values unintentionally being cleared when there are
+  multiple backend logic rules that specify the visibility state of the same component.
+
 3.4.2 (2026-02-20)
 ==================
 

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -2,7 +2,7 @@
 Open Formulieren
 ================
 
-:Version: 3.4.2
+:Version: 3.4.3
 :Source: https://github.com/open-formulieren/open-forms
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Forms
 ==========
 
-:Version: 3.4.2
+:Version: 3.4.3
 :Source: https://github.com/open-formulieren/open-forms
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openforms",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openforms",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openforms",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Open Forms",
   "main": "src/static/openforms/js/openforms.js",
   "directories": {

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,7 +7,7 @@ publiccodeYmlVersion: '0.2'
 name: Open Forms Builder and API
 url: 'http://github.com/open-formulieren/open-forms.git'
 softwareType: standalone/backend
-softwareVersion: 3.4.2
+softwareVersion: 3.4.3
 releaseDate: '2022-03-10'
 logo: 'https://github.com/open-formulieren/open-forms/blob/main/docs/logo.svg'
 platforms:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "== 3.12"
 emit-index-url = false
 
 [tool.bumpversion]
-current_version = "3.4.2"
+current_version = "3.4.3"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -655,7 +655,7 @@ urllib3==2.6.3
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.26
+uwsgi==2.0.31
     # via -r requirements/base.in
 vine==5.1.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1198,7 +1198,7 @@ urllib3==2.6.3
     #   sentry-sdk
     #   types-requests
     #   vcrpy
-uwsgi==2.0.26
+uwsgi==2.0.31
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1350,7 +1350,7 @@ urllib3==2.6.3
     #   sentry-sdk
     #   types-requests
     #   vcrpy
-uwsgi==2.0.26
+uwsgi==2.0.31
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -1086,7 +1086,7 @@ urllib3==2.6.3
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.26
+uwsgi==2.0.31
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -1312,7 +1312,7 @@ urllib3==2.6.3
     #   sentry-sdk
     #   types-requests
     #   vcrpy
-uwsgi==2.0.26
+uwsgi==2.0.31
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/__init__.py
+++ b/src/openforms/__init__.py
@@ -1,6 +1,6 @@
 from .celery import app as celery_app
 
 __all__ = ("celery_app",)
-__version__ = "3.4.2"
+__version__ = "3.4.3"
 __author__ = "Maykin Media"
 __homepage__ = "https://github.com/open-formulieren/open-forms"

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1138,6 +1138,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ):
         key = component["key"]
         # We only need to process children if the value was not already cleared.
@@ -1177,6 +1178,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=components_to_ignore_hidden,
+                original_input_data=original_input_data,
             )
             edit_grid_data_new.append(item_data)
 
@@ -1195,6 +1197,7 @@ class Columns(BasePlugin[ColumnsComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ):
         for column in component["columns"]:
             # If the hidden property of the parent should be ignored, so should it for
@@ -1213,6 +1216,7 @@ class Columns(BasePlugin[ColumnsComponent]):
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=components_to_ignore_hidden,
+                original_input_data=original_input_data,
             )
 
 
@@ -1228,6 +1232,7 @@ class Fieldset(BasePlugin[FieldsetComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ):
         # If the hidden property of the parent should be ignored, so should it for
         # its children.
@@ -1247,4 +1252,5 @@ class Fieldset(BasePlugin[FieldsetComponent]):
             parent_hidden=parent_hidden,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=components_to_ignore_hidden,
+            original_input_data=original_input_data,
         )

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -167,6 +167,9 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):
           evaluation of the conditional.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
+        :param original_input_data: The input data from the frontend when called through
+          the check logic endpoint. Used to restore values when flipping visibility
+          states.
         """
 
     @staticmethod
@@ -271,6 +274,9 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
           evaluation of the conditional.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
+        :param original_input_data: The input data from the frontend when called through
+          the check logic endpoint. Used to restore values when flipping visibility
+          states.
         """
         if (component_type := component["type"]) not in self:
             return

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -152,6 +152,7 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ) -> None:
         """
         Apply (conditional) visibility of this component. This routine should be
@@ -255,6 +256,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ) -> None:
         """
         Apply (conditional) visibility of this component. This routine should be
@@ -282,6 +284,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
             parent_hidden=parent_hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
+            original_input_data=original_input_data,
         )
 
     def update_config(

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -91,6 +91,7 @@ def process_visibility(
     parent_hidden: bool = False,
     get_evaluation_data: GetEvaluationData | None = None,
     components_to_ignore_hidden: set[str] | None = None,
+    original_input_data: FormioData | None = None,
 ) -> None:
     """
     Process the visibility of the components inside the configuration, by checking if
@@ -134,6 +135,18 @@ def process_visibility(
             # always present in the submission data
             # If we don't have an initial value available, just use the empty value.
             data[key] = initial_data.get(key) or get_component_empty_value(component)
+
+        # if it's visible, check if any input data should be restored because earlier
+        # logic rules may have cleared it (visible -> hidden -> visible)
+        if not hidden and original_input_data is not None:
+            if data.get(key) != (original_value := original_input_data.get(key)):
+                # restore the value from the original input data - likely there was a
+                # sequence in logic that lead to the data being cleared because of hidden
+                # state, while a subsequent action makes the component visible again. In
+                # that case, the frontend will have the component visible and data can
+                # be entered, which needs to be grabbed from the initial data to avoid
+                # wiping user input.
+                data[key] = original_value
 
         # Apply the visibility to children components, if applicable
         register.apply_visibility(

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -157,4 +157,5 @@ def process_visibility(
             parent_hidden=hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
+            original_input_data=original_input_data,
         )

--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -91,7 +91,7 @@ class CosignState:
         """
         from .form_logic import check_submission_logic
 
-        check_submission_logic(self.submission)
+        check_submission_logic(self.submission, reset_configuration_wrapper=False)
 
         # use the complete view on the Formio component tree(s)
         configuration_wrapper = self.submission.total_configuration_wrapper

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -266,6 +266,7 @@ def evaluate_conditional_logic(
 def check_submission_logic(
     submission: Submission,
     current_step: SubmissionStep | None = None,
+    reset_configuration_wrapper: bool = True,
 ) -> None:
     if getattr(submission, "_form_logic_evaluated", False):
         return
@@ -309,6 +310,9 @@ def check_submission_logic(
             mutation.apply(step, configuration)
 
     # Note that the total configuration wrapper is a cached property, so we need to
-    # reset to ensure we are not operating on outdated configurations later
-    submission._total_configuration_wrapper = None
+    # reset to ensure we are not operating on outdated configurations later.
+    # XXX: not sure why this is necessary - removing it entirely doesn't seem to break
+    # any tests? Check with Viktor.
+    if reset_configuration_wrapper:
+        submission._total_configuration_wrapper = None
     submission._form_logic_evaluated = True

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -76,6 +76,8 @@ class ActionOperation:
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         """
         Return a mapping [name/path -> new_value] with changes that are to be
@@ -101,6 +103,9 @@ class PropertyAction(ActionOperation):
     def apply(
         self, step: SubmissionStep, configuration: FormioConfigurationWrapper
     ) -> None:
+        # handled directly inside eval
+        if self.property == "hidden":
+            return None
         if self.component not in configuration:
             return None
         component = configuration[self.component]
@@ -112,20 +117,41 @@ class PropertyAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         # To avoid doing unnecessary work, only apply clear-on-hide logic for components
         # for which their action sets the "hidden" property to True.
-        if not (self.property == "hidden" and self.value):
+        if self.property != "hidden":
             return None
 
-        # Note that this can happen when the action applies to a component of a
-        # different step than we are currently evaluating. We don't have to do
+        # we now know that we're making the component visible or hidden, but we're not
+        # guaranteed that we're actually changing the visibility state at all! For that
+        # we need to check at the current component configuration, and that requires
+        # first checking if the component is in the current step's configuration. The
+        # component *can* be absent if it refers to a component in another step than
+        # the one we are currently evaluating. We don't have to do
         # anything in this case, because the clear-on-hide behaviour of that
         # component will be handled once the user has reached that step.
         if self.component not in configuration:
             return None
 
         component = configuration[self.component]
+        was_hidden = component.get("hidden", False)
+        should_be_hidden = self.value is True
+
+        # apply the state mutation immediately, so that it's visible to follow up
+        # actions and rules operating on the same component. This obsoletes the
+        # apply method/side-effects.
+        component[self.property] = self.value
+
+        has_visibility_change = was_hidden ^ should_be_hidden
+        # is the visibility state changing? Then we need to do additional processing.
+        # * visible -> hidden: values need to be cleared based on clearOnHide
+        # * hidden -> visible: possibly original input data needs to be restored, as the
+        #   value may have been cleared by earlier visible -> hidden actions.
+        if not has_visibility_change:
+            return None
 
         # Process the visibility of the component. We want to process the component
         # itself, not try to iterate over its children, so we create a 'fake'
@@ -135,7 +161,8 @@ class PropertyAction(ActionOperation):
             context,
             configuration,
             initial_data=initial_data,
-            parent_hidden=True,
+            parent_hidden=should_be_hidden,
+            original_input_data=original_input_data,
         )
         return None
 
@@ -217,6 +244,8 @@ class VariableAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping:
         with log_errors(self.value, self.rule):
             return {self.variable: jsonLogic(self.value, context.data)}
@@ -326,6 +355,8 @@ class SynchronizeVariablesAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         configuration = submission.total_configuration_wrapper
         if self.source_variable not in configuration:
@@ -349,6 +380,8 @@ class ServiceFetchAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping:
         var = self.rule.form.formvariable_set.get(key=self.variable)
         with log_errors({}, self.rule):  # TODO proper error handling
@@ -392,6 +425,8 @@ class EvaluateDMNAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         # Mapping from form variables to DMN inputs
         dmn_inputs = {

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -121,7 +121,7 @@ class PropertyAction(ActionOperation):
         original_input_data: FormioData,
     ) -> DataMapping | None:
         # To avoid doing unnecessary work, only apply clear-on-hide logic for components
-        # for which their action sets the "hidden" property to True.
+        # for which their action touches the "hidden" property.
         if self.property != "hidden":
             return None
 
@@ -137,21 +137,12 @@ class PropertyAction(ActionOperation):
             return None
 
         component = configuration[self.component]
-        was_hidden = component.get("hidden", False)
         should_be_hidden = self.value is True
 
         # apply the state mutation immediately, so that it's visible to follow up
         # actions and rules operating on the same component. This obsoletes the
         # apply method/side-effects.
         component[self.property] = self.value
-
-        has_visibility_change = was_hidden ^ should_be_hidden
-        # is the visibility state changing? Then we need to do additional processing.
-        # * visible -> hidden: values need to be cleared based on clearOnHide
-        # * hidden -> visible: possibly original input data needs to be restored, as the
-        #   value may have been cleared by earlier visible -> hidden actions.
-        if not has_visibility_change:
-            return None
 
         # Process the visibility of the component. We want to process the component
         # itself, not try to iterate over its children, so we create a 'fake'

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Iterator
+from copy import deepcopy
 
 import elasticapm
 from json_logic import jsonLogic
@@ -136,6 +137,18 @@ def iter_evaluate_rules(
     :returns: An iterator yielding :class:`ActionOperation` instances.
     """
     state = submission.load_submission_value_variables_state()
+
+    # keep a copy of the start data that is not affected by the mutations applied by
+    # logic. Due to the instant processing of clearOnHide side-effects and multiple
+    # logic rules potentially changing the visibility of the same component, we need to
+    # make sure to restore the data for every hidden -> visible flip, as the visible ->
+    # hidden flip results in clearing the data - see #6001. For this restoration, we
+    # use the start data as source, as that is coming from the frontend state that is
+    # the result of logic evaluations.
+    # For the hotfix, we deliberately keep this isolated from initial_data, which is
+    # populated differently based on whether the new renderer is enabled or not.
+    original_input_data = deepcopy(data)
+
     for rule in rules:
         with elasticapm.capture_span(
             "evaluate_rule",
@@ -150,12 +163,22 @@ def iter_evaluate_rules(
             # as components can be hidden by default and shown when a logic rule is
             # triggered
             if not triggered:
-                _handle_clear_on_hide(rule, data, configuration, initial_data)
+                _handle_clear_on_hide_for_untriggered_rule(
+                    rule,
+                    data,
+                    configuration,
+                    initial_data,
+                    original_input_data=original_input_data,
+                )
                 continue
 
             for operation in rule.action_operations:
                 if mutations := operation.eval(
-                    data, configuration, submission, initial_data
+                    data,
+                    configuration,
+                    submission,
+                    initial_data,
+                    original_input_data=original_input_data,
                 ):
                     mutations_python = {
                         key: state.variables[key].to_python(value)
@@ -166,11 +189,13 @@ def iter_evaluate_rules(
                 yield operation
 
 
-def _handle_clear_on_hide(
+def _handle_clear_on_hide_for_untriggered_rule(
     rule: FormLogic,
     data: FormioData,
     configuration: FormioConfigurationWrapper,
     initial_data: FormioData,
+    *,
+    original_input_data: FormioData,
 ):
     """
     Handle clear-on-hide behaviour for components of which the "hidden" property
@@ -187,11 +212,11 @@ def _handle_clear_on_hide(
             continue
 
         component = configuration[operation.component]
-
-        # To avoid doing unnecessary work, only call ``process_visibility`` when the
-        # component is actually hidden.
-        if not component.get("hidden", False):
-            continue
+        # # is the visibility state going from visible to hidden? Only then the
+        # # clear-on-hide should be triggered.
+        # require_clear_on_hide_processing = not was_hidden and should_be_hidden
+        # if not require_clear_on_hide_processing:
+        #     continue
 
         # Process the visibility of the component. We want to process the component
         # itself, not try to iterate over its children, so we create a 'fake'
@@ -199,6 +224,13 @@ def _handle_clear_on_hide(
         # Note that we cannot pass ``parent_hidden=True`` here, and skip conditional
         # evaluation (like in ``PropertyAction.eval``), because a component can be
         # affected by a simple conditional which makes it visible.
+        # Additionally (see #6001), when a component flips back to visible after being
+        # hidden and having its value cleared before, we need to restore the original
+        # input data, so we must always call this.
         process_visibility(
-            {"components": [component]}, data, configuration, initial_data=initial_data
+            {"components": [component]},
+            data,
+            configuration,
+            initial_data=initial_data,
+            original_input_data=original_input_data,
         )

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -212,19 +212,13 @@ def _handle_clear_on_hide_for_untriggered_rule(
             continue
 
         component = configuration[operation.component]
-        # # is the visibility state going from visible to hidden? Only then the
-        # # clear-on-hide should be triggered.
-        # require_clear_on_hide_processing = not was_hidden and should_be_hidden
-        # if not require_clear_on_hide_processing:
-        #     continue
-
         # Process the visibility of the component. We want to process the component
         # itself, not try to iterate over its children, so we create a 'fake'
         # configuration.
         # Note that we cannot pass ``parent_hidden=True`` here, and skip conditional
         # evaluation (like in ``PropertyAction.eval``), because a component can be
         # affected by a simple conditional which makes it visible.
-        # Additionally (see #6001), when a component flips back to visible after being
+        # Additionally (see #6005), when a component flips back to visible after being
         # hidden and having its value cleared before, we need to restore the original
         # input data, so we must always call this.
         process_visibility(

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1132,6 +1132,250 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         self.assertNotIn("date", data["step"]["data"])
 
 
+@tag("gh-6001", "gh-6005")
+class MultipleRulesTargettingSameComponentVisibilityTests(
+    SubmissionsMixin, APITestCase
+):
+    def test_first_rule_triggers_second_does_not_must_not_clear_value(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "show-when-a",
+                        "hidden": True,
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+        # just a single rule does not reproduce the issue (!).
+        # Rule 1: show the textfield when 'a' is selected in the radio
+        show_textfield_action = {
+            "formStep": None,
+            "component": "show-when-a",
+            "action": {
+                "type": "property",
+                "property": {"value": "hidden", "type": "bool"},
+                "value": {},
+                "state": False,
+            },
+        }
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[show_textfield_action],
+        )
+        # Rule 2: show the textfield when a non-sense value is selected in the radio
+        # (never triggers!)
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "nonsense-value"]},
+            actions=[show_textfield_action],
+        )
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {"data": {"radio": "a", "show-when-a": "do-not-clear-me"}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertFalse(
+            data["step"]["formStep"]["configuration"]["components"][1]["hidden"]
+        )
+        self.assertEqual(data["step"]["data"], {})
+
+    def test_second_rule_triggers_first_does_not_must_not_clear_value(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "show-when-a",
+                        "hidden": True,
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+        # just a single rule does not reproduce the issue (!).
+        # Rule 1: show the textfield when a non-sense value is selected in the radio
+        # (never triggers!)
+        show_textfield_action = {
+            "formStep": None,
+            "component": "show-when-a",
+            "action": {
+                "type": "property",
+                "property": {"value": "hidden", "type": "bool"},
+                "value": {},
+                "state": False,
+            },
+        }
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "nonsense-value"]},
+            actions=[show_textfield_action],
+        )
+        # Rule 2: show the textfield when 'a' is selected in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[show_textfield_action],
+        )
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {"data": {"radio": "a", "show-when-a": "do-not-clear-me"}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertFalse(
+            data["step"]["formStep"]["configuration"]["components"][1]["hidden"]
+        )
+        self.assertEqual(data["step"]["data"], {})
+
+    def test_rules_flip_from_hidden_to_visible_state_should_not_clear_value(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "hide-when-a-but-show-when-checkbox-checked",
+                        "hidden": False,
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+
+        def _build_action(make_hidden: bool):
+            return {
+                "formStep": None,
+                "component": "hide-when-a-but-show-when-checkbox-checked",
+                "action": {
+                    "type": "property",
+                    "property": {"value": "hidden", "type": "bool"},
+                    "value": {},
+                    "state": make_hidden,
+                },
+            }
+
+        # Hide (and clear) the textfield when 'a' is selected in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[_build_action(make_hidden=True)],
+        )
+        # Expected to trigger: the value of the textfield gets cleared because of the
+        # above rule.
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [{"var": "hide-when-a-but-show-when-checkbox-checked"}, ""]
+            },
+            actions=[
+                {
+                    "formStep": None,
+                    "component": "hide-when-a-but-show-when-checkbox-checked",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "validate.required", "type": "bool"},
+                        "value": {},
+                        "state": True,
+                    },
+                }
+            ],
+        )
+        # Show the textfield when the checkbox is checked
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"var": "checkbox"},
+            actions=[_build_action(make_hidden=False)],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {
+                "data": {
+                    "radio": "a",
+                    "checkbox": True,
+                    "hide-when-a-but-show-when-checkbox-checked": "do-not-clear-me",
+                }
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        textfield_component = data["step"]["formStep"]["configuration"]["components"][2]
+        self.assertFalse(textfield_component["hidden"])
+        self.assertTrue(textfield_component["validate"]["required"])
+        self.assertEqual(data["step"]["data"], {})
+
+
 def is_valid_expression(expr: dict):
     try:
         JsonLogicValidator()(expr)

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1296,15 +1296,27 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                         "key": "hide-when-a-but-show-when-checkbox-checked",
                         "hidden": False,
                     },
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "nestedTextfield",
+                                "hidden": False,
+                            }
+                        ],
+                    },
                 ]
             },
         )
         form_step = form.formstep_set.get()
 
-        def _build_action(make_hidden: bool):
+        def _build_visibility_action(key: str, make_hidden: bool):
             return {
                 "formStep": None,
-                "component": "hide-when-a-but-show-when-checkbox-checked",
+                "component": key,
                 "action": {
                     "type": "property",
                     "property": {"value": "hidden", "type": "bool"},
@@ -1317,7 +1329,12 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         FormLogicFactory.create(
             form=form,
             json_logic_trigger={"==": [{"var": "radio"}, "a"]},
-            actions=[_build_action(make_hidden=True)],
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=True
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=True),
+            ],
         )
         # Expected to trigger: the value of the textfield gets cleared because of the
         # above rule.
@@ -1343,7 +1360,12 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         FormLogicFactory.create(
             form=form,
             json_logic_trigger={"var": "checkbox"},
-            actions=[_build_action(make_hidden=False)],
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=False
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=False),
+            ],
         )
 
         submission = SubmissionFactory.create(form=form)
@@ -1363,6 +1385,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     "radio": "a",
                     "checkbox": True,
                     "hide-when-a-but-show-when-checkbox-checked": "do-not-clear-me",
+                    "nestedTextfield": "do-not-clear-me",
                 }
             },
         )
@@ -1370,10 +1393,22 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        textfield_component = data["step"]["formStep"]["configuration"]["components"][2]
-        self.assertFalse(textfield_component["hidden"])
-        self.assertTrue(textfield_component["validate"]["required"])
-        self.assertEqual(data["step"]["data"], {})
+        with self.subTest("textfield"):
+            textfield_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][2]
+            self.assertFalse(textfield_component["hidden"])
+            self.assertTrue(textfield_component["validate"]["required"])
+
+        with self.subTest("fieldset"):
+            fieldset_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][3]
+            self.assertFalse(fieldset_component["hidden"])
+            self.assertFalse(fieldset_component["components"][0]["hidden"])
+
+        with self.subTest("data mutations"):
+            self.assertEqual(data["step"]["data"], {})
 
 
 def is_valid_expression(expr: dict):

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1132,7 +1132,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         self.assertNotIn("date", data["step"]["data"])
 
 
-@tag("gh-6001", "gh-6005")
+@tag("gh-6005")
 class MultipleRulesTargettingSameComponentVisibilityTests(
     SubmissionsMixin, APITestCase
 ):
@@ -1192,6 +1192,9 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
             },
         )
 
+        # this assumes there has been a call before with `radio: a` that results in
+        # show-when-a becoming visible, after which the user enters a value for that
+        # field.
         response = self.client.post(
             logic_check_endpoint,
             {"data": {"radio": "a", "show-when-a": "do-not-clear-me"}},
@@ -1338,6 +1341,148 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         )
         # Expected to trigger: the value of the textfield gets cleared because of the
         # above rule.
+        # NOTE: this rule is illegal in 3.5.x due to the cyclic reference. When
+        # backporting, make sure it targets another component.
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [{"var": "hide-when-a-but-show-when-checkbox-checked"}, ""]
+            },
+            actions=[
+                {
+                    "formStep": None,
+                    "component": "hide-when-a-but-show-when-checkbox-checked",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "validate.required", "type": "bool"},
+                        "value": {},
+                        "state": True,
+                    },
+                }
+            ],
+        )
+        # Show the textfield when the checkbox is checked
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"var": "checkbox"},
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=False
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=False),
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {
+                "data": {
+                    "radio": "a",
+                    "checkbox": True,
+                    "hide-when-a-but-show-when-checkbox-checked": "do-not-clear-me",
+                    "nestedTextfield": "do-not-clear-me",
+                }
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        with self.subTest("textfield"):
+            textfield_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][2]
+            self.assertFalse(textfield_component["hidden"])
+            self.assertTrue(textfield_component["validate"]["required"])
+
+        with self.subTest("fieldset"):
+            fieldset_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][3]
+            self.assertFalse(fieldset_component["hidden"])
+            self.assertFalse(fieldset_component["components"][0]["hidden"])
+
+        with self.subTest("data mutations"):
+            self.assertEqual(data["step"]["data"], {})
+
+    def test_rules_flip_from_hidden_to_visible_state_should_not_clear_value_inverse(
+        self,
+    ):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "hide-when-a-but-show-when-checkbox-checked",
+                        "hidden": True,
+                    },
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "hidden": True,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "nestedTextfield",
+                                "hidden": False,
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+
+        def _build_visibility_action(key: str, make_hidden: bool):
+            return {
+                "formStep": None,
+                "component": key,
+                "action": {
+                    "type": "property",
+                    "property": {"value": "hidden", "type": "bool"},
+                    "value": {},
+                    "state": make_hidden,
+                },
+            }
+
+        # Hide (and clear) the textfield when 'a' is selected in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=True
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=True),
+            ],
+        )
+        # Expected to trigger: the value of the textfield gets cleared because of the
+        # above rule.
+        # NOTE: this rule is illegal in 3.5.x due to the cyclic reference. When
+        # backporting, make sure it targets another component.
         FormLogicFactory.create(
             form=form,
             json_logic_trigger={


### PR DESCRIPTION
Closes #6005

**Changes**

* Added regression tests for observed situations, hopefully covering all possible variants
* Change visibility processing logic:
    * Immediately commit the component property state change
    * Ensure that values from input data are restored when flipping from hidden -> visible

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
