### PR TITLE
[#5956] add `registration_backends` field to v3 form endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -9021,6 +9021,10 @@ components:
           readOnly: true
         translationEnabled:
           type: boolean
+        registrationBackends:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormRegistrationBackend'
         appointmentOptions:
           allOf:
           - $ref: '#/components/schemas/AppointmentOptions'

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -24,9 +24,17 @@ from openforms.typing import StrOrPromise
 
 from ....api.serializers.form import (
     FormLiteralsSerializer,
+    FormRegistrationBackendSerializer,
     SubmissionsRemovalOptionsSerializer,
 )
-from ....models import Category, Form, FormDefinition, FormStep, FormVariable
+from ....models import (
+    Category,
+    Form,
+    FormDefinition,
+    FormRegistrationBackend,
+    FormStep,
+    FormVariable,
+)
 from ..typing import FormStepData, FormValidatedData
 from .form_step import FormStepSerializer
 
@@ -73,9 +81,12 @@ class FormSerializer(serializers.ModelSerializer):
 
     translations = ModelTranslationsSerializer()
 
+    registration_backends = FormRegistrationBackendSerializer(many=True, required=False)
+
     _nested_fields = (
         "confirmation_email_template",
         "formstep_set",
+        "registration_backends",
     )
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -87,6 +98,7 @@ class FormSerializer(serializers.ModelSerializer):
             "internal_remarks",
             "login_required",
             "translation_enabled",
+            "registration_backends",
             "appointment_options",
             "literals",
             "product",
@@ -158,6 +170,12 @@ class FormSerializer(serializers.ModelSerializer):
                 form=instance,
             )
 
+        registration_backends = validated_data.get("registration_backends", [])
+        FormRegistrationBackend.objects.bulk_create(
+            FormRegistrationBackend(form=instance, **backend)
+            for backend in registration_backends
+        )
+
         return instance
 
     @transaction.atomic()
@@ -208,6 +226,15 @@ class FormSerializer(serializers.ModelSerializer):
         # the `order` field.
         for step in sorted(assigned_steps, key=lambda step: step.order):
             step.save()
+
+        registration_backends = validated_data.get("registration_backends", None)
+        if registration_backends is not None:
+            instance.registration_backends.all().delete()
+            FormRegistrationBackend.objects.bulk_create(
+                FormRegistrationBackend(form=instance, **backend)
+                for backend in registration_backends
+            )
+
         return instance
 
     def validate_steps(self, value: list[FormStepData]) -> list[FormStepData]:

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -46,7 +46,7 @@ User = get_user_model()
 logger = structlog.stdlib.get_logger(__name__)
 
 if TYPE_CHECKING:
-    from . import FormAuthenticationBackend, FormStep
+    from . import FormAuthenticationBackend, FormRegistrationBackend, FormStep
 
 
 class FormQuerySet(models.QuerySet["Form"]):
@@ -412,6 +412,7 @@ class Form(models.Model):
     ] = FormManager()
     formstep_set: models.Manager[FormStep]
     auth_backends: Manager[FormAuthenticationBackend]
+    registration_backends: Manager[FormRegistrationBackend]
 
     get_begin_text = literal_getter("begin_text", "form_begin_text")
     get_previous_text = literal_getter("previous_text", "form_previous_text")

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -21,7 +21,7 @@ from openforms.products.tests.factories import ProductFactory
 from openforms.typing import JSONObject
 
 from ...constants import StatementCheckboxChoices, SubmissionAllowedChoices
-from ...models import Form, FormDefinition
+from ...models import Form, FormDefinition, FormRegistrationBackend
 from ...tests.factories import (
     CategoryFactory,
     FormDefinitionFactory,
@@ -104,6 +104,16 @@ class FormEndpointTests(APITestCase):
             "internalName": "Create form internal",
             "internalRemarks": "This form is used for xyz",
             "translationEnabled": True,
+            "registrationBackends": [
+                {
+                    "name": "Email registration",
+                    "key": "email-fu",
+                    "backend": "email",
+                    "options": {
+                        "to_emails": ["foo@example.com"],
+                    },
+                }
+            ],
             "appointmentOptions": {
                 "isAppointment": True,
             },
@@ -276,6 +286,20 @@ class FormEndpointTests(APITestCase):
                         "clear_on_hide": True,
                     },
                 ],
+            },
+        )
+
+        # registration backends
+        registration_backend = FormRegistrationBackend.objects.get()
+        self.assertEqual(form.registration_backends.get(), registration_backend)
+        self.assertEqual(registration_backend.name, "Email registration")
+        self.assertEqual(registration_backend.key, "email-fu")
+        self.assertEqual(registration_backend.backend, "email")
+        self.assertEqual(
+            registration_backend.options,
+            {
+                "to_emails": ["foo@example.com"],
+                "attach_files_to_email": None,
             },
         )
 
@@ -461,6 +485,74 @@ class FormEndpointTests(APITestCase):
             },
         )
         self.assertEqual(FormDefinition.objects.count(), 1)
+
+    def test_update_clears_existing_registration_backends(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            registration_backend="camunda",
+        )
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "registrationBackends": [
+                {
+                    "key": "email-fu",
+                    "name": "Email registration backend",
+                    "backend": "email",
+                    "options": {"toEmails": ["booboo@example.com", "yogi@example.com"]},
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Form.objects.count(), 1)
+        form.refresh_from_db()
+
+        registration_backend = FormRegistrationBackend.objects.get()
+        self.assertEqual(form.registration_backends.get(), registration_backend)
+        self.assertEqual(registration_backend.name, "Email registration backend")
+        self.assertEqual(registration_backend.key, "email-fu")
+        self.assertEqual(registration_backend.backend, "email")
+        self.assertEqual(
+            registration_backend.options,
+            {
+                "attach_files_to_email": None,
+                "to_emails": ["booboo@example.com", "yogi@example.com"],
+            },
+        )
 
     def test_create_form_incorrect_request(self):
         url = reverse(


### PR DESCRIPTION
Closes #5956

[skip: e2e]

**Changes**

Adds the `registration_backends` field to the v3 form endpoint.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
