### PR TITLE
Fix invalid BAG responses being cached

### DIFF
--- a/src/openforms/contrib/kadaster/api/views.py
+++ b/src/openforms/contrib/kadaster/api/views.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from django.core.cache import cache
 from django.utils.translation import gettext_lazy as _
 
@@ -12,7 +10,7 @@ from rest_framework.views import APIView
 
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.api.views.mixins import ListMixin
-from openforms.contrib.kadaster.clients.bag import AddressResult
+from openforms.contrib.kadaster.clients.bag import AddressResult, build_address_result
 from openforms.submissions.api.permissions import AnyActiveSubmissionPermission
 
 from ..clients import get_bag_client, get_locatieserver_client
@@ -73,11 +71,19 @@ class AddressAutocompleteView(APIView):
 
         # check the cache so we avoid hitting the remote API too often (and risk
         # of being throttled, see #1832)
-        address_data = cache.get_or_set(
-            key=f"BAG|get_address|{postcode}|{number}",
-            default=partial(lookup_address, postcode, number),
-            timeout=ADDRESS_AUTOCOMPLETE_CACHE_TIMEOUT,
-        )
+        cache_key = f"BAG|get_address|{postcode}|{number}"
+        # `cache.get(...)` returns `None` if the key does not exist.
+        address_data = cache.get(cache_key)
+        if address_data is None:
+            address_data = lookup_address(postcode, number)
+            # If address data is still `None`, the request to look up the address has
+            # failed for whatever reason, so we shouldn't add it to the cache.
+            if address_data is not None:
+                cache.set(cache_key, address_data, ADDRESS_AUTOCOMPLETE_CACHE_TIMEOUT)
+            else:
+                # Make sure we return an empty address result instead of `None`
+                # (see #4430).
+                address_data = build_address_result(postcode, number)
 
         return Response(GetStreetNameAndCityViewResultSerializer(address_data).data)
 

--- a/src/openforms/contrib/kadaster/clients/bag.py
+++ b/src/openforms/contrib/kadaster/clients/bag.py
@@ -38,7 +38,13 @@ class BAGClient(HALClient):
     @elasticapm.capture_span(span_type="app.bag.query")
     def get_address(
         self, postcode: str, house_number: str, reraise_errors: bool = False
-    ) -> AddressResult:
+    ) -> AddressResult | None:
+        """
+        Look up the address in the BAG.
+
+        :return: The (empty) address result if we received a valid response, `None`
+          otherwise.
+        """
         params = {
             "huisnummer": house_number,
             "postcode": postcode.replace(" ", ""),
@@ -51,33 +57,34 @@ class BAGClient(HALClient):
             if reraise_errors:
                 raise exc
             logger.exception("bag_request_failure", exc_info=exc)
-            return self.build_address_result(postcode, house_number)
+            return None
 
         response_data = response.json()
         if "_embedded" not in response_data:
             # No addresses were found
-            return self.build_address_result(postcode, house_number)
+            return build_address_result(postcode, house_number)
 
         first_result = response_data["_embedded"]["adressen"][0]
         street_name = first_result.pop("korteNaam")
         city = first_result.pop("woonplaatsNaam")
 
-        return self.build_address_result(postcode, house_number, city, street_name)
+        return build_address_result(postcode, house_number, city, street_name)
 
-    def build_address_result(
-        self, postcode: str, house_number: str, city: str = "", street_name: str = ""
-    ) -> AddressResult:
-        secret_street_city = salt_location_message(
-            {
-                "postcode": postcode.upper().replace(" ", ""),
-                "number": house_number,
-                "city": city,
-                "street_name": street_name,
-            }
-        )
 
-        return AddressResult(
-            street_name=street_name,
-            city=city,
-            secret_street_city=secret_street_city,
-        )
+def build_address_result(
+    postcode: str, house_number: str, city: str = "", street_name: str = ""
+) -> AddressResult:
+    secret_street_city = salt_location_message(
+        {
+            "postcode": postcode.upper().replace(" ", ""),
+            "number": house_number,
+            "city": city,
+            "street_name": street_name,
+        }
+    )
+
+    return AddressResult(
+        street_name=street_name,
+        city=city,
+        secret_street_city=secret_street_city,
+    )

--- a/src/openforms/contrib/kadaster/tests/test_api_address_autocomplete.py
+++ b/src/openforms/contrib/kadaster/tests/test_api_address_autocomplete.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 import requests_mock
+from requests import RequestException
 from zgw_consumers.constants import AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
 
@@ -179,6 +180,47 @@ class GetStreetNameAndCityViewAPITests(SubmissionsMixin, TestCase):
             m.get(
                 "https://bag/api/adressen?huisnummer=117&postcode=1015CJ", json={}
             )  # pretend there are no results
+
+            response = self.client.get(
+                endpoint, {"postcode": "1015CJ", "house_number": "117"}
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "streetName": "",
+                "city": "",
+                "secretStreetCity": salt_location_message(
+                    {
+                        "postcode": "1015CJ",
+                        "number": "117",
+                        "city": "",
+                        "street_name": "",
+                    }
+                ),
+            },
+        )
+
+    @patch("openforms.contrib.kadaster.clients.KadasterApiConfig.get_solo")
+    def test_returns_empty_address_result_when_bag_exception_was_thrown(
+        self, m_get_solo
+    ):
+        submission = SubmissionFactory.create()
+        self._add_submission_to_session(submission)
+        m_get_solo.return_value = KadasterApiConfig(
+            bag_service=ServiceFactory.build(
+                api_root="https://bag/api/",
+                auth_type=AuthTypes.no_auth,
+            )
+        )
+        endpoint = reverse("api:geo:address-autocomplete")
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://bag/api/adressen?huisnummer=117&postcode=1015CJ",
+                exc=RequestException,
+            )
 
             response = self.client.get(
                 endpoint, {"postcode": "1015CJ", "house_number": "117"}

--- a/src/openforms/contrib/kadaster/tests/test_api_address_autocomplete.py
+++ b/src/openforms/contrib/kadaster/tests/test_api_address_autocomplete.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from django.conf import settings
 from django.core.cache import caches
@@ -163,6 +163,29 @@ class GetStreetNameAndCityViewAPITests(SubmissionsMixin, TestCase):
 
         # assert that the client call was only made once
         m_lookup_address.assert_called_once_with("1015CJ", "117")
+
+    @tag("gh-5950")
+    @patch(
+        "openforms.contrib.kadaster.api.views.lookup_address",
+        side_effect=[
+            None,  # means the client raised an exception
+            AddressResult(
+                street_name="Keizersgracht", city="Amsterdam", secret_street_city=""
+            ),
+        ],
+    )
+    def test_bag_exceptions_are_not_cached(self, m_lookup_address):
+        endpoint = reverse("api:geo:address-autocomplete")
+
+        # Make the request twice - first one shouldn't be cached, because we didn't
+        # receive a valid response.
+        self.client.get(endpoint, {"postcode": "1015CJ", "house_number": "117"})
+        self.client.get(endpoint, {"postcode": "1015CJ", "house_number": "117"})
+
+        # Assert that the client call was made twice.
+        m_lookup_address.assert_has_calls(
+            [call("1015CJ", "117"), call("1015CJ", "117")]
+        )
 
     @patch("openforms.contrib.kadaster.clients.KadasterApiConfig.get_solo")
     def test_bag_config_client_used(self, m_get_solo):

--- a/src/openforms/contrib/kadaster/tests/test_bag_client.py
+++ b/src/openforms/contrib/kadaster/tests/test_bag_client.py
@@ -92,18 +92,4 @@ class BAGClientTests(SimpleTestCase):
         with get_bag_client() as client:
             address_data = client.get_address("1015CJ", "115")
 
-        self.assertEqual(
-            address_data,
-            AddressResult(
-                street_name="",
-                city="",
-                secret_street_city=salt_location_message(
-                    {
-                        "postcode": "1015CJ",
-                        "number": "115",
-                        "city": "",
-                        "street_name": "",
-                    }
-                ),
-            ),
-        )
+        self.assertIsNone(address_data)


### PR DESCRIPTION
Closes #5950

[skip: e2e]

**Changes**

* Added regression test
* Added test to ensure we don't reintroduce old bug (#4430)
* Ensured invalid BAG responses are not cached

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes