### PR TITLE
[#5954] add nested `steps` field to `FormSerializer`

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8349,6 +8349,14 @@ components:
         components:
           type: array
           items: {}
+    FormDefinitionConfigurationV3:
+      type: object
+      properties:
+        components:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
     FormDefinitionDetail:
       type: object
       properties:
@@ -8490,6 +8498,41 @@ components:
           nullable: true
           title: Name [nl]
           maxLength: 50
+    FormDefinitionV3:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+          readOnly: true
+        internalName:
+          type: string
+          description: internal name for management purposes
+          maxLength: 50
+        slug:
+          type: string
+          maxLength: 100
+          pattern: ^[-a-zA-Z0-9_]+$
+          deprecated: true
+        configuration:
+          allOf:
+          - $ref: '#/components/schemas/FormDefinitionConfigurationV3'
+          title: Form.io configuration
+          description: The form definition as Form.io JSON schema
+        loginRequired:
+          type: boolean
+          description: DigID Login required for form step
+        isReusable:
+          type: boolean
+          description: Allow this definition to be re-used in multiple forms
+        translations:
+          $ref: '#/components/schemas/FormDefinitionModelTranslations'
+      required:
+      - configuration
+      - name
+      - uuid
     FormENTranslations:
       type: object
       description: |-
@@ -8858,6 +8901,15 @@ components:
           $ref: '#/components/schemas/ButtonText'
         nextText:
           $ref: '#/components/schemas/ButtonText'
+    FormStepLiteralsV3:
+      type: object
+      properties:
+        previousText:
+          $ref: '#/components/schemas/ButtonText'
+        saveText:
+          $ref: '#/components/schemas/ButtonText'
+        nextText:
+          $ref: '#/components/schemas/ButtonText'
     FormStepModelTranslations:
       type: object
       description: |-
@@ -8913,6 +8965,34 @@ components:
           description: The text that will be displayed in the form step to go to the
             next step. Leave blank to get value from global configuration.
           maxLength: 50
+    FormStepV3:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        index:
+          type: integer
+          readOnly: true
+        slug:
+          type: string
+          nullable: true
+          maxLength: 100
+          pattern: ^[-a-zA-Z0-9_]+$
+        formDefinition:
+          $ref: '#/components/schemas/FormDefinitionV3'
+        isApplicable:
+          type: boolean
+          description: Whether the step is applicable by default.
+        literals:
+          $ref: '#/components/schemas/FormStepLiteralsV3'
+        translations:
+          $ref: '#/components/schemas/FormStepModelTranslations'
+      required:
+      - formDefinition
+      - index
+      - uuid
     FormV3:
       type: object
       properties:
@@ -8959,6 +9039,10 @@ components:
           type: string
           format: uuid
           nullable: true
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormStepV3'
         showProgressIndicator:
           type: boolean
           description: Whether the step progression should be displayed in the UI
@@ -9080,6 +9164,7 @@ components:
       - loginRequired
       - name
       - slug
+      - steps
       - uuid
     FormVariable:
       type: object

--- a/src/openforms/emails/models.py
+++ b/src/openforms/emails/models.py
@@ -9,9 +9,20 @@ from openforms.emails.validators import URLSanitationValidator
 from openforms.forms.models import Form
 from openforms.template.validators import DjangoTemplateValidator
 
+from .typing import (
+    ConfirmationEmailTemplateData,
+    ConfirmationEmailTemplateTranslatedData,
+)
+
 
 class ConfirmationEmailTemplateManager(models.Manager["ConfirmationEmailTemplate"]):
-    def set_for_form(self, form: Form, data: dict | None):
+    def set_for_form(
+        self,
+        form: Form,
+        data: ConfirmationEmailTemplateData
+        | ConfirmationEmailTemplateTranslatedData
+        | None,
+    ) -> tuple[ConfirmationEmailTemplate, bool]:
         # if there's *no* template data, make sure that we do indeed wipe the fields,
         # making the template not usable
         if not data:

--- a/src/openforms/emails/typing.py
+++ b/src/openforms/emails/typing.py
@@ -1,0 +1,17 @@
+from typing import TypedDict
+
+
+class ConfirmationEmailTemplateData(TypedDict):
+    subject: str
+    content: str
+    cosign_subject: str
+    cosign_content: str
+
+
+class ConfirmationEmailTemplateTranslationsData(TypedDict):
+    en: ConfirmationEmailTemplateData
+    nl: ConfirmationEmailTemplateData
+
+
+class ConfirmationEmailTemplateTranslatedData(TypedDict):
+    translations: ConfirmationEmailTemplateTranslationsData

--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -16,6 +16,16 @@ from .utils import flatten_by_path, is_visible_in_frontend, iter_components
 RE_PATH = re.compile(r"(components|columns|rows)\.([0-9]+)")
 
 
+class DuplicateKeyError(Exception):
+    """
+    Error raised for unique component key violations.
+    """
+
+    def __init__(self, key: str, *args):
+        super().__init__(*args)
+        self.key = key
+
+
 def _get_editgrid_component_map(component: EditGridComponent) -> dict[str, Component]:
     """
     Given an edit grid component, return a component map with namespaced keys.
@@ -50,8 +60,12 @@ class FormioConfigurationWrapper:
     _flattened_by_path: None | dict[str, Component] = None
     _reverse_flattened: None | dict[str, str] = None
 
-    def __init__(self, configuration: FormioConfiguration):
+    def __init__(
+        self, configuration: FormioConfiguration, *, validate_unique_keys: bool = False
+    ):
         self._configuration = configuration
+        # this flag should not be necessary, but we likely need to address #2713 first
+        self.validate_unique_keys = validate_unique_keys
 
     @property
     def component_map(self) -> dict[str, Component]:
@@ -59,13 +73,21 @@ class FormioConfigurationWrapper:
             self._cached_component_map = {}
 
             for component in iter_components(self.configuration, recursive=True):
+                # Keys are supposed to be unique for the entire form, and the frontend
+                # validates this. However, frontend validation can be bypassed so we
+                # perform an additional check that can be used by backend validation.
+                if (
+                    key := component["key"]
+                ) in self._cached_component_map and self.validate_unique_keys:
+                    raise DuplicateKeyError(key)
+
                 # first, ensure we add every component by its own key so that we can
-                # look it up. This is okay *because* in our UI we enforce unique keys
-                # across the entire form, even if the key is present in an edit grid
-                # (repeating group). Note that formio is perfectly fine with a root
-                # 'foo' key and 'foo' key inside an editgrid. Our behaviour is different
-                # from that because of historical reasons...
-                self._cached_component_map[component["key"]] = component
+                # look it up. This is okay because we just validated its uniqueness.
+                # Even if the key is present in an edit grid (repeating group), we lean
+                # on this uniqueness guarantee. Note that formio is perfectly fine with
+                # a root 'foo' key and 'foo' key inside an editgrid. Our behaviour is
+                # different from that because of historical reasons...
+                self._cached_component_map[key] = component
 
                 # now, formio itself addresses components inside an edit grid with the
                 # pattern ``<editGridKey>.<componentKey>`` (e.g. in simple conditionals),

--- a/src/openforms/formio/dynamic_config/__init__.py
+++ b/src/openforms/formio/dynamic_config/__init__.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
 
-__all__ = ["rewrite_formio_components", "rewrite_formio_components_for_request"]
+__all__ = ["rewrite_formio_components"]
 
 
 def rewrite_formio_components(

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -19,7 +19,7 @@ from opentelemetry import trace
 
 from openforms.typing import JSONObject
 
-from .datastructures import FormioConfigurationWrapper, FormioData
+from .datastructures import DuplicateKeyError, FormioConfigurationWrapper, FormioData
 from .dynamic_config import (
     get_translated_custom_error_messages,
     localize_components,
@@ -36,6 +36,7 @@ from .typing import (
 )
 from .utils import (
     get_component_empty_value,
+    get_readable_path_from_configuration_path,
     iter_components,
     iterate_data_with_components,
 )
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from openforms.submissions.models import Submission
 
 __all__ = [
+    "DuplicateKeyError",
     "extract_variables_from_template_properties",
     "get_dynamic_configuration",
     "normalize_value_for_component",
@@ -61,6 +63,7 @@ __all__ = [
     "as_json_schema",
     "process_visibility",
     "get_component_empty_value",
+    "get_readable_path_from_configuration_path",
 ]
 
 tracer = trace.get_tracer("openforms.formio.service")

--- a/src/openforms/formio/tests/test_datastructures.py
+++ b/src/openforms/formio/tests/test_datastructures.py
@@ -2,7 +2,12 @@ from unittest import TestCase
 
 from openforms.formio.typing import Component, EditGridComponent
 
-from ..datastructures import FormioConfiguration, FormioConfigurationWrapper, FormioData
+from ..datastructures import (
+    DuplicateKeyError,
+    FormioConfiguration,
+    FormioConfigurationWrapper,
+    FormioData,
+)
 
 
 class FormioDataTests(TestCase):
@@ -302,3 +307,15 @@ class FormioConfigurationWrapperTests(TestCase):
             config_wrapper["outerEditgrid.innerEditgrid.innerTextfield"],
             inner_textfield,
         )
+
+    def test_raises_when_duplicate_keys_are_encountered(self):
+        duplicate: Component = {
+            "type": "textfield",
+            "key": "duplicated.key",
+            "label": "Duplicated key component",
+        }
+        config: FormioConfiguration = {"components": [duplicate, duplicate]}
+        config_wrapper = FormioConfigurationWrapper(config, validate_unique_keys=True)
+
+        with self.assertRaises(DuplicateKeyError):
+            config_wrapper["duplicated.key"]

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -113,7 +113,7 @@ def iterate_components_with_configuration_path(
     },
 )
 @elasticapm.capture_span(span_type="app.formio.configuration")
-def flatten_by_path(configuration: JSONObject) -> dict[str, Component]:
+def flatten_by_path(configuration: FormioConfiguration) -> dict[str, Component]:
     """
     Flatten the formio configuration.
 
@@ -126,7 +126,7 @@ def flatten_by_path(configuration: JSONObject) -> dict[str, Component]:
 
 
 def get_readable_path_from_configuration_path(
-    configuration: JSONObject, path: str, prefix: str | None = ""
+    configuration: FormioConfiguration, path: str, prefix: str | None = ""
 ) -> str:
     """
     Get a readable version of the configuration path.

--- a/src/openforms/forms/api/serializers/button_text.py
+++ b/src/openforms/forms/api/serializers/button_text.py
@@ -1,3 +1,5 @@
+from django.db.models import Model
+
 from rest_framework import serializers
 
 
@@ -5,13 +7,19 @@ class ButtonTextSerializer(serializers.Serializer):
     resolved = serializers.SerializerMethodField()
     value = serializers.CharField(allow_blank=True)
 
-    def __init__(self, resolved_getter=None, raw_field=None, *args, **kwargs):
+    def __init__(
+        self,
+        resolved_getter: str | None = None,
+        raw_field: str | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
         kwargs.setdefault("source", "*")
         self.resolved_getter = resolved_getter
         self.raw_field = raw_field
         super().__init__(*args, **kwargs)
 
-    def bind(self, field_name, parent):
+    def bind(self, field_name: str, parent: serializers.BaseSerializer) -> None:
         super().bind(field_name, parent)
 
         if self.resolved_getter is None:
@@ -22,7 +30,9 @@ class ButtonTextSerializer(serializers.Serializer):
 
         value_field = self.fields["value"]
         value_field.source = self.raw_field
+        assert value_field.field_name, "Field name is required"
         value_field.bind(value_field.field_name, self)
 
-    def get_resolved(self, obj) -> str:
+    def get_resolved(self, obj: Model) -> str:
+        assert self.resolved_getter
         return getattr(obj, self.resolved_getter)()

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -1,22 +1,34 @@
+from collections import Counter
+from uuid import UUID
+
 from django.db import transaction
+from django.utils.text import get_text_list
+from django.utils.translation import gettext as _
 
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from openforms.appointments.api.serializers import AppointmentOptionsSerializer
-from openforms.config.models.theme import Theme
+from openforms.config.models import Theme
 from openforms.emails.api.serializers import ConfirmationEmailTemplateSerializer
 from openforms.emails.models import ConfirmationEmailTemplate
-from openforms.forms.api.v3.typing import FormValidatedData
-from openforms.products.models.product import Product
+from openforms.formio.service import (
+    DuplicateKeyError,
+    FormioConfigurationWrapper,
+    get_readable_path_from_configuration_path,
+)
+from openforms.products.models import Product
 from openforms.translations.api.serializers import ModelTranslationsSerializer
+from openforms.typing import StrOrPromise
 
 from ....api.serializers.form import (
     FormLiteralsSerializer,
     SubmissionsRemovalOptionsSerializer,
 )
-from ....models.category import Category
-from ....models.form import Form
+from ....models import Category, Form, FormDefinition, FormStep, FormVariable
+from ..typing import FormStepData, FormValidatedData
+from .form_step import FormStepSerializer
 
 
 @extend_schema_serializer(component_name="FormV3Serializer")
@@ -40,6 +52,8 @@ class FormSerializer(serializers.ModelSerializer):
         slug_field="uuid",
     )
 
+    steps = FormStepSerializer(many=True, source="formstep_set", min_length=1)  # pyright: ignore[reportCallIssue]
+
     appointment_options = AppointmentOptionsSerializer(
         source="*",
         required=False,
@@ -59,7 +73,10 @@ class FormSerializer(serializers.ModelSerializer):
 
     translations = ModelTranslationsSerializer()
 
-    _nested_fields = ("confirmation_email_template",)
+    _nested_fields = (
+        "confirmation_email_template",
+        "formstep_set",
+    )
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = Form
@@ -76,6 +93,7 @@ class FormSerializer(serializers.ModelSerializer):
             "slug",
             "category",
             "theme",
+            "steps",
             "show_progress_indicator",
             "show_summary_progress",
             "maintenance_mode",
@@ -117,10 +135,33 @@ class FormSerializer(serializers.ModelSerializer):
         ConfirmationEmailTemplate.objects.set_for_form(
             form=instance, data=confirmation_email_template
         )
+
+        form_step_data = validated_data["formstep_set"]
+        # fmt:off
+        form_definitions = (
+            FormDefinition.objects
+            .select_for_update(nowait=True)
+            .filter(uuid__in=(step_data["form_definition"]["uuid"] for step_data in form_step_data))
+        )
+        # fmt:on
+        len(form_definitions)  # Evaluate the queryset to acquire the locks.
+        for index, step_data in enumerate(form_step_data):
+            form_definition_data = step_data["form_definition"]
+            form_definition, _ = form_definitions.update_or_create(
+                uuid=form_definition_data["uuid"],
+                defaults={k: v for k, v in form_definition_data.items() if k != "uuid"},
+            )
+
+            FormStep.objects.create(
+                **{**step_data, "form_definition": form_definition},
+                order=index,
+                form=instance,
+            )
+
         return instance
 
     @transaction.atomic()
-    def update(self, instance, validated_data: FormValidatedData) -> Form:
+    def update(self, instance: Form, validated_data: FormValidatedData) -> Form:
         instance = super().update(
             instance,
             {k: v for k, v in validated_data.items() if k not in self._nested_fields},
@@ -132,7 +173,115 @@ class FormSerializer(serializers.ModelSerializer):
         ConfirmationEmailTemplate.objects.set_for_form(
             form=instance, data=confirmation_email_template
         )
+
+        assigned_steps: list[FormStep] = []
+        form_step_data = validated_data["formstep_set"]
+        # fmt:off
+        form_definitions = (
+            FormDefinition.objects
+            .select_for_update(nowait=True)
+            .filter(uuid__in=(step_data["form_definition"]["uuid"] for step_data in form_step_data))
+        )
+        # fmt:on
+        len(form_definitions)  # Evaluate the queryset to acquire the locks.
+        for index, step_data in enumerate(form_step_data):
+            form_definition_data = step_data["form_definition"]
+            form_definition, _ = form_definitions.update_or_create(
+                uuid=form_definition_data["uuid"],
+                defaults={k: v for k, v in form_definition_data.items() if k != "uuid"},
+            )
+
+            step = FormStep(  # TODO: use update_or_create (nice to have)
+                **{**step_data, "form_definition": form_definition},
+                order=index,
+                form=instance,
+            )
+            assigned_steps.append(step)
+
+        steps_to_delete = instance.formstep_set.exclude(
+            pk__in=(step.pk for step in assigned_steps)
+        )
+        for step in steps_to_delete:
+            step.delete()  # Removes the form definition when applicable by calling `.delete`.
+
+        # Generate form steps after deleting existings steps, to allow correct calculation of
+        # the `order` field.
+        for step in sorted(assigned_steps, key=lambda step: step.order):
+            step.save()
         return instance
 
+    def validate_steps(self, value: list[FormStepData]) -> list[FormStepData]:
+        # Step 1: Validate form definitions are unique across all steps.
+        unique_fd_uuids = {step["form_definition"]["uuid"] for step in value}
+        if len(unique_fd_uuids) < len(value):
+            raise serializers.ValidationError(
+                _("Non-unique form step - form definition duplicate(s) detected.")
+            )
+
+        # Step 2: Validate that the form definitions don't have duplicate component keys.
+        configurations: dict[UUID, FormioConfigurationWrapper] = {
+            step["form_definition"]["uuid"]: FormioConfigurationWrapper(
+                step["form_definition"]["configuration"], validate_unique_keys=True
+            )
+            for step in value
+        }
+
+        all_keys: list[str] = []
+        for form_definition, configuration in configurations.items():
+            try:
+                for component in configuration:
+                    all_keys.append(component["key"])
+            except DuplicateKeyError as exc:
+                error_message = _(
+                    "Duplicate component key detected in form definition {form_definition}."
+                ).format(form_definition=form_definition)
+                raise ValidationError(error_message) from exc
+
+        # Check the counter to find duplicates.
+        errors: list[StrOrPromise] = []
+        for component_key, count in Counter(all_keys).items():
+            if count < 2:  # no duplicates
+                continue
+
+            # Find all the places where it occurs to produce a human readable error
+            # message.
+            readable_paths: list[str] = []
+            for configuration in configurations.values():
+                if component_key not in configuration:
+                    continue
+
+                paths = [
+                    path
+                    for path, component in configuration.flattened_by_path.items()
+                    if component["key"] == component_key
+                ]
+
+                for path in paths:
+                    readable_path = get_readable_path_from_configuration_path(
+                        configuration.configuration, path
+                    )
+                    readable_paths.append(readable_path)
+
+            error_message = _('"{duplicate_key}" (in {paths})').format(
+                duplicate_key=component_key, paths=", ".join(readable_paths)
+            )
+            errors.append(error_message)
+
+        if errors:
+            raise serializers.ValidationError(
+                _("Detected duplicate keys in configuration: {errors}").format(
+                    errors=get_text_list(errors, ", ")
+                )
+            )
+
+        return value
+
+    @transaction.atomic()
     def save(self, **kwargs):
-        return super().save(**kwargs, uuid=self.context["uuid"])
+        instance = super().save(**kwargs, uuid=self.context["form_uuid"])
+
+        for step in instance.formstep_set.all():
+            # call this synchronously so that it's part of the same DB transaction.
+            FormVariable.objects.synchronize_for(step.form_definition)
+
+        return instance

--- a/src/openforms/forms/api/v3/serializers/form_definition.py
+++ b/src/openforms/forms/api/v3/serializers/form_definition.py
@@ -1,0 +1,88 @@
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+from openforms.formio.service import rewrite_formio_components_for_request
+from openforms.translations.api.serializers import ModelTranslationsSerializer
+
+from ....models import FormDefinition
+from ....validators import (
+    validate_form_definition_is_reusable,
+    validate_template_expressions,
+)
+from ...validators import FormIOComponentsValidator
+from ..typing import FormDefinitionData
+
+
+@extend_schema_serializer(component_name="FormDefinitionConfigurationV3Serializer")
+class FormDefinitionConfigurationSerializer(serializers.Serializer):
+    components = serializers.ListField(required=False, child=serializers.DictField())
+
+
+@extend_schema_serializer(
+    deprecate_fields=["slug"], component_name="FormDefinitionV3Serializer"
+)
+class FormDefinitionSerializer(serializers.ModelSerializer[FormDefinition]):
+    translations = ModelTranslationsSerializer()
+    configuration = FormDefinitionConfigurationSerializer(
+        label=_("Form.io configuration"),
+        help_text=_("The form definition as Form.io JSON schema"),
+        validators=[
+            FormIOComponentsValidator(),
+            validate_template_expressions,
+        ],
+    )
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = FormDefinition
+        fields = (
+            "uuid",
+            "name",
+            "internal_name",
+            "slug",
+            "configuration",
+            "login_required",
+            "is_reusable",
+            "translations",
+        )
+        extra_kwargs = {
+            "name": {
+                "read_only": True  # Writing is done via the `translations` field.
+            },
+            "slug": {
+                "required": False,
+                "allow_blank": True,
+            },
+            "uuid": {
+                "required": True,  # Model's `default` would allow empty values.
+                "read_only": False,
+                "validators": [],  # Removes the uniqueness validator, which allows reusing existing form definitions.
+            },
+        }
+
+    def to_representation(self, instance: FormDefinition) -> dict:
+        representation = super().to_representation(instance=instance)
+        # if "configuration" in self.fields:
+        # Finalize formio component configuration with dynamic parts that depend on the
+        # HTTP request. Note that this is invoked through:
+        # 1. the :class:`openforms.submissions.api.serializers.SubmissionStepSerializer`
+        #    for the dynamic formio configuration in the context of a submission.
+        # 2. The serializers/API endpoints of :module:`openforms.forms.api` for
+        #    'standalone' use/introspection.
+        rewrite_formio_components_for_request(
+            instance.configuration_wrapper,
+            request=self.context["request"],
+        )
+
+        representation["configuration"] = instance.configuration_wrapper.configuration
+
+        return representation
+
+    def validate(self, attrs: FormDefinitionData) -> FormDefinitionData:
+        validated_data = super().validate(attrs)
+        if self.instance:
+            validate_form_definition_is_reusable(
+                self.instance, new_value=validated_data.get("is_reusable")
+            )
+        return validated_data

--- a/src/openforms/forms/api/v3/serializers/form_step.py
+++ b/src/openforms/forms/api/v3/serializers/form_step.py
@@ -1,0 +1,53 @@
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+from openforms.translations.api.serializers import ModelTranslationsSerializer
+
+from ....models import FormStep
+from ...serializers.button_text import ButtonTextSerializer
+from ...validators import FormStepIsApplicableIfFirstValidator
+from .form_definition import (
+    FormDefinitionSerializer,
+)
+
+
+@extend_schema_serializer(component_name="FormStepLiteralsV3Serializer")
+class FormStepLiteralsSerializer(serializers.Serializer):
+    previous_text = ButtonTextSerializer(raw_field="previous_text", required=False)
+    save_text = ButtonTextSerializer(raw_field="save_text", required=False)
+    next_text = ButtonTextSerializer(raw_field="next_text", required=False)
+
+    class Meta:
+        fields = (
+            "previous_text",
+            "save_text",
+            "next_text",
+        )
+
+
+@extend_schema_serializer(component_name="FormStepV3Serializer")
+class FormStepSerializer(serializers.ModelSerializer):
+    index = serializers.IntegerField(source="order", read_only=True)
+    literals = FormStepLiteralsSerializer(source="*", required=False)
+    form_definition = FormDefinitionSerializer()
+    translations = ModelTranslationsSerializer()
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = FormStep
+        fields = (
+            "uuid",
+            "index",
+            "slug",
+            "form_definition",
+            "is_applicable",
+            "literals",
+            "translations",
+        )
+
+        extra_kwargs = {
+            "uuid": {  # TODO: reuse existing steps (nice to have).
+                "read_only": True,
+            },
+            "slug": {"allow_blank": True},
+        }
+        validators = [FormStepIsApplicableIfFirstValidator()]

--- a/src/openforms/forms/api/v3/typing.py
+++ b/src/openforms/forms/api/v3/typing.py
@@ -3,11 +3,13 @@ from typing import NotRequired, TypedDict
 from uuid import UUID
 
 from openforms.appointments.base import Product
-from openforms.config.models.theme import Theme
+from openforms.config.models import Theme
 from openforms.data_removal.constants import RemovalMethods
-from openforms.formio.typing.base import FormioConfiguration
-from openforms.forms.constants import StatementCheckboxChoices
-from openforms.forms.models.category import Category
+from openforms.emails.typing import ConfirmationEmailTemplateTranslatedData
+from openforms.formio.typing import FormioConfiguration
+
+from ...constants import StatementCheckboxChoices
+from ...models import Category
 
 
 class AppointmentData(TypedDict):
@@ -62,7 +64,7 @@ class FormDefinitionData(TypedDict):
     configuration: FormioConfiguration
     login_required: NotRequired[bool]
     is_reusable: NotRequired[bool]
-    translations: FormDefinitionTranslationsData
+    translations: NotRequired[FormDefinitionTranslationsData]
 
 
 class FormStepLiteralData(TypedDict):
@@ -78,7 +80,6 @@ class FormStepTranslationData(TypedDict):
 
 
 class FormStepData(TypedDict):
-    order: int
     slug: NotRequired[str]
     form_definition: FormDefinitionData
     is_applicable: NotRequired[bool]
@@ -123,6 +124,7 @@ class FormValidatedData(TypedDict):
 
     submission_removal_options: NotRequired[SubmissionRemovalOptionsData]
 
+    confirmation_email_template: NotRequired[ConfirmationEmailTemplateTranslatedData]
     send_confirmation_email: NotRequired[bool]
     display_main_website_link: NotRequired[bool]
     include_confirmation_page_content_in_pdf: NotRequired[bool]

--- a/src/openforms/forms/api/v3/viewsets.py
+++ b/src/openforms/forms/api/v3/viewsets.py
@@ -1,6 +1,7 @@
 from typing import TypedDict, Unpack
 from uuid import UUID
 
+from django.db import OperationalError
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
@@ -8,6 +9,8 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
+
+from openforms.api.exceptions import Conflict
 
 from ...api.parsers import FormCamelCaseJSONParser
 from ...api.permissions import FormAPIPermissions
@@ -49,12 +52,16 @@ class FormViewSet(viewsets.GenericViewSet):
             data=request.data,
             context={
                 **self.get_serializer_context(),
-                "uuid": kwargs[lookup_url_kwarg],
+                "form_uuid": kwargs[lookup_url_kwarg],
             },
         )
 
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+
+        try:
+            serializer.save()
+        except OperationalError as exc:
+            raise Conflict() from exc
 
         if self.object is None:
             status_code = status.HTTP_201_CREATED

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -125,7 +125,6 @@ class Form(models.Model):
     auto_login_authentication_backend = models.CharField(
         _("automatic login"), max_length=UNIQUE_ID_MAX_LENGTH, blank=True
     )
-    auth_backends: Manager[FormAuthenticationBackend]
 
     # appointments
     is_appointment = models.BooleanField(
@@ -411,6 +410,8 @@ class Form(models.Model):
     objects: ClassVar[  # pyright: ignore[reportIncompatibleVariableOverride]
         FormManager
     ] = FormManager()
+    formstep_set: models.Manager[FormStep]
+    auth_backends: Manager[FormAuthenticationBackend]
 
     get_begin_text = literal_getter("begin_text", "form_begin_text")
     get_previous_text = literal_getter("previous_text", "form_previous_text")

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -1,18 +1,33 @@
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import timedelta
+from uuid import UUID, uuid4
 
+from django.db.models.base import connections
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.text import get_text_list
+from django.utils.translation import gettext as _
 
+from djangorestframework_camel_case.util import underscoreize
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.response import Response
+from rest_framework.test import APIClient, APITestCase, APITransactionTestCase
 
+from openforms.accounts.models import User
 from openforms.accounts.tests.factories import UserFactory
 from openforms.config.tests.factories import ThemeFactory
 from openforms.data_removal.constants import RemovalMethods
-from openforms.forms.constants import StatementCheckboxChoices, SubmissionAllowedChoices
-from openforms.forms.models.form import Form
-from openforms.forms.tests.factories import CategoryFactory, FormFactory
 from openforms.products.tests.factories import ProductFactory
+from openforms.typing import JSONObject
+
+from ...constants import StatementCheckboxChoices, SubmissionAllowedChoices
+from ...models import Form, FormDefinition
+from ...tests.factories import (
+    CategoryFactory,
+    FormDefinitionFactory,
+    FormFactory,
+    FormStepFactory,
+)
 
 
 class FormEndpointTests(APITestCase):
@@ -35,7 +50,34 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "create-form",
-            "maintenanceMode": True,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
         }
         response = self.client.put(url, data=data)
 
@@ -45,12 +87,12 @@ class FormEndpointTests(APITestCase):
 
         self.assertEqual(form.name, "Create form")
         self.assertEqual(form.slug, "create-form")
-        self.assertEqual(form.maintenance_mode, True)
 
     def test_create_detailed_form(self):
         product = ProductFactory.create()
         category = CategoryFactory.create()
         theme = ThemeFactory.create()
+        form_definition_uuid = str(uuid4())
         activate_on = timezone.now() + timedelta(days=1)
         deactivate_on = timezone.now() + timedelta(days=2)
         url = reverse(
@@ -77,6 +119,42 @@ class FormEndpointTests(APITestCase):
             "theme": theme.uuid,
             "showProgressIndicator": True,
             "showSummaryProgress": True,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                }
+            ],
             "maintenanceMode": True,
             "active": True,
             "activateOn": activate_on.isoformat(),
@@ -154,7 +232,7 @@ class FormEndpointTests(APITestCase):
         self.assertEqual(form.name_nl, "Create formulier")
         self.assertEqual(form.internal_name, "Create form internal")
         self.assertEqual(form.internal_remarks, "This form is used for xyz")
-        self.assertFalse(form.login_required)
+        self.assertTrue(form.login_required)
         self.assertTrue(form.translation_enabled)
 
         self.assertTrue(form.is_appointment)
@@ -170,6 +248,36 @@ class FormEndpointTests(APITestCase):
         # theme
         theme = form.theme
         self.assertEqual(form.theme, theme)
+
+        # form step
+        form_step = form.formstep_set.get()
+        self.assertEqual(form_step.order, 0)
+        self.assertEqual(form_step.slug, "step-1")
+
+        # step form definition
+        form_definition = form_step.form_definition
+        self.assertEqual(str(form_definition.uuid), form_definition_uuid)
+        self.assertTrue(form_definition.is_reusable)
+        self.assertTrue(form_definition.login_required)
+        self.assertEqual(
+            form_definition.configuration,
+            {
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "component1",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "component2",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                ],
+            },
+        )
 
         self.assertTrue(form.show_progress_indicator)
         self.assertTrue(form.show_summary_progress)
@@ -264,6 +372,96 @@ class FormEndpointTests(APITestCase):
 
         self.assertTrue(form.new_renderer_enabled)
 
+    def test_create_reuse_existing_definition(self):
+        form_definition = FormDefinitionFactory.create(
+            name="Form definition",
+            slug="form-definition",
+            is_reusable=True,
+            configuration={"components": [{"key": "textfield", "type": "textfield"}]},
+        )
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(form_definition.uuid),
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                }
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+
+        # form step
+        form_step = form.formstep_set.get()
+        self.assertEqual(form_step.order, 0)
+        self.assertEqual(form_step.slug, "step-1")
+
+        # step form definition
+        self.assertEqual(form_step.form_definition, form_definition)
+        form_definition.refresh_from_db()
+        self.assertEqual(str(form_definition.uuid), str(form_definition.uuid))
+        self.assertTrue(form_definition.is_reusable)
+        self.assertTrue(form_definition.login_required)
+        self.assertEqual(
+            form_definition.configuration,
+            {
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "component1",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "component2",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                ],
+            },
+        )
+        self.assertEqual(FormDefinition.objects.count(), 1)
+
     def test_create_form_incorrect_request(self):
         url = reverse(
             "api:v3:form-detail",
@@ -272,6 +470,34 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "Create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
             "literals": "foobar",
         }
         response = self.client.put(url, data=data)
@@ -284,6 +510,79 @@ class FormEndpointTests(APITestCase):
         self.assertEqual(response_data["invalidParams"][0]["code"], "invalid")
         self.assertEqual(
             response_data["invalidParams"][0]["name"], "literals.nonFieldErrors"
+        )
+
+    def test_create_incorrect_form_configuration(self):
+        form_definition_uuid = str(uuid4())
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "index": 1,
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [["bogus", "data"]],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                }
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        assert "invalidParams" in response_data
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["invalidParams"][0]["code"], "not_a_dict")
+        self.assertEqual(
+            response_data["invalidParams"][0]["name"],
+            "steps.0.formDefinition.configuration.components.0",
+        )
+
+    def test_create_form_requires_one_step(self):
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "invalidParams" in response_data and response_data["invalidParams"]
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["invalidParams"][0]["code"], "min_length")
+        self.assertEqual(
+            response_data["invalidParams"][0]["name"], "steps.nonFieldErrors"
+        )
+        self.assertEqual(
+            response_data["invalidParams"][0]["reason"],
+            _("Ensure this field has at least {min_length} elements.").format(
+                min_length=1
+            ),
         )
 
     def test_update_existing_form(self):
@@ -300,6 +599,34 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Update form",
             "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
         }
         response = self.client.put(url, data=data)
 
@@ -326,6 +653,34 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Update form",
             "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
         }
         response = self.client.put(url, data=data)
 
@@ -336,6 +691,566 @@ class FormEndpointTests(APITestCase):
         self.assertEqual(form.name, "Update form")
         self.assertEqual(form.slug, "update-form")
         self.assertTrue(form._is_deleted)
+
+    def test_update_clears_existing_form_steps(self):
+        form = FormFactory.create()
+        FormStepFactory.create_batch(size=2, form=form)
+        form_step_1_definition_uuid = uuid4()
+        form_step_2_definition_uuid = uuid4()
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-2",
+                    "formDefinition": {
+                        "uuid": str(form_step_2_definition_uuid),
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 2",
+                                "internalName": "Form configuration 2",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 2",
+                                "internalName": "Form configuratie 2",
+                            },
+                        },
+                    },
+                },
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(form_step_1_definition_uuid),
+                        "isReusable": False,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component3",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Form.objects.count(), 1)
+        form.refresh_from_db()
+
+        # form step
+        form_steps = form.formstep_set.order_by("order")
+        self.assertEqual(form_steps[0].order, 0)
+        self.assertEqual(form_steps[0].slug, "step-2")
+        self.assertEqual(form_steps[1].order, 1)
+        self.assertEqual(form_steps[1].slug, "step-1")
+
+        # step form definitions
+        form_definition = form_steps[0].form_definition
+        self.assertEqual(form_definition.uuid, form_step_2_definition_uuid)
+        self.assertTrue(form_definition.is_reusable)
+        self.assertTrue(form_definition.login_required)
+        self.assertEqual(
+            form_definition.configuration,
+            {
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "component1",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                ],
+            },
+        )
+
+        form_definition = form_steps[1].form_definition
+        self.assertEqual(form_definition.uuid, form_step_1_definition_uuid)
+        self.assertFalse(form_definition.is_reusable)
+        self.assertFalse(form_definition.login_required)
+        self.assertEqual(
+            form_definition.configuration,
+            {
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "component2",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "component3",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                ],
+            },
+        )
+
+    def test_update_reuse_existing_form_definition(self):
+        # Generate an unrelated form with an existing form definition which will be reused
+        existing_form_definition_uuid = uuid4()
+        unrelated_form_step = FormStepFactory.create(
+            form_definition__configuration={
+                "components": [{"key": "textfield", "type": "textfield"}]
+            },
+            form_definition__is_reusable=True,
+            form_definition__uuid=existing_form_definition_uuid,
+        )
+
+        existing_form_step = FormStepFactory.create()
+        existing_form = existing_form_step.form
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": existing_form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(existing_form_definition_uuid),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Form.objects.count(), 2)
+        existing_form.refresh_from_db()
+
+        # form step
+        form_step = existing_form.formstep_set.get()
+        self.assertEqual(form_step.order, 0)
+        self.assertEqual(form_step.slug, "step-1")
+
+        # step form definition
+        self.assertEqual(form_step.form_definition, unrelated_form_step.form_definition)
+        self.assertEqual(
+            form_step.form_definition.configuration,
+            {
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "component1",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "component2",
+                        "hidden": False,
+                        "clear_on_hide": True,
+                    },
+                ],
+            },
+        )
+        self.assertEqual(FormDefinition.objects.count(), 1)
+
+    def test_update_unique_form_step_form_definition(self):
+        form = FormFactory.create()
+        FormStepFactory.create_batch(size=2, form=form)
+        new_form_definition_uuid = uuid4()
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "index": 2,
+                    "slug": "step-2",
+                    "formDefinition": {
+                        "uuid": str(new_form_definition_uuid),
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+                {
+                    "index": 1,
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(new_form_definition_uuid),
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "invalidParams" in response_data
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["invalidParams"][0]["code"], "invalid")
+        self.assertEqual(response_data["invalidParams"][0]["name"], "steps")
+        self.assertEqual(
+            response_data["invalidParams"][0]["reason"],
+            _("Non-unique form step - form definition duplicate(s) detected."),
+        )
+
+        self.assertEqual(Form.objects.count(), 1)
+
+    def test_update_unique_form_definition_keys_across_steps(self):
+        form = FormFactory.create()
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "index": 2,
+                    "slug": "step-2",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 2",
+                                "internalName": "Form configuration 2",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 2",
+                                "internalName": "Form configuratie 2",
+                            },
+                        },
+                    },
+                },
+                {
+                    "index": 1,
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "isReusable": False,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "invalidParams" in response_data and response_data["invalidParams"]
+        errors = response_data["invalidParams"]
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "invalid")
+        self.assertEqual(errors[0]["name"], "steps")
+        assert "reason" in errors[0]
+        expected_error_message = _(
+            "Detected duplicate keys in configuration: {errors}"
+        ).format(
+            errors=get_text_list(
+                [
+                    _('"{duplicate_key}" (in {paths})').format(
+                        duplicate_key="component1",
+                        paths="component1, component1",
+                    )
+                ],
+                ", ",
+            )
+        )
+        self.assertEqual(errors[0]["reason"], expected_error_message)
+
+    def test_update_unique_form_definition_keys_one_step(self):
+        form = FormFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "index": 1,
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(form_definition_uuid),
+                        "isReusable": False,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component2",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "invalidParams" in response_data and response_data["invalidParams"]
+        errors = response_data["invalidParams"]
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "invalid")
+        self.assertEqual(errors[0]["name"], "steps")
+        assert "reason" in errors[0]
+        expected_error_message = _(
+            "Duplicate component key detected in form definition {form_definition}."
+        ).format(form_definition=form_definition_uuid)
+        self.assertEqual(errors[0]["reason"], expected_error_message)
+
+    def test_update_unique_form_definition_keys_one_step_editgrid(self):
+        form = FormFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "index": 1,
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(form_definition_uuid),
+                        "isReusable": False,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "key": "repeatingGroup",
+                                    "type": "editgrid",
+                                    "components": [
+                                        {
+                                            "type": "file",
+                                            "key": "fileInRepeatingGroup1",
+                                        },
+                                        {
+                                            "type": "file",
+                                            "key": "fileInRepeatingGroup1",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "invalidParams" in response_data and response_data["invalidParams"]
+        errors = response_data["invalidParams"]
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "invalid")
+        self.assertEqual(errors[0]["name"], "steps")
+        assert "reason" in errors[0]
+        expected_error_message = _(
+            "Duplicate component key detected in form definition {form_definition}.".format(
+                form_definition=form_definition_uuid
+            )
+        )
+        self.assertEqual(errors[0]["reason"], expected_error_message)
 
     def test_update_form_incorrect_request(self):
         form = FormFactory.create(
@@ -350,6 +1265,34 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Update form",
             "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
             "literals": "foobar",
         }
         response = self.client.put(url, data=data)
@@ -390,6 +1333,34 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Update form",
             "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
         }
         response = self.client.put(url, data=data)
 
@@ -415,6 +1386,7 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Update form",
             "slug": "update-form",
+            "steps": [],
         }
         response = self.client.patch(url, data=data)
 
@@ -429,7 +1401,7 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "create-form",
-            "maintenanceMode": True,
+            "steps": [],
         }
         response = self.client.post(url, data=data)
 
@@ -446,7 +1418,7 @@ class FormEndpointAccessTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "create-form",
-            "maintenanceMode": True,
+            "steps": [],
         }
 
         non_staff_user = UserFactory.create(is_staff=False, user_permissions=tuple())
@@ -464,7 +1436,7 @@ class FormEndpointAccessTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "create-form",
-            "maintenanceMode": True,
+            "steps": [],
         }
 
         non_staff_user = UserFactory.create(is_staff=True, user_permissions=tuple())
@@ -482,10 +1454,312 @@ class FormEndpointAccessTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "create-form",
-            "maintenanceMode": True,
+            "steps": [],
         }
 
         response = self.client.put(url, data=data)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(Form.objects.count(), 0)
+
+
+def create_or_update_form(
+    user: User, form_uuid: UUID, form_data: JSONObject
+) -> Response:
+    url = reverse(
+        "api:v3:form-detail",
+        kwargs={"uuid": str(form_uuid)},
+    )
+    client = APIClient(raise_request_exception=False)
+    client.force_authenticate(user=user)
+    return client.put(url, data=form_data)  # pyright: ignore[reportReturnType]
+
+
+def close_db_connections(future: Future) -> None:
+    connections.close_all()
+
+
+class FormEndpointConcurrentTests(APITransactionTestCase):
+    def test_create_form_with_definitions_with_update(self):
+        """
+        Test that updating the same form definition, by creating two forms
+        concurrently, is not possible.
+        """
+        form_definition = FormDefinitionFactory(is_reusable=True)
+
+        user_1 = UserFactory.create(
+            is_staff=True, user_permissions=("forms.change_form",)
+        )
+        user_2 = UserFactory.create(
+            is_staff=True, user_permissions=("forms.change_form",)
+        )
+
+        test_data = (
+            (
+                user_1,
+                uuid4(),
+                {
+                    "name": "Create form",
+                    "slug": "create-form-1",
+                    "steps": [
+                        {
+                            "slug": "step-1",
+                            "formDefinition": {
+                                "uuid": str(form_definition.uuid),
+                                "isReusable": True,
+                                "loginRequired": True,
+                                "configuration": {
+                                    "components": [
+                                        {
+                                            "type": "textfield",
+                                            "key": "component1",
+                                            "hidden": False,
+                                            "clearOnHide": True,
+                                        },
+                                    ],
+                                },
+                                "translations": {
+                                    "en": {
+                                        "name": "Form configuration 1",
+                                        "internalName": "Form configuration 1",
+                                    },
+                                    "nl": {
+                                        "name": "Form configuratie 1",
+                                        "internalName": "Form configuratie 1",
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                },
+            ),
+            (
+                user_2,
+                uuid4(),
+                {
+                    "name": "Create form",
+                    "slug": "create-form-2",
+                    "steps": [
+                        {
+                            "slug": "step-1",
+                            "formDefinition": {
+                                "uuid": str(form_definition.uuid),
+                                "isReusable": True,
+                                "loginRequired": True,
+                                "configuration": {
+                                    "components": [
+                                        {
+                                            "type": "textfield",
+                                            "key": "component2",
+                                            "hidden": False,
+                                            "clearOnHide": True,
+                                        },
+                                    ],
+                                },
+                                "translations": {
+                                    "en": {
+                                        "name": "Form configuration 1",
+                                        "internalName": "Form configuration 1",
+                                    },
+                                    "nl": {
+                                        "name": "Form configuratie 1",
+                                        "internalName": "Form configuratie 1",
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                },
+            ),
+        )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = []
+            for user, form_uuid, form_data in test_data:
+                future = executor.submit(
+                    create_or_update_form, user, form_uuid, form_data
+                )
+                future.add_done_callback(close_db_connections)
+                futures.append(future)
+
+            responses = [future.result() for future in as_completed(futures)]
+
+        error_responses = [
+            response
+            for response in responses
+            if response.status_code == status.HTTP_409_CONFLICT
+        ]
+        success_responses = [
+            response
+            for response in responses
+            if response.status_code == status.HTTP_201_CREATED
+        ]
+        self.assertEqual(len(error_responses), 1)
+        self.assertEqual(len(success_responses), 1)
+        response_data = underscoreize(success_responses[0].json())
+        expected_form_definition = response_data["steps"][0]["form_definition"][  # pyright: ignore[reportArgumentType,reportCallIssue,reportIndexIssue]
+            "configuration"
+        ]
+
+        form = Form.objects.get()
+
+        # form step
+        form_step = form.formstep_set.get()
+        self.assertEqual(form_step.order, 0)
+        self.assertEqual(form_step.slug, "step-1")
+
+        # step form definition
+        step_form_definition = form_step.form_definition
+        self.assertEqual(step_form_definition.uuid, form_definition.uuid)
+        self.assertTrue(step_form_definition.login_required)
+        self.assertEqual(step_form_definition.configuration, expected_form_definition)
+
+    def test_update_form_definitions(self):
+        """
+        Test that updating the same form definition, by updating two forms
+        concurrently, is not possible.
+        """
+        form_definition = FormDefinitionFactory(
+            configuration={"components": [{"key": "textfield", "type": "textfield"}]},
+            is_reusable=True,
+            uuid=uuid4(),
+        )
+        form_1 = FormFactory(formstep__form_definition=form_definition)
+        form_2 = FormFactory(formstep__form_definition=form_definition)
+        user_1 = UserFactory.create(
+            is_staff=True, user_permissions=("forms.change_form",)
+        )
+        user_2 = UserFactory.create(
+            is_staff=True, user_permissions=("forms.change_form",)
+        )
+
+        test_data = (
+            (
+                user_1,
+                form_1.uuid,
+                {
+                    "name": "Update form",
+                    "slug": "update-form-1",
+                    "steps": [
+                        {
+                            "slug": "step-1",
+                            "formDefinition": {
+                                "uuid": str(form_definition.uuid),
+                                "isReusable": True,
+                                "loginRequired": True,
+                                "configuration": {
+                                    "components": [
+                                        {
+                                            "type": "textfield",
+                                            "key": "component1",
+                                            "hidden": False,
+                                            "clearOnHide": True,
+                                        },
+                                    ],
+                                },
+                                "translations": {
+                                    "en": {
+                                        "name": "Form configuration 1",
+                                        "internalName": "Form configuration 1",
+                                    },
+                                    "nl": {
+                                        "name": "Form configuratie 1",
+                                        "internalName": "Form configuratie 1",
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                },
+            ),
+            (
+                user_2,
+                form_2.uuid,
+                {
+                    "name": "Update form",
+                    "slug": "update-form-2",
+                    "steps": [
+                        {
+                            "slug": "step-1",
+                            "formDefinition": {
+                                "uuid": str(form_definition.uuid),
+                                "isReusable": True,
+                                "loginRequired": True,
+                                "configuration": {
+                                    "components": [
+                                        {
+                                            "type": "textfield",
+                                            "key": "component2",
+                                            "hidden": False,
+                                            "clearOnHide": True,
+                                        },
+                                    ],
+                                },
+                                "translations": {
+                                    "en": {
+                                        "name": "Form configuration 1",
+                                        "internalName": "Form configuration 1",
+                                    },
+                                    "nl": {
+                                        "name": "Form configuratie 1",
+                                        "internalName": "Form configuratie 1",
+                                    },
+                                },
+                            },
+                        }
+                    ],
+                },
+            ),
+        )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = []
+            for user, form_uuid, form_data in test_data:
+                future = executor.submit(
+                    create_or_update_form, user, form_uuid, form_data
+                )
+                future.add_done_callback(close_db_connections)
+                futures.append(future)
+
+            responses = [future.result() for future in as_completed(futures)]
+
+        error_responses = [
+            response
+            for response in responses
+            if response.status_code == status.HTTP_409_CONFLICT
+        ]
+        success_responses = [
+            response
+            for response in responses
+            if response.status_code == status.HTTP_200_OK
+        ]
+        self.assertEqual(len(error_responses), 1)
+        self.assertEqual(len(success_responses), 1)
+        response_data = underscoreize(success_responses[0].json())
+        expected_form_definition = response_data["steps"][0]["form_definition"][  # pyright: ignore[reportArgumentType,reportCallIssue,reportIndexIssue]
+            "configuration"
+        ]
+
+        self.assertEqual(Form.objects.count(), 2)
+        updated_form = next(
+            (
+                form
+                for form in (form_1, form_2)
+                if response_data["uuid"] == str(form.uuid)  # pyright: ignore[reportArgumentType,reportCallIssue,reportIndexIssue]
+            ),
+            None,
+        )
+        assert updated_form, "Unknown form was updated"
+        updated_form.refresh_from_db()
+
+        # form step
+        form_step = updated_form.formstep_set.get()
+        self.assertEqual(form_step.order, 0)
+        self.assertEqual(form_step.slug, "step-1")
+
+        # step form definition
+        self.assertEqual(form_step.form_definition, form_definition)
+        self.assertEqual(
+            form_step.form_definition.configuration, expected_form_definition
+        )
+        self.assertEqual(FormDefinition.objects.count(), 1)  # pyright: ignore[reportAttributeAccessIssue]

--- a/src/openforms/forms/validators.py
+++ b/src/openforms/forms/validators.py
@@ -1,15 +1,15 @@
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from django.core.exceptions import ValidationError
 from django.utils.text import get_text_list
 from django.utils.translation import gettext_lazy as _
 
-from openforms.formio.utils import (
-    flatten_by_path,
-    get_readable_path_from_configuration_path,
-)
+from openforms.formio.service import get_readable_path_from_configuration_path
+from openforms.formio.typing import FormioConfiguration
+from openforms.formio.utils import flatten_by_path
 from openforms.formio.variables import validate_configuration
 from openforms.typing import JSONObject
 
@@ -73,21 +73,27 @@ def validate_template_expressions(configuration: JSONObject) -> None:
     raise ValidationError(all_errors)
 
 
+class FormDefinitionLike(Protocol):
+    configuration: FormioConfiguration
+    name: str
+
+
 @dataclass
 class FakeFormDefinition:
-    configuration: JSONObject
+    configuration: FormioConfiguration
     name: str = ""
 
 
 def validate_no_duplicate_keys(
-    configuration: JSONObject,
+    configuration: FormioConfiguration,
 ) -> None:
     form_definition = FakeFormDefinition(configuration=configuration)
     validate_no_duplicate_keys_across_steps(form_definition, other_form_definitions=[])
 
 
 def validate_no_duplicate_keys_across_steps(
-    current_form_definition, other_form_definitions
+    current_form_definition: FormDefinitionLike,
+    other_form_definitions: Sequence[FormDefinitionLike],
 ):
     """
     Validate that there are no duplicate keys in a configuration.
@@ -100,7 +106,7 @@ def validate_no_duplicate_keys_across_steps(
     """
     component_path_map = defaultdict(list)
     duplicate_keys = []
-    for form_definition in [current_form_definition] + other_form_definitions:
+    for form_definition in [current_form_definition, *other_form_definitions]:
         for configuration_path, component in flatten_by_path(
             form_definition.configuration
         ).items():


### PR DESCRIPTION
Closes #5954 

 [skip: e2e]

**Changes**

Adds the `steps` field to the new v3 form endpoint.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
