### PR TITLE
"Backport" the 3.4.x bugfixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,14 @@ their settings mechanism and now allows for distinct enforced/report-only config
 
 We'll work on bridging this gap, possibly through an upgrade to Django 6.0.
 
+3.4.3 (2026-02-26)
+==================
+
+Hotfix release.
+
+* [:backend:`6005`] Fixed input values unintentionally being cleared when there are
+  multiple backend logic rules that specify the visibility state of the same component.
+
 3.4.2 (2026-02-20)
 ==================
 

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1138,6 +1138,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ):
         key = component["key"]
         # We only need to process children if the value was not already cleared.
@@ -1177,6 +1178,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=components_to_ignore_hidden,
+                original_input_data=original_input_data,
             )
             edit_grid_data_new.append(item_data)
 
@@ -1195,6 +1197,7 @@ class Columns(BasePlugin[ColumnsComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ):
         for column in component["columns"]:
             # If the hidden property of the parent should be ignored, so should it for
@@ -1213,6 +1216,7 @@ class Columns(BasePlugin[ColumnsComponent]):
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=components_to_ignore_hidden,
+                original_input_data=original_input_data,
             )
 
 
@@ -1228,6 +1232,7 @@ class Fieldset(BasePlugin[FieldsetComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ):
         # If the hidden property of the parent should be ignored, so should it for
         # its children.
@@ -1247,4 +1252,5 @@ class Fieldset(BasePlugin[FieldsetComponent]):
             parent_hidden=parent_hidden,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=components_to_ignore_hidden,
+            original_input_data=original_input_data,
         )

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -152,6 +152,7 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ) -> None:
         """
         Apply (conditional) visibility of this component. This routine should be
@@ -166,6 +167,9 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
           evaluation of the conditional.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
+        :param original_input_data: The input data from the frontend when called through
+          the check logic endpoint. Used to restore values when flipping visibility
+          states.
         """
 
     @staticmethod
@@ -255,6 +259,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        original_input_data: FormioData | None = None,
     ) -> None:
         """
         Apply (conditional) visibility of this component. This routine should be
@@ -269,6 +274,9 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
           evaluation of the conditional.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
+        :param original_input_data: The input data from the frontend when called through
+          the check logic endpoint. Used to restore values when flipping visibility
+          states.
         """
         if (component_type := component["type"]) not in self:
             return
@@ -282,6 +290,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
             parent_hidden=parent_hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
+            original_input_data=original_input_data,
         )
 
     def update_config(

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -91,6 +91,7 @@ def process_visibility(
     parent_hidden: bool = False,
     get_evaluation_data: GetEvaluationData | None = None,
     components_to_ignore_hidden: set[str] | None = None,
+    original_input_data: FormioData | None = None,
 ) -> None:
     """
     Process the visibility of the components inside the configuration, by checking if
@@ -135,6 +136,18 @@ def process_visibility(
             # If we don't have an initial value available, just use the empty value.
             data[key] = initial_data.get(key) or get_component_empty_value(component)
 
+        # if it's visible, check if any input data should be restored because earlier
+        # logic rules may have cleared it (visible -> hidden -> visible)
+        if not hidden and original_input_data is not None:
+            if data.get(key) != (original_value := original_input_data.get(key)):
+                # restore the value from the original input data - likely there was a
+                # sequence in logic that lead to the data being cleared because of hidden
+                # state, while a subsequent action makes the component visible again. In
+                # that case, the frontend will have the component visible and data can
+                # be entered, which needs to be grabbed from the initial data to avoid
+                # wiping user input.
+                data[key] = original_value
+
         # Apply the visibility to children components, if applicable
         register.apply_visibility(
             component,
@@ -144,4 +157,5 @@ def process_visibility(
             parent_hidden=hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
+            original_input_data=original_input_data,
         )

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -452,7 +452,10 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
         log = logger.bind(submission_uuid=str(submission.uuid))
         state = submission.load_submission_value_variables_state()
 
-        all_values = state.get_data(include_static_variables=True)
+        all_values = state.get_data(
+            include_static_variables=True,
+            include_unsaved=True,
+        )
         # update with the registration static values - a special subtype of static
         # variables. They're possibly derived from user input.
         registration_vars = state.get_static_data(other_registry=variables_registry)

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -1411,3 +1411,68 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 ],
             },
         )
+
+    @tag("gh-6007")
+    def test_hidden_fields_still_get_emitted_to_object(self):
+        """
+        Assert that components that are hidden are not omitted from the JSON payload.
+
+        4a295cb968ed8f96dee7d27405c9cb4a80defd19 results in hidden fields no longer
+        creating a database record for the hidden variable, but it *is* still available
+        in the submission state and should be processed accordingly.
+        """
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "textfield",
+                    "key": "textfield",
+                    "hidden": True,
+                },
+                {
+                    "type": "fieldset",
+                    "key": "hiddenFieldset",
+                    "hidden": True,
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "nestedTextfield",
+                            "hidden": False,
+                        }
+                    ],
+                },
+            ],
+            completed=True,
+            submitted_data={},
+        )
+        state = submission.load_submission_value_variables_state()
+        assert not state.saved_variables
+        v2_options: RegistrationOptionsV2 = {
+            "version": 2,
+            "objects_api_group": self.objects_api_group,
+            # See the docker compose fixtures for more info on these values:
+            "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
+            "objecttype_version": 1,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "variables_mapping": [
+                {"variable_key": "textfield", "target_path": ["textfield"]},
+                {"variable_key": "nestedTextfield", "target_path": ["nestedTextfield"]},
+            ],
+            "transform_to_list": [],
+            "iot_attachment": "",
+            "iot_submission_csv": "",
+            "iot_submission_report": "",
+        }
+        plugin = ObjectsAPIRegistration(PLUGIN_IDENTIFIER)
+
+        # Run the registration
+        result = plugin.register_submission(submission, v2_options)
+
+        assert result is not None
+        self.assertEqual(
+            result["record"]["data"],
+            {
+                "textfield": "",
+                "nestedTextfield": "",
+            },
+        )

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_hidden_fields_still_get_emitted_to_object.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_hidden_fields_still_get_emitted_to_object.yaml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+        everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '619'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 26 Feb 2026 14:42:49 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.5
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e",
+      "record": {"typeVersion": 1, "data": {"textfield": "", "nestedTextfield": ""},
+      "startAt": "2024-03-19"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Token 7657474c3d75f56ae0abd0d1bf7994b09964dca9
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/fd1f4fd1-18de-4d0c-8aad-2af20a69a5e8","uuid":"fd1f4fd1-18de-4d0c-8aad-2af20a69a5e8","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"textfield":"","nestedTextfield":""},"geometry":null,"startAt":"2024-03-19","endAt":null,"registrationAt":"2026-02-26","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '428'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 26 Feb 2026 14:42:49 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/fd1f4fd1-18de-4d0c-8aad-2af20a69a5e8
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.5
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -91,7 +91,7 @@ class CosignState:
         """
         from .form_logic import check_submission_logic
 
-        check_submission_logic(self.submission)
+        check_submission_logic(self.submission, reset_configuration_wrapper=False)
 
         # use the complete view on the Formio component tree(s)
         configuration_wrapper = self.submission.total_configuration_wrapper

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -287,6 +287,7 @@ def evaluate_conditional_logic(
 def check_submission_logic(
     submission: Submission,
     current_step: SubmissionStep | None = None,
+    reset_configuration_wrapper: bool = True,
 ) -> None:
     if getattr(submission, "_form_logic_evaluated", False):
         return
@@ -330,6 +331,9 @@ def check_submission_logic(
             mutation.apply(step, configuration)
 
     # Note that the total configuration wrapper is a cached property, so we need to
-    # reset to ensure we are not operating on outdated configurations later
-    submission._total_configuration_wrapper = None
+    # reset to ensure we are not operating on outdated configurations later.
+    # XXX: not sure why this is necessary - removing it entirely doesn't seem to break
+    # any tests? Check with Viktor.
+    if reset_configuration_wrapper:
+        submission._total_configuration_wrapper = None
     submission._form_logic_evaluated = True

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -137,6 +137,8 @@ class ActionOperation:
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         """
         Return a mapping [name/path -> new_value] with changes that are to be
@@ -177,6 +179,9 @@ class PropertyAction(ActionOperation):
     def apply(
         self, step: SubmissionStep, configuration: FormioConfigurationWrapper
     ) -> None:
+        # handled directly inside eval
+        if self.property_name == "hidden":
+            return None
         if self.component not in configuration:
             return None
         component = configuration[self.component]
@@ -188,20 +193,32 @@ class PropertyAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         # To avoid doing unnecessary work, only apply clear-on-hide logic for components
-        # for which their action sets the "hidden" property to True.
-        if not (self.property_name == "hidden" and self.value):
+        # for which their action touches the "hidden" property.
+        if self.property_name != "hidden":
             return None
 
-        # Note that this can happen when the action applies to a component of a
-        # different step than we are currently evaluating. We don't have to do
+        # we now know that we're making the component visible or hidden, but we're not
+        # guaranteed that we're actually changing the visibility state at all! For that
+        # we need to check at the current component configuration, and that requires
+        # first checking if the component is in the current step's configuration. The
+        # component *can* be absent if it refers to a component in another step than
+        # the one we are currently evaluating. We don't have to do
         # anything in this case, because the clear-on-hide behaviour of that
         # component will be handled once the user has reached that step.
         if self.component not in configuration:
             return None
 
         component = configuration[self.component]
+        should_be_hidden = self.value is True
+
+        # apply the state mutation immediately, so that it's visible to follow up
+        # actions and rules operating on the same component. This obsoletes the
+        # apply method/side-effects.
+        component[self.property_name] = self.value
 
         # Process the visibility of the component. We want to process the component
         # itself, not try to iterate over its children, so we create a 'fake'
@@ -211,7 +228,8 @@ class PropertyAction(ActionOperation):
             context,
             configuration,
             initial_data=initial_data,
-            parent_hidden=True,
+            parent_hidden=should_be_hidden,
+            original_input_data=original_input_data,
         )
         return None
 
@@ -373,6 +391,8 @@ class VariableAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping:
         with log_errors(self.value, self.rule):
             return {self.variable: jsonLogic(self.value, context.data)}
@@ -505,6 +525,8 @@ class SynchronizeVariablesAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         configuration = submission.total_configuration_wrapper
         if self.source_variable not in configuration:
@@ -562,6 +584,8 @@ class ServiceFetchAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping:
         var = self.rule.form.formvariable_set.get(key=self.variable)
         with log_errors({}, self.rule):  # TODO proper error handling
@@ -626,6 +650,8 @@ class EvaluateDMNAction(ActionOperation):
         configuration: FormioConfigurationWrapper,
         submission: Submission,
         initial_data: FormioData,
+        *,
+        original_input_data: FormioData,
     ) -> DataMapping | None:
         # Mapping from form variables to DMN inputs
         dmn_inputs = {

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Iterator
+from copy import deepcopy
 
 import elasticapm
 from json_logic import jsonLogic
@@ -186,6 +187,18 @@ def iter_evaluate_rules(
     :returns: An iterator yielding :class:`ActionOperation` instances.
     """
     state = submission.load_submission_value_variables_state()
+
+    # keep a copy of the start data that is not affected by the mutations applied by
+    # logic. Due to the instant processing of clearOnHide side-effects and multiple
+    # logic rules potentially changing the visibility of the same component, we need to
+    # make sure to restore the data for every hidden -> visible flip, as the visible ->
+    # hidden flip results in clearing the data - see #6001. For this restoration, we
+    # use the start data as source, as that is coming from the frontend state that is
+    # the result of logic evaluations.
+    # For the hotfix, we deliberately keep this isolated from initial_data, which is
+    # populated differently based on whether the new renderer is enabled or not.
+    original_input_data = deepcopy(data)
+
     for rule in rules:
         with (
             tracer.start_as_current_span(
@@ -211,12 +224,22 @@ def iter_evaluate_rules(
             # as components can be hidden by default and shown when a logic rule is
             # triggered
             if not triggered:
-                _handle_clear_on_hide(rule, data, configuration, initial_data)
+                _handle_clear_on_hide_for_untriggered_rule(
+                    rule,
+                    data,
+                    configuration,
+                    initial_data,
+                    original_input_data=original_input_data,
+                )
                 continue
 
             for operation in rule.action_operations:
                 if mutations := operation.eval(
-                    data, configuration, submission, initial_data
+                    data,
+                    configuration,
+                    submission,
+                    initial_data,
+                    original_input_data=original_input_data,
                 ):
                     mutations_python = {
                         key: state.variables[key].to_python(value)
@@ -227,11 +250,13 @@ def iter_evaluate_rules(
                 yield operation
 
 
-def _handle_clear_on_hide(
+def _handle_clear_on_hide_for_untriggered_rule(
     rule: FormLogic,
     data: FormioData,
     configuration: FormioConfigurationWrapper,
     initial_data: FormioData,
+    *,
+    original_input_data: FormioData,
 ):
     """
     Handle clear-on-hide behaviour for components of which the "hidden" property
@@ -248,18 +273,19 @@ def _handle_clear_on_hide(
             continue
 
         component = configuration[operation.component]
-
-        # To avoid doing unnecessary work, only call ``process_visibility`` when the
-        # component is actually hidden.
-        if not component.get("hidden", False):
-            continue
-
         # Process the visibility of the component. We want to process the component
         # itself, not try to iterate over its children, so we create a 'fake'
         # configuration.
         # Note that we cannot pass ``parent_hidden=True`` here, and skip conditional
         # evaluation (like in ``PropertyAction.eval``), because a component can be
         # affected by a simple conditional which makes it visible.
+        # Additionally (see #6005), when a component flips back to visible after being
+        # hidden and having its value cleared before, we need to restore the original
+        # input data, so we must always call this.
         process_visibility(
-            {"components": [component]}, data, configuration, initial_data=initial_data
+            {"components": [component]},
+            data,
+            configuration,
+            initial_data=initial_data,
+            original_input_data=original_input_data,
         )

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1130,6 +1130,430 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         self.assertNotIn("date", data["step"]["data"])
 
 
+@tag("gh-6005")
+class MultipleRulesTargettingSameComponentVisibilityTests(
+    SubmissionsMixin, APITestCase
+):
+    def test_first_rule_triggers_second_does_not_must_not_clear_value(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "show-when-a",
+                        "hidden": True,
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+        # just a single rule does not reproduce the issue (!).
+        # Rule 1: show the textfield when 'a' is selected in the radio
+        show_textfield_action = {
+            "formStep": None,
+            "component": "show-when-a",
+            "action": {
+                "type": "property",
+                "property": {"value": "hidden", "type": "bool"},
+                "value": {},
+                "state": False,
+            },
+        }
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[show_textfield_action],
+        )
+        # Rule 2: show the textfield when a non-sense value is selected in the radio
+        # (never triggers!)
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "nonsense-value"]},
+            actions=[show_textfield_action],
+        )
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        # this assumes there has been a call before with `radio: a` that results in
+        # show-when-a becoming visible, after which the user enters a value for that
+        # field.
+        response = self.client.post(
+            logic_check_endpoint,
+            {"data": {"radio": "a", "show-when-a": "do-not-clear-me"}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertFalse(
+            data["step"]["formStep"]["configuration"]["components"][1]["hidden"]
+        )
+        self.assertEqual(data["step"]["data"], {})
+
+    def test_second_rule_triggers_first_does_not_must_not_clear_value(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "show-when-a",
+                        "hidden": True,
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+        # just a single rule does not reproduce the issue (!).
+        # Rule 1: show the textfield when a non-sense value is selected in the radio
+        # (never triggers!)
+        show_textfield_action = {
+            "formStep": None,
+            "component": "show-when-a",
+            "action": {
+                "type": "property",
+                "property": {"value": "hidden", "type": "bool"},
+                "value": {},
+                "state": False,
+            },
+        }
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "nonsense-value"]},
+            actions=[show_textfield_action],
+        )
+        # Rule 2: show the textfield when 'a' is selected in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[show_textfield_action],
+        )
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {"data": {"radio": "a", "show-when-a": "do-not-clear-me"}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertFalse(
+            data["step"]["formStep"]["configuration"]["components"][1]["hidden"]
+        )
+        self.assertEqual(data["step"]["data"], {})
+
+    def test_rules_flip_from_hidden_to_visible_state_should_not_clear_value(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "hide-when-a-but-show-when-checkbox-checked",
+                        "hidden": False,
+                    },
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "nestedTextfield",
+                                "hidden": False,
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+
+        def _build_visibility_action(key: str, make_hidden: bool):
+            return {
+                "formStep": None,
+                "component": key,
+                "action": {
+                    "type": "property",
+                    "property": {"value": "hidden", "type": "bool"},
+                    "value": {},
+                    "state": make_hidden,
+                },
+            }
+
+        # Hide (and clear) the textfield when 'a' is selected in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=True
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=True),
+            ],
+        )
+        # Expected to trigger: the value of the textfield gets cleared because of the
+        # above rule.
+        # NOTE: this rule is illegal in 3.5.x due to the cyclic reference. When
+        # backporting, make sure it targets another component.
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [{"var": "hide-when-a-but-show-when-checkbox-checked"}, ""]
+            },
+            actions=[
+                {
+                    "formStep": None,
+                    "component": "hide-when-a-but-show-when-checkbox-checked",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "validate.required", "type": "bool"},
+                        "value": {},
+                        "state": True,
+                    },
+                }
+            ],
+        )
+        # Show the textfield when the checkbox is checked
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"var": "checkbox"},
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=False
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=False),
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {
+                "data": {
+                    "radio": "a",
+                    "checkbox": True,
+                    "hide-when-a-but-show-when-checkbox-checked": "do-not-clear-me",
+                    "nestedTextfield": "do-not-clear-me",
+                }
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        with self.subTest("textfield"):
+            textfield_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][2]
+            self.assertFalse(textfield_component["hidden"])
+            self.assertTrue(textfield_component["validate"]["required"])
+
+        with self.subTest("fieldset"):
+            fieldset_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][3]
+            self.assertFalse(fieldset_component["hidden"])
+            self.assertFalse(fieldset_component["components"][0]["hidden"])
+
+        with self.subTest("data mutations"):
+            self.assertEqual(data["step"]["data"], {})
+
+    def test_rules_flip_from_hidden_to_visible_state_should_not_clear_value_inverse(
+        self,
+    ):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "hide-when-a-but-show-when-checkbox-checked",
+                        "hidden": True,
+                    },
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "hidden": True,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "nestedTextfield",
+                                "hidden": False,
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+
+        def _build_visibility_action(key: str, make_hidden: bool):
+            return {
+                "formStep": None,
+                "component": key,
+                "action": {
+                    "type": "property",
+                    "property": {"value": "hidden", "type": "bool"},
+                    "value": {},
+                    "state": make_hidden,
+                },
+            }
+
+        # Hide (and clear) the textfield when 'a' is selected in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "radio"}, "a"]},
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=True
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=True),
+            ],
+        )
+        # Expected to trigger: the value of the textfield gets cleared because of the
+        # above rule.
+        # NOTE: this rule is illegal in 3.5.x due to the cyclic reference. When
+        # backporting, make sure it targets another component.
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [{"var": "hide-when-a-but-show-when-checkbox-checked"}, ""]
+            },
+            actions=[
+                {
+                    "formStep": None,
+                    "component": "hide-when-a-but-show-when-checkbox-checked",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "validate.required", "type": "bool"},
+                        "value": {},
+                        "state": True,
+                    },
+                }
+            ],
+        )
+        # Show the textfield when the checkbox is checked
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"var": "checkbox"},
+            actions=[
+                _build_visibility_action(
+                    key="hide-when-a-but-show-when-checkbox-checked", make_hidden=False
+                ),
+                _build_visibility_action(key="fieldset", make_hidden=False),
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            logic_check_endpoint,
+            {
+                "data": {
+                    "radio": "a",
+                    "checkbox": True,
+                    "hide-when-a-but-show-when-checkbox-checked": "do-not-clear-me",
+                    "nestedTextfield": "do-not-clear-me",
+                }
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        with self.subTest("textfield"):
+            textfield_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][2]
+            self.assertFalse(textfield_component["hidden"])
+            self.assertTrue(textfield_component["validate"]["required"])
+
+        with self.subTest("fieldset"):
+            fieldset_component = data["step"]["formStep"]["configuration"][
+                "components"
+            ][3]
+            self.assertFalse(fieldset_component["hidden"])
+            self.assertFalse(fieldset_component["components"][0]["hidden"])
+
+        with self.subTest("data mutations"):
+            self.assertEqual(data["step"]["data"], {})
+
+
 def is_valid_expression(expr: dict):
     try:
         JsonLogicValidator()(expr)

--- a/src/openforms/variables/utils.py
+++ b/src/openforms/variables/utils.py
@@ -50,7 +50,9 @@ def get_variables_for_context(
     """
     state = submission.load_submission_value_variables_state()
     data = state.get_data(
-        include_static_variables=True, is_confirmation_email=is_confirmation_email
+        include_static_variables=True,
+        include_unsaved=True,
+        is_confirmation_email=is_confirmation_email,
     ).data
 
     if settings.ESCAPE_REGISTRATION_OUTPUT:


### PR DESCRIPTION
Closes #6005
Closes #6007

**Changes**

* Fixes the handling of multiple logic rules that target the same component visibility state + clear on hide behaviour
* Fixes unsaved variables not being included during registration/template rendering

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
