### PR TITLE
Fix overlapping component keys causing crash in logic evalution

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1085,3 +1085,13 @@ class CustomerProfile(BasePlugin):
         )
         result["data"] = data
         return result
+
+
+@register("softRequiredErrors")
+class SoftRequiredErrors(BasePlugin):
+    holds_submission_data = False
+
+
+@register("coSign")
+class CoSign(BasePlugin):
+    holds_submission_data = False

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -958,6 +958,7 @@ class Content(BasePlugin):
 
     # not really relevant as content components don't have values
     formatter = DefaultFormatter
+    holds_submission_data = False
 
     @staticmethod
     def rewrite_for_request(component: ContentComponent, request: Request):
@@ -1187,6 +1188,8 @@ class EditGrid(BasePlugin[EditGridComponent]):
 
 @register("columns")
 class Columns(BasePlugin[ColumnsComponent]):
+    holds_submission_data = False
+
     @staticmethod
     def apply_visibility(
         component: ColumnsComponent,
@@ -1222,6 +1225,8 @@ class Columns(BasePlugin[ColumnsComponent]):
 
 @register("fieldset")
 class Fieldset(BasePlugin[FieldsetComponent]):
+    holds_submission_data = False
+
     @staticmethod
     def apply_visibility(
         component: FieldsetComponent,

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Generic,
     Literal,
     NotRequired,
@@ -91,6 +92,10 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
     pre_registration_hook: PreRegistrationHookProtocol[ComponentT] | None = None
     """
     Hook to perform component-specific registration logic during the "pre-registration" phase.
+    """
+    holds_submission_data: ClassVar[bool] = True
+    """
+    Flag to indicate whether data can be submitted for this component.
     """
 
     @property
@@ -388,6 +393,13 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         assert hook is not None
 
         return hook(component, submission)
+
+    def holds_submission_data(self, component: Component) -> bool:
+        """Return whether data can be submitted for a particular component."""
+        if (component_type := component["type"]) not in self:
+            return True
+
+        return self[component_type].holds_submission_data
 
 
 # Sentinel to provide the default registry. You can easily instantiate another

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -96,8 +96,7 @@ def process_visibility(
     """
     Process the visibility of the components inside the configuration, by checking if
     they were hidden because of conditional logic or a hidden parent, and clearing the
-    value (set to empty component value) when applicable (which is the case unless
-    ``clearOnHide`` is ``False``).
+    value when applicable (``clearOnHide`` is ``True``).
 
     Note that the data mutations are applied directly.
 
@@ -113,6 +112,9 @@ def process_visibility(
     :param components_to_ignore_hidden: Set of components for which the "hidden"
       property is ignored in determining whether the component is hidden. Note that if
       it was not passed, the hidden property WILL be checked.
+    :param original_input_data: The input data from the frontend when called through
+      the check logic endpoint. Used to restore values when flipping visibility
+      states.
     """
     components_to_ignore_hidden = components_to_ignore_hidden or set()
     for component in configuration.get("components", []):
@@ -129,7 +131,8 @@ def process_visibility(
 
         # Need to check whether the component is present in the data because layout
         # components have no value
-        if hidden and clear_on_hide and key in data:
+        holds_submission_data = register.holds_submission_data(component)
+        if hidden and clear_on_hide and holds_submission_data:
             # NOTE - formio.js (and our own renderer) *delete* the key entirely from the
             # data instead, while we assign the empty value to ensure every variable is
             # always present in the submission data
@@ -138,7 +141,7 @@ def process_visibility(
 
         # if it's visible, check if any input data should be restored because earlier
         # logic rules may have cleared it (visible -> hidden -> visible)
-        if not hidden and original_input_data is not None:
+        if not hidden and original_input_data is not None and holds_submission_data:
             if data.get(key) != (original_value := original_input_data.get(key)):
                 # restore the value from the original input data - likely there was a
                 # sequence in logic that lead to the data being cleared because of hidden

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1129,3 +1129,80 @@ class ComponentModificationTests(TestCase):
         }
 
         self.assertEqual(configuration, expected)
+
+    @tag("gh-6014")
+    def test_hidden_fieldset_with_partially_overlapping_key(self):
+        """
+        Ensure that a field inside a layout component (fieldset in this case) gets
+        properly cleared, when the key of the child component ('container.textfield')
+        is a nested version of the parent ('container').
+        """
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "key": "container",
+                        "type": "fieldset",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "container.textfield",
+                                "label": "Textfield",
+                            },
+                            # Components to make codecov happy
+                            {
+                                "type": "coSign",
+                                "key": "coSign",
+                                "label": "Cosign",
+                            },
+                            {
+                                "type": "softRequiredErrors",
+                                "key": "softRequiredErrors",
+                                "label": "Errors",
+                            },
+                        ],
+                    },
+                ]
+            },
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "component": "container",
+                    "action": {
+                        "name": "Hide fieldset",
+                        "type": "property",
+                        "property": {
+                            "type": "bool",
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                }
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        submission_step = SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step,
+        )
+
+        evaluate_form_logic(
+            submission,
+            submission_step,
+            FormioData({"checkbox": True, "container": {"textfield": "clear me"}}),
+        )
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data(include_unsaved=True)
+        self.assertEqual(data["container.textfield"], "")


### PR DESCRIPTION
Closes #6014

[skip: e2e]

**Changes**

* Added flag `holds_submission_data` to component registry
* Added "softRequiredErrors" and "coSign" to the registry

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
