### PR TITLE
Clean up and optimize SDK asset redirect building

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -328,7 +328,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                "openforms.forms.context_processors.sdk_urls",
                 "openforms.utils.context_processors.settings",
             ],
         },
@@ -1306,7 +1305,6 @@ LOG_OUTGOING_REQUESTS_RESET_DB_SAVE_AFTER = config(
 #
 FLAGS = {
     "ENABLE_DEMO_PLUGINS": [],
-    "DISPLAY_SDK_INFORMATION": [],
     "DIGID_EHERKENNING_OIDC_STRICT": [
         {
             "condition": "boolean",

--- a/src/openforms/forms/templates/forms/form_detail.html
+++ b/src/openforms/forms/templates/forms/form_detail.html
@@ -1,7 +1,6 @@
 {% extends 'ui/views/abstract/detail.html' %}
-{% load static openforms %}
+{% load static %}
 
 {% block card %}
-    {% sdk_info_banner %}
     {% include "forms/sdk_snippet.html" %}
 {% endblock %}

--- a/src/openforms/forms/templates/forms/sdk_info_banner.html
+++ b/src/openforms/forms/templates/forms/sdk_info_banner.html
@@ -1,6 +1,0 @@
-{% load i18n %}{% if enabled %}
-<div class="info-bar">
-    <span>{% trans "Javascript SDK used" %}</span>
-    <code>{{ sdk_umd_url }}</code>
-</div>
-{% endif %}

--- a/src/openforms/forms/templatetags/openforms.py
+++ b/src/openforms/forms/templatetags/openforms.py
@@ -1,12 +1,9 @@
 from django.template import Library
 from django.template.defaultfilters import stringfilter
 
-from flags.state import flag_enabled
 from rest_framework.reverse import reverse
 
 from openforms.utils.redirect import allow_redirect_url
-
-from ..context_processors import sdk_urls
 
 register = Library()
 
@@ -22,15 +19,6 @@ def api_base_url(context: dict):
 @stringfilter
 def trim(value):
     return value.strip()
-
-
-@register.inclusion_tag("forms/sdk_info_banner.html")
-def sdk_info_banner():
-    enabled = flag_enabled("DISPLAY_SDK_INFORMATION")
-    return {
-        "enabled": enabled,
-        **sdk_urls(request=None),
-    }
 
 
 @register.simple_tag

--- a/src/openforms/forms/views/form.py
+++ b/src/openforms/forms/views/form.py
@@ -9,6 +9,7 @@ from openforms.config.models import GlobalConfiguration, Theme
 from openforms.config.templatetags.theme import THEME_OVERRIDE_CONTEXT_VAR
 from openforms.utils.decorators import conditional_search_engine_index
 from openforms.utils.mixins import UserIsStaffMixin
+from openforms.utils.sdk_static import get_sdk_urls
 
 from ..models import Form
 
@@ -45,7 +46,12 @@ class FormDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context[THEME_OVERRIDE_CONTEXT_VAR] = self.object.theme
+        context.update(
+            {
+                THEME_OVERRIDE_CONTEXT_VAR: self.object.theme,
+                **get_sdk_urls(),
+            }
+        )
         return context
 
 
@@ -60,9 +66,14 @@ class ThemePreviewFormView(UserIsStaffMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context[THEME_OVERRIDE_CONTEXT_VAR] = self.theme
-        context["base_path"] = reverse(
-            "forms:theme-preview",
-            kwargs={"theme_pk": self.theme.pk, "slug": self.object.slug},
+        context.update(
+            {
+                THEME_OVERRIDE_CONTEXT_VAR: self.object.theme,
+                **get_sdk_urls(),
+                "base_path": reverse(
+                    "forms:theme-preview",
+                    kwargs={"theme_pk": self.theme.pk, "slug": self.object.slug},
+                ),
+            }
         )
         return context

--- a/src/openforms/tests/e2e/base.py
+++ b/src/openforms/tests/e2e/base.py
@@ -23,6 +23,7 @@ from playwright.async_api import (
 )
 
 from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.utils.sdk_static import get_sdk_urls
 
 type SupportedBrowser = Literal["chromium", "firefox", "webkit"]
 
@@ -122,6 +123,11 @@ async def browser_page():
 @disable_admin_mfa()
 @override_settings(ALLOWED_HOSTS=["*"])
 class E2ETestCase(StaticLiveServerTestCase):
+    def setUp(self):
+        super().setUp()
+
+        get_sdk_urls.cache_clear()
+
     async def _admin_login(self, page: Page) -> None:
         login_url = furl(self.live_server_url) / reverse("admin-mfa-login")
         await page.goto(str(login_url))

--- a/src/openforms/utils/middleware.py
+++ b/src/openforms/utils/middleware.py
@@ -27,6 +27,9 @@ class UpdateCSPMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
 
+        if getattr(response, "_csp_exempt", False):
+            return response
+
         update = self.get_csp_update()
         if not update:
             return response

--- a/src/openforms/utils/sdk_static.py
+++ b/src/openforms/utils/sdk_static.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.templatetags.static import static
 
 
-def sdk_urls(request):
+def get_sdk_urls():
     # use the locally included SDK build rather than referring to a hosted variant,
     # which is intended more for 3rd party CMS'es.
     sdk_path = Path("sdk/")

--- a/src/openforms/utils/sdk_static.py
+++ b/src/openforms/utils/sdk_static.py
@@ -1,12 +1,24 @@
+import functools
 from pathlib import Path
 
 from django.conf import settings
 from django.templatetags.static import static
 
 
+@functools.cache
 def get_sdk_urls():
-    # use the locally included SDK build rather than referring to a hosted variant,
-    # which is intended more for 3rd party CMS'es.
+    """
+    Resolve the unversioned URLs to their versioned counterparts.
+
+    Based on the ``SDK_RELEASE`` setting, taken from the environment variables and/or
+    ``.sdk-version`` file, resolve the static asset path for the 'active' version
+    included in this backend. Using the versioned URLs is important to bust user-agent
+    caches when new versions are deployed.
+
+    The version for a given image tag is fixed, so we can safely cache this in memory
+    of the Python process through ``functools.cache`` - a new image/container will have
+    its own process cache.
+    """
     sdk_path = Path("sdk/")
     if settings.SDK_RELEASE != "latest":
         sdk_path /= settings.SDK_RELEASE

--- a/src/openforms/utils/tests/test_sdk_urls.py
+++ b/src/openforms/utils/tests/test_sdk_urls.py
@@ -1,7 +1,11 @@
 from django.test import TestCase, override_settings
 
+from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
-class StableSDKUrlTests(TestCase):
+from ..sdk_static import get_sdk_urls
+
+
+class StableSDKUrlTests(ParametrizedTestCase, TestCase):
     """
     Ensure that stable SDK URLs can be used, independent of which version is deployed.
 
@@ -11,39 +15,37 @@ class StableSDKUrlTests(TestCase):
     which emits a 302 redirect to the correct asset location.
     """
 
+    def setUp(self):
+        super().setUp()
+
+        get_sdk_urls.cache_clear()
+        self.addCleanup(get_sdk_urls.cache_clear)
+
+    @parametrize(
+        ("stable_url", "resolved_url"),
+        [
+            param(
+                "/static/sdk/open-forms-sdk.js",
+                "/static/sdk/1.2.3/bundles/open-forms-sdk.js",
+                id="umd",
+            ),
+            param(
+                "/static/sdk/open-forms-sdk.mjs",
+                "/static/sdk/1.2.3/bundles/open-forms-sdk.mjs",
+                id="esm",
+            ),
+            param(
+                "/static/sdk/open-forms-sdk.css",
+                "/static/sdk/1.2.3/bundles/open-forms-sdk.css",
+                id="css",
+            ),
+        ],
+    )
     @override_settings(SDK_RELEASE="1.2.3")
-    def test_sdk_latest(self):
-        base = "/static/sdk/"
+    def test_sdk_latest(self, stable_url: str, resolved_url: str):
+        response = self.client.get(stable_url)
 
-        js_url = f"{base}open-forms-sdk.js"
-        with self.subTest(js_url=js_url):
-            js_response = self.client.get(js_url)
-
-            self.assertRedirects(
-                js_response,
-                f"{base}1.2.3/bundles/open-forms-sdk.js",
-                fetch_redirect_response=False,
-            )
-
-        mjs_url = f"{base}open-forms-sdk.mjs"
-        with self.subTest(js_url=mjs_url):
-            js_response = self.client.get(mjs_url)
-
-            self.assertRedirects(
-                js_response,
-                f"{base}1.2.3/bundles/open-forms-sdk.mjs",
-                fetch_redirect_response=False,
-            )
-
-        css_url = f"{base}open-forms-sdk.css"
-        with self.subTest(css_url=css_url):
-            css_response = self.client.get(css_url)
-
-            self.assertRedirects(
-                css_response,
-                f"{base}1.2.3/bundles/open-forms-sdk.css",
-                fetch_redirect_response=False,
-            )
+        self.assertRedirects(response, resolved_url, fetch_redirect_response=False)
 
     def test_invalid_extension(self):
         response = self.client.get("/static/sdk/open-forms-sdk.svg")

--- a/src/openforms/utils/views.py
+++ b/src/openforms/utils/views.py
@@ -9,10 +9,10 @@ from django.views.generic import RedirectView, TemplateView
 from rest_framework import exceptions as drf_exceptions
 
 from openforms.emails.context import get_wrapper_context
-from openforms.forms.context_processors import sdk_urls
 from openforms.submissions.models import Submission
 
 from ..api import exceptions
+from .sdk_static import get_sdk_urls
 
 
 class ErrorDetailView(TemplateView):
@@ -47,7 +47,7 @@ class SDKRedirectView(RedirectView):
     permanent = False
 
     def get_redirect_url(self, ext: str):
-        urls = sdk_urls(self.request)
+        urls = get_sdk_urls()
         match ext:
             case "js":
                 return urls["sdk_umd_url"]

--- a/src/openforms/utils/views.py
+++ b/src/openforms/utils/views.py
@@ -6,6 +6,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView, TemplateView
 
+from csp.decorators import csp_exempt
 from rest_framework import exceptions as drf_exceptions
 
 from openforms.emails.context import get_wrapper_context
@@ -42,6 +43,7 @@ class ErrorDetailView(TemplateView):
         return context
 
 
+@method_decorator(csp_exempt(), name="dispatch")
 @method_decorator(never_cache, name="dispatch")
 class SDKRedirectView(RedirectView):
     permanent = False


### PR DESCRIPTION
No ticket, just something that caught my eye on some test envs.

The endpoint that translates `/static/sdk/open-forms-sdk.*` into the versioned URLs like `/static/sdk/3.5.0-beta.2/bundles/open-forms-sdk.*` took longer than I'd expect for something that's supposed to just look up in staticfiles and return a redirect response. I had seen timings up to 150-200ms (!) and with this endpoint not being cacheable client-side, I felt there were some easy wins.

**Changes**

* Removed some unused functionality (SDK info banner, context processor)
* Applied caching to SDK path resolution
* Ensure that no DB queries are done to csp-exempted views

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
