### PR TITLE
Fix infinite loop when clear-on-hide applies to editgrid children but not the parent

### DIFF
--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -80,6 +80,11 @@ def normalize_value_for_component(component: Component, value: Any) -> Any:
     return register.normalize(component, value)
 
 
+def holds_submission_data(component: Component) -> bool:
+    """Return whether data can be submitted for a particular component."""
+    return register.holds_submission_data(component)
+
+
 @tracer.start_as_current_span(
     name="get-dynamic-configuration",
     attributes={"span.type": "app", "span.subtype": "formio"},

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -1189,7 +1189,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                         {"type": "bsn", "key": "bsn"},
                         {
                             "type": "textfield",
-                            "key": "childName",
+                            "key": "firstNames",
                             "label": "Child name",
                         },
                     ],
@@ -1313,7 +1313,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                         {"type": "bsn", "key": "bsn"},
                         {
                             "type": "textfield",
-                            "key": "childName",
+                            "key": "firstNames",
                             "label": "Child name",
                         },
                     ],

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any
@@ -16,12 +16,16 @@ from django.utils.translation import gettext_lazy as _
 import structlog
 from typing_extensions import deprecated
 
-from openforms.formio.service import FormioData, normalize_value_for_component
+from openforms.formio.service import (
+    FormioData,
+    get_component_empty_value,
+    holds_submission_data,
+    normalize_value_for_component,
+)
 from openforms.formio.typing import Component
 from openforms.formio.utils import (
     get_component_data_subtype,
     get_component_datatype,
-    get_component_empty_value,
     iter_components,
 )
 from openforms.forms.models.form_variable import FormVariable
@@ -132,7 +136,7 @@ class SubmissionValueVariablesState:
         data = FormioData()
         for variable in variables.values():
             if variable.source != SubmissionValueVariableSources.sensitive_data_cleaner:
-                data[variable.key] = variable.to_python()
+                data[variable.key] = variable.to_python(include_unsaved=include_unsaved)
 
         if include_static_variables:
             data.update(
@@ -608,7 +612,11 @@ class SubmissionValueVariable(models.Model):
 
         return value
 
-    def to_python(self, value: VariableValue | object = empty) -> VariableValue:
+    def to_python(
+        self,
+        value: VariableValue | object = empty,
+        include_unsaved: bool = False,
+    ) -> VariableValue:
         """
         Deserialize a value into the appropriate python type, using the data type
         information.
@@ -620,6 +628,8 @@ class SubmissionValueVariable(models.Model):
         as we focus on NL first.
 
         :param value: JSON value to deserialize. If empty, ``self.value`` is used.
+        :param include_unsaved: When unsaved value are included, missing keys (e.g. in
+          editgrid items) will be populated with their default values.
         """
         if value is empty:
             value = self.value
@@ -631,8 +641,14 @@ class SubmissionValueVariable(models.Model):
             return self._value_to_python(value, self.data_type, self.configuration)
         else:
             assert self.data_type == FormVariableDataTypes.array
+            assert isinstance(value, Sequence)
             return [
-                self._value_to_python(v, self.data_subtype, self.configuration)
+                self._value_to_python(
+                    v,
+                    self.data_subtype,
+                    self.configuration,
+                    include_unsaved=include_unsaved,
+                )
                 for v in value
             ]
 
@@ -641,6 +657,7 @@ class SubmissionValueVariable(models.Model):
         value: VariableValue,
         data_type: str,
         configuration: Component | None = None,
+        include_unsaved: bool = False,
     ) -> VariableValue:
         if value is None:
             return None
@@ -714,24 +731,40 @@ class SubmissionValueVariable(models.Model):
             )
             return value
 
-        if value and data_type == FormVariableDataTypes.editgrid:
+        if data_type == FormVariableDataTypes.editgrid:
+            assert isinstance(value, dict)
             value = FormioData(value)
-            for child_component in iter_components(configuration):
+            for child_component in iter_components(
+                configuration, recurse_into_editgrid=False
+            ):
                 child_key = child_component["key"]
-                if (child_value := value.get(child_key, empty)) is empty:
-                    continue
+                child_value: VariableValue | object = value.get(child_key, empty)
+
+                if child_value is empty:
+                    if include_unsaved and holds_submission_data(child_component):
+                        child_value = get_component_empty_value(child_component)
+                    else:
+                        continue
 
                 data_type = get_component_datatype(child_component)
                 data_subtype = get_component_data_subtype(child_component)
 
                 if not data_subtype:
                     value[child_key] = self._value_to_python(
-                        child_value, data_type, child_component
+                        child_value,
+                        data_type,
+                        child_component,
+                        include_unsaved=include_unsaved,
                     )
                 else:
                     assert data_type == FormVariableDataTypes.array
                     value[child_key] = [
-                        self._value_to_python(v, data_subtype, child_component)
+                        self._value_to_python(
+                            v,
+                            data_subtype,
+                            child_component,
+                            include_unsaved=include_unsaved,
+                        )
                         for v in child_value
                     ]
 

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -1238,6 +1238,136 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 """),
             )
 
+    @tag("gh-6045")
+    def test_clear_on_hide_clears_children_of_editgrids_new_renderer(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            new_renderer_enabled=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "outerTextfield",
+                        "label": "Outer textfield",
+                        "clearOnHide": True,
+                    },
+                    {
+                        "type": "editgrid",
+                        "key": "editgrid",
+                        "label": "Edit grid",
+                        "clearOnHide": False,
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "innerTextfield",
+                                "label": "Inner textfield",
+                                "clearOnHide": True,
+                            },
+                        ],
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                ]
+            },
+        )
+        form_step = form.formstep_set.get()
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "component": "outerTextfield",
+                    "action": {
+                        "name": "Hide textfield",
+                        "type": "property",
+                        "property": {
+                            "type": "object",
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                },
+                {
+                    "component": "editgrid",
+                    "action": {
+                        "name": "Hide edit grid",
+                        "type": "property",
+                        "property": {
+                            "type": "object",
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                },
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": form_step.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        with self.subTest("initial call after checking checkbox"):
+            response_1 = self.client.post(
+                endpoint,
+                data={
+                    "data": {
+                        "checkbox": True,
+                        "outerTextfield": "clear-me",
+                        "editgrid": [{"innerTextfield": "clear-me"}],
+                    }
+                },
+            )
+
+            self.assertEqual(response_1.status_code, status.HTTP_200_OK)
+            step_data = response_1.json()["step"]
+            # the backend replies with the "empty" values as the result of clear-on-hide,
+            # but the important part is the updated component configurations, which the
+            # renderer handles by itself and *that* leads to the second call.
+            self.assertEqual(
+                step_data["data"],
+                {
+                    "outerTextfield": "",
+                    "editgrid": [{"innerTextfield": ""}],
+                },
+            )
+
+            textfield, editgrid = step_data["formStep"]["configuration"]["components"][
+                0:2
+            ]
+            self.assertTrue(textfield["hidden"])
+            self.assertTrue(editgrid["hidden"])
+
+        # the rendere applies `undefined` to the hidden components, which *removes the
+        # keys* from the submission data.
+        with self.subTest("follow up call after renderer mutations"):
+            response_2 = self.client.post(
+                endpoint,
+                data={
+                    "data": {
+                        "checkbox": True,
+                        # "outerTextfield" key is absent
+                        "editgrid": [{}],  # "innerTextfield" key is absent
+                    }
+                },
+            )
+
+            self.assertEqual(response_2.status_code, status.HTTP_200_OK)
+            step_data = response_2.json()["step"]
+            # we expect *no* data diff to be returned - otherwise you get an infinite
+            # loop
+            self.assertEqual(step_data["data"], {})
+
+            textfield, editgrid = step_data["formStep"]["configuration"]["components"][
+                0:2
+            ]
+            self.assertTrue(textfield["hidden"])
+            self.assertTrue(editgrid["hidden"])
+
 
 @tag("gh-6005")
 class MultipleRulesTargettingSameComponentVisibilityTests(


### PR DESCRIPTION
Closes #6045

The crux is in the repeated logic check calls because of the state/data changes added by the renderer.

In the long run, the proper solution is probably to include an array of paths/component keys that need to be cleared so that the ambiguity of undefined/empty value is handled.

- [x] I've verified (manually) that this patch doesn't introduce infinite loops in the legacy renderer.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
