### PR TITLE
Display cosign validation errors close to the relevant field

### DIFF
--- a/src/openforms/forms/templates/forms/sdk_css_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_css_snippet.html
@@ -1,1 +1,3 @@
-<link href="{{ sdk_css_url }}" rel="stylesheet" />
+{% load openforms %}
+{% sdk_urls as urls %}
+<link href="{{ urls.sdk_css_url }}" rel="stylesheet" />

--- a/src/openforms/forms/templates/forms/sdk_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_snippet.html
@@ -1,10 +1,11 @@
 {% load openforms static %}{% if form %}{% with 'openforms-container' as div_id %}
+{% sdk_urls as urls %}
 {# Preload the module #}
-<link href="{{ sdk_esm_url }}" rel="modulepreload" />
+<link href="{{ urls.sdk_esm_url }}" rel="modulepreload" />
 <div
     class="open-forms-sdk-root"
     id="{{ div_id }}"
-    data-sdk-module="{{ sdk_esm_url }}"
+    data-sdk-module="{{ urls.sdk_esm_url }}"
     data-form-id="{{ form.slug }}"
     data-base-url="{% api_base_url %}"
     data-base-path="{% if base_path %}{{ base_path }}{% else %}{% url 'forms:form-detail' slug=form.slug %}{% endif %}"
@@ -16,7 +17,7 @@
 <script type="module" src="{% static 'sdk-wrapper.mjs' %}"></script>
 
 {# Fallback #}
-<script src="{{ sdk_umd_url }}" nomodule></script>
+<script src="{{ urls.sdk_umd_url }}" nomodule></script>
 <script nonce="{{ request.csp_nonce }}" nomodule>
     const formId = '{{ form.slug|escapejs }}';
     const baseUrl = '{% filter escapejs %}{% api_base_url %}{% endfilter %}';

--- a/src/openforms/forms/templatetags/openforms.py
+++ b/src/openforms/forms/templatetags/openforms.py
@@ -4,6 +4,7 @@ from django.template.defaultfilters import stringfilter
 from rest_framework.reverse import reverse
 
 from openforms.utils.redirect import allow_redirect_url
+from openforms.utils.sdk_static import get_sdk_urls
 
 register = Library()
 
@@ -36,3 +37,8 @@ def get_allowed_redirect_url(*candidates: str) -> str:
         if allow_redirect_url(candidate):
             return candidate
     return ""
+
+
+@register.simple_tag()
+def sdk_urls():
+    return get_sdk_urls()

--- a/src/openforms/forms/views/form.py
+++ b/src/openforms/forms/views/form.py
@@ -9,7 +9,6 @@ from openforms.config.models import GlobalConfiguration, Theme
 from openforms.config.templatetags.theme import THEME_OVERRIDE_CONTEXT_VAR
 from openforms.utils.decorators import conditional_search_engine_index
 from openforms.utils.mixins import UserIsStaffMixin
-from openforms.utils.sdk_static import get_sdk_urls
 
 from ..models import Form
 
@@ -46,12 +45,7 @@ class FormDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update(
-            {
-                THEME_OVERRIDE_CONTEXT_VAR: self.object.theme,
-                **get_sdk_urls(),
-            }
-        )
+        context[THEME_OVERRIDE_CONTEXT_VAR] = self.object.theme
         return context
 
 
@@ -69,7 +63,6 @@ class ThemePreviewFormView(UserIsStaffMixin, DetailView):
         context.update(
             {
                 THEME_OVERRIDE_CONTEXT_VAR: self.object.theme,
-                **get_sdk_urls(),
                 "base_path": reverse(
                     "forms:theme-preview",
                     kwargs={"theme_pk": self.theme.pk, "slug": self.object.slug},

--- a/src/openforms/submissions/forms.py
+++ b/src/openforms/submissions/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -37,22 +36,24 @@ class SearchSubmissionForCosignForm(forms.Form):
         # always store the resolved submission so that form_invalid can handle it
         self.cleaned_data["submission"] = submission
 
-        err_msg = _(
-            "Could not find a submission corresponding to this code that requires "
-            "co-signing"
-        )
         # check that we actually expect cosign for this submission
         if not submission or not submission.cosign_state.is_waiting:
-            raise ValidationError(err_msg)
-
-        if check_user_is_submission_initiator(self.request, submission):
+            self.add_error(
+                "code",
+                _(
+                    "Could not find a submission corresponding to this code that requires "
+                    "co-signing"
+                ),
+            )
+        elif check_user_is_submission_initiator(self.request, submission):
             logger.info(
                 "cosign_start_blocked",
                 reason="cosigner_same_as_submitter",
                 submission_uuid=str(submission.uuid),
             )
-            raise ValidationError(
-                _("The submission cannot be co-signed by the original submitter.")
+            self.add_error(
+                "code",
+                _("The submission cannot be co-signed by the original submitter."),
             )
 
         return self.cleaned_data

--- a/src/openforms/submissions/tests/test_views.py
+++ b/src/openforms/submissions/tests/test_views.py
@@ -539,7 +539,7 @@ class SearchSubmissionForCosignViewTests(WebTest):
         self.assertEqual(submission_response.status_code, 200)
         self.assertFormError(
             submission_response.context["form"],
-            field=None,
+            field="code",
             errors=_(
                 "Could not find a submission corresponding to this code that "
                 "requires co-signing"

--- a/src/openforms/submissions/views.py
+++ b/src/openforms/submissions/views.py
@@ -371,7 +371,7 @@ class SearchSubmissionForCosignFormView(ThrottleMixin, UserPassesTestMixin, Form
             audit_log.warning(
                 "cosign_lookup_blocked", submission_uuid=str(submission.uuid)
             )
-        elif code := form.cleaned_data.get("code"):
+        elif code := form.data.get("code"):
             audit_log.warning("cosign_lookup_failed", form_id=self.form.pk, code=code)
 
         return super().form_invalid(form)


### PR DESCRIPTION
**Changes**

This fixes the proper error styling for the field instead of using the non-field errors.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
