### PR TITLE
Fix infinite loop with new renderer and editgrid with clear on hide

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1143,9 +1143,11 @@ class EditGrid(BasePlugin[EditGridComponent]):
         original_input_data: FormioData | None = None,
     ):
         key = component["key"]
+        clear_on_hide = component.get("clearOnHide", True)
         # We only need to process children if the value was not already cleared.
-        if not (edit_grid_data := data[key]):
+        if parent_hidden and clear_on_hide:
             return
+        edit_grid_data = data[key]
         assert isinstance(edit_grid_data, list)
 
         # We might be dealing with nested editgrids

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -1123,6 +1123,19 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                         "defaultValue": "foo",
                         "clearOnHide": True,
                     },
+                    {
+                        "type": "editgrid",
+                        "key": "editgrid",
+                        "label": "Editgrid",
+                        "clearOnHide": True,
+                        "components": [
+                            {
+                                "type": "number",
+                                "key": "number",
+                                "label": "Number",
+                            }
+                        ],
+                    },
                 ]
             },
         )
@@ -1142,7 +1155,19 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                         },
                         "state": True,
                     },
-                }
+                },
+                {
+                    "component": "editgrid",
+                    "action": {
+                        "name": "Hide editgrid",
+                        "type": "property",
+                        "property": {
+                            "type": "object",
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                },
             ],
         )
         FormLogicFactory.create(
@@ -1163,7 +1188,11 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
         SubmissionStepFactory.create(
             submission=submission,
             form_step=step,
-            data={"checkbox": False, "textfield": "already submitted value"},
+            data={
+                "checkbox": False,
+                "textfield": "already submitted value",
+                "editgrid": [{"number": 1}, {"number": 2}],
+            },
         )
 
         # Perform logic check
@@ -1175,10 +1204,22 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
 
         response = self.client.post(
             endpoint,
-            data={"data": {"checkbox": True, "textfield": "some custom input"}},
+            data={
+                "data": {
+                    "checkbox": True,
+                    "textfield": "some custom input",
+                    "editgrid": [{"number": 42}],
+                },
+            },
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         step_data = response.json()["step"]
-        self.assertEqual(step_data["data"], {"textfield": "already submitted value"})
+        self.assertEqual(
+            step_data["data"],
+            {
+                "textfield": "already submitted value",
+                "editgrid": [{"number": 1}, {"number": 2}],
+            },
+        )
         # Logic rule should be triggered
         self.assertEqual(step_data["canSubmit"], False)


### PR DESCRIPTION
Closes #5685

[skip: e2e]

**Changes**

* Extended existing regression test with an editgrid component
* Revise check whether editgrid value was cleared already

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
