### PR TITLE
:bug: Preserve querystring when logging in to the admin via OIDC

### DIFF
--- a/src/openforms/accounts/tests/test_oidc.py
+++ b/src/openforms/accounts/tests/test_oidc.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from django_webtest import WebTest
+from furl import furl
 from mozilla_django_oidc_db.models import OIDCClient
 from mozilla_django_oidc_db.tests.mixins import OIDCMixin
 
@@ -57,6 +58,20 @@ class OIDCLoginButtonTestCase(OIDCMixin, WebTest):
         self.assertEqual(
             oidc_login_link.attrs["href"], reverse("oidc_authentication_init")
         )
+
+    def test_next_parameter_is_preserved(self):
+        OFOIDCClientFactory.create(
+            with_keycloak_provider=True, with_admin=True, enabled=True
+        )
+
+        response = self.app.get(reverse("admin-mfa-login"), {"next": "/foo"})
+
+        oidc_login_link = response.html.find(
+            "a", string=_("Login with organization account")
+        )
+        self.assertIsNotNone(oidc_login_link)
+        parsed_link = furl(oidc_login_link["href"])
+        self.assertEqual(parsed_link.args["next"], "/foo")
 
     def test_config_not_found(self):
         assert not OIDCClient.objects.exists()

--- a/src/openforms/templates/maykin_2fa/login.html
+++ b/src/openforms/templates/maykin_2fa/login.html
@@ -15,7 +15,7 @@
 
         <div class="admin-login-divider"><span>{% trans "or" %}</span></div>
         <div class="admin-login-option admin-login-option--oidc">
-            <a href="{% url 'oidc_authentication_init' %}">{% trans "Login with organization account" %}</a>
+            <a href="{% url 'oidc_authentication_init' %}{% querystring %}">{% trans "Login with organization account" %}</a>
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
No ticket - something that has been bothering me a long time and I decided to finally fix it.

**Changes**

* Pass along the query parameters in the OIDC auth init link in the admin

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
