### PR TITLE
[#6016] Fix stuf-zds concerning null characters in test strategy

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -9,7 +9,7 @@ from django.test import override_settings, tag
 
 import requests_mock
 from freezegun import freeze_time
-from hypothesis import example, given, settings, strategies as st
+from hypothesis import example, given, settings
 from hypothesis.extra.django import TestCase as HypothesisTestCase
 from lxml import etree
 from privates.test import temp_private_root
@@ -40,6 +40,7 @@ from openforms.submissions.tests.factories import (
     SubmissionStepFactory,
     SubmissionValueVariableFactory,
 )
+from openforms.tests.search_strategies import jsonb_text
 from openforms.utils.tests.vcr import OFVCRMixin
 from stuf.stuf_zds.client import PaymentStatus as StuFPaymentStatus
 from stuf.stuf_zds.models import StufZDSConfig
@@ -3271,7 +3272,7 @@ class XMLSanitizerVCRTests(OFVCRMixin, StUFAssertionsMixin, HypothesisTestCase):
 
     @tag("gh-6016")
     @settings(max_examples=20)
-    @given(st.text(min_size=1))
+    @given(jsonb_text())
     @example("bad" + "\x01" + "value")
     @example("bad" + "\x02" + "value")
     @example("bad" + "\x03" + "value")


### PR DESCRIPTION
**Changes**

Null characters break the hypothesis test.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
