### PR TITLE
Clean up variables, comments and docstrings

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1137,7 +1137,6 @@ class EditGrid(BasePlugin[EditGridComponent]):
         *,
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
-        ignore_hidden_property: bool,
         components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
         data_for_visible_state: FormioData | None = None,
@@ -1159,7 +1158,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
         # children.
         _components_to_ignore_hidden = (
             set(child["key"] for child in component["components"])
-            if ignore_hidden_property
+            if key in components_to_ignore_hidden
             else set()
         ).union(components_to_ignore_hidden)
         edit_grid_data_new = []
@@ -1212,17 +1211,17 @@ class Columns(BasePlugin[ColumnsComponent]):
         *,
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
-        ignore_hidden_property: bool,
         components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
         data_for_visible_state: FormioData | None = None,
     ):
+        key = component["key"]
         for column in component["columns"]:
             # If the hidden property of the parent should be ignored, so should it for
             # its children.
             _components_to_ignore_hidden: set[str] = (
                 set(child["key"] for child in column["components"])
-                if ignore_hidden_property
+                if key in components_to_ignore_hidden
                 else set()
             ).union(components_to_ignore_hidden)
 
@@ -1250,17 +1249,16 @@ class Fieldset(BasePlugin[FieldsetComponent]):
         *,
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
-        ignore_hidden_property: bool,
         components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
         data_for_visible_state: FormioData | None = None,
     ):
-
+        key = component["key"]
         # If the hidden property of the parent should be ignored, so should it for
         # its children.
         _components_to_ignore_hidden: set[str] = (
             set(child["key"] for child in component["components"])
-            if ignore_hidden_property
+            if key in components_to_ignore_hidden
             else set()
         ).union(components_to_ignore_hidden)
 

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1138,8 +1138,8 @@ class EditGrid(BasePlugin[EditGridComponent]):
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
+        components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
-        components_to_ignore_hidden: set[str] | None = None,
         data_for_visible_state: FormioData | None = None,
     ):
         key = component["key"]
@@ -1161,7 +1161,7 @@ class EditGrid(BasePlugin[EditGridComponent]):
             set(child["key"] for child in component["components"])
             if ignore_hidden_property
             else set()
-        ).union(components_to_ignore_hidden or set())
+        ).union(components_to_ignore_hidden)
         edit_grid_data_new = []
 
         # For evaluation of the conditionals, we only care about the current item, so we
@@ -1213,8 +1213,8 @@ class Columns(BasePlugin[ColumnsComponent]):
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
+        components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
-        components_to_ignore_hidden: set[str] | None = None,
         data_for_visible_state: FormioData | None = None,
     ):
         for column in component["columns"]:
@@ -1224,7 +1224,7 @@ class Columns(BasePlugin[ColumnsComponent]):
                 set(child["key"] for child in column["components"])
                 if ignore_hidden_property
                 else set()
-            ).union(components_to_ignore_hidden or set())
+            ).union(components_to_ignore_hidden)
 
             process_visibility(
                 column,
@@ -1251,8 +1251,8 @@ class Fieldset(BasePlugin[FieldsetComponent]):
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
+        components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
-        components_to_ignore_hidden: set[str] | None = None,
         data_for_visible_state: FormioData | None = None,
     ):
 
@@ -1262,7 +1262,7 @@ class Fieldset(BasePlugin[FieldsetComponent]):
             set(child["key"] for child in component["components"])
             if ignore_hidden_property
             else set()
-        ).union(components_to_ignore_hidden or set())
+        ).union(components_to_ignore_hidden)
 
         # We need to process the children, so we just pass the component as the
         # configuration.

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1135,12 +1135,12 @@ class EditGrid(BasePlugin[EditGridComponent]):
         data: FormioData,
         wrapper: FormioConfigurationWrapper,
         *,
-        initial_data: FormioData,
+        data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
         components_to_ignore_hidden: set[str] | None = None,
-        original_input_data: FormioData | None = None,
+        data_for_visible_state: FormioData | None = None,
     ):
         key = component["key"]
         clear_on_hide = component.get("clearOnHide", True)
@@ -1175,13 +1175,13 @@ class EditGrid(BasePlugin[EditGridComponent]):
             inner_evaluation_data[key] = item_data_.data
             return outer_get_evaluation_data(inner_evaluation_data)
 
-        original_edit_grid_data = (
-            original_input_data[key] if original_input_data else None
+        edit_grid_data_for_visible_state = (
+            data_for_visible_state[key] if data_for_visible_state else None
         )
         for i, item_data in enumerate(edit_grid_data):
-            original_item_data = (
-                FormioData(original_edit_grid_data[i])
-                if original_edit_grid_data
+            item_data_for_visible_state = (
+                FormioData(edit_grid_data_for_visible_state[i])
+                if edit_grid_data_for_visible_state
                 else None
             )
             item_data = FormioData(item_data)
@@ -1189,11 +1189,11 @@ class EditGrid(BasePlugin[EditGridComponent]):
                 component,
                 item_data,
                 wrapper,
-                initial_data=initial_data,
+                data_for_hidden_state=data_for_hidden_state,
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=_components_to_ignore_hidden,
-                original_input_data=original_item_data,
+                data_for_visible_state=item_data_for_visible_state,
             )
             edit_grid_data_new.append(item_data.data)
 
@@ -1210,12 +1210,12 @@ class Columns(BasePlugin[ColumnsComponent]):
         data: FormioData,
         wrapper: FormioConfigurationWrapper,
         *,
-        initial_data: FormioData,
+        data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
         components_to_ignore_hidden: set[str] | None = None,
-        original_input_data: FormioData | None = None,
+        data_for_visible_state: FormioData | None = None,
     ):
         for column in component["columns"]:
             # If the hidden property of the parent should be ignored, so should it for
@@ -1230,11 +1230,11 @@ class Columns(BasePlugin[ColumnsComponent]):
                 column,
                 data,
                 wrapper,
-                initial_data=initial_data,
+                data_for_hidden_state=data_for_hidden_state,
                 parent_hidden=parent_hidden,
                 get_evaluation_data=get_evaluation_data,
                 components_to_ignore_hidden=_components_to_ignore_hidden,
-                original_input_data=original_input_data,
+                data_for_visible_state=data_for_visible_state,
             )
 
 
@@ -1248,12 +1248,12 @@ class Fieldset(BasePlugin[FieldsetComponent]):
         data: FormioData,
         wrapper: FormioConfigurationWrapper,
         *,
-        initial_data: FormioData,
+        data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
         components_to_ignore_hidden: set[str] | None = None,
-        original_input_data: FormioData | None = None,
+        data_for_visible_state: FormioData | None = None,
     ):
 
         # If the hidden property of the parent should be ignored, so should it for
@@ -1270,9 +1270,9 @@ class Fieldset(BasePlugin[FieldsetComponent]):
             component,
             data,
             wrapper,
-            initial_data=initial_data,
+            data_for_hidden_state=data_for_hidden_state,
             parent_hidden=parent_hidden,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=_components_to_ignore_hidden,
-            original_input_data=original_input_data,
+            data_for_visible_state=data_for_visible_state,
         )

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -155,7 +155,6 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         *,
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
-        ignore_hidden_property: bool,
         components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
         data_for_visible_state: FormioData | None = None,
@@ -173,8 +172,6 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
           evaluation of the conditional.
         :param components_to_ignore_hidden: Set of components for which the "hidden"
           property is ignored in determining whether the component is hidden.
-        :param ignore_hidden_property: Whether to ignore the "hidden" property during
-          further processing of its children.
         :param data_for_visible_state: The data used to restore values when flipping
           visibility states.
         """
@@ -264,7 +261,6 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         *,
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
-        ignore_hidden_property: bool,
         components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
         data_for_visible_state: FormioData | None = None,
@@ -282,8 +278,6 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
           evaluation of the conditional.
         :param components_to_ignore_hidden: Set of components for which the "hidden"
           property is ignored in determining whether the component is hidden.
-        :param ignore_hidden_property: Whether to ignore the "hidden" property during
-          further processing of its children.
         :param data_for_visible_state: The data used to restore values when flipping
           visibility states.
         """
@@ -297,7 +291,6 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
             wrapper,
             data_for_hidden_state=data_for_hidden_state,
             parent_hidden=parent_hidden,
-            ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=components_to_ignore_hidden,
             data_for_visible_state=data_for_visible_state,

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -153,12 +153,12 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         data: FormioData,
         wrapper: FormioConfigurationWrapper,
         *,
-        initial_data: FormioData,
+        data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
         components_to_ignore_hidden: set[str] | None = None,
-        original_input_data: FormioData | None = None,
+        data_for_visible_state: FormioData | None = None,
     ) -> None:
         """
         Apply (conditional) visibility of this component. This routine should be
@@ -167,7 +167,7 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         :param component: Component configuration.
         :param data: Data used for processing.
         :param wrapper: Formio configuration wrapper. Required for component lookup.
-        :param initial_data: Initial data for clear-on-hide behavior.
+        :param data_for_hidden_state: Data to apply when a component is hidden.
         :param parent_hidden: Indicates whether the parent component was hidden.
         :param get_evaluation_data: Function used to get the evaluation data used during
           evaluation of the conditional.
@@ -176,9 +176,8 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
           it was not passed, the hidden property WILL be checked.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
-        :param original_input_data: The input data from the frontend when called through
-          the check logic endpoint. Used to restore values when flipping visibility
-          states.
+        :param data_for_visible_state: The data used to restore values when flipping
+          visibility states.
         """
 
     @staticmethod
@@ -264,12 +263,12 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         data: FormioData,
         wrapper: FormioConfigurationWrapper,
         *,
-        initial_data: FormioData,
+        data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
         get_evaluation_data: Callable | None = None,
         components_to_ignore_hidden: set[str] | None = None,
-        original_input_data: FormioData | None = None,
+        data_for_visible_state: FormioData | None = None,
     ) -> None:
         """
         Apply (conditional) visibility of this component. This routine should be
@@ -278,7 +277,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         :param component: Component configuration.
         :param data: Data used for processing.
         :param wrapper: Formio configuration wrapper. Required for component lookup.
-        :param initial_data: Initial data for clear-on-hide behavior.
+        :param data_for_hidden_state: Data to apply when a component is hidden.
         :param parent_hidden: Indicates whether the parent component was hidden.
         :param get_evaluation_data: Function used to get the evaluation data used during
           evaluation of the conditional.
@@ -287,9 +286,8 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
           it was not passed, the hidden property WILL be checked.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
-        :param original_input_data: The input data from the frontend when called through
-          the check logic endpoint. Used to restore values when flipping visibility
-          states.
+        :param data_for_visible_state: The data used to restore values when flipping
+          visibility states.
         """
         if (component_type := component["type"]) not in self:
             return
@@ -299,12 +297,12 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
             component,
             data,
             wrapper,
-            initial_data=initial_data,
+            data_for_hidden_state=data_for_hidden_state,
             parent_hidden=parent_hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=components_to_ignore_hidden,
-            original_input_data=original_input_data,
+            data_for_visible_state=data_for_visible_state,
         )
 
     def update_config(

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -156,8 +156,8 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
+        components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
-        components_to_ignore_hidden: set[str] | None = None,
         data_for_visible_state: FormioData | None = None,
     ) -> None:
         """
@@ -172,8 +172,7 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         :param get_evaluation_data: Function used to get the evaluation data used during
           evaluation of the conditional.
         :param components_to_ignore_hidden: Set of components for which the "hidden"
-          property is ignored in determining whether the component is hidden. Note that if
-          it was not passed, the hidden property WILL be checked.
+          property is ignored in determining whether the component is hidden.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
         :param data_for_visible_state: The data used to restore values when flipping
@@ -266,8 +265,8 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         data_for_hidden_state: FormioData,
         parent_hidden: bool,
         ignore_hidden_property: bool,
+        components_to_ignore_hidden: set[str],
         get_evaluation_data: Callable | None = None,
-        components_to_ignore_hidden: set[str] | None = None,
         data_for_visible_state: FormioData | None = None,
     ) -> None:
         """
@@ -282,8 +281,7 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         :param get_evaluation_data: Function used to get the evaluation data used during
           evaluation of the conditional.
         :param components_to_ignore_hidden: Set of components for which the "hidden"
-          property is ignored in determining whether the component is hidden. Note that if
-          it was not passed, the hidden property WILL be checked.
+          property is ignored in determining whether the component is hidden.
         :param ignore_hidden_property: Whether to ignore the "hidden" property during
           further processing of its children.
         :param data_for_visible_state: The data used to restore values when flipping

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -120,12 +120,11 @@ def process_visibility(
         key = component["key"]
         clear_on_hide = component.get("clearOnHide", True)
 
-        ignore_hidden_property = key in components_to_ignore_hidden
         hidden = parent_hidden or is_hidden(
             component,
             get_evaluation_data(data) if get_evaluation_data else data,
             wrapper,
-            ignore_hidden_property,
+            key in components_to_ignore_hidden,
         )
 
         # Need to check whether the component holds submission data, as we do not have
@@ -159,7 +158,6 @@ def process_visibility(
             wrapper,
             data_for_hidden_state=data_for_hidden_state,
             parent_hidden=hidden,
-            ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=components_to_ignore_hidden,
             data_for_visible_state=data_for_visible_state,

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -87,11 +87,11 @@ def process_visibility(
     data: FormioData,
     wrapper: FormioConfigurationWrapper,
     *,
-    initial_data: FormioData,
+    data_for_hidden_state: FormioData,
     parent_hidden: bool = False,
     get_evaluation_data: GetEvaluationData | None = None,
     components_to_ignore_hidden: set[str] | None = None,
-    original_input_data: FormioData | None = None,
+    data_for_visible_state: FormioData | None = None,
 ) -> None:
     """
     Process the visibility of the components inside the configuration, by checking if
@@ -104,7 +104,7 @@ def process_visibility(
       or column.
     :param data: Data used for processing.
     :param wrapper: Formio configuration wrapper. Required for component lookup.
-    :param initial_data: Initial data for clear-on-hide behavior.
+    :param data_for_hidden_state: Data to apply when a component is hidden.
     :param parent_hidden: Indicates whether the parent component was hidden. Note that
       the conditional will not be evaluated at all when this is set to ``True``.
     :param get_evaluation_data: Function used to get the evaluation data used during
@@ -112,9 +112,8 @@ def process_visibility(
     :param components_to_ignore_hidden: Set of components for which the "hidden"
       property is ignored in determining whether the component is hidden. Note that if
       it was not passed, the hidden property WILL be checked.
-    :param original_input_data: The input data from the frontend when called through
-      the check logic endpoint. Used to restore values when flipping visibility
-      states.
+    :param data_for_visible_state: The data used to restore values when flipping
+      visibility states.
     """
     components_to_ignore_hidden = components_to_ignore_hidden or set()
     for component in configuration.get("components", []):
@@ -129,20 +128,22 @@ def process_visibility(
             ignore_hidden_property,
         )
 
-        # Need to check whether the component is present in the data because layout
-        # components have no value
+        # Need to check whether the component holds submission data, as we do not have
+        # to clear those that don't (fieldset, content, softRequiredErrors, etc.)
         holds_submission_data = register.holds_submission_data(component)
         if hidden and clear_on_hide and holds_submission_data:
             # NOTE - formio.js (and our own renderer) *delete* the key entirely from the
             # data instead, while we assign the empty value to ensure every variable is
             # always present in the submission data
             # If we don't have an initial value available, just use the empty value.
-            data[key] = initial_data.get(key) or get_component_empty_value(component)
+            data[key] = data_for_hidden_state.get(key) or get_component_empty_value(
+                component
+            )
 
         # if it's visible, check if any input data should be restored because earlier
         # logic rules may have cleared it (visible -> hidden -> visible)
-        if not hidden and original_input_data is not None and holds_submission_data:
-            if data.get(key) != (original_value := original_input_data.get(key)):
+        if not hidden and data_for_visible_state is not None and holds_submission_data:
+            if data.get(key) != (original_value := data_for_visible_state.get(key)):
                 # restore the value from the original input data - likely there was a
                 # sequence in logic that lead to the data being cleared because of hidden
                 # state, while a subsequent action makes the component visible again. In
@@ -156,10 +157,10 @@ def process_visibility(
             component,
             data,
             wrapper,
-            initial_data=initial_data,
+            data_for_hidden_state=data_for_hidden_state,
             parent_hidden=hidden,
             ignore_hidden_property=ignore_hidden_property,
             get_evaluation_data=get_evaluation_data,
             components_to_ignore_hidden=components_to_ignore_hidden,
-            original_input_data=original_input_data,
+            data_for_visible_state=data_for_visible_state,
         )

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -100,7 +100,7 @@ def evaluate_form_logic(
     # 4. Apply the (dirty) data to the variable state.
     # We need to get the initial data for clear on hide first, as we don't want it to
     # include the unsaved data.
-    initial_data_for_clear_on_hide = (
+    data_for_hidden_state = (
         _get_initial_data_for_clear_on_hide(step)
         if submission.form.new_renderer_enabled
         else FormioData()
@@ -127,7 +127,7 @@ def evaluate_form_logic(
         data_for_evaluation,
         config_wrapper,
         components_with_hidden_action,
-        initial_data_for_clear_on_hide,
+        data_for_hidden_state,
     )
 
     # 6. Evaluate the logic rules in order
@@ -157,7 +157,7 @@ def evaluate_form_logic(
             data_for_evaluation,
             config_wrapper,
             submission=submission,
-            initial_data=initial_data_for_clear_on_hide,
+            data_for_hidden_state=data_for_hidden_state,
         ):
             mutation_operations.append(operation)
 
@@ -251,7 +251,7 @@ def evaluate_conditional_logic(
     data: FormioData,
     wrapper: FormioConfigurationWrapper,
     components_to_ignore_hidden: set[str],
-    initial_data: FormioData,
+    data_for_hidden_state: FormioData,
 ):
     """
     Evaluate conditional logic through iteration.
@@ -265,7 +265,7 @@ def evaluate_conditional_logic(
     :param wrapper: Formio configuration wrapper. Required for component lookup.
     :param components_to_ignore_hidden: Set of components for which the "hidden"
       property is ignored in determining whether the component is hidden.
-    :param initial_data: Initial data for clear-on-hide behavior.
+    :param data_for_hidden_state: Data to apply when a component is hidden.
     """
     processed_data = None
     _loop_count = 0
@@ -278,7 +278,7 @@ def evaluate_conditional_logic(
             configuration,
             data,
             wrapper,
-            initial_data=initial_data,
+            data_for_hidden_state=data_for_hidden_state,
             components_to_ignore_hidden=components_to_ignore_hidden,
         )
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -146,9 +146,9 @@ class ActionOperation:
         context: FormioData,
         configuration: FormioConfigurationWrapper,
         submission: Submission,
-        initial_data: FormioData,
         *,
-        original_input_data: FormioData,
+        data_for_hidden_state: FormioData,
+        data_for_visible_state: FormioData,
     ) -> DataMapping | None:
         """
         Return a mapping [name/path -> new_value] with changes that are to be
@@ -203,9 +203,9 @@ class PropertyAction(ActionOperation):
         context: FormioData,
         configuration: FormioConfigurationWrapper,
         submission: Submission,
-        initial_data: FormioData,
         *,
-        original_input_data: FormioData,
+        data_for_hidden_state: FormioData,
+        data_for_visible_state: FormioData,
     ) -> DataMapping | None:
         # To avoid doing unnecessary work, only apply clear-on-hide logic for components
         # for which their action touches the "hidden" property.
@@ -227,8 +227,7 @@ class PropertyAction(ActionOperation):
         should_be_hidden = self.value is True
 
         # apply the state mutation immediately, so that it's visible to follow up
-        # actions and rules operating on the same component. This obsoletes the
-        # apply method/side-effects.
+        # actions and rules operating on the same component.
         component[self.property_name] = self.value
 
         # Process the visibility of the component. We want to process the component
@@ -238,9 +237,9 @@ class PropertyAction(ActionOperation):
             {"components": [component]},
             context,
             configuration,
-            initial_data=initial_data,
+            data_for_hidden_state=data_for_hidden_state,
             parent_hidden=should_be_hidden,
-            original_input_data=original_input_data,
+            data_for_visible_state=data_for_visible_state,
         )
         return None
 
@@ -431,9 +430,9 @@ class VariableAction(ActionOperation):
         context: FormioData,
         configuration: FormioConfigurationWrapper,
         submission: Submission,
-        initial_data: FormioData,
         *,
-        original_input_data: FormioData,
+        data_for_hidden_state: FormioData,
+        data_for_visible_state: FormioData,
     ) -> DataMapping:
         with log_errors(self.value, self.rule):
             return {self.variable: jsonLogic(self.value, context.data)}
@@ -572,9 +571,9 @@ class SynchronizeVariablesAction(ActionOperation):
         context: FormioData,
         configuration: FormioConfigurationWrapper,
         submission: Submission,
-        initial_data: FormioData,
         *,
-        original_input_data: FormioData,
+        data_for_hidden_state: FormioData,
+        data_for_visible_state: FormioData,
     ) -> DataMapping | None:
         configuration = submission.total_configuration_wrapper
         if self.source_variable not in configuration:
@@ -637,9 +636,9 @@ class ServiceFetchAction(ActionOperation):
         context: FormioData,
         configuration: FormioConfigurationWrapper,
         submission: Submission,
-        initial_data: FormioData,
         *,
-        original_input_data: FormioData,
+        data_for_hidden_state: FormioData,
+        data_for_visible_state: FormioData,
     ) -> DataMapping:
         var = self.rule.form.formvariable_set.get(key=self.variable)
         with log_errors({}, self.rule):  # TODO proper error handling
@@ -712,9 +711,9 @@ class EvaluateDMNAction(ActionOperation):
         context: FormioData,
         configuration: FormioConfigurationWrapper,
         submission: Submission,
-        initial_data: FormioData,
         *,
-        original_input_data: FormioData,
+        data_for_hidden_state: FormioData,
+        data_for_visible_state: FormioData,
     ) -> DataMapping | None:
         # Mapping from form variables to DMN inputs
         dmn_inputs = {

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -186,7 +186,7 @@ def iter_evaluate_rules(
     data: FormioData,
     configuration: FormioConfigurationWrapper,
     submission: Submission,
-    initial_data: FormioData,
+    data_for_hidden_state: FormioData,
 ) -> Iterator[ActionOperation]:
     """
     Iterate over the rules and evaluate the trigger, yielding action operations and
@@ -203,21 +203,23 @@ def iter_evaluate_rules(
       structure is updated after every mutation.
     :param configuration: Formio configuration wrapper of a step.
     :param submission: Submission instance.
-    :param initial_data: Initial data for clear-on-hide behavior.
+    :param data_for_hidden_state: Data to apply when a component is hidden.
     :returns: An iterator yielding :class:`ActionOperation` instances.
     """
     state = submission.variables_state
 
     # keep a copy of the start data that is not affected by the mutations applied by
-    # logic. Due to the instant processing of clearOnHide side-effects and multiple
-    # logic rules potentially changing the visibility of the same component, we need to
-    # make sure to restore the data for every hidden -> visible flip, as the visible ->
-    # hidden flip results in clearing the data - see #6001. For this restoration, we
-    # use the start data as source, as that is coming from the frontend state that is
-    # the result of logic evaluations.
-    # For the hotfix, we deliberately keep this isolated from initial_data, which is
-    # populated differently based on whether the new renderer is enabled or not.
-    original_input_data = deepcopy(data)
+    # clearOnHide logic. Due to the instant processing of clearOnHide side-effects and
+    # multiple logic rules potentially changing the visibility of the same component,
+    # we need to make sure to restore the data for every hidden -> visible flip, as the
+    # visible -> hidden flip results in clearing the data - see #6001. For this
+    # restoration, we use the start data as source, as that is coming from the frontend
+    # state that is the result of logic evaluations. Note that we do need to update this
+    # data with non-clearOnHide mutations that have been applied, to make sure we don't
+    # override it again with user data.
+    # We need to keep this isolated from data_for_hidden_state, as this contains values
+    # that should be applied when a component goes from visible -> hidden.
+    data_for_visible_state = deepcopy(data)
 
     for rule in rules:
         with (
@@ -248,8 +250,8 @@ def iter_evaluate_rules(
                     rule,
                     data,
                     configuration,
-                    initial_data,
-                    original_input_data=original_input_data,
+                    data_for_hidden_state=data_for_hidden_state,
+                    data_for_visible_state=data_for_visible_state,
                 )
                 continue
 
@@ -258,15 +260,15 @@ def iter_evaluate_rules(
                     data,
                     configuration,
                     submission,
-                    initial_data,
-                    original_input_data=original_input_data,
+                    data_for_hidden_state=data_for_hidden_state,
+                    data_for_visible_state=data_for_visible_state,
                 ):
                     mutations_python = {
                         key: state.variables[key].to_python(value)
                         for key, value in mutations.items()
                     }
                     data.update(mutations_python)
-                    original_input_data.update(mutations_python)
+                    data_for_visible_state.update(mutations_python)
 
                 yield operation
 
@@ -275,9 +277,9 @@ def _handle_clear_on_hide_for_untriggered_rule(
     rule: FormLogic,
     data: FormioData,
     configuration: FormioConfigurationWrapper,
-    initial_data: FormioData,
     *,
-    original_input_data: FormioData,
+    data_for_hidden_state: FormioData,
+    data_for_visible_state: FormioData,
 ):
     """
     Handle clear-on-hide behaviour for components of which the "hidden" property
@@ -307,6 +309,6 @@ def _handle_clear_on_hide_for_untriggered_rule(
             {"components": [component]},
             data,
             configuration,
-            initial_data=initial_data,
-            original_input_data=original_input_data,
+            data_for_hidden_state=data_for_hidden_state,
+            data_for_visible_state=data_for_visible_state,
         )


### PR DESCRIPTION
Partly closes #6018

[skip: e2e]

~~(also contains changes of #6047)~~

**Changes**

* Clean up variable names
* Updated comments and docstrings

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
