### PR TITLE
Add data type information to JSON logic expressions

### DIFF
--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -88,6 +88,7 @@ include = [
     # core submissions app
     "src/openforms/submissions/api/validation.py",
     "src/openforms/submissions/cosigning.py",
+    "src/openforms/submissions/json_logic.py",
     "src/openforms/submissions/logic/actions.py",
     "src/openforms/submissions/metrics.py",
     "src/openforms/submissions/query.py",

--- a/src/openforms/submissions/json_logic.py
+++ b/src/openforms/submissions/json_logic.py
@@ -1,0 +1,156 @@
+from collections.abc import Mapping
+
+from json_logic.meta.expressions import (
+    JSONLogicExpression,
+    destructure,
+)
+from json_logic.typing import JSON
+
+from openforms.variables.constants import FormVariableDataTypes
+from openforms.variables.service import resolve_key
+
+from .models import SubmissionValueVariablesState
+
+DATA_TYPE_TO_DATA_OPERATOR_MAP: Mapping[str, str] = {
+    FormVariableDataTypes.date: "date",
+    FormVariableDataTypes.datetime: "datetime",
+}
+
+
+def _get_data_type_operator(
+    var_key: str, state: SubmissionValueVariablesState
+) -> str | None:
+    """Get a data-type operator from a data-access key."""
+    variables = {**state.variables, **state.static_variables}
+
+    form_variable_key = resolve_key(var_key, variables)
+    if form_variable_key is None:
+        return None
+
+    variable = variables[form_variable_key]
+    if (data_type := variable.get_data_type(var_key)) is not None:
+        return DATA_TYPE_TO_DATA_OPERATOR_MAP.get(data_type, None)
+
+    return None
+
+
+def add_data_type_information(
+    expression: JSON,
+    state: SubmissionValueVariablesState,
+    parent_key: str | None = None,
+    in_reduce: bool = False,
+) -> JSON:
+    """
+    Add data-type information to a JSON logic expression.
+
+    Searches the expression for variable operations, and wraps them with the relevant
+    data-type operator were applicable.
+
+    For example (consider a form with a date component "dateField"):
+    >>> expression = {"==": [{"var": "dateField"}, {"date": "2026-03-10"}]}
+    >>> result = add_data_type_information(
+    ...     expression, submission.load_submission_value_variables_state()
+    ... )
+    >>> print(result)
+    {"==" [{"date": [{"var": ["dateField"]}]}, {"date": ["2026-03-10"]}]}
+
+    Note that a normalization to wrap all arguments of an operator in a list is applied
+    here.
+
+    :param expression: JSON logic expression
+    :param state: Submission value variables state, used to get the data-type
+      information from.
+    :param parent_key: Parent variable name, passed when processing array
+      operations (map and reduce).
+    :param in_reduce: Flag indicating whether we are inside a reduce operation.
+    :return: JSON logic expression with added data-type information.
+    """
+    # Recursively process the expression.
+    if isinstance(expression, list):
+        expression_new = [
+            add_data_type_information(expr, state, parent_key, in_reduce)
+            for expr in expression
+        ]
+        return expression_new
+
+    # Expression is a primitive.
+    if not isinstance(expression, dict):
+        return expression
+
+    # Apply normalization.
+    normalized = JSONLogicExpression.normalize(expression)
+    assert isinstance(normalized, dict)
+    operator, argument = destructure(normalized)
+    assert isinstance(argument, list)
+
+    match operator:
+        case "var":
+            var_name = argument[0]
+            # We can't add any data type information if the argument is another
+            # (variable) expression, because we have no data available here.
+            if not isinstance(var_name, str):
+                return normalized  # pyright: ignore[reportReturnType]
+
+            # The reduce item expression only has access to variables "current" and
+            # "accumulator", where "current" can access individual items of the array
+            # using dot notation, e.g. "current.date". Before determining the data type
+            # operator, we need to strip "current." from it.
+            if in_reduce:
+                if var_name == "accumulator":
+                    return normalized  # pyright: ignore[reportReturnType]
+                var_name = var_name.removeprefix("current").lstrip(".")
+
+            # The array operations access each item individually, but "parent.var_name"
+            # is not a valid data-access key, so we create one ourselves :poop:
+            # If `var_name` is an empty string, it means the variable was either
+            # "current" (reduce operation) or "" (map operation), so we just add a
+            # single index to the parent.
+            if parent_key:
+                var_name = (
+                    f"{parent_key}.0.{var_name}" if var_name else f"{parent_key}.0"
+                )
+
+            data_type_operator = _get_data_type_operator(var_name, state)
+            if data_type_operator is None:
+                return normalized  # pyright: ignore[reportReturnType]
+
+            return {data_type_operator: [normalized]}  # pyright: ignore[reportReturnType]
+        case "reduce":
+            assert len(argument) == 3
+            var_expression = add_data_type_information(argument[0], state)
+            # We can only determine the data type if we have a (non-nested) variable
+            # expression.
+            parent = None
+            if isinstance(var_expression, dict) and "var" in var_expression:
+                assert isinstance(var_expression["var"], list)  # normalized
+                if isinstance(var_expression["var"][0], str):
+                    parent = var_expression["var"][0]
+
+            item_expression = add_data_type_information(
+                argument[1], state, parent, in_reduce=True
+            )
+            return {operator: [var_expression, item_expression, argument[2]]}
+        case "map":
+            assert len(argument) == 2
+            var_expression = add_data_type_information(argument[0], state, parent_key)
+            # We can only determine the data type if we have a (non-nested) variable
+            # expression.
+            parent = None
+            if isinstance(var_expression, dict) and "var" in var_expression:
+                assert isinstance(var_expression["var"], list)  # normalized
+                if isinstance(var_expression["var"][0], str):
+                    parent = var_expression["var"][0]
+
+            item_expression = add_data_type_information(argument[1], state, parent)
+            return {
+                operator: [var_expression, item_expression],
+            }
+        case "date" | "datetime":
+            # It already contains a date operator.
+            return normalized  # pyright: ignore[reportReturnType]
+        case _:
+            pass
+
+    # Evaluate the argument
+    argument_new = add_data_type_information(argument, state, parent_key, in_reduce)
+    return {operator: argument_new}

--- a/src/openforms/submissions/models/__init__.py
+++ b/src/openforms/submissions/models/__init__.py
@@ -12,7 +12,10 @@ from .submission_files import (
 )
 from .submission_report import SubmissionReport
 from .submission_step import SubmissionStep
-from .submission_value_variable import SubmissionValueVariable
+from .submission_value_variable import (
+    SubmissionValueVariable,
+    SubmissionValueVariablesState,
+)
 
 __all__ = [
     "PostCompletionMetadata",
@@ -23,6 +26,7 @@ __all__ = [
     "SubmissionFileAttachmentManager",
     "SubmissionFileAttachmentQuerySet",
     "SubmissionValueVariable",
+    "SubmissionValueVariablesState",
     "TemporaryFileUpload",
     "submission_file_upload_to",
     "temporary_file_upload_to",

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
@@ -64,6 +65,9 @@ class SubmissionValueVariablesState:
         init=False, default=None
     )
     _static_data: dict[str, Any] | None = field(init=False, default=None)
+    _static_variables: dict[str, SubmissionValueVariable] | None = field(
+        init=False, default=None
+    )
 
     @property
     def variables(self) -> dict[str, SubmissionValueVariable]:
@@ -95,6 +99,22 @@ class SubmissionValueVariablesState:
             for variable in self.variables.values()
             if variable.is_initially_prefilled
         }
+
+    @property
+    def static_variables(self) -> dict[str, SubmissionValueVariable]:
+        if self._static_variables is not None:
+            return self._static_variables
+
+        self._static_variables = {
+            variable.key: SubmissionValueVariable(
+                submission=self.submission,
+                key=variable.key,
+                value=variable.initial_value,
+                data_type=variable.data_type,
+            )
+            for variable in get_static_variables(submission=self.submission)
+        }
+        return self._static_variables
 
     @deprecated("Use `state.variables[key]` instead.")
     def get_variable(self, key: str) -> SubmissionValueVariable:
@@ -771,6 +791,73 @@ class SubmissionValueVariable(models.Model):
             return value.data
 
         return value
+
+    def get_data_type(self, key: str) -> str | None:
+        """
+        Get the data type based on a data-access key.
+
+        For example (valid):
+         - "datetimeMultiple.0" -> "datetime"
+         - "editgrid.0.textfield" -> "string"
+         - "children.3.dateOfBirth -> "date"
+
+        For example (invalid):
+         - "datetimeMultiple.foo" -> None
+         - "editgrid.0.nonExistingChild -> None
+         - "children.invalidIndex" -> None
+
+        .. warning:: It does not support deeply-nested data access keys at the moment,
+          e.g. "editgrid.0.datetimeMultiple.0".
+
+        :param key: The data-access key.
+        :return: The data type, or `None` if the key was invalid.
+        """
+        if key == self.key:
+            return self.data_type
+
+        # Data type is not array -> no support for nested data access -> any key other
+        # than `self.key` is not relevant.
+        if self.data_type != FormVariableDataTypes.array:
+            return None
+
+        # If it doesn't start with `{self.key}.[index](.)` -> it is not relevant.
+        if not re.match(f"^{self.key}.\d+($|\.)", key):
+            return None
+
+        assert self.data_subtype is not None
+        # We cannot infer anything here.
+        if self.data_subtype == FormVariableDataTypes.object:
+            return None
+
+        # Try parsing it as a child data access key, e.g. "editgrid.0.textfield", by
+        # stripping the parent key and index.
+        key_list = key.removeprefix(f"{self.key}.").split(".", 1)
+        match self.data_subtype:
+            case FormVariableDataTypes.editgrid:
+                child_key = key_list[1]
+                for child_component in iter_components(self.configuration):
+                    if child_key != child_component["key"]:
+                        continue
+                    return get_component_datatype(child_component)
+                return None
+            case FormVariableDataTypes.partners | FormVariableDataTypes.children:
+                child_key = key_list[1]
+                match child_key:
+                    case "dateOfBirth":
+                        return FormVariableDataTypes.date
+                    case "selected":
+                        return FormVariableDataTypes.boolean
+                    case "bsn" | "initials" | "affixes" | "lastName" | "firstNames":
+                        return FormVariableDataTypes.string
+                    case _:
+                        return None
+            case _:
+                # For the other types, the only relevant keys are of the format
+                # `{self.key}.[index]` (components with `"multiple": True`), so the key
+                # list must contain a single index.
+                if len(key_list) == 1:
+                    return self.data_subtype
+                return None
 
     @cached_property
     def is_registration_attempt_allowed(self) -> bool:

--- a/src/openforms/submissions/tests/test_json_logic.py
+++ b/src/openforms/submissions/tests/test_json_logic.py
@@ -1,0 +1,431 @@
+from django.test import TestCase
+
+from openforms.forms.tests.factories import FormFactory
+
+from ..json_logic import add_data_type_information
+from .factories import SubmissionFactory
+
+
+class AddDataTypeInformationTests(TestCase):
+    maxDiff = None
+
+    def test_date_and_datetime(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                    },
+                    {
+                        "key": "date",
+                        "type": "date",
+                        "label": "Date",
+                    },
+                    {
+                        "key": "datetime",
+                        "type": "datetime",
+                        "label": "Datetime",
+                    },
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        state = submission.load_submission_value_variables_state()
+
+        expressions = [
+            {"==": [{"var": "date"}, {"var": "today"}]},  # today is static variable
+            {"==": [{"datetime": "2026-03-06T15:37:00"}, {"var": "datetime"}]},
+            {"==": [{"var": "textfield"}, "foo"]},
+        ]
+        expected_results = [
+            {
+                "==": [
+                    {"date": [{"var": ["date"]}]},
+                    {"date": [{"var": ["today"]}]},
+                ]
+            },
+            {
+                "==": [
+                    {"datetime": ["2026-03-06T15:37:00"]},
+                    {"datetime": [{"var": ["datetime"]}]},
+                ]
+            },
+            {"==": [{"var": ["textfield"]}, "foo"]},
+        ]
+
+        for expression, expected_result in zip(
+            expressions, expected_results, strict=True
+        ):
+            result = add_data_type_information(expression, state)
+            with self.subTest(expression):
+                self.assertEqual(expected_result, result)
+
+    def test_components_with_multiple_true(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "multiple": True,
+                    },
+                    {
+                        "key": "date",
+                        "type": "date",
+                        "label": "Date",
+                        "multiple": True,
+                    },
+                    {
+                        "key": "datetime",
+                        "type": "datetime",
+                        "label": "Datetime",
+                        "multiple": True,
+                    },
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        state = submission.load_submission_value_variables_state()
+
+        expressions = [
+            {"==": [{"var": "date.0"}, {"date": "2026-03-06"}]},
+            {"==": [{"datetime": "2026-03-06T15:37:00"}, {"var": "datetime.1"}]},
+            {"==": [{"var": "textfield.2"}, "foo"]},
+            {"map": [{"var": "date"}, {">": [{"var": ""}, {"date": "2026-01-01"}]}]},
+        ]
+        expected_results = [
+            {"==": [{"date": [{"var": ["date.0"]}]}, {"date": ["2026-03-06"]}]},
+            {
+                "==": [
+                    {"datetime": ["2026-03-06T15:37:00"]},
+                    {"datetime": [{"var": ["datetime.1"]}]},
+                ]
+            },
+            {"==": [{"var": ["textfield.2"]}, "foo"]},
+            {
+                "map": [
+                    {"var": ["date"]},
+                    {">": [{"date": [{"var": [""]}]}, {"date": ["2026-01-01"]}]},
+                ]
+            },
+        ]
+
+        for expression, expected_result in zip(
+            expressions, expected_results, strict=True
+        ):
+            result = add_data_type_information(expression, state)
+            with self.subTest(expression):
+                self.assertEqual(expected_result, result)
+
+    def test_children(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "children",
+                        "type": "children",
+                        "label": "Children",
+                    },
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        state = submission.load_submission_value_variables_state()
+
+        expressions = [
+            {"==": [{"var": "children.0.dateOfBirth"}, {"date": "2026-03-06"}]},
+            {"==": [{"date": "2026-03-06"}, {"var": "children.1.dateOfBirth"}]},
+            {"==": [{"var": "children.2.lastName"}, "Bekker"]},  # string
+            {
+                "==": [
+                    {"var": "children.dateOfBirth"},
+                    {"datetime": "2026-03-06T15:37:00"},
+                ]
+            },  # incorrect data access
+            {"==": [{"var": "children.0.nonExisting"}, "foo"]},  # non-existing field
+        ]
+        expected_results = [
+            {
+                "==": [
+                    {"date": [{"var": ["children.0.dateOfBirth"]}]},
+                    {"date": ["2026-03-06"]},
+                ]
+            },
+            {
+                "==": [
+                    {"date": ["2026-03-06"]},
+                    {"date": [{"var": ["children.1.dateOfBirth"]}]},
+                ]
+            },
+            {"==": [{"var": ["children.2.lastName"]}, "Bekker"]},
+            {
+                "==": [
+                    {"var": ["children.dateOfBirth"]},
+                    {"datetime": ["2026-03-06T15:37:00"]},
+                ]
+            },
+            {"==": [{"var": ["children.0.nonExisting"]}, "foo"]},
+        ]
+
+        for expression, expected_result in zip(
+            expressions, expected_results, strict=True
+        ):
+            result = add_data_type_information(expression, state)
+            with self.subTest(expression):
+                self.assertEqual(expected_result, result)
+
+    def test_children_with_array_operations(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "children",
+                        "type": "children",
+                        "label": "Children",
+                    },
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        state = submission.load_submission_value_variables_state()
+
+        expressions = [
+            {
+                "map": [
+                    {"var": "children"},
+                    {">": [{"var": "dateOfBirth"}, {"date": "2026-03-06"}]},
+                ]
+            },
+            {
+                "map": [
+                    {"var": {"var": "foo"}},
+                    {">": [{"var": "dateOfBirth"}, {"date": "2026-03-06"}]},
+                ]
+            },
+            {
+                "reduce": [
+                    {"var": "children"},
+                    {">": [{"var": "current.dateOfBirth"}, {"date": "2026-03-06"}]},
+                    0,
+                ]
+            },
+            {
+                "reduce": [
+                    {"var": {"var": "foo"}},
+                    {">": [{"var": "current.dateOfBirth"}, {"date": "2026-03-06"}]},
+                    0,
+                ]
+            },
+            # A cursed expression:
+            {
+                "reduce": [
+                    {
+                        "map": [
+                            {"var": "children"},
+                            {">": [{"var": "dateOfBirth"}, {"date": "2026-03-06"}]},
+                        ]
+                    },
+                    {"+": [{"var": "current"}, {"var": "accumulator"}]},
+                    0,
+                ]
+            },
+        ]
+        expected_results = [
+            {
+                "map": [
+                    {"var": ["children"]},
+                    {
+                        ">": [
+                            {"date": [{"var": ["dateOfBirth"]}]},
+                            {"date": ["2026-03-06"]},
+                        ]
+                    },
+                ],
+            },
+            {
+                "map": [
+                    {"var": [{"var": "foo"}]},
+                    {">": [{"var": ["dateOfBirth"]}, {"date": ["2026-03-06"]}]},
+                ]
+            },
+            {
+                "reduce": [
+                    {"var": ["children"]},
+                    {
+                        ">": [
+                            {"date": [{"var": ["current.dateOfBirth"]}]},
+                            {"date": ["2026-03-06"]},
+                        ]
+                    },
+                    0,
+                ]
+            },
+            {
+                "reduce": [
+                    {"var": [{"var": "foo"}]},
+                    {">": [{"var": ["current.dateOfBirth"]}, {"date": ["2026-03-06"]}]},
+                    0,
+                ]
+            },
+            {
+                "reduce": [
+                    {
+                        "map": [
+                            {"var": ["children"]},
+                            {
+                                ">": [
+                                    {"date": [{"var": ["dateOfBirth"]}]},
+                                    {"date": ["2026-03-06"]},
+                                ]
+                            },
+                        ]
+                    },
+                    {"+": [{"var": ["current"]}, {"var": ["accumulator"]}]},
+                    0,
+                ]
+            },
+        ]
+
+        for expected, expression in zip(expected_results, expressions, strict=True):
+            result = add_data_type_information(expression, state)
+            with self.subTest(expression):
+                self.assertEqual(expected, result)
+
+    def test_array_operations_without_component(self):
+        form = FormFactory.create(generate_minimal_setup=True)
+        submission = SubmissionFactory.create(form=form)
+        state = submission.load_submission_value_variables_state()
+
+        expressions = [
+            {"map": [[1, 2, 3, 4], {">": [{"var": ""}, 3]}]},
+            {
+                "reduce": [
+                    [1, 2, 3, 4],
+                    {"+": [{"var": "current"}, {"var": "accumulator"}]},
+                    0,
+                ]
+            },
+            # A cursed expression:
+            {
+                "reduce": [
+                    {"map": [[1, 2, 3, 4], {">": [{"var": ""}, 3]}]},
+                    {"+": [{"var": "current"}, {"var": "accumulator"}]},
+                    0,
+                ]
+            },
+        ]
+        expected_results = [
+            {"map": [[1, 2, 3, 4], {">": [{"var": [""]}, 3]}]},
+            {
+                "reduce": [
+                    [1, 2, 3, 4],
+                    {"+": [{"var": ["current"]}, {"var": ["accumulator"]}]},
+                    0,
+                ]
+            },
+            # A cursed expression:
+            {
+                "reduce": [
+                    {"map": [[1, 2, 3, 4], {">": [{"var": [""]}, 3]}]},
+                    {"+": [{"var": ["current"]}, {"var": ["accumulator"]}]},
+                    0,
+                ]
+            },
+        ]
+
+        for expected, expression in zip(expected_results, expressions, strict=True):
+            result = add_data_type_information(expression, state)
+            with self.subTest(expression):
+                self.assertEqual(expected, result)
+
+    def test_editgrid(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "editgrid",
+                        "type": "editgrid",
+                        "label": "Editgrid",
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "textfield",
+                                "label": "Textfield",
+                            },
+                            {
+                                "type": "date",
+                                "key": "date",
+                                "label": "Date",
+                            },
+                            {
+                                "type": "datetime",
+                                "key": "datetime",
+                                "label": "Datetime",
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        submission = SubmissionFactory.create(form=form)
+        state = submission.load_submission_value_variables_state()
+
+        expressions = [
+            {
+                "==": [
+                    {"var": "editgrid.0.date"},
+                    {"date": "2026-03-06"},
+                ]
+            },
+            {
+                "==": [
+                    {"datetime": "2026-03-06T11:22:33"},
+                    {"var": "editgrid.1.datetime"},
+                ]
+            },
+            {"==": [{"var": "editgrid.2.textfield"}, "Bekker"]},
+            {
+                "==": [
+                    {"var": "editgrid.date"},
+                    {"date": "2026-03-06"},
+                ]
+            },
+            {"==": [{"var": "editgrid.0.nonExisting"}, "foo"]},
+        ]
+        expected_results = [
+            {
+                "==": [
+                    {"date": [{"var": ["editgrid.0.date"]}]},
+                    {"date": ["2026-03-06"]},
+                ]
+            },
+            {
+                "==": [
+                    {"datetime": ["2026-03-06T11:22:33"]},
+                    {"datetime": [{"var": ["editgrid.1.datetime"]}]},
+                ]
+            },
+            {"==": [{"var": ["editgrid.2.textfield"]}, "Bekker"]},
+            {
+                "==": [
+                    {"var": ["editgrid.date"]},
+                    {"date": ["2026-03-06"]},
+                ]
+            },
+            {"==": [{"var": ["editgrid.0.nonExisting"]}, "foo"]},
+        ]
+
+        for expression, expected_result in zip(
+            expressions, expected_results, strict=True
+        ):
+            result = add_data_type_information(expression, state)
+            with self.subTest(expression):
+                self.assertEqual(expected_result, result)

--- a/src/openforms/submissions/tests/test_variables/test_model.py
+++ b/src/openforms/submissions/tests/test_variables/test_model.py
@@ -4,6 +4,8 @@ from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 
+from unittest_parametrize import ParametrizedTestCase, param, parametrize
+
 from openforms.formio.service import FormioData
 from openforms.forms.tests.factories import (
     FormFactory,
@@ -20,7 +22,7 @@ from ..factories import (
 )
 
 
-class SubmissionValueVariableModelTests(TestCase):
+class SubmissionValueVariableModelTests(ParametrizedTestCase, TestCase):
     def test_unique_together_submission_key(self):
         variable1 = SubmissionValueVariableFactory.create(key="var1")
 
@@ -485,6 +487,116 @@ class SubmissionValueVariableModelTests(TestCase):
 
             stored = SubmissionValueVariable.objects.get(key=variable.key)
             self.assertEqual(stored.value, [{"date": "", "time": [""]}])
+
+    @parametrize(
+        ("key", "expected_data_type"),
+        [
+            param("foo.bar", FormVariableDataTypes.string),
+            param("foo.barbaz", None),
+            param("foo", None),
+            param("foo.bar.baz", None),
+            param("foo.barSomeExtraCharacters", None),
+        ],
+    )
+    def test_get_data_type_textfield(self, key, expected_data_type):
+        var = SubmissionValueVariableFactory.create(
+            key="foo.bar",
+            value="",
+            data_type=FormVariableDataTypes.string,
+            configuration={"type": "textfield", "key": "foo.bar"},
+        )
+        data_type = var.get_data_type(key)
+        self.assertEqual(expected_data_type, data_type)
+
+    @parametrize(
+        ("key", "expected_data_type"),
+        [
+            param("foo.bar", FormVariableDataTypes.array),
+            param("foo.bar.0", FormVariableDataTypes.date),
+            param("foo.bar.0.baz", None),
+            param("foo.bar.0baz", None),
+            param("foo.bar.baz", None),
+        ],
+    )
+    def test_get_data_type_date_multiple(self, key, expected_data_type):
+        var = SubmissionValueVariableFactory.create(
+            key="foo.bar",
+            value=[],
+            data_type=FormVariableDataTypes.array,
+            data_subtype=FormVariableDataTypes.date,
+            configuration={"type": "date", "key": "foo.bar", "multiple": True},
+        )
+        data_type = var.get_data_type(key)
+        self.assertEqual(expected_data_type, data_type)
+
+    @parametrize(
+        ("key", "expected_data_type"),
+        [
+            param("children", FormVariableDataTypes.array),
+            param("children.0.dateOfBirth", FormVariableDataTypes.date),
+            param("children.1.selected", FormVariableDataTypes.boolean),
+            param("children.42.lastName", FormVariableDataTypes.string),
+            param("children.42.nonExisting", None),
+            param("children.lastName", None),
+        ],
+    )
+    def test_get_data_type_children(self, key, expected_data_type):
+        var = SubmissionValueVariableFactory.create(
+            key="children",
+            value=[],
+            data_type=FormVariableDataTypes.array,
+            data_subtype=FormVariableDataTypes.children,
+            configuration={"type": "children", "key": "children"},
+        )
+        data_type = var.get_data_type(key)
+        self.assertEqual(expected_data_type, data_type)
+
+    @parametrize(
+        ("key", "expected_data_type"),
+        [
+            param("editgrid", FormVariableDataTypes.array),
+            param("editgrid.0.date", FormVariableDataTypes.date),
+            param("editgrid.1.textfield", FormVariableDataTypes.string),
+            param("editgrid.2.nonExisting", None),
+            param("editgrid.textfield", None),
+        ],
+    )
+    def test_get_data_type_editgrid(self, key, expected_data_type):
+        var = SubmissionValueVariableFactory.create(
+            key="editgrid",
+            value=[],
+            data_type=FormVariableDataTypes.array,
+            data_subtype=FormVariableDataTypes.editgrid,
+            configuration={
+                "type": "editgrid",
+                "key": "editgrid",
+                "components": [
+                    {"type": "date", "key": "date"},
+                    {"type": "textfield", "key": "textfield"},
+                ],
+            },
+        )
+        data_type = var.get_data_type(key)
+        self.assertEqual(expected_data_type, data_type)
+
+    @parametrize(
+        ("key", "expected_data_type"),
+        [
+            param("file", FormVariableDataTypes.array),
+            param("file.0.url", None),
+            param("file.invalidIndex", None),
+        ],
+    )
+    def test_get_data_file(self, key, expected_data_type):
+        var = SubmissionValueVariableFactory.create(
+            key="file",
+            value=[],
+            data_type=FormVariableDataTypes.array,
+            data_subtype=FormVariableDataTypes.object,
+            configuration={"type": "file", "key": "file"},
+        )
+        data_type = var.get_data_type(key)
+        self.assertEqual(expected_data_type, data_type)
 
 
 class SubmissionValueVariableManagerTests(TestCase):


### PR DESCRIPTION
Closes #6038

[skip: e2e]

**Changes**

* Added routine to include data-type information in JSON logic expressions
* Added `static_variables` property to `SubmissionValueVariableState`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
