### PR TITLE
[#5957] add payment related fields to v3 form endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8795,6 +8795,19 @@ components:
           title: Explanation template [nl]
           description: Content that will be shown on the start page of the form, below
             the title and above the log in text.
+    FormPayment:
+      type: object
+      properties:
+        backend:
+          oneOf:
+          - $ref: '#/components/schemas/PaymentBackendEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        options:
+          type: object
+          additionalProperties: {}
+      required:
+      - backend
+      - options
     FormRegistrationBackend:
       type: object
       properties:
@@ -9025,6 +9038,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FormRegistrationBackend'
+        payment:
+          $ref: '#/components/schemas/FormPayment'
         appointmentOptions:
           allOf:
           - $ref: '#/components/schemas/AppointmentOptions'

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1138,6 +1138,7 @@ SPECTACULAR_SETTINGS = {
         "IncompleteSubmissionsRemovalMethodEnum": "openforms.data_removal.constants.RemovalMethods",
         "AvailableLanguagesEnum": "django.conf.settings.LANGUAGES",
         "StatementCheckboxEnum": "openforms.forms.constants.StatementCheckboxChoices",
+        "PaymentBackendEnum": "openforms.forms.api.v3.serializers.payment.get_payment_backend_choices",
     },
     "GET_LIB_DOC_EXCLUDES": "openforms.api.drf_spectacular.plumbing.get_lib_doc_excludes",
 }

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from django.db import transaction
 from django.utils.text import get_text_list
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
@@ -37,6 +37,7 @@ from ....models import (
 )
 from ..typing import FormStepData, FormValidatedData
 from .form_step import FormStepSerializer
+from .payment import FormPaymentSerializer
 
 
 @extend_schema_serializer(component_name="FormV3Serializer")
@@ -61,6 +62,8 @@ class FormSerializer(serializers.ModelSerializer):
     )
 
     steps = FormStepSerializer(many=True, source="formstep_set", min_length=1)  # pyright: ignore[reportCallIssue]
+
+    payment = FormPaymentSerializer(required=False, source="*")
 
     appointment_options = AppointmentOptionsSerializer(
         source="*",
@@ -99,6 +102,7 @@ class FormSerializer(serializers.ModelSerializer):
             "login_required",
             "translation_enabled",
             "registration_backends",
+            "payment",
             "appointment_options",
             "literals",
             "product",

--- a/src/openforms/forms/api/v3/serializers/payment.py
+++ b/src/openforms/forms/api/v3/serializers/payment.py
@@ -1,0 +1,53 @@
+from rest_framework import serializers
+
+from openforms.api.utils import get_from_serializer_data_or_instance
+from openforms.payments.registry import register as payment_register
+
+from ....models import Form
+from ..typing import PaymentData
+
+
+def get_payment_backend_choices():
+    return [("", "")] + payment_register.get_choices()
+
+
+class FormPaymentSerializer(serializers.ModelSerializer):
+    backend = serializers.ChoiceField(source="payment_backend", choices=[])
+    options = serializers.DictField(source="payment_backend_options")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_fields(self):
+        fields = super().get_fields()
+        backend_field = fields["backend"]
+        assert isinstance(backend_field, serializers.ChoiceField)
+        backend_field.choices = get_payment_backend_choices()
+        return fields
+
+    def validate(self, attrs: PaymentData) -> PaymentData:
+        plugin_id = get_from_serializer_data_or_instance(
+            "payment_backend", data=attrs, serializer=self
+        )
+        options = get_from_serializer_data_or_instance(
+            "payment_backend_options", data=attrs, serializer=self
+        )
+        if not plugin_id:
+            return attrs
+        plugin = payment_register[plugin_id]
+        serializer = plugin.configuration_options(data=options)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError as e:
+            # wrap detail in dict so we can attach it to the field
+            # DRF will create the .invalidParams with a dotted path to nested fields
+            # like registrationBackends.0.options.toEmails.0 if the first email was invalid
+            detail = {"options": e.detail}
+            raise serializers.ValidationError(detail) from e
+        # serializer does some normalization, so make sure to update the data
+        attrs["payment_backend_options"] = serializer.data
+        return attrs
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = Form
+        fields = ("backend", "options")

--- a/src/openforms/forms/api/v3/typing.py
+++ b/src/openforms/forms/api/v3/typing.py
@@ -87,6 +87,11 @@ class FormStepData(TypedDict):
     translations: NotRequired[FormStepTranslationData]
 
 
+class PaymentData(TypedDict):
+    payment_backend: str
+    payment_backend_options: dict
+
+
 class FormValidatedData(TypedDict):
     uuid: UUID
     name: str
@@ -100,6 +105,7 @@ class FormValidatedData(TypedDict):
     category: NotRequired[Category]
     theme: NotRequired[Theme]
     formstep_set: list[FormStepData]
+    payment: NotRequired[PaymentData]
 
     show_progress_indicator: NotRequired[bool]
     show_summary_progress: NotRequired[bool]

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -17,8 +17,12 @@ from openforms.accounts.models import User
 from openforms.accounts.tests.factories import UserFactory
 from openforms.config.tests.factories import ThemeFactory
 from openforms.data_removal.constants import RemovalMethods
+from openforms.payments.contrib.worldline.tests.factories import (
+    WorldlineMerchantFactory,
+)
 from openforms.products.tests.factories import ProductFactory
 from openforms.typing import JSONObject
+from openforms.utils.tests.feature_flags import enable_feature_flag
 
 from ...constants import StatementCheckboxChoices, SubmissionAllowedChoices
 from ...models import Form, FormDefinition, FormRegistrationBackend
@@ -93,6 +97,7 @@ class FormEndpointTests(APITestCase):
         category = CategoryFactory.create()
         theme = ThemeFactory.create()
         form_definition_uuid = str(uuid4())
+        merchant = WorldlineMerchantFactory.create(pspid="wordline-merchant")
         activate_on = timezone.now() + timedelta(days=1)
         deactivate_on = timezone.now() + timedelta(days=2)
         url = reverse(
@@ -114,6 +119,14 @@ class FormEndpointTests(APITestCase):
                     },
                 }
             ],
+            "payment": {
+                "backend": "worldline",
+                "options": {
+                    "merchant": merchant.pspid,
+                    "variant": "Form v3 payments",
+                    "descriptorTemplate": "{{ foo }}",
+                },
+            },
             "appointmentOptions": {
                 "isAppointment": True,
             },
@@ -300,6 +313,18 @@ class FormEndpointTests(APITestCase):
             {
                 "to_emails": ["foo@example.com"],
                 "attach_files_to_email": None,
+            },
+        )
+
+        # payment options
+        self.assertEqual(form.payment_required, True)
+        self.assertEqual(form.payment_backend, "worldline")
+        self.assertEqual(
+            form.payment_backend_options,
+            {
+                "merchant": merchant.pspid,
+                "variant": "Form v3 payments",
+                "descriptor_template": "{{ foo }}",
             },
         )
 
@@ -554,6 +579,57 @@ class FormEndpointTests(APITestCase):
             },
         )
 
+    @enable_feature_flag("ENABLE_DEMO_PLUGINS")
+    def test_create_form_without_configuration_options(self):
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "payment": {
+                "backend": "demo",
+                "options": {},
+            },
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+
+        self.assertEqual(form.payment_backend, "demo")
+
     def test_create_form_incorrect_request(self):
         url = reverse(
             "api:v3:form-detail",
@@ -675,6 +751,63 @@ class FormEndpointTests(APITestCase):
             _("Ensure this field has at least {min_length} elements.").format(
                 min_length=1
             ),
+        )
+
+    def test_incorrect_payment_backend_options(self):
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "payment": {
+                "backend": "worldline",
+                "options": {
+                    "foo": "bar",
+                },
+            },
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        response_data = response.json()
+        assert "invalidParams" in response_data
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["invalidParams"][0]["code"], "required")
+        self.assertEqual(
+            response_data["invalidParams"][0]["name"],
+            "payment.options.merchant",
         )
 
     def test_update_existing_form(self):

--- a/src/openforms/plugins/registry.py
+++ b/src/openforms/plugins/registry.py
@@ -76,7 +76,7 @@ class BaseRegistry[PluginT: AbstractBasePlugin]:
             with_demos = flag_enabled("ENABLE_DEMO_PLUGINS")
             enable_all = False
         except OperationalError:
-            # fix CI trying to access non-existing database to generate OAS
+            # fix CI trying to access non-existing database or table to generate OAS
             with_demos = False
             enable_all = True
 


### PR DESCRIPTION
Closes #5957

[skip: e2e]

**Changes**

Adds payment related fields to the v3 form endpoint.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
