### PR TITLE
[#5967] Fix wrong main website and favicon links

### DIFF
--- a/src/openforms/templates/includes/page-header.html
+++ b/src/openforms/templates/includes/page-header.html
@@ -20,7 +20,7 @@ include the SDK snippet directly.
 <header class="utrecht-page-header {% if theme.logo %}utrecht-page-header--openforms-with-logo{% endif %}">
     <a
         class="utrecht-link utrecht-link--html-a utrecht-link--openforms utrecht-page-header__openforms-return-url"
-        href="{% firstof config.main_website '#' %}"
+        href="{% firstof theme.main_website config.main_website '#' %}"
         title="{{ logo_alt }}"
         aria-label="{{ logo_alt }}"
     >{% if config.main_website %}{{ logo_alt }}{% endif %}</a>

--- a/src/openforms/templates/master.html
+++ b/src/openforms/templates/master.html
@@ -20,9 +20,15 @@
     {% endif %}
     
     {% static 'ico/favicon.png' as static_icon %}
-    {% firstof theme.favicon config.favicon static_icon as favicon %}
     
-    <link href="{{ favicon }}" rel="shortcut icon">
+    {% if theme.favicon %}
+        <link href="{{ theme.favicon.url }}" rel="shortcut icon">
+    {% elif config.favicon %}
+        <link href="{{ config.favicon.url }}" rel="shortcut icon">
+    {% else %}
+        <link href="{{ static_icon }}" rel="shortcut icon">
+    {% endif %}
+
         
     <link href="{% static 'bundles/public-styles.css' %}" media="all" rel="stylesheet"/>
     {% include "forms/sdk_css_snippet.html" %}


### PR DESCRIPTION
Closes #5967

**Changes**

The main website and favicon links were not properly configured. Main website from a theme connected to a form was not taken into account and the favicon url was not properly rendered in the template.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
