### PR TITLE
Fix components with chained conditional logic included in submission overview

### DIFF
--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -289,11 +289,13 @@ class FormioNode(Node):
         assert self.step.form_step  # nosec: intended use of B101
         configuration = self.step.form_step.form_definition.configuration
 
+        state = self.step.submission.load_submission_value_variables_state()
+        data = state.get_data(include_unsaved=True, submission_step=self.step)
         for configuration_path, component in iterate_components_with_configuration_path(
             configuration, recursive=False
         ):
             child_node = ComponentNode.build_node(
-                step_data=self.step.data,
+                step_data=data,
                 component=component,
                 renderer=self.renderer,
                 configuration_path=configuration_path,

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+import warnings
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
@@ -752,6 +753,14 @@ class Submission(models.Model):
             Keys containing dots (``.``) will be nested under another mapping.
             Static variables values are *not* included.
         """
+        warnings.warn(
+            "Using `Submission.data` to access submission data is deprecated. Please "
+            "use `SubmissionValueVariablesState.get_data(...)` with the relevant flags "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         values_state = self.load_submission_value_variables_state()
         return values_state.get_data()
 

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -1,4 +1,5 @@
 import uuid
+import warnings
 from copy import deepcopy
 
 from django.core import serializers
@@ -212,6 +213,14 @@ class SubmissionStep(models.Model):  # noqa: DJ008
 
     @property
     def data(self) -> FormioData:
+        warnings.warn(
+            "Using `SubmissionStep.data` to access submission data is deprecated. "
+            "Please use `SubmissionValueVariablesState.get_data(...)` with the "
+            "relevant flags instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         values_state = self.submission.load_submission_value_variables_state()
         step_data = values_state.get_data(submission_step=self)
         if self._unsaved_data:

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -354,6 +354,60 @@ class SubmissionSummaryRendererTests(TestCase):
         self.assertEqual(1, len(step_data))
         self.assertEqual(step_data[0]["name"], "")
 
+    @tag("gh-5980")
+    def test_with_conditional_logic(self):
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "label": "Radio",
+                        "values": [
+                            {"label": "A", "value": "a"},
+                            {"label": "B", "value": "b"},
+                        ],
+                        "conditional": {"show": False, "when": "checkbox", "eq": True},
+                        "clearOnHide": True,
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                        "clearOnHide": True,
+                        "conditional": {
+                            "show": False,
+                            "when": "radio",
+                            "eq": "",
+                        },
+                    },
+                ]
+            },
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        # Simulate submitting a step with checkbox checked. Note that because of the
+        # conditionals, neither "radio" nor "textfield" is visible, which means they
+        # will not be included in the submitted step data -> no submission value
+        # variables will be created in the database.
+        SubmissionStepFactory.create(
+            submission=submission, form_step=step, data={"checkbox": True}
+        )
+
+        data = submission.render_summary_page()
+        step_data = data[0]["data"]
+
+        # Only the checkbox should be visible in the overview
+        self.assertEqual(len(step_data), 1)
+        self.assertEqual(step_data[0]["name"], "Checkbox")
+
 
 class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
     def test_summary_page_endpoint(self):

--- a/src/openforms/submissions/tests/test_exports.py
+++ b/src/openforms/submissions/tests/test_exports.py
@@ -124,11 +124,11 @@ class ExportTests(TestCase):
                 "Export test",
                 datetime(2022, 5, 9, 15, 0, 0),
                 "Input 1",
-                None,
+                "",
                 "Input 3",
-                None,
-                None,
-                None,
+                "",
+                "",
+                "",
             ),
         )
 
@@ -247,7 +247,7 @@ class ExportTests(TestCase):
                 "Export form 1",
                 datetime(2022, 5, 9, 15, 0, 0),
                 "sub2.input1",
-                None,
+                "",
             ),
         )
         self.assertEqual(


### PR DESCRIPTION
Closes #5980

[skip: e2e]

**Changes**

* Use `SubmissionValueVariablesState.get_data(...)` in the `FormioNode.get_children`
* Update failing tests
* Add deprecation warnings for `SubmissionStep.data` and `Submission.data`  

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes