### PR TITLE
Fix fields inside editgrids being unexpectedly cleared

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1169,10 +1169,20 @@ class EditGrid(BasePlugin[EditGridComponent]):
         inner_evaluation_data = deepcopy(data)
 
         def get_evaluation_data(item_data_: FormioData) -> FormioData:
-            inner_evaluation_data[key] = item_data_
+            # We cannot have nested FormioData structures.
+            inner_evaluation_data[key] = item_data_.data
             return outer_get_evaluation_data(inner_evaluation_data)
 
-        for item_data in edit_grid_data:
+        original_edit_grid_data = (
+            original_input_data[key] if original_input_data else None
+        )
+        for i, item_data in enumerate(edit_grid_data):
+            original_item_data = (
+                FormioData(original_edit_grid_data[i])
+                if original_edit_grid_data
+                else None
+            )
+            item_data = FormioData(item_data)
             process_visibility(
                 component,
                 item_data,
@@ -1181,9 +1191,9 @@ class EditGrid(BasePlugin[EditGridComponent]):
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=_components_to_ignore_hidden,
-                original_input_data=original_input_data,
+                original_input_data=original_item_data,
             )
-            edit_grid_data_new.append(item_data)
+            edit_grid_data_new.append(item_data.data)
 
         data[key] = edit_grid_data_new
 

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1206,3 +1206,126 @@ class ComponentModificationTests(TestCase):
         state = submission.load_submission_value_variables_state()
         data = state.get_data(include_unsaved=True)
         self.assertEqual(data["container.textfield"], "")
+
+    @tag("gh-6040")
+    def test_fields_inside_a_visible_editgrid(self):
+        """
+        Ensure that fields inside visible editgrids do not get cleared unexpectedly.
+        """
+        form = FormFactory.create()
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "key": "editgridHiddenByDefault",
+                        "type": "editgrid",
+                        "hidden": True,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "text.field",
+                                "label": "Textfield",
+                                "clearOnHide": False,
+                            },
+                            {
+                                "type": "textfield",
+                                "key": "textfield2",
+                                "label": "Textfield 2",
+                                "clearOnHide": True,
+                            },
+                        ],
+                    },
+                    {
+                        "key": "editgridShownByDefault",
+                        "type": "editgrid",
+                        "hidden": False,
+                        "components": [
+                            {
+                                "type": "number",
+                                "key": "number",
+                                "label": "Number",
+                                "clearOnHide": False,
+                            },
+                            {
+                                "type": "number",
+                                "key": "number2",
+                                "label": "Number 2",
+                                "clearOnHide": True,
+                            },
+                        ],
+                    },
+                ]
+            },
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "component": "editgridHiddenByDefault",
+                    "action": {
+                        "name": "Show editgridHiddenByDefault",
+                        "type": "property",
+                        "property": {
+                            "type": "bool",
+                            "value": "hidden",
+                        },
+                        "state": False,
+                    },
+                }
+            ],
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, False]},
+            actions=[
+                {
+                    "component": "editgridShownByDefault",
+                    "action": {
+                        "name": "Hide editgridShownByDefault",
+                        "type": "property",
+                        "property": {
+                            "type": "bool",
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                }
+            ],
+        )
+
+        submission = SubmissionFactory.create(form=form)
+        submission_step = SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step,
+        )
+
+        # This assumes the user has checked the checkbox, causing
+        # "editgridHiddenByDefault" to be visible in the first place
+        data = FormioData(
+            {
+                "checkbox": True,
+                "editgridHiddenByDefault": [
+                    {"text": {"field": "don't clear me"}, "textfield2": "me neither"}
+                ],
+                "editgridShownByDefault": [{"number": 42, "number2": 100}],
+            }
+        )
+        evaluate_form_logic(submission, submission_step, data)
+
+        # Check the data
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data(include_unsaved=True)
+        self.assertEqual(
+            data["editgridHiddenByDefault.0"],
+            {"text": {"field": "don't clear me"}, "textfield2": "me neither"},
+        )
+        self.assertEqual(
+            data["editgridShownByDefault.0"], {"number": 42, "number2": 100}
+        )


### PR DESCRIPTION
Closes #6040

[skip: e2e]

**Changes**

* Added processing of original input data for editgrids

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
