### PR TITLE
[#5887] Add `gor.openbareRuimteNaam` StUF-ZDS addresses 

### DIFF
--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -470,6 +470,13 @@ class StufZDSPluginTests(StUFZDSTestBase):
                     },
                 },
                 {
+                    "key": "straatnaam",
+                    "type": "textfield",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_straat,
+                    },
+                },
+                {
                     "key": "coordinaat",
                     "type": "map",
                     "registration": {
@@ -505,6 +512,7 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "achternaam": "Bar",
                 "tussenvoegsel": "de",
                 "postcode": "1000 aa",
+                "straatnaam": "foo bar",
                 "geboortedatum": "2000-12-31",
                 "coordinaat": {
                     "type": "Point",
@@ -597,6 +605,8 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:heeftAlsAanspreekpunt/zkn:gerelateerde/zkn:naam": "Naam",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:heeftAlsAanspreekpunt/zkn:gerelateerde/zkn:telefoonnummer": "0612345678",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:heeftAlsAanspreekpunt/zkn:gerelateerde/zkn:emailadres": "foo@example.com",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:verblijfsadres/bg:gor.openbareRuimteNaam": "foo bar",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:verblijfsadres/bg:gor.straatnaam": "foo bar",
                 "//zkn:object/zkn:anderZaakObject/zkn:omschrijving": "coordinaat",
                 "//zkn:object/zkn:anderZaakObject/zkn:lokatie/gml:Point/gml:pos": "4.893164274470299 52.36673378967122",
                 "//zkn:isVan/zkn:gerelateerde/zkn:omschrijving": "zt-omschrijving",
@@ -865,12 +875,20 @@ class StufZDSPluginTests(StUFZDSTestBase):
                         "attribute": RegistrationAttribute.initiator_postcode,
                     },
                 },
+                {
+                    "key": "straatnaam",
+                    "type": "textfield",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_straat,
+                    },
+                },
             ],
             public_registration_reference="foo-zaak",
             registration_result={"intermediate": {"zaaknummer": "foo-zaak"}},
             submitted_data={
                 "handelsnaam": "Foo",
                 "postcode": "2022XY",
+                "straatnaam": "foo bar",
             },
         )
 
@@ -931,6 +949,8 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:statutaireNaam": "Foo",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:authentiek": "N",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:bezoekadres/bg:aoa.postcode": "2022XY",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:bezoekadres/bg:gor.openbareRuimteNaam": "foo bar",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:nietNatuurlijkPersoon/bg:bezoekadres/bg:gor.straatnaam": "foo bar",
             },
         )
 
@@ -971,6 +991,13 @@ class StufZDSPluginTests(StUFZDSTestBase):
                     },
                 },
                 {
+                    "key": "straatnaam",
+                    "type": "textfield",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_straat,
+                    },
+                },
+                {
                     "key": "coordinaat",
                     "type": "map",
                     "registration": {
@@ -990,6 +1017,7 @@ class StufZDSPluginTests(StUFZDSTestBase):
             submitted_data={
                 "handelsnaam": "ACME",
                 "postcode": "1000 AA",
+                "straatnaam": "foo bar",
                 "coordinaat": {
                     "type": "Point",
                     "coordinates": [4.893164274470299, 52.36673378967122],
@@ -1074,6 +1102,9 @@ class StufZDSPluginTests(StUFZDSTestBase):
                 "//zkn:heeft/zkn:gerelateerde/zkn:omschrijving": "aaabbc",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:vestiging/bg:vestigingsNummer": "87654321",
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:vestiging/bg:handelsnaam": "ACME",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:vestiging/bg:verblijfsadres/bg:gor.openbareRuimteNaam": "foo bar",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:vestiging/bg:verblijfsadres/bg:gor.straatnaam": "foo bar",
+                "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:vestiging/bg:verblijfsadres/bg:aoa.postcode": "1000AA",
             },
         )
 

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/bezoekadres.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/bezoekadres.xml
@@ -2,7 +2,10 @@
     <BG:authentiek>N</BG:authentiek>
     {% with verblijfsadres=initiator.verblijfsadres %}
     {% if verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
-    {% if verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
+    {% if verblijfsadres.straatnaam %}
+        <BG:gor.openbareRuimteNaam>{{ verblijfsadres.straatnaam }}</BG:gor.openbareRuimteNaam>
+        <BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>
+    {% endif %}
     {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode|upper|cut:" " }}</BG:aoa.postcode>{% endif %}
     {% if verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
     {% if verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/verblijfsadres.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/includes/verblijfsadres.xml
@@ -2,7 +2,10 @@
     <BG:authentiek>N</BG:authentiek>
     {% with verblijfsadres=initiator.verblijfsadres %}
     {% if verblijfsadres.woonplaatsNaam %}<BG:wpl.woonplaatsNaam>{{ verblijfsadres.woonplaatsNaam }}</BG:wpl.woonplaatsNaam>{% endif %}
-    {% if verblijfsadres.straatnaam %}<BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>{% endif %}
+    {% if verblijfsadres.straatnaam %}
+        <BG:gor.openbareRuimteNaam>{{ verblijfsadres.straatnaam }}</BG:gor.openbareRuimteNaam>
+        <BG:gor.straatnaam>{{ verblijfsadres.straatnaam }}</BG:gor.straatnaam>
+    {% endif %}
     {% if verblijfsadres.postcode %}<BG:aoa.postcode>{{ verblijfsadres.postcode|upper|cut:" " }}</BG:aoa.postcode>{% endif %}
     {% if verblijfsadres.huisnummer %}<BG:aoa.huisnummer>{{ verblijfsadres.huisnummer }}</BG:aoa.huisnummer>{% endif %}
     {% if verblijfsadres.huisletter %}<BG:aoa.huisletter>{{ verblijfsadres.huisletter }}</BG:aoa.huisletter>{% endif %}


### PR DESCRIPTION
Closes #5887

[skip: e2e]

**Changes**

Added `gor.openbareRuimteNaam` to StUF-ZDS, which is a copy of `gor.straatnaam` and include both in de creeerzaak messages.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
