### PR TITLE
Fix step (not) applicable actions not applied correctly with new logic evalution

### DIFF
--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -285,7 +285,15 @@ class StepNotApplicableAction(ActionOperation):
 
     @property
     def steps(self) -> set[FormStep]:
-        return self._get_steps(self.rule.unresolved_input_variables_from_trigger)
+        steps = self._get_steps(self.rule.unresolved_input_variables_from_trigger)
+
+        # If we couldn't resolve steps (likely because the input variables are user
+        # defined) we need to execute it on all steps.
+        if not steps:
+            return set(self.rule.form.formstep_set.all())
+
+        first_step = min(steps, key=lambda step: step.order)
+        return set(self.rule.form.formstep_set.filter(order__gte=first_step.order))
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -332,7 +340,15 @@ class StepApplicableAction(ActionOperation):
 
     @property
     def steps(self) -> set[FormStep]:
-        return self._get_steps(self.rule.unresolved_input_variables_from_trigger)
+        steps = self._get_steps(self.rule.unresolved_input_variables_from_trigger)
+
+        # If we couldn't resolve steps (likely because the input variables are user
+        # defined) we need to execute it on all steps.
+        if not steps:
+            return set(self.rule.form.formstep_set.all())
+
+        first_step = min(steps, key=lambda step: step.order)
+        return set(self.rule.form.formstep_set.filter(order__gte=first_step.order))
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -124,7 +124,7 @@ def get_rules_to_evaluate_new(
 
     # Note that this an OrderedModelQuerySet, so the logic order is already resolved
     # here
-    return current_step.form_step.logic_rules.iterator()
+    return current_step.form_step.logic_rules.all()
 
 
 def get_current_step(submission: Submission) -> SubmissionStep | None:

--- a/src/openforms/submissions/tests/form_logic/test_get_rules_to_evaluate.py
+++ b/src/openforms/submissions/tests/form_logic/test_get_rules_to_evaluate.py
@@ -129,3 +129,63 @@ class GetRulesToEvaluateTests(TestCase):
 
             rules = get_rules_to_evaluate(submission, submission_step_2)
             self.assertEqual(list(rules), [rule_2])
+
+    def test_get_rules_to_evaluate_new_iterating_over_rules_does_not_exhaust_them(self):
+        """
+        Ensure iterating over the rules once does not exhaust them, as we iterate
+        evaluation we iterate over the rules multiple times.
+        """
+        form = FormFactory.create(new_logic_evaluation_enabled=True)
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "checkbox", "key": "checkbox", "label": "Checkbox"},
+                    {"type": "number", "key": "number", "label": "Number"},
+                ]
+            },
+        )
+        rule_1 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "variable": "number",
+                    "action": {
+                        "name": "Set number",
+                        "type": LogicActionTypes.variable,
+                        "value": 42,
+                    },
+                }
+            ],
+        )
+        rule_1.form_steps.set([step])
+        rule_2 = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "number"}, 42]},
+            actions=[
+                {
+                    "action": {
+                        "name": "Disable next step",
+                        "type": LogicActionTypes.disable_next,
+                        "value": 42,
+                    },
+                    "form_step_uuid": str(step.uuid),
+                }
+            ],
+        )
+        rule_2.form_steps.set([step])
+
+        submission = SubmissionFactory.create(form=form)
+        submission_step = SubmissionStepFactory.create(
+            submission=submission, form_step=step
+        )
+
+        rules = get_rules_to_evaluate(submission, submission_step)
+
+        for i in (0, 1):
+            rule = None
+            for r in rules:
+                rule = r
+            with self.subTest(f"Iteration {i}"):
+                self.assertEqual(rule, rule_2)

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1402,3 +1402,53 @@ class ComponentModificationTests(TestCase):
         state = submission.load_submission_value_variables_state()
         data = state.get_data(include_unsaved=True)
         self.assertEqual("foo", data["textfield"])
+
+    def test_change_component_to_hidden_with_new_logic_evaluation(self):
+        form = FormFactory.create(new_logic_evaluation_enabled=True)
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                        "hidden": False,
+                    },
+                ]
+            },
+        )
+        rule = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "component": "textfield",
+                    "action": {
+                        "name": "Hide textfield",
+                        "type": "property",
+                        "property": {
+                            "type": "bool",
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                }
+            ],
+        )
+        rule.form_steps.set([step])
+        submission = SubmissionFactory.create(form=form)
+        submission_step = SubmissionStepFactory.create(
+            submission=submission, form_step=step
+        )
+
+        configuration = evaluate_form_logic(
+            submission, submission_step, FormioData({"checkbox": True})
+        )
+
+        self.assertTrue(configuration["components"][1]["hidden"])

--- a/src/openforms/submissions/tests/form_logic/test_rule_analysis.py
+++ b/src/openforms/submissions/tests/form_logic/test_rule_analysis.py
@@ -229,6 +229,18 @@ class DetermineVariablesAndStepTests(TestCase):
                 ]
             },
         )
+        step_4 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "number",
+                        "type": "number",
+                        "label": "Number",
+                    },
+                ]
+            },
+        )
         FormVariableFactory.create(
             form=form,
             name="user_defined",
@@ -241,7 +253,6 @@ class DetermineVariablesAndStepTests(TestCase):
             form=form,
             json_logic_trigger={
                 "and": [
-                    {"==": [{"var": "checkbox"}, True]},
                     {"==": [{"var": "checkbox2"}, True]},
                 ]
             },
@@ -264,13 +275,13 @@ class DetermineVariablesAndStepTests(TestCase):
             ],
         )
 
-        with self.subTest("All input variable steps are set"):
-            self.assertEqual(rule_1.steps, {step_1, step_2})
-            self.assertEqual(rule_1.input_variable_keys, {"checkbox", "checkbox2"})
+        with self.subTest("All steps after the trigger step are set"):
+            self.assertEqual(rule_1.steps, {step_2, step_3, step_4})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox2"})
             self.assertEqual(rule_1.output_variable_keys, {"textfield"})
 
-        with self.subTest("No step if trigger includes user-defined variable"):
-            self.assertEqual(rule_2.steps, set())
+        with self.subTest("All steps if trigger includes user-defined variable"):
+            self.assertEqual(rule_2.steps, {step_1, step_2, step_3, step_4})
             self.assertEqual(rule_2.input_variable_keys, {"user_defined"})
             self.assertEqual(rule_2.output_variable_keys, {"textfield"})
 
@@ -312,6 +323,18 @@ class DetermineVariablesAndStepTests(TestCase):
                 ]
             },
         )
+        step_4 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "number",
+                        "type": "number",
+                        "label": "Number",
+                    },
+                ]
+            },
+        )
         FormVariableFactory.create(
             form=form,
             name="user_defined",
@@ -324,7 +347,6 @@ class DetermineVariablesAndStepTests(TestCase):
             form=form,
             json_logic_trigger={
                 "and": [
-                    {"==": [{"var": "checkbox"}, True]},
                     {"==": [{"var": "checkbox2"}, True]},
                 ]
             },
@@ -347,13 +369,13 @@ class DetermineVariablesAndStepTests(TestCase):
             ],
         )
 
-        with self.subTest("All input variable steps are set"):
-            self.assertEqual(rule_1.steps, {step_1, step_2})
-            self.assertEqual(rule_1.input_variable_keys, {"checkbox", "checkbox2"})
+        with self.subTest("All steps after the trigger step are set"):
+            self.assertEqual(rule_1.steps, {step_2, step_3, step_4})
+            self.assertEqual(rule_1.input_variable_keys, {"checkbox2"})
             self.assertEqual(rule_1.output_variable_keys, {"textfield"})
 
-        with self.subTest("No step if trigger includes user-defined variable"):
-            self.assertEqual(rule_2.steps, set())
+        with self.subTest("All steps if trigger includes user-defined variable"):
+            self.assertEqual(rule_2.steps, {step_1, step_2, step_3, step_4})
             self.assertEqual(rule_2.input_variable_keys, {"user_defined"})
             self.assertEqual(rule_2.output_variable_keys, {"textfield"})
 


### PR DESCRIPTION
Closes #5996

[skip: e2e]

**Changes**

* Ensured subsequent steps are assigned for "step (not) applicable" actions
* Fixed logic rules iterator possibly being exhausted after the first iteration pass

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
