### PR TITLE
[#5955] add `confirmation_email_template` field to v3 form endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -9048,6 +9048,10 @@ components:
             * `disabled` - Disabled
         submissionsRemovalOptions:
           $ref: '#/components/schemas/SubmissionsRemovalOptions'
+        confirmationEmailTemplate:
+          allOf:
+          - $ref: '#/components/schemas/ConfirmationEmailTemplate'
+          nullable: true
         sendConfirmationEmail:
           type: boolean
           description: Whether a confirmation email should be sent to the end user

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -1,16 +1,21 @@
+from django.db import transaction
+
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from openforms.appointments.api.serializers import AppointmentOptionsSerializer
 from openforms.config.models.theme import Theme
-from openforms.forms.api.serializers.form import (
-    FormLiteralsSerializer,
-    SubmissionsRemovalOptionsSerializer,
-)
-from openforms.forms.models.category import Category
+from openforms.emails.api.serializers import ConfirmationEmailTemplateSerializer
+from openforms.emails.models import ConfirmationEmailTemplate
+from openforms.forms.api.v3.typing import FormValidatedData
 from openforms.products.models.product import Product
 from openforms.translations.api.serializers import ModelTranslationsSerializer
 
+from ....api.serializers.form import (
+    FormLiteralsSerializer,
+    SubmissionsRemovalOptionsSerializer,
+)
+from ....models.category import Category
 from ....models.form import Form
 
 
@@ -43,12 +48,18 @@ class FormSerializer(serializers.ModelSerializer):
 
     literals = FormLiteralsSerializer(source="*", required=False)
 
+    confirmation_email_template = ConfirmationEmailTemplateSerializer(
+        required=False, allow_null=True
+    )
+
     is_deleted = serializers.BooleanField(source="_is_deleted", required=False)
     submissions_removal_options = SubmissionsRemovalOptionsSerializer(
         source="*", required=False
     )
 
     translations = ModelTranslationsSerializer()
+
+    _nested_fields = ("confirmation_email_template",)
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = Form
@@ -82,6 +93,7 @@ class FormSerializer(serializers.ModelSerializer):
             "ask_privacy_consent",
             "ask_statement_of_truth",
             "submissions_removal_options",
+            "confirmation_email_template",
             "send_confirmation_email",
             "display_main_website_link",
             "include_confirmation_page_content_in_pdf",
@@ -94,6 +106,33 @@ class FormSerializer(serializers.ModelSerializer):
                 "read_only": True,
             },
         }
+
+    @transaction.atomic()
+    def create(self, validated_data: FormValidatedData) -> Form:
+        instance = super().create(
+            {k: v for k, v in validated_data.items() if k not in self._nested_fields}
+        )
+
+        confirmation_email_template = validated_data.get("confirmation_email_template")
+        ConfirmationEmailTemplate.objects.set_for_form(
+            form=instance, data=confirmation_email_template
+        )
+        return instance
+
+    @transaction.atomic()
+    def update(self, instance, validated_data: FormValidatedData) -> Form:
+        instance = super().update(
+            instance,
+            {k: v for k, v in validated_data.items() if k not in self._nested_fields},
+        )
+
+        confirmation_email_template = validated_data.get(
+            "confirmation_email_template", None
+        )
+        ConfirmationEmailTemplate.objects.set_for_form(
+            form=instance, data=confirmation_email_template
+        )
+        return instance
 
     def save(self, **kwargs):
         return super().save(**kwargs, uuid=self.context["uuid"])

--- a/src/openforms/forms/api/v3/typing.py
+++ b/src/openforms/forms/api/v3/typing.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+from typing import NotRequired, TypedDict
+from uuid import UUID
+
+from openforms.appointments.base import Product
+from openforms.config.models.theme import Theme
+from openforms.data_removal.constants import RemovalMethods
+from openforms.formio.typing.base import FormioConfiguration
+from openforms.forms.constants import StatementCheckboxChoices
+from openforms.forms.models.category import Category
+
+
+class AppointmentData(TypedDict):
+    is_appointment: bool
+
+
+class ButtonTextData(TypedDict):
+    value: str
+    resolved: str
+
+
+class FormLiteralData(TypedDict):
+    previous_text: NotRequired[ButtonTextData]
+    begin_text: NotRequired[ButtonTextData]
+    change_text: NotRequired[ButtonTextData]
+    confirm_text: NotRequired[ButtonTextData]
+
+
+class SubmissionRemovalOptionsData(TypedDict):
+    successful_submissions_removal_limit: NotRequired[int | None]
+    successful_submissions_removal_method: NotRequired[RemovalMethods]
+    incomplete_submissions_removal_limit: NotRequired[int | None]
+    incomplete_submissions_removal_method: NotRequired[RemovalMethods]
+    errored_submissions_removal_limit: NotRequired[int | None]
+    errored_submissions_removal_method: NotRequired[RemovalMethods]
+    all_submissions_removal_limit: NotRequired[int | None]
+
+
+class FormTranslations(TypedDict):
+    name: str
+    internal_name: str
+
+
+class FormTranslationsData(TypedDict):
+    en: FormTranslations
+    nl: FormTranslations
+
+
+class FormDefinitionTranslations(TypedDict):
+    name: str
+
+
+class FormDefinitionTranslationsData(TypedDict):
+    en: FormDefinitionTranslations
+    nl: FormDefinitionTranslations
+
+
+class FormDefinitionData(TypedDict):
+    uuid: UUID
+    internal_name: NotRequired[str]
+    slug: NotRequired[str]
+    configuration: FormioConfiguration
+    login_required: NotRequired[bool]
+    is_reusable: NotRequired[bool]
+    translations: FormDefinitionTranslationsData
+
+
+class FormStepLiteralData(TypedDict):
+    previous_text: NotRequired[ButtonTextData]
+    save_text: NotRequired[ButtonTextData]
+    next_text: NotRequired[ButtonTextData]
+
+
+class FormStepTranslationData(TypedDict):
+    previous_text: NotRequired[str]
+    save_text: NotRequired[str]
+    next_text: NotRequired[str]
+
+
+class FormStepData(TypedDict):
+    order: int
+    slug: NotRequired[str]
+    form_definition: FormDefinitionData
+    is_applicable: NotRequired[bool]
+    literals: NotRequired[FormStepLiteralData]
+    translations: NotRequired[FormStepTranslationData]
+
+
+class FormValidatedData(TypedDict):
+    uuid: UUID
+    name: str
+    internal_name: NotRequired[str]
+    internal_remarks: NotRequired[str]
+    translations_enabled: NotRequired[bool]
+    appointment_options: NotRequired[AppointmentData]
+    literals: NotRequired[FormLiteralData]
+    product: NotRequired[Product]
+    slug: str
+    category: NotRequired[Category]
+    theme: NotRequired[Theme]
+    formstep_set: list[FormStepData]
+
+    show_progress_indicator: NotRequired[bool]
+    show_summary_progress: NotRequired[bool]
+    maintenance_mode: NotRequired[bool]
+    active: NotRequired[bool]
+    activate_on: NotRequired[datetime]
+    deactivate_on: NotRequired[datetime]
+    _is_deleted: NotRequired[bool]
+
+    submission_confirmation_template: NotRequired[str]
+    introduction_page_content: NotRequired[str]
+    explanation_template: NotRequired[str]
+
+    submission_allowed: NotRequired[str]
+    submission_limit: NotRequired[int | None]
+    submission_counter: NotRequired[int]
+
+    suspension_allowed: NotRequired[bool]
+
+    ask_privacy_consent: NotRequired[StatementCheckboxChoices]
+    ask_statement_of_truth: NotRequired[StatementCheckboxChoices]
+
+    submission_removal_options: NotRequired[SubmissionRemovalOptionsData]
+
+    send_confirmation_email: NotRequired[bool]
+    display_main_website_link: NotRequired[bool]
+    include_confirmation_page_content_in_pdf: NotRequired[bool]
+
+    new_renderer_enabled: NotRequired[bool]
+    new_logic_evaluation_enabled: NotRequired[bool]
+
+    translations: NotRequired[FormTranslationsData]

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -100,6 +100,22 @@ class FormEndpointTests(APITestCase):
                 "erroredSubmissionsRemovalMethod": RemovalMethods.delete_permanently,
                 "allSubmissionsRemovalLimit": 30,
             },
+            "confirmationEmailTemplate": {
+                "translations": {
+                    "en": {
+                        "subject": "Submission received",
+                        "content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+                        "cosign_subject": "Cosign submission received",
+                        "cosign_content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+                    },
+                    "nl": {
+                        "subject": "Inzending ontvangen",
+                        "content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+                        "cosign_subject": "Cosign inzending ontvangen",
+                        "cosign_content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+                    },
+                }
+            },
             "sendConfirmationEmail": True,
             "displayMainWebsiteLink": True,
             "includeConfirmationPageContentInPdf": True,
@@ -193,6 +209,34 @@ class FormEndpointTests(APITestCase):
         self.assertTrue(form.send_confirmation_email)
         self.assertTrue(form.display_main_website_link)
         self.assertTrue(form.include_confirmation_page_content_in_pdf)
+
+        # confirmation email
+        confirmation_email_template = form.confirmation_email_template
+        assert confirmation_email_template, "No confirmation email coupled to form"
+        self.assertEqual(confirmation_email_template.subject_en, "Submission received")
+        self.assertEqual(
+            confirmation_email_template.content_en,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_subject_en, "Cosign submission received"
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_content_en,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+        )
+        self.assertEqual(confirmation_email_template.subject_nl, "Inzending ontvangen")
+        self.assertEqual(
+            confirmation_email_template.content_nl,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_subject_nl, "Cosign inzending ontvangen"
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_content_nl,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+        )
 
         # translations
         self.assertEqual(form.begin_text_en, "start")


### PR DESCRIPTION
Closes #5955

[skip: e2e]

**Changes**

Adds the `confirmation_email_template` field to the v3 form endpoint.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
