### PR TITLE
Fix backend visibility processing clearing valid input state

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1138,12 +1138,14 @@ class EditGrid(BasePlugin[EditGridComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        components_to_ignore_hidden: set[str] | None = None,
         original_input_data: FormioData | None = None,
     ):
         key = component["key"]
         # We only need to process children if the value was not already cleared.
         if not (edit_grid_data := data[key]):
             return
+        assert isinstance(edit_grid_data, list)
 
         # We might be dealing with nested editgrids
         outer_get_evaluation_data = (
@@ -1152,11 +1154,11 @@ class EditGrid(BasePlugin[EditGridComponent]):
 
         # If the hidden property of the parent should be ignored, so should it for its
         # children.
-        components_to_ignore_hidden = (
+        _components_to_ignore_hidden = (
             set(child["key"] for child in component["components"])
             if ignore_hidden_property
-            else None
-        )
+            else set()
+        ).union(components_to_ignore_hidden or set())
         edit_grid_data_new = []
 
         # For evaluation of the conditionals, we only care about the current item, so we
@@ -1177,7 +1179,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
                 initial_data=initial_data,
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
-                components_to_ignore_hidden=components_to_ignore_hidden,
+                components_to_ignore_hidden=_components_to_ignore_hidden,
                 original_input_data=original_input_data,
             )
             edit_grid_data_new.append(item_data)
@@ -1197,16 +1199,17 @@ class Columns(BasePlugin[ColumnsComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        components_to_ignore_hidden: set[str] | None = None,
         original_input_data: FormioData | None = None,
     ):
         for column in component["columns"]:
             # If the hidden property of the parent should be ignored, so should it for
             # its children.
-            components_to_ignore_hidden = (
+            _components_to_ignore_hidden: set[str] = (
                 set(child["key"] for child in column["components"])
                 if ignore_hidden_property
-                else None
-            )
+                else set()
+            ).union(components_to_ignore_hidden or set())
 
             process_visibility(
                 column,
@@ -1215,7 +1218,7 @@ class Columns(BasePlugin[ColumnsComponent]):
                 initial_data=initial_data,
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
-                components_to_ignore_hidden=components_to_ignore_hidden,
+                components_to_ignore_hidden=_components_to_ignore_hidden,
                 original_input_data=original_input_data,
             )
 
@@ -1232,15 +1235,17 @@ class Fieldset(BasePlugin[FieldsetComponent]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        components_to_ignore_hidden: set[str] | None = None,
         original_input_data: FormioData | None = None,
     ):
+
         # If the hidden property of the parent should be ignored, so should it for
         # its children.
-        components_to_ignore_hidden = (
+        _components_to_ignore_hidden: set[str] = (
             set(child["key"] for child in component["components"])
             if ignore_hidden_property
-            else None
-        )
+            else set()
+        ).union(components_to_ignore_hidden or set())
 
         # We need to process the children, so we just pass the component as the
         # configuration.
@@ -1251,6 +1256,6 @@ class Fieldset(BasePlugin[FieldsetComponent]):
             initial_data=initial_data,
             parent_hidden=parent_hidden,
             get_evaluation_data=get_evaluation_data,
-            components_to_ignore_hidden=components_to_ignore_hidden,
+            components_to_ignore_hidden=_components_to_ignore_hidden,
             original_input_data=original_input_data,
         )

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -152,6 +152,7 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        components_to_ignore_hidden: set[str] | None = None,
         original_input_data: FormioData | None = None,
     ) -> None:
         """
@@ -165,6 +166,9 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         :param parent_hidden: Indicates whether the parent component was hidden.
         :param get_evaluation_data: Function used to get the evaluation data used during
           evaluation of the conditional.
+        :param components_to_ignore_hidden: Set of components for which the "hidden"
+          property is ignored in determining whether the component is hidden. Note that if
+          it was not passed, the hidden property WILL be checked.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
         :param original_input_data: The input data from the frontend when called through
@@ -259,6 +263,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
+        components_to_ignore_hidden: set[str] | None = None,
         original_input_data: FormioData | None = None,
     ) -> None:
         """
@@ -272,6 +277,9 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         :param parent_hidden: Indicates whether the parent component was hidden.
         :param get_evaluation_data: Function used to get the evaluation data used during
           evaluation of the conditional.
+        :param components_to_ignore_hidden: Set of components for which the "hidden"
+          property is ignored in determining whether the component is hidden. Note that if
+          it was not passed, the hidden property WILL be checked.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
         :param original_input_data: The input data from the frontend when called through
@@ -290,6 +298,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
             parent_hidden=parent_hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
+            components_to_ignore_hidden=components_to_ignore_hidden,
             original_input_data=original_input_data,
         )
 

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -157,5 +157,6 @@ def process_visibility(
             parent_hidden=hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
+            components_to_ignore_hidden=components_to_ignore_hidden,
             original_input_data=original_input_data,
         )

--- a/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
@@ -92,9 +92,9 @@ class ConditionalLogicTests(TestCase):
                     "key": "file",
                     "hidden": False,
                     "conditional": {
-                        "eq": False,
-                        "show": "hide",
+                        "show": False,
                         "when": "textfieldVisible",
+                        "eq": "hide",
                     },
                     "clearOnHide": True,
                 },

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1,4 +1,5 @@
 import json
+import textwrap
 
 from django.db import connection
 from django.test import override_settings, tag
@@ -1128,6 +1129,114 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
 
         # The date hasn't changed, so it should not be present in the step data
         self.assertNotIn("date", data["step"]["data"])
+
+    @tag("gh-6001", "gh-6005")
+    def test_initial_hidden_visible_through_backend_logic_does_not_nuke_input_data(
+        self,
+    ):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                    },
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "textfieldClientSide",
+                                "hidden": True,
+                                "conditional": {
+                                    "show": True,
+                                    "when": "checkbox",
+                                    "eq": True,
+                                },
+                            },
+                            {
+                                "type": "textfield",
+                                "key": "textfieldServerSide",
+                                "hidden": True,
+                            },
+                        ],
+                    },
+                    {
+                        "type": "content",
+                        "key": "content",
+                        "html": textwrap.dedent(r"""
+                        textfieldClientSide: {{ textfieldClientSide }}
+                        textfieldServerSide: {{ textfieldServerSide }}
+                        """),
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"var": "checkbox"},
+            actions=[
+                {
+                    "formStep": None,
+                    "component": "textfieldServerSide",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "hidden", "type": "bool"},
+                        "value": {},
+                        "state": False,
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        # this simulates:
+        # 1. User checkx checkbox, client side logic instantly makes textfieldClientSide
+        #    visible
+        # 2. Server logic check makes textfieldServerSide visible
+        # 3. Input values in both fields, as they're both visible.
+        # 4. Value changes trigger new call and we expect to see the values in the
+        #    content component HTML.
+        response = self.client.post(
+            logic_check_endpoint,
+            {
+                "data": {
+                    "checkbox": True,
+                    "textfieldClientSide": "client-side-visible",
+                    "textfieldServerSide": "server-side-visible",
+                }
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        with self.subTest("data mutations"):
+            self.assertEqual(data["step"]["data"], {})
+
+        with self.subTest("evaluated content template"):
+            content_component = data["step"]["formStep"]["configuration"]["components"][
+                2
+            ]
+            self.assertEqual(
+                content_component["html"],
+                textwrap.dedent("""
+                textfieldClientSide: client-side-visible
+                textfieldServerSide: server-side-visible
+                """),
+            )
 
 
 @tag("gh-6005")


### PR DESCRIPTION
Closes #6001

**Changes**

* Added regression test after reproducing it through test form
* Lifted up the input restoration to take the state *before* applying client side conditional logic into account

This patch is basically an extension of #6005

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
