### PR TITLE
Unchecking deceased children by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/prepare-release.md
+++ b/.github/ISSUE_TEMPLATE/prepare-release.md
@@ -36,7 +36,7 @@ assignees: sergei-maertens
 
     - [ ] `openforms.contrib.brk`
     - [ ] `openforms.contrib.customer_interactions`
-    - [ ] `openforms.contrib.haal_centraal.tests.test_integration`
+    - [ ] `openforms.contrib.haal_centraal`
     - [ ] `openforms.contrib.kvk`
     - [ ] `openforms.contrib.objects_api`
     - [ ] `openforms.contrib.reference_lists`

--- a/src/openforms/contrib/haal_centraal/clients/brp.py
+++ b/src/openforms/contrib/haal_centraal/clients/brp.py
@@ -208,7 +208,7 @@ class V2Client(BRPClient):
         bsn: str,
         include_children: bool,
         include_partner: bool,
-        include_deceased: bool = True,
+        include_deceased: bool = False,
         **kwargs,
     ) -> list[NaturalPersonDetails]:
         fields = []

--- a/src/openforms/contrib/haal_centraal/tests/test_brp_clients.py
+++ b/src/openforms/contrib/haal_centraal/tests/test_brp_clients.py
@@ -13,6 +13,7 @@ from openforms.config.models import GlobalConfiguration
 from openforms.pre_requests.base import PreRequestHookBase
 from openforms.pre_requests.registry import Registry
 from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.utils.tests.vcr import OFVCRMixin
 
 from ..clients import get_brp_client
 from ..constants import DEFAULT_HC_BRP_PERSONEN_GEBRUIKER_HEADER, BRPVersions
@@ -42,10 +43,24 @@ class HaalCentraalFindPersonTests:
     def setUp(self):
         super().setUp()  # type: ignore
 
+        # For the BRP v2 tests we use VCR as we have a representative Docker image.
+        # For the BRP v1.3 tests we continue to use the requests_mock library, as finding
+        # a representative Docker image is rather challenging. Additionally, v1.3 might
+        # be dropped in the near future, see GitHub issue #6087.
+        using_vcr_testing = self.version == BRPVersions.v20
+
+        # When testing with VCR we need a different api_root,
+        # then when testing with requests_mock
+        api_root = (
+            "http://localhost:5010/haalcentraal/api/brp/"
+            if using_vcr_testing
+            else "https://personen/api/"
+        )
+
         # set up patcher for the configuration
         config = HaalCentraalConfig(
             brp_personen_service=ServiceFactory.build(
-                api_root="https://personen/api/",
+                api_root=api_root,
                 auth_type=AuthTypes.no_auth,
             ),
             brp_personen_version=self.version,
@@ -65,10 +80,12 @@ class HaalCentraalFindPersonTests:
         global_config_patcher.start()
         self.addCleanup(global_config_patcher.stop)  # type: ignore
 
-        # prepare a requests mock instance to wire up the mocks
-        self.requests_mock = requests_mock.Mocker()
-        self.requests_mock.start()
-        self.addCleanup(self.requests_mock.stop)  # type: ignore
+        # For the tests that don't use VCR, we use the requests_mock library
+        if not using_vcr_testing:
+            # prepare a requests mock instance to wire up the mocks
+            self.requests_mock = requests_mock.Mocker()
+            self.requests_mock.start()
+            self.addCleanup(self.requests_mock.stop)  # type: ignore
 
     def test_find_person_succesfully(self, bsn):
         with get_brp_client() as client:
@@ -85,42 +102,28 @@ class HaalCentraalFindPersonTests:
     def test_person_not_found(self):
         with get_brp_client() as client:
             raw_data = client.find_persons(
-                bsns=["999990676"], attributes=self.attributes_to_query
+                bsns=["111222333"], attributes=self.attributes_to_query
             )
 
         self.assertIsNone(raw_data)  # type: ignore
 
-    def test_find_person_server_error(self):
-        self.requests_mock.register_uri(
-            requests_mock.ANY,
-            requests_mock.ANY,
-            status_code=500,
-        )
-
-        with get_brp_client() as client:
-            raw_data = client.find_persons(
-                bsns=["999990676"], attributes=self.attributes_to_query
-            )
-
-        self.assertIsNone(raw_data)  # type: ignore
-
-    def test_get_kinderen(self):
+    def test_get_children(self):
         with get_brp_client() as client:
             children = client.get_family_members(
-                bsn="999990676", include_children=True, include_partner=False
+                bsn="999990792", include_children=True, include_partner=False
             )
 
         self.assertEqual(len(children), 1)  # type: ignore
         child = children[0]
-        self.assertEqual(child.bsn, "999991863")  # type: ignore
-        self.assertEqual(child.first_names, "Frieda")  # type: ignore
-        self.assertEqual(child.affixes, "")  # type: ignore
-        self.assertEqual(child.last_name, "Kroket")  # type: ignore
+        self.assertEqual(child.bsn, "999990408")  # type: ignore
+        self.assertEqual(child.first_names, "Paolo")  # type: ignore
+        self.assertEqual(child.affixes, "de")  # type: ignore
+        self.assertEqual(child.last_name, "Jager")  # type: ignore
 
-    def test_get_kinderen_no_bsn(self):
+    def test_get_children_no_bsn(self):
         with get_brp_client() as client:
             children = client.get_family_members(
-                bsn="999990676", include_children=True, include_partner=False
+                bsn="999990718", include_children=True, include_partner=False
             )
 
         self.assertEqual(len(children), 0)  # type: ignore
@@ -133,15 +136,15 @@ class HaalCentraalFindPersonTests:
 
         self.assertEqual(len(partners), 1)  # type: ignore
         partner = partners[0]
-        self.assertEqual(partner.bsn, "999991863")  # type: ignore
-        self.assertEqual(partner.first_names, "Frieda")  # type: ignore
+        self.assertEqual(partner.bsn, "999990421")  # type: ignore
+        self.assertEqual(partner.first_names, "Adrianus Hendrikus")  # type: ignore
         self.assertEqual(partner.affixes, "")  # type: ignore
-        self.assertEqual(partner.last_name, "Kroket")  # type: ignore
+        self.assertEqual(partner.last_name, "Holthuizen")  # type: ignore
 
     def test_partner_without_bsn(self):
         with get_brp_client() as client:
             partners = client.get_family_members(
-                bsn="999990676", include_children=False, include_partner=True
+                bsn="999990718", include_children=False, include_partner=True
             )
 
         self.assertEqual(len(partners), 0)  # type: ignore
@@ -149,24 +152,30 @@ class HaalCentraalFindPersonTests:
     def test_get_family_members(self):
         with get_brp_client() as client:
             family_members = client.get_family_members(
-                bsn="999990676", include_children=True, include_partner=True
+                bsn="999990858", include_children=True, include_partner=True
             )
 
-        self.assertEqual(len(family_members), 2)  # type: ignore
+        self.assertEqual(len(family_members), 3)  # type: ignore
 
-        child = family_members[0]
+        child_1 = family_members[0]
+        child_2 = family_members[1]
 
-        self.assertEqual(child.bsn, "999991111")  # type: ignore
-        self.assertEqual(child.first_names, "Fredo")  # type: ignore
-        self.assertEqual(child.affixes, "")  # type: ignore
-        self.assertEqual(child.last_name, "Kroket")  # type: ignore
+        self.assertEqual(child_1.bsn, "999992879")  # type: ignore
+        self.assertEqual(child_1.first_names, "Lonneke")  # type: ignore
+        self.assertEqual(child_1.affixes, "")  # type: ignore
+        self.assertEqual(child_1.last_name, "Smit")  # type: ignore
 
-        partner = family_members[1]
+        self.assertEqual(child_2.bsn, "999993525")  # type: ignore
+        self.assertEqual(child_2.first_names, "Koos")  # type: ignore
+        self.assertEqual(child_2.affixes, "")  # type: ignore
+        self.assertEqual(child_2.last_name, "Smit")  # type: ignore
 
-        self.assertEqual(partner.bsn, "999992222")  # type: ignore
-        self.assertEqual(partner.first_names, "Frieda")  # type: ignore
-        self.assertEqual(partner.affixes, "")  # type: ignore
-        self.assertEqual(partner.last_name, "Kroket")  # type: ignore
+        partner = family_members[2]
+
+        self.assertEqual(partner.bsn, "999990949")  # type: ignore
+        self.assertEqual(partner.first_names, "Marianne")  # type: ignore
+        self.assertEqual(partner.affixes, "de")  # type: ignore
+        self.assertEqual(partner.last_name, "Jong")  # type: ignore
 
     def test_default_client_context(self):
         client = get_brp_client()
@@ -219,18 +228,32 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
 
     def test_person_not_found(self):
         self.requests_mock.get(
-            "https://personen/api/ingeschrevenpersonen/999990676", status_code=404
+            "https://personen/api/ingeschrevenpersonen/111222333", status_code=404
         )
         super().test_person_not_found()
 
-    def test_get_kinderen(self):
+    def test_find_person_server_error(self):
+        self.requests_mock.register_uri(
+            requests_mock.ANY,
+            requests_mock.ANY,
+            status_code=500,
+        )
+
+        with get_brp_client() as client:
+            raw_data = client.find_persons(
+                bsns=["999990676"], attributes=self.attributes_to_query
+            )
+
+        self.assertIsNone(raw_data)  # type: ignore
+
+    def test_get_children(self):
         # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v1/redoc#tag/Ingeschreven-Personen/operation/GetKinderen
         self.requests_mock.get(
-            "https://personen/api/ingeschrevenpersonen/999990676/kinderen",
+            "https://personen/api/ingeschrevenpersonen/999990792/kinderen",
             json={
                 "_links": {
                     "self": {
-                        "href": "https://personen/api/ingeschrevenpersonen/999990676/kinderen",
+                        "href": "https://personen/api/ingeschrevenpersonen/999990792/kinderen",
                         "templated": False,
                         "title": "",
                     }
@@ -238,13 +261,13 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                 "_embedded": {
                     "kinderen": [
                         {
-                            "burgerservicenummer": "999991863",
+                            "burgerservicenummer": "999990408",
                             "leeftijd": 12,
                             "naam": {
-                                "geslachtsnaam": "Kroket",
-                                "voorletters": "F.",
-                                "voornamen": "Frieda",
-                                "voorvoegsel": "",
+                                "geslachtsnaam": "Jager",
+                                "voorletters": "P.",
+                                "voornamen": "Paolo",
+                                "voorvoegsel": "de",
                                 # "adellijkeTitelPredikaat": {...},
                                 # "inOnderzoek": {...},
                             },
@@ -257,16 +280,16 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                 },
             },
         )
-        super().test_get_kinderen()
+        super().test_get_children()
 
-    def test_get_kinderen_no_bsn(self):
+    def test_get_children_no_bsn(self):
         # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v1/redoc#tag/Ingeschreven-Personen/operation/GetKinderen
         self.requests_mock.get(
-            "https://personen/api/ingeschrevenpersonen/999990676/kinderen",
+            "https://personen/api/ingeschrevenpersonen/999990718/kinderen",
             json={
                 "_links": {
                     "self": {
-                        "href": "https://personen/api/ingeschrevenpersonen/999990676/kinderen",
+                        "href": "https://personen/api/ingeschrevenpersonen/999990718/kinderen",
                         "templated": False,
                         "title": "",
                     }
@@ -287,7 +310,7 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                 },
             },
         )
-        super().test_get_kinderen_no_bsn()
+        super().test_get_children_no_bsn()
 
     def test_get_partners(self):
         # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v1/redoc#tag/Ingeschreven-Personen/operation/GetPartners
@@ -304,11 +327,11 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                 "_embedded": {
                     "partners": [
                         {
-                            "burgerservicenummer": "999991863",
+                            "burgerservicenummer": "999990421",
                             "naam": {
-                                "geslachtsnaam": "Kroket",
-                                "voorletters": "F.",
-                                "voornamen": "Frieda",
+                                "geslachtsnaam": "Holthuizen",
+                                "voorletters": "A.H.",
+                                "voornamen": "Adrianus Hendrikus",
                                 "voorvoegsel": "",
                             },
                         }
@@ -321,11 +344,11 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
     def test_partner_without_bsn(self):
         # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v1/redoc#tag/Ingeschreven-Personen/operation/GetPartners
         self.requests_mock.get(
-            "https://personen/api/ingeschrevenpersonen/999990676/partners",
+            "https://personen/api/ingeschrevenpersonen/999990718/partners",
             json={
                 "_links": {
                     "self": {
-                        "href": "https://personen/api/ingeschrevenpersonen/999990676/partners",
+                        "href": "https://personen/api/ingeschrevenpersonen/999990718/partners",
                         "templated": False,
                         "title": "",
                     }
@@ -334,9 +357,9 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                     "partners": [
                         {
                             "naam": {
-                                "geslachtsnaam": "Kroket",
-                                "voorletters": "F.",
-                                "voornamen": "Frieda",
+                                "geslachtsnaam": "Tuinstra",
+                                "voorletters": "A.",
+                                "voornamen": "August",
                                 "voorvoegsel": "",
                             },
                         }
@@ -349,11 +372,11 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
     def test_get_family_members(self):
         # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v1/redoc#tag/Ingeschreven-Personen/operation/GetPartners
         self.requests_mock.get(
-            "https://personen/api/ingeschrevenpersonen/999990676/partners",
+            "https://personen/api/ingeschrevenpersonen/999990858/partners",
             json={
                 "_links": {
                     "self": {
-                        "href": "https://personen/api/ingeschrevenpersonen/999990676/partners",
+                        "href": "https://personen/api/ingeschrevenpersonen/999990858/partners",
                         "templated": False,
                         "title": "",
                     }
@@ -361,12 +384,12 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                 "_embedded": {
                     "partners": [
                         {
-                            "burgerservicenummer": "999992222",
+                            "burgerservicenummer": "999990949",
                             "naam": {
-                                "geslachtsnaam": "Kroket",
-                                "voorletters": "F.",
-                                "voornamen": "Frieda",
-                                "voorvoegsel": "",
+                                "geslachtsnaam": "Jong",
+                                "voorletters": "M.",
+                                "voornamen": "Marianne",
+                                "voorvoegsel": "de",
                             },
                         }
                     ],
@@ -375,11 +398,11 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
         )
         # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v1/redoc#tag/Ingeschreven-Personen/operation/GetKinderen
         self.requests_mock.get(
-            "https://personen/api/ingeschrevenpersonen/999990676/kinderen",
+            "https://personen/api/ingeschrevenpersonen/999990858/kinderen",
             json={
                 "_links": {
                     "self": {
-                        "href": "https://personen/api/ingeschrevenpersonen/999990676/kinderen",
+                        "href": "https://personen/api/ingeschrevenpersonen/999990858/kinderen",
                         "templated": False,
                         "title": "",
                     }
@@ -387,16 +410,27 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
                 "_embedded": {
                     "kinderen": [
                         {
-                            "burgerservicenummer": "999991111",
+                            "burgerservicenummer": "999992879",
                             "leeftijd": 12,
                             "naam": {
-                                "geslachtsnaam": "Kroket",
-                                "voorletters": "F.",
-                                "voornamen": "Fredo",
+                                "geslachtsnaam": "Smit",
+                                "voorletters": "L.",
+                                "voornamen": "Lonneke",
                                 "voorvoegsel": "",
                             },
                             "geheimhoudingPersoonsgegevens": True,
-                        }
+                        },
+                        {
+                            "burgerservicenummer": "999993525",
+                            "leeftijd": 12,
+                            "naam": {
+                                "geslachtsnaam": "Smit",
+                                "voorletters": "K.",
+                                "voornamen": "Koos",
+                                "voorvoegsel": "",
+                            },
+                            "geheimhoudingPersoonsgegevens": True,
+                        },
                     ],
                 },
             },
@@ -412,191 +446,26 @@ class HaalCentraalFindPersonV1Test(HaalCentraalFindPersonTests, TestCase):
         super().test_pre_request_hooks_called()
 
 
-class HaalCentraalFindPersonV2Test(HaalCentraalFindPersonTests, TestCase):
+class HaalCentraalFindPersonV2Test(OFVCRMixin, HaalCentraalFindPersonTests, TestCase):
+    """This test case requires the HaalCentraal BRP API to be running.
+    See the relevant Docker compose in the ``docker/`` folder.
+
+    Note: please ensure that all patches to the test data have been applied. See the
+    README.md file of the relevant container.
+    """
+
     version = BRPVersions.v20
 
     def test_find_person_succesfully(self, bsn=None):
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            status_code=200,
-            json=load_json_mock("ingeschrevenpersonen.v2-full.json"),
-        )
         super().test_find_person_succesfully("999990676")
 
-    def test_person_not_found(self):
-        self.requests_mock.post("https://personen/api/personen", status_code=404)
-        super().test_person_not_found()
-
-    def test_find_person_without_personen_key(self):
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            status_code=200,
-            json=load_json_mock(
-                "ingeschrevenpersonen.v2-full-find-personen-response.json"
-            ),
-        )
-        super().test_person_not_found()
-
-    def test_get_kinderen(self):
-        # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v2/redoc#tag/Personen/operation/Personen
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            json={
-                "type": "RaadpleegMetBurgerservicenummer",
-                "personen": [
-                    {
-                        "kinderen": [
-                            {
-                                # only kinderen.burgerservicenummer and kinderen.naam are requested!
-                                "burgerservicenummer": "999991863",
-                                "naam": {
-                                    "voornamen": "Frieda",
-                                    "voorvoegsel": "",
-                                    "geslachtsnaam": "Kroket",
-                                    "voorletters": "F.",
-                                    # "adellijkeTitelPredikaat": {...},
-                                    # "inOnderzoek": {...},
-                                },
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
-        super().test_get_kinderen()
-
-    def test_get_kinderen_no_bsn(self):
-        # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v2/redoc#tag/Personen/operation/Personen
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            json={
-                "type": "RaadpleegMetBurgerservicenummer",
-                "personen": [
-                    {
-                        "kinderen": [
-                            {
-                                "naam": {
-                                    "voornamen": "Frieda",
-                                    "voorvoegsel": "",
-                                    "geslachtsnaam": "Kroket",
-                                    "voorletters": "F.",
-                                },
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
-        super().test_get_kinderen_no_bsn()
-
-    def test_get_kinderen_person_not_found_results(self):
-        # TODO: replace this with VCR and the Docker container of BRP v2
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            json={
-                "type": "RaadpleegMetBurgerservicenummer",
-                "personen": [],
-            },
-        )
-
+    def test_get_children_person_not_found_results(self):
         with get_brp_client() as client:
             children = client.get_family_members(
-                bsn="999990676", include_children=True, include_partner=False
+                bsn="111222333", include_children=True, include_partner=False
             )
 
         self.assertEqual(children, [])
-
-    def test_get_partners(self):
-        # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v2/redoc#tag/Personen/operation/Personen
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            json={
-                "type": "RaadpleegMetBurgerservicenummer",
-                "personen": [
-                    {
-                        "partners": [
-                            {
-                                "burgerservicenummer": "999991863",
-                                "naam": {
-                                    "voornamen": "Frieda",  # Not all the names have voorvoegsels
-                                    "geslachtsnaam": "Kroket",
-                                    "voorletters": "F.",
-                                    "voorvoegsel": "",
-                                },
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
-        super().test_get_partners()
-
-    def test_partner_without_bsn(self):
-        # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v2/redoc#tag/Personen/operation/Personen
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            json={
-                "type": "RaadpleegMetBurgerservicenummer",
-                "personen": [
-                    {
-                        "partners": [
-                            {
-                                "naam": {
-                                    "voornamen": "Jean Marie",
-                                    "geslachtsnaam": "Beaudelaire",
-                                    "voorletters": "J.M.",
-                                }
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
-        super().test_partner_without_bsn()
-
-    def test_get_family_members(self):
-        # https://brp-api.github.io/Haal-Centraal-BRP-bevragen/v2/redoc#tag/Personen/operation/Personen
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            json={
-                "type": "RaadpleegMetBurgerservicenummer",
-                "personen": [
-                    {
-                        "partners": [
-                            {
-                                "burgerservicenummer": "999992222",
-                                "naam": {
-                                    "voornamen": "Frieda",  # Not all the names have voorvoegsels
-                                    "geslachtsnaam": "Kroket",
-                                    "voorletters": "F.",
-                                    "voorvoegsel": "",
-                                },
-                            }
-                        ],
-                        "kinderen": [
-                            {
-                                "burgerservicenummer": "999991111",
-                                "naam": {
-                                    "geslachtsnaam": "Kroket",
-                                    "voorletters": "F.",
-                                    "voornamen": "Fredo",
-                                    "voorvoegsel": "",
-                                },
-                            }
-                        ],
-                    }
-                ],
-            },
-        )
-        super().test_get_family_members()
-
-    def test_pre_request_hooks_called(self):
-        self.requests_mock.post(
-            "https://personen/api/personen",
-            status_code=200,
-            json=load_json_mock("ingeschrevenpersonen.v2-full.json"),
-        )
-        super().test_pre_request_hooks_called()
 
 
 class ClientFactoryInvalidVersionTests(SimpleTestCase):

--- a/src/openforms/contrib/haal_centraal/tests/test_brp_clients.py
+++ b/src/openforms/contrib/haal_centraal/tests/test_brp_clients.py
@@ -467,6 +467,189 @@ class HaalCentraalFindPersonV2Test(OFVCRMixin, HaalCentraalFindPersonTests, Test
 
         self.assertEqual(children, [])
 
+    def test_get_children_exclude_deceased(self):
+        with get_brp_client() as client:
+            children = client.get_family_members(
+                bsn="999970124",
+                include_children=True,
+                include_partner=False,
+                include_deceased=False,
+            )
+
+        self.assertEqual(len(children), 3)  # type: ignore
+
+        child_1 = children[0]
+        self.assertEqual(child_1.bsn, "999970409")  # type: ignore
+        self.assertEqual(child_1.first_names, "Pero")  # type: ignore
+        self.assertEqual(child_1.affixes, "van")  # type: ignore
+        self.assertEqual(child_1.last_name, "Paassen")  # type: ignore
+
+        child_2 = children[1]
+        self.assertEqual(child_2.bsn, "999970161")  # type: ignore
+        self.assertEqual(child_2.first_names, "Peet")  # type: ignore
+        self.assertEqual(child_2.affixes, "van")  # type: ignore
+        self.assertEqual(child_2.last_name, "Paassen")  # type: ignore
+
+        child_3 = children[2]
+        self.assertEqual(child_3.bsn, "999970185")  # type: ignore
+        self.assertEqual(child_3.first_names, "Pep")  # type: ignore
+        self.assertEqual(child_3.affixes, "van")  # type: ignore
+        self.assertEqual(child_3.last_name, "Paassen")  # type: ignore
+
+    def test_get_children_include_deceased(self):
+        with get_brp_client() as client:
+            children = client.get_family_members(
+                bsn="999970124",
+                include_children=True,
+                include_partner=False,
+                include_deceased=True,
+            )
+
+        self.assertEqual(len(children), 4)  # type: ignore
+
+        child_1 = children[0]
+        self.assertEqual(child_1.bsn, "999970409")  # type: ignore
+        self.assertEqual(child_1.first_names, "Pero")  # type: ignore
+        self.assertEqual(child_1.affixes, "van")  # type: ignore
+        self.assertEqual(child_1.last_name, "Paassen")  # type: ignore
+
+        child_2 = children[1]
+        self.assertEqual(child_2.bsn, "999970161")  # type: ignore
+        self.assertEqual(child_2.first_names, "Peet")  # type: ignore
+        self.assertEqual(child_2.affixes, "van")  # type: ignore
+        self.assertEqual(child_2.last_name, "Paassen")  # type: ignore
+
+        child_3 = children[2]
+        self.assertEqual(child_3.bsn, "999970173")  # type: ignore
+        self.assertEqual(child_3.first_names, "Pelle")  # type: ignore
+        self.assertEqual(child_3.affixes, "van")  # type: ignore
+        self.assertEqual(child_3.last_name, "Paassen")  # type: ignore
+
+        child_4 = children[3]
+        self.assertEqual(child_4.bsn, "999970185")  # type: ignore
+        self.assertEqual(child_4.first_names, "Pep")  # type: ignore
+        self.assertEqual(child_4.affixes, "van")  # type: ignore
+        self.assertEqual(child_4.last_name, "Paassen")  # type: ignore
+
+    def test_get_partners_exclude_deceased(self):
+        # This scenario is not supported by the current frontend. Right now, only
+        # children can actively be excluded. This test was added for completeness, as the
+        # BRP client `get_family_members` does support excluding partners.
+
+        with get_brp_client() as client:
+            partners = client.get_family_members(
+                bsn="999999709",
+                include_children=False,
+                include_partner=True,
+                include_deceased=False,
+            )
+
+        self.assertEqual(len(partners), 0)  # type: ignore
+
+    def test_get_partners_include_deceased(self):
+        # This scenario is not supported by the current frontend. Right now, only
+        # children can actively be excluded. This test was added for completeness, as the
+        # BRP client `get_family_members` does support excluding partners.
+
+        with get_brp_client() as client:
+            partners = client.get_family_members(
+                bsn="999999709",
+                include_children=False,
+                include_partner=True,
+                include_deceased=True,
+            )
+
+        self.assertEqual(len(partners), 1)  # type: ignore
+        partner = partners[0]
+        self.assertEqual(partner.bsn, "999999692")  # type: ignore
+        self.assertEqual(partner.first_names, "Brand")  # type: ignore
+        self.assertEqual(partner.affixes, "")  # type: ignore
+        self.assertEqual(partner.last_name, "Berendsen")  # type: ignore
+
+    def test_get_family_members_exclude_deceased(self):
+        # This scenario is not supported by the current frontend. Right now, only
+        # children can actively be excluded. This test was added for completeness, as the
+        # BRP client `get_family_members` does support excluding partners.
+
+        with get_brp_client() as client:
+            family_members = client.get_family_members(
+                bsn="999970124",
+                include_children=True,
+                include_partner=True,
+                include_deceased=False,
+            )
+
+        self.assertEqual(len(family_members), 4)  # type: ignore
+
+        child_1 = family_members[0]
+        self.assertEqual(child_1.bsn, "999970409")  # type: ignore
+        self.assertEqual(child_1.first_names, "Pero")  # type: ignore
+        self.assertEqual(child_1.affixes, "van")  # type: ignore
+        self.assertEqual(child_1.last_name, "Paassen")  # type: ignore
+
+        child_2 = family_members[1]
+        self.assertEqual(child_2.bsn, "999970161")  # type: ignore
+        self.assertEqual(child_2.first_names, "Peet")  # type: ignore
+        self.assertEqual(child_2.affixes, "van")  # type: ignore
+        self.assertEqual(child_2.last_name, "Paassen")  # type: ignore
+
+        child_3 = family_members[2]
+        self.assertEqual(child_3.bsn, "999970185")  # type: ignore
+        self.assertEqual(child_3.first_names, "Pep")  # type: ignore
+        self.assertEqual(child_3.affixes, "van")  # type: ignore
+        self.assertEqual(child_3.last_name, "Paassen")  # type: ignore
+
+        partner = family_members[3]
+        self.assertEqual(partner.bsn, "999970136")  # type: ignore
+        self.assertEqual(partner.first_names, "Pia")  # type: ignore
+        self.assertEqual(partner.affixes, "")  # type: ignore
+        self.assertEqual(partner.last_name, "Pauw")  # type: ignore
+
+    def test_get_family_members_include_deceased(self):
+        # This scenario is not supported by the current frontend. Right now, only
+        # children can actively be excluded. This test was added for completeness, as the
+        # BRP client `get_family_members` does support excluding partners.
+
+        with get_brp_client() as client:
+            family_members = client.get_family_members(
+                bsn="999970124",
+                include_children=True,
+                include_partner=True,
+                include_deceased=True,
+            )
+
+        self.assertEqual(len(family_members), 5)  # type: ignore
+
+        child_1 = family_members[0]
+        self.assertEqual(child_1.bsn, "999970409")  # type: ignore
+        self.assertEqual(child_1.first_names, "Pero")  # type: ignore
+        self.assertEqual(child_1.affixes, "van")  # type: ignore
+        self.assertEqual(child_1.last_name, "Paassen")  # type: ignore
+
+        child_2 = family_members[1]
+        self.assertEqual(child_2.bsn, "999970161")  # type: ignore
+        self.assertEqual(child_2.first_names, "Peet")  # type: ignore
+        self.assertEqual(child_2.affixes, "van")  # type: ignore
+        self.assertEqual(child_2.last_name, "Paassen")  # type: ignore
+
+        child_3 = family_members[2]
+        self.assertEqual(child_3.bsn, "999970173")  # type: ignore
+        self.assertEqual(child_3.first_names, "Pelle")  # type: ignore
+        self.assertEqual(child_3.affixes, "van")  # type: ignore
+        self.assertEqual(child_3.last_name, "Paassen")  # type: ignore
+
+        child_4 = family_members[3]
+        self.assertEqual(child_4.bsn, "999970185")  # type: ignore
+        self.assertEqual(child_4.first_names, "Pep")  # type: ignore
+        self.assertEqual(child_4.affixes, "van")  # type: ignore
+        self.assertEqual(child_4.last_name, "Paassen")  # type: ignore
+
+        partner = family_members[4]
+        self.assertEqual(partner.bsn, "999970136")  # type: ignore
+        self.assertEqual(partner.first_names, "Pia")  # type: ignore
+        self.assertEqual(partner.affixes, "")  # type: ignore
+        self.assertEqual(partner.last_name, "Pauw")  # type: ignore
+
 
 class ClientFactoryInvalidVersionTests(SimpleTestCase):
     def test_invalid_version_raises_error(self):

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_find_person_succesfully.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_find_person_succesfully.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990676"],
+      "fields": ["burgerservicenummer", "naam.voornamen", "naam.geslachtsnaam"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999990676","naam":{"voornamen":"Cornelia
+        Francisca","geslachtsnaam":"Wiegman"}}]}'
+    headers:
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children.yaml
@@ -1,0 +1,86 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990792"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"geheimhoudingPersoonsgegevens":true,"kinderen":[{"burgerservicenummer":"999990408","naam":{"voornamen":"Paolo","voorvoegsel":"de","geslachtsnaam":"Jager","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2009-01-01","langFormaat":"1
+        januari 2009"}}}]}]}'
+    headers:
+      Content-Length:
+      - '324'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990408"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999990408"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_exclude_deceased.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_exclude_deceased.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970124"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"kinderen":[{"burgerservicenummer":"999970409","naam":{"voornamen":"Pero","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2023-02-01","langFormaat":"1
+        februari 2023"}}},{"burgerservicenummer":"999970161","naam":{"voornamen":"Peet","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2018-12-01","langFormaat":"1
+        december 2018"}}},{"burgerservicenummer":"999970173","naam":{"voornamen":"Pelle","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2017-09-01","langFormaat":"1
+        september 2017"}}},{"burgerservicenummer":"999970185","naam":{"voornamen":"Pep","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2016-05-01","langFormaat":"1
+        mei 2016"}}}]}]}'
+    headers:
+      Content-Length:
+      - '946'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970409",
+      "999970161", "999970173", "999970185"], "fields": ["burgerservicenummer", "burgerservicenummer",
+      "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: "{\"type\":\"RaadpleegMetBurgerservicenummer\",\"personen\":[{\"burgerservicenummer\":\"999970161\"},{\"burgerservicenummer\":\"999970173\",\"opschortingBijhouding\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
+        december 2025\"},\"reden\":{\"code\":\"O\",\"omschrijving\":\"overlijden\"}},\"overlijden\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
+        december 2025\"},\"land\":{\"code\":\"5103\",\"omschrijving\":\"Servi\xEB\"}}},{\"burgerservicenummer\":\"999970185\"},{\"burgerservicenummer\":\"999970409\"}]}"
+    headers:
+      Content-Length:
+      - '493'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_include_deceased.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_include_deceased.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970124"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"kinderen":[{"burgerservicenummer":"999970409","naam":{"voornamen":"Pero","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2023-02-01","langFormaat":"1
+        februari 2023"}}},{"burgerservicenummer":"999970161","naam":{"voornamen":"Peet","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2018-12-01","langFormaat":"1
+        december 2018"}}},{"burgerservicenummer":"999970173","naam":{"voornamen":"Pelle","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2017-09-01","langFormaat":"1
+        september 2017"}}},{"burgerservicenummer":"999970185","naam":{"voornamen":"Pep","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2016-05-01","langFormaat":"1
+        mei 2016"}}}]}]}'
+    headers:
+      Content-Length:
+      - '946'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_no_bsn.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_no_bsn.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990718"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: "{\"type\":\"RaadpleegMetBurgerservicenummer\",\"personen\":[{\"kinderen\":[{\"naam\":{\"voornamen\":\"Carla\",\"geslachtsnaam\":\"Tuinstra\",\"voorletters\":\"C.\"},\"geboorte\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"1973-10-22\",\"langFormaat\":\"22
+        oktober 1973\"}}},{\"naam\":{\"voornamen\":\"Adriaan Franti\u0161ek\",\"geslachtsnaam\":\"Tuinstra\",\"voorletters\":\"A.F.\"},\"geboorte\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"1972-08-20\",\"langFormaat\":\"20
+        augustus 1972\"}}}]}]}"
+    headers:
+      Content-Length:
+      - '422'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_person_not_found_results.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_children_person_not_found_results.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["111222333"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[]}'
+    headers:
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_family_members.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_family_members.yaml
@@ -1,0 +1,91 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990858"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum",
+      "partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '443'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"kinderen":[{"burgerservicenummer":"999992879","naam":{"voornamen":"Lonneke","geslachtsnaam":"Smit","voorletters":"L."},"geboorte":{"datum":{"type":"Datum","datum":"1978-06-12","langFormaat":"12
+        juni 1978"}}},{"burgerservicenummer":"999993525","naam":{"voornamen":"Koos","geslachtsnaam":"Smit","voorletters":"K."},"geboorte":{"datum":{"type":"Datum","datum":"1975-11-18","langFormaat":"18
+        november 1975"}}}],"partners":[{"burgerservicenummer":"999990949","naam":{"voornamen":"Marianne","voorvoegsel":"de","geslachtsnaam":"Jong","voorletters":"M."},"geboorte":{"datum":{"type":"Datum","datum":"1952-04-22","langFormaat":"22
+        april 1952"}}}]}]}'
+    headers:
+      Content-Length:
+      - '696'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999992879",
+      "999993525", "999990949"], "fields": ["burgerservicenummer", "burgerservicenummer",
+      "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999990949"},{"burgerservicenummer":"999992879"},{"burgerservicenummer":"999993525"}]}'
+    headers:
+      Content-Length:
+      - '163'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_family_members_exclude_deceased.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_family_members_exclude_deceased.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970124"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum",
+      "partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '443'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"kinderen":[{"burgerservicenummer":"999970409","naam":{"voornamen":"Pero","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2023-02-01","langFormaat":"1
+        februari 2023"}}},{"burgerservicenummer":"999970161","naam":{"voornamen":"Peet","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2018-12-01","langFormaat":"1
+        december 2018"}}},{"burgerservicenummer":"999970173","naam":{"voornamen":"Pelle","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2017-09-01","langFormaat":"1
+        september 2017"}}},{"burgerservicenummer":"999970185","naam":{"voornamen":"Pep","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2016-05-01","langFormaat":"1
+        mei 2016"}}}],"partners":[{"burgerservicenummer":"999970136","naam":{"voornamen":"Pia","geslachtsnaam":"Pauw","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"1989-04-01","langFormaat":"1
+        april 1989"}}}]}]}'
+    headers:
+      Content-Length:
+      - '1152'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:04 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970409",
+      "999970161", "999970173", "999970185", "999970136"], "fields": ["burgerservicenummer",
+      "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '205'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: "{\"type\":\"RaadpleegMetBurgerservicenummer\",\"personen\":[{\"burgerservicenummer\":\"999970136\"},{\"burgerservicenummer\":\"999970161\"},{\"burgerservicenummer\":\"999970173\",\"opschortingBijhouding\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
+        december 2025\"},\"reden\":{\"code\":\"O\",\"omschrijving\":\"overlijden\"}},\"overlijden\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
+        december 2025\"},\"land\":{\"code\":\"5103\",\"omschrijving\":\"Servi\xEB\"}}},{\"burgerservicenummer\":\"999970185\"},{\"burgerservicenummer\":\"999970409\"}]}"
+    headers:
+      Content-Length:
+      - '529'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:04 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_family_members_include_deceased.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_family_members_include_deceased.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970124"],
+      "fields": ["kinderen.burgerservicenummer", "kinderen.naam.voornamen", "kinderen.naam.voorletters",
+      "kinderen.naam.voorvoegsel", "kinderen.naam.geslachtsnaam", "kinderen.geboorte.datum",
+      "partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '443'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"kinderen":[{"burgerservicenummer":"999970409","naam":{"voornamen":"Pero","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2023-02-01","langFormaat":"1
+        februari 2023"}}},{"burgerservicenummer":"999970161","naam":{"voornamen":"Peet","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2018-12-01","langFormaat":"1
+        december 2018"}}},{"burgerservicenummer":"999970173","naam":{"voornamen":"Pelle","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2017-09-01","langFormaat":"1
+        september 2017"}}},{"burgerservicenummer":"999970185","naam":{"voornamen":"Pep","voorvoegsel":"van","geslachtsnaam":"Paassen","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"2016-05-01","langFormaat":"1
+        mei 2016"}}}],"partners":[{"burgerservicenummer":"999970136","naam":{"voornamen":"Pia","geslachtsnaam":"Pauw","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"1989-04-01","langFormaat":"1
+        april 1989"}}}]}]}'
+    headers:
+      Content-Length:
+      - '1152'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_partners.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_partners.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990676"],
+      "fields": ["partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"partners":[{"burgerservicenummer":"999990421","naam":{"voornamen":"Adrianus
+        Hendrikus","geslachtsnaam":"Holthuizen","voorletters":"A.H."},"geboorte":{"datum":{"type":"Datum","datum":"1904-02-15","langFormaat":"15
+        februari 1904"}}}]}]}'
+    headers:
+      Content-Length:
+      - '290'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990421"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999990421"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_partners_exclude_deceased.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_partners_exclude_deceased.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999999709"],
+      "fields": ["partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"partners":[{"burgerservicenummer":"999999692","naam":{"voornamen":"Brand","geslachtsnaam":"Berendsen","voorletters":"B."},"geboorte":{"datum":{"type":"Datum","datum":"1972-08-08","langFormaat":"8
+        augustus 1972"}}}]}]}'
+    headers:
+      Content-Length:
+      - '273'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999999692"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999999692","opschortingBijhouding":{"datum":{"type":"Datum","datum":"2020-10-01","langFormaat":"1
+        oktober 2020"},"reden":{"code":"O","omschrijving":"overlijden"}},"overlijden":{"datum":{"type":"Datum","datum":"2020-10-01","langFormaat":"1
+        oktober 2020"},"land":{"code":"6030","omschrijving":"Nederland"},"plaats":{"code":"0518","omschrijving":"''s-Gravenhage"}}}]}'
+    headers:
+      Content-Length:
+      - '441'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_partners_include_deceased.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_get_partners_include_deceased.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999999709"],
+      "fields": ["partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"partners":[{"burgerservicenummer":"999999692","naam":{"voornamen":"Brand","geslachtsnaam":"Berendsen","voorletters":"B."},"geboorte":{"datum":{"type":"Datum","datum":"1972-08-08","langFormaat":"8
+        augustus 1972"}}}]}]}'
+    headers:
+      Content-Length:
+      - '273'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 13:20:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_partner_without_bsn.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_partner_without_bsn.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990718"],
+      "fields": ["partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"partners":[{"naam":{"voornamen":"August","geslachtsnaam":"Tuinstra","voorletters":"A."},"geboorte":{"datum":{"type":"Datum","datum":"1943-10-15","langFormaat":"15
+        oktober 1943"}}}]}]}'
+    headers:
+      Content-Length:
+      - '239'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_person_not_found.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_person_not_found.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["111222333"],
+      "fields": ["burgerservicenummer", "naam.voornamen", "naam.geslachtsnaam"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[]}'
+    headers:
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_pre_request_hooks_called.yaml
+++ b/src/openforms/contrib/haal_centraal/tests/vcr_cassettes/test_brp_clients/HaalCentraalFindPersonV2Test/test_pre_request_hooks_called.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999990676"],
+      "fields": ["burgerservicenummer", "naam.voornamen", "naam.geslachtsnaam"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999990676","naam":{"voornamen":"Cornelia
+        Francisca","geslachtsnaam":"Wiegman"}}]}'
+    headers:
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Mar 2026 11:31:45 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/js/components/admin/form_design/variables/prefill/family_members/FamilyMembersFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/family_members/FamilyMembersFields.js
@@ -26,7 +26,7 @@ const FamilyMembersFields = () => {
     type: null,
     minAge: null,
     maxAge: null,
-    includeDeceased: true,
+    includeDeceased: false,
   };
 
   //   Merge defaults into options if not already set

--- a/src/openforms/js/components/admin/form_design/variables/prefill/family_members/PersonsFields.js
+++ b/src/openforms/js/components/admin/form_design/variables/prefill/family_members/PersonsFields.js
@@ -51,7 +51,7 @@ const PersonFields = () => {
                   mutableDataFormVariable: '',
                   minAge: null,
                   maxAge: null,
-                  includeDeceased: true,
+                  includeDeceased: false,
                 },
               }));
             }}

--- a/src/openforms/prefill/contrib/family_members/config.py
+++ b/src/openforms/prefill/contrib/family_members/config.py
@@ -31,7 +31,7 @@ class FamilyMembersChildrenSerializer(serializers.Serializer):
     include_deceased = serializers.BooleanField(
         label=_("include deceased"),
         help_text=_("Whether to include deceased persons or not."),
-        default=True,
+        default=False,
     )
 
 

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -160,15 +160,6 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
                 "dateOfBirthPrecision": "date",
             },
             {
-                "bsn": "999970173",
-                "firstNames": "Pelle",
-                "initials": "P.",
-                "affixes": "van",
-                "lastName": "Paassen",
-                "dateOfBirth": "2017-09-01",
-                "dateOfBirthPrecision": "date",
-            },
-            {
                 "bsn": "999970185",
                 "firstNames": "Pep",
                 "initials": "P.",
@@ -236,7 +227,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
             state.variables["hc_prefill_children_immutable"].value, expected_data
         )
 
-    def test_children_deceased(self):
+    def test_children_exclude_deceased(self):
         submission = SubmissionFactory.from_components(
             auth_info__value="999970124",
             auth_info__attribute=AuthAttribute.bsn,
@@ -285,6 +276,84 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
                 "affixes": "van",
                 "lastName": "Paassen",
                 "dateOfBirth": "2018-12-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970185",
+                "firstNames": "Pep",
+                "initials": "P.",
+                "affixes": "van",
+                "lastName": "Paassen",
+                "dateOfBirth": "2016-05-01",
+                "dateOfBirthPrecision": "date",
+            },
+        ]
+
+        self.assertEqual(
+            state.variables["hc_prefill_children_mutable"].value, expected_data
+        )
+        self.assertEqual(
+            state.variables["hc_prefill_children_immutable"].value, expected_data
+        )
+
+    def test_children_include_deceased(self):
+        submission = SubmissionFactory.from_components(
+            auth_info__value="999970124",
+            auth_info__attribute=AuthAttribute.bsn,
+            components_list=[
+                {
+                    "key": "hc_prefill_children_mutable",
+                    "type": "children",
+                    "label": "Children",
+                },
+            ],
+        )
+        FormVariableFactory.create(
+            key="hc_prefill_children_immutable",
+            form=submission.form,
+            user_defined=True,
+            data_type=FormVariableDataTypes.array,
+            prefill_plugin=PLUGIN_IDENTIFIER,
+            prefill_options={
+                "mutable_data_form_variable": "hc_prefill_children_mutable",
+                "type": "children",
+                "min_age": None,
+                "max_age": None,
+                "include_deceased": True,
+            },
+        )
+
+        with freeze_time("2025-04-25T18:00:00+01:00"):
+            prefill_variables(submission=submission)
+
+        state = submission.load_submission_value_variables_state()
+
+        expected_data = [
+            {
+                "bsn": "999970409",
+                "firstNames": "Pero",
+                "initials": "P.",
+                "affixes": "van",
+                "lastName": "Paassen",
+                "dateOfBirth": "2023-02-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970161",
+                "firstNames": "Peet",
+                "initials": "P.",
+                "affixes": "van",
+                "lastName": "Paassen",
+                "dateOfBirth": "2018-12-01",
+                "dateOfBirthPrecision": "date",
+            },
+            {
+                "bsn": "999970173",
+                "firstNames": "Pelle",
+                "initials": "P.",
+                "affixes": "van",
+                "lastName": "Paassen",
+                "dateOfBirth": "2017-09-01",
                 "dateOfBirthPrecision": "date",
             },
             {
@@ -472,15 +541,6 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
                 "dateOfBirth": "",
                 "deceased": False,
             },
-            {
-                "bsn": "789123543",
-                "firstNames": "Other",
-                "initials": "K",
-                "affixes": "van",
-                "lastName": "Doens",
-                "dateOfBirth": "1998-07-16",
-                "deceased": True,
-            },
         ]
 
         self.assertEqual(
@@ -490,7 +550,7 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
             state.variables["stuf_bg_prefill_children_immutable"].value, expected_data
         )
 
-    def test_children_with_deceased_filter(self):
+    def test_children_with_exclude_deceased_filter(self):
         submission = SubmissionFactory.from_components(
             auth_info__value="111222333",
             auth_info__attribute=AuthAttribute.bsn,
@@ -576,6 +636,104 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
         )
         self.assertEqual(
             state.variables["stuf_bg_prefill_children_immutable"].value, expected_data
+        )
+
+    def test_children_with_include_deceased_filter(self):
+        submission = SubmissionFactory.from_components(
+            auth_info__value="111222333",
+            auth_info__attribute=AuthAttribute.bsn,
+            components_list=[
+                {
+                    "key": "stuf_bg_prefill_children_mutable",
+                    "type": "children",
+                    "label": "Children",
+                },
+            ],
+        )
+        FormVariableFactory.create(
+            key="stuf_bg_prefill_children_immutable",
+            form=submission.form,
+            user_defined=True,
+            data_type=FormVariableDataTypes.array,
+            prefill_plugin=PLUGIN_IDENTIFIER,
+            prefill_options={
+                "type": "children",
+                "mutable_data_form_variable": "stuf_bg_prefill_children_mutable",
+                "min_age": None,
+                "max_age": None,
+                "include_deceased": True,
+            },
+        )
+
+        response_content = self.extract_soap_response(
+            "family_members/tests/responses/stuf_bg_children.xml",
+            self.stuf_bg_service,
+        )
+
+        # validate response
+        self.assertSoapBodyIsValid(response_content)
+
+        with requests_mock.Mocker() as m:
+            m.post(
+                self.stuf_bg_service.get_endpoint(type=EndpointType.vrije_berichten),
+                content=response_content,
+            )
+            prefill_variables(submission=submission)
+
+        request_body = m.last_request.body
+
+        # validate request
+        self.assertSoapBodyIsValid(request_body)
+
+        state = submission.load_submission_value_variables_state()
+
+        expected_data = [
+            {
+                "bsn": "456789123",
+                "firstNames": "Bolly",
+                "initials": "K",
+                "affixes": "van",
+                "lastName": "Doe",
+                "dateOfBirth": "1999-06-15",
+                "deceased": False,
+            },
+            {
+                "bsn": "789123456",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastName": "Doe",
+                "dateOfBirth": "1998-07-16",
+                "deceased": False,
+            },
+            # included because no age filter boundaries are provided, so even the
+            # children without known DOB are returned
+            {
+                "bsn": "123456789",
+                "firstNames": "Billy",
+                "initials": "K",
+                "affixes": "van",
+                "lastName": "Doe",
+                "dateOfBirth": "",
+                "deceased": False,
+            },
+            {
+                "bsn": "789123543",
+                "firstNames": "Other",
+                "initials": "K",
+                "affixes": "van",
+                "lastName": "Doens",
+                "dateOfBirth": "1998-07-16",
+                "deceased": True,
+            },
+        ]
+
+        self.assertEqual(
+            state.variables["stuf_bg_prefill_children_mutable"].value, expected_data
+        )
+        self.assertEqual(
+            state.variables["stuf_bg_prefill_children_immutable"].value,
+            expected_data,
         )
 
     def test_children_with_incomplete_dateOfBirth_are_shown_when_no_filter(self):

--- a/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_children_exclude_deceased.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_children_exclude_deceased.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +39,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:11:14 GMT
+      - Wed, 18 Mar 2026 13:30:53 GMT
       Server:
       - Kestrel
     status:
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -83,7 +83,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:11:14 GMT
+      - Wed, 18 Mar 2026 13:30:53 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_children_include_deceased.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_children_include_deceased.yaml
@@ -45,48 +45,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970409",
-      "999970161", "999970173", "999970185"], "fields": ["burgerservicenummer", "burgerservicenummer",
-      "overlijden"]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '192'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - python-requests/2.32.5
-      x-doelbinding:
-      - ''
-      x-gebruiker:
-      - BurgerZelf
-      x-origin-oin:
-      - ''
-      x-verwerking:
-      - ''
-    method: POST
-    uri: http://localhost:5010/haalcentraal/api/brp/personen
-  response:
-    body:
-      string: "{\"type\":\"RaadpleegMetBurgerservicenummer\",\"personen\":[{\"burgerservicenummer\":\"999970161\"},{\"burgerservicenummer\":\"999970173\",\"opschortingBijhouding\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
-        december 2025\"},\"reden\":{\"code\":\"O\",\"omschrijving\":\"overlijden\"}},\"overlijden\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
-        december 2025\"},\"land\":{\"code\":\"5103\",\"omschrijving\":\"Servi\xEB\"}}},{\"burgerservicenummer\":\"999970185\"},{\"burgerservicenummer\":\"999970409\"}]}"
-    headers:
-      Content-Length:
-      - '493'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 17 Mar 2026 10:03:22 GMT
-      Server:
-      - Kestrel
-    status:
-      code: 200
-      message: OK
 version: 1

--- a/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_children_prefill_happy_flow.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_children_prefill_happy_flow.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +39,51 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:11:14 GMT
+      - Tue, 17 Mar 2026 10:03:22 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970409",
+      "999970161", "999970173", "999970185"], "fields": ["burgerservicenummer", "burgerservicenummer",
+      "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: "{\"type\":\"RaadpleegMetBurgerservicenummer\",\"personen\":[{\"burgerservicenummer\":\"999970161\"},{\"burgerservicenummer\":\"999970173\",\"opschortingBijhouding\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
+        december 2025\"},\"reden\":{\"code\":\"O\",\"omschrijving\":\"overlijden\"}},\"overlijden\":{\"datum\":{\"type\":\"Datum\",\"datum\":\"2025-12-01\",\"langFormaat\":\"1
+        december 2025\"},\"land\":{\"code\":\"5103\",\"omschrijving\":\"Servi\xEB\"}}},{\"burgerservicenummer\":\"999970185\"},{\"burgerservicenummer\":\"999970409\"}]}"
+    headers:
+      Content-Length:
+      - '493'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 10:03:23 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_partners_prefill_happy_flow.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_partners_prefill_happy_flow.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -36,7 +36,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:11:14 GMT
+      - Tue, 17 Mar 2026 10:03:23 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970136"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970136"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 10:03:23 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_submission_with_children_component_and_selection_disabled.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_submission_with_children_component_and_selection_disabled.yaml
@@ -6,17 +6,15 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8001/api/v2/objecttypes
   response:
     body:
-      string: '{"count":8,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","uuid":"db4e8653-1f84-4df7-82bd-96787c52b298","name":"Children","namePlural":"Children","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+      string: '{"count":8,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","uuid":"db4e8653-1f84-4df7-82bd-96787c52b298","name":"Children","namePlural":"Children","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/2"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
         everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e","uuid":"644ab597-e88c-43c0-8321-f12113510b0e","name":"Fieldset
         component","namePlural":"Fieldset component","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705","uuid":"f1dde4fe-b7f9-46dc-84ae-429ae49e3705","name":"Geo
         in data","namePlural":"Geo in data","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2","uuid":"527b8408-7421-4808-a744-43ccb7bdaaa2","name":"File
@@ -27,17 +25,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '5218'
+      - '5315'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 Dec 2025 14:47:31 GMT
+      - Tue, 17 Mar 2026 11:13:05 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.29.1
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -54,34 +52,32 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8001/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","status":"published","jsonSchema":{"$id":"https://example.com/children.schema.json","type":"object","title":"Children","$schema":"https://json-schema.org/draft/2020-12/schema","required":["children"],"properties":{"children":{"type":"array","items":{"type":"object","required":["bsn"],"properties":{"bsn":{"type":"string","format":"nl-bsn","pattern":"^\\d{9}$"},"affixes":{"type":"string"},"initials":{"type":"string"},"lastName":{"type":"string"},"firstNames":{"type":"string"},"dateOfBirth":{"type":"string","format":"date"}},"additionalProperties":false},"title":"Children"},"extraDetails":{"type":"array","items":{"type":"object","additionalProperties":{"type":"string"}}}},"additionalProperties":false},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","publishedAt":"2025-09-15"}]}'
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/2","version":2,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","status":"draft","jsonSchema":{"$id":"https://example.com/person.schema.json","type":"object","title":"Person","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"bsn":{"type":"string"},"name":{"type":"object","properties":{"last.name":{"type":"string"}}},"address":{"type":"object","properties":{"city":{"type":"string"},"postcode":{"type":"string"},"streetName":{"type":"string"},"houseNumber":{"type":"string"}}}}},"createdAt":"2025-01-08","modifiedAt":"2025-01-08","publishedAt":"2025-01-08"},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","status":"published","jsonSchema":{"$id":"https://example.com/children.schema.json","type":"object","title":"Children","$schema":"https://json-schema.org/draft/2020-12/schema","required":["children"],"properties":{"children":{"type":"array","items":{"type":"object","required":["bsn"],"properties":{"bsn":{"type":"string","format":"nl-bsn","pattern":"^\\d{9}$"},"affixes":{"type":"string"},"initials":{"type":"string"},"lastName":{"type":"string"},"firstNames":{"type":"string"},"dateOfBirth":{"type":"string","format":"date"}},"additionalProperties":false},"title":"Children"},"extraDetails":{"type":"array","items":{"type":"object","additionalProperties":{"type":"string"}}}},"additionalProperties":false},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","publishedAt":"2025-09-15"}]}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Connection:
       - keep-alive
       Content-Length:
-      - '1053'
+      - '1785'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 Dec 2025 14:47:31 GMT
+      - Tue, 17 Mar 2026 11:13:05 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.29.1
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -100,8 +96,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3MTA4NTU2MzQsImV4cCI6MTcxMDg5ODgzNCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.t6t4_Vm4NTG31vOVdyHgoT9gnEzD4lqld4dDmB7IHQc
       Connection:
       - keep-alive
       Content-Length:
@@ -109,7 +103,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -131,7 +125,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 14:47:30 GMT
+      - Tue, 17 Mar 2026 11:13:05 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970100",
+      "999970112"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970100"},{"burgerservicenummer":"999970112"}]}'
+    headers:
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:13:05 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_submission_with_children_component_and_selection_enabled.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_submission_with_children_component_and_selection_enabled.yaml
@@ -6,17 +6,15 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8001/api/v2/objecttypes
   response:
     body:
-      string: '{"count":8,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","uuid":"db4e8653-1f84-4df7-82bd-96787c52b298","name":"Children","namePlural":"Children","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+      string: '{"count":8,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","uuid":"db4e8653-1f84-4df7-82bd-96787c52b298","name":"Children","namePlural":"Children","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/2"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
         everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e","uuid":"644ab597-e88c-43c0-8321-f12113510b0e","name":"Fieldset
         component","namePlural":"Fieldset component","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705","uuid":"f1dde4fe-b7f9-46dc-84ae-429ae49e3705","name":"Geo
         in data","namePlural":"Geo in data","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2","uuid":"527b8408-7421-4808-a744-43ccb7bdaaa2","name":"File
@@ -27,17 +25,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '5218'
+      - '5315'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 Dec 2025 14:47:31 GMT
+      - Tue, 17 Mar 2026 11:13:53 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.29.1
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -54,34 +52,32 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8001/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","status":"published","jsonSchema":{"$id":"https://example.com/children.schema.json","type":"object","title":"Children","$schema":"https://json-schema.org/draft/2020-12/schema","required":["children"],"properties":{"children":{"type":"array","items":{"type":"object","required":["bsn"],"properties":{"bsn":{"type":"string","format":"nl-bsn","pattern":"^\\d{9}$"},"affixes":{"type":"string"},"initials":{"type":"string"},"lastName":{"type":"string"},"firstNames":{"type":"string"},"dateOfBirth":{"type":"string","format":"date"}},"additionalProperties":false},"title":"Children"},"extraDetails":{"type":"array","items":{"type":"object","additionalProperties":{"type":"string"}}}},"additionalProperties":false},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","publishedAt":"2025-09-15"}]}'
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/2","version":2,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","status":"draft","jsonSchema":{"$id":"https://example.com/person.schema.json","type":"object","title":"Person","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"bsn":{"type":"string"},"name":{"type":"object","properties":{"last.name":{"type":"string"}}},"address":{"type":"object","properties":{"city":{"type":"string"},"postcode":{"type":"string"},"streetName":{"type":"string"},"houseNumber":{"type":"string"}}}}},"createdAt":"2025-01-08","modifiedAt":"2025-01-08","publishedAt":"2025-01-08"},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","version":1,"objectType":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","status":"published","jsonSchema":{"$id":"https://example.com/children.schema.json","type":"object","title":"Children","$schema":"https://json-schema.org/draft/2020-12/schema","required":["children"],"properties":{"children":{"type":"array","items":{"type":"object","required":["bsn"],"properties":{"bsn":{"type":"string","format":"nl-bsn","pattern":"^\\d{9}$"},"affixes":{"type":"string"},"initials":{"type":"string"},"lastName":{"type":"string"},"firstNames":{"type":"string"},"dateOfBirth":{"type":"string","format":"date"}},"additionalProperties":false},"title":"Children"},"extraDetails":{"type":"array","items":{"type":"object","additionalProperties":{"type":"string"}}}},"additionalProperties":false},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","publishedAt":"2025-09-15"}]}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Connection:
       - keep-alive
       Content-Length:
-      - '1053'
+      - '1785'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 Dec 2025 14:47:31 GMT
+      - Tue, 17 Mar 2026 11:13:53 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.29.1
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -100,8 +96,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3MTA4NTU2MzQsImV4cCI6MTcxMDg5ODgzNCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.t6t4_Vm4NTG31vOVdyHgoT9gnEzD4lqld4dDmB7IHQc
       Connection:
       - keep-alive
       Content-Length:
@@ -109,7 +103,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -131,7 +125,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 14:47:31 GMT
+      - Tue, 17 Mar 2026 11:13:53 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970100",
+      "999970112"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970100"},{"burgerservicenummer":"999970112"}]}'
+    headers:
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:13:53 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_submission_with_partners_component.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_submission_with_partners_component.yaml
@@ -6,17 +6,15 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8001/api/v2/objecttypes
   response:
     body:
-      string: '{"count":8,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","uuid":"db4e8653-1f84-4df7-82bd-96787c52b298","name":"Children","namePlural":"Children","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+      string: '{"count":8,"next":null,"previous":null,"results":[{"url":"http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298","uuid":"db4e8653-1f84-4df7-82bd-96787c52b298","name":"Children","namePlural":"Children","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-09-15","modifiedAt":"2025-09-15","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/db4e8653-1f84-4df7-82bd-96787c52b298/versions/2"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09","uuid":"59cdc902-576b-495f-ae63-c9c78b8afc09","name":"Partners","namePlural":"Partners","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2025-07-22","modifiedAt":"2025-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
         everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e","uuid":"644ab597-e88c-43c0-8321-f12113510b0e","name":"Fieldset
         component","namePlural":"Fieldset component","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/644ab597-e88c-43c0-8321-f12113510b0e/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705","uuid":"f1dde4fe-b7f9-46dc-84ae-429ae49e3705","name":"Geo
         in data","namePlural":"Geo in data","description":"","dataClassification":"confidential","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-02-08","modifiedAt":"2024-02-08","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/f1dde4fe-b7f9-46dc-84ae-429ae49e3705/versions/1"]},{"url":"http://objecttypes-web:8000/api/v2/objecttypes/527b8408-7421-4808-a744-43ccb7bdaaa2","uuid":"527b8408-7421-4808-a744-43ccb7bdaaa2","name":"File
@@ -27,17 +25,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '5218'
+      - '5315'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 Dec 2025 14:47:34 GMT
+      - Tue, 17 Mar 2026 11:11:55 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.29.1
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -54,12 +52,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Token 171be5abaf41e7856b423ad513df1ef8f867ff48
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8001/api/v2/objecttypes/59cdc902-576b-495f-ae63-c9c78b8afc09/versions
   response:
@@ -77,11 +73,11 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 Dec 2025 14:47:34 GMT
+      - Tue, 17 Mar 2026 11:11:55 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.29.1
+      - nginx/1.27.3
       Vary:
       - origin
       X-Content-Type-Options:
@@ -100,8 +96,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3MTA4NTU2MzQsImV4cCI6MTcxMDg5ODgzNCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.t6t4_Vm4NTG31vOVdyHgoT9gnEzD4lqld4dDmB7IHQc
       Connection:
       - keep-alive
       Content-Length:
@@ -109,7 +103,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -133,7 +127,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 14:47:34 GMT
+      - Tue, 17 Mar 2026 11:11:55 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999995182",
+      "123456782"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999995182"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:11:55 GMT
       Server:
       - Kestrel
     status:

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_betrokkene.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_betrokkene.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -37,7 +37,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 14:46:14 GMT
+      - Tue, 17 Mar 2026 11:14:36 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999993677"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999993677"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:14:36 GMT
       Server:
       - Kestrel
     status:
@@ -50,20 +91,20 @@ interactions:
       \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>98e7f1ac-44d8-4cca-8dcd-5c17db3066ab</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f842331c-b760-43b3-9671-c4a40f354de8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111437</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20251219</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20251219</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260317</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260317</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20251219</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260317</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -73,7 +114,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -103,7 +144,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -130,9 +171,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:14:37 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK
@@ -142,8 +183,8 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>86c72df5-4d00-4a4b-a6c6-240763d3bc01</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>745d071c-a96b-412c-96cb-1a9f82a7a51b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111437</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -160,7 +201,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -177,7 +218,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>bfc37fa2af826d56</ZKN:identificatie>\n
+        \               <ZKN:identificatie>3f98d2ee369dbcc0</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -188,9 +229,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:14:37 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK
@@ -200,26 +241,26 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8019351b-235b-4d8d-a308-18b8b445db0c</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ccd1129c-d942-4e64-9d39-ac13ec3e20c5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111437</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>bfc37fa2af826d56</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20251219</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20251219</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>3f98d2ee369dbcc0</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260317</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260317</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20251219</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260317</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20251219</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260317</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -235,7 +276,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -262,9 +303,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:14:37 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_extraelementen.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_extraelementen.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -37,7 +37,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 14:46:14 GMT
+      - Tue, 17 Mar 2026 11:16:06 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999993677"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999993677"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:16:07 GMT
       Server:
       - Kestrel
     status:
@@ -50,16 +91,16 @@ interactions:
       \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>258425d2-6815-4748-98a2-b5b3cc8b7160</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>99b4bc7a-443a-4926-8539-2ae5fbd0f221</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111607</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20251219</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20251219</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260317</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260317</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260317111607</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"childrenKey.0.bsn\">999993677</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"childrenKey.0.firstNames\">Truus</StUF:extraElement>\n\n<StUF:extraElement
@@ -69,7 +110,7 @@ interactions:
       naam=\"childrenKey.0.dateOfBirth\">1960-09-12</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20251219</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260317</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -79,7 +120,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260317111607</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -97,7 +138,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -124,9 +165,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:16:07 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK
@@ -136,8 +177,8 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>13bfc107-ea69-4d37-b57e-c825e4fe06bb</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>53fda444-3825-4483-9c7d-9b5a2870734f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111608</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -154,7 +195,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -171,7 +212,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>fc990ca8ec794d7c</ZKN:identificatie>\n
+        \               <ZKN:identificatie>bfa7c0d5c1b740e8</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -182,9 +223,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:16:08 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK
@@ -194,26 +235,26 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>751a2bf2-4be0-4e61-8b14-6cdcb41fc0de</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ceebb88d-becb-4a57-8264-b643a9f4eebc</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111608</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>fc990ca8ec794d7c</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20251219</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20251219</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>bfa7c0d5c1b740e8</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260317</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260317</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20251219</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260317</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20251219</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260317</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260317111608</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260317111608</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -229,7 +270,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -256,9 +297,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:16:08 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_enabled_children_selection.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_enabled_children_selection.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -37,7 +37,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:15:32 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970100",
+      "999970112"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970100"},{"burgerservicenummer":"999970112"}]}'
+    headers:
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:15:32 GMT
       Server:
       - Kestrel
     status:
@@ -50,20 +91,20 @@ interactions:
       \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c0bfcb3e-4256-4d96-8ab4-8d0b1b7e9dd6</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>90b9337f-a175-4d29-b653-f11347147576</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111533</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20251219</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20251219</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260317</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260317</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20251219</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260317</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -73,7 +114,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -102,7 +143,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -129,9 +170,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:15:33 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK
@@ -141,8 +182,8 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5b92e379-c321-4af4-b892-680fd406b485</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>612d805e-c899-4162-a49f-8a1d26dcd570</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111533</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -159,7 +200,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -176,7 +217,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>832648c1d0056e08</ZKN:identificatie>\n
+        \               <ZKN:identificatie>be3bf76624258b57</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -187,9 +228,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:15:33 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK
@@ -199,26 +240,26 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7c25d52a-fe71-4bfe-a64a-4481d006bff6</StUF:referentienummer>\n<StUF:tijdstipBericht>20251219144615</StUF:tijdstipBericht>\n\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>32351591-d890-4f67-bf57-ea96e5f9019f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111533</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>832648c1d0056e08</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20251219</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20251219</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>be3bf76624258b57</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260317</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260317</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20251219</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260317</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20251219</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260317</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20251219144615</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -234,7 +275,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -261,9 +302,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 19 Dec 2025 14:46:15 GMT
+      - Tue, 17 Mar 2026 11:15:33 GMT
       Server:
-      - Werkzeug/3.1.4 Python/3.12.12
+      - Werkzeug/3.1.6 Python/3.12.13
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -4446,7 +4446,7 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
             )
 
         self.plugin.register_submission(submission, self.options)
-        stuf_request = self.cassette.requests[1]
+        stuf_request = self.cassette.requests[2]
         xml_doc = etree.fromstring(stuf_request.body)
 
         self.assertSoapXMLCommon(xml_doc)
@@ -4552,7 +4552,7 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         )
 
         self.plugin.register_submission(submission, self.options)
-        stuf_request = self.cassette.requests[1]
+        stuf_request = self.cassette.requests[2]
         xml_doc = etree.fromstring(stuf_request.body)
 
         self.assertSoapXMLCommon(xml_doc)
@@ -4880,7 +4880,7 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
             )
 
         self.plugin.register_submission(submission, self.options)
-        stuf_request = self.cassette.requests[1]
+        stuf_request = self.cassette.requests[2]
         xml_doc = etree.fromstring(stuf_request.body)
 
         self.assertSoapXMLCommon(xml_doc)

--- a/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_submission_with_children_component_and_selection_disabled.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_submission_with_children_component_and_selection_disabled.yaml
@@ -8,8 +8,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NjYxNTAwNDUsImV4cCI6MTc2NjE5MzI0NSwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.Gpl3rfSqpe28rxd2Uv8P5uL_FPUyz3Vs9AS_ppg2xKQ
       Connection:
       - keep-alive
       Content-Length:
@@ -17,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +37,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:14:05 GMT
+      - Tue, 17 Mar 2026 11:41:24 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970100",
+      "999970112"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970100"},{"burgerservicenummer":"999970112"}]}'
+    headers:
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:41:24 GMT
       Server:
       - Kestrel
     status:
@@ -52,12 +91,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=CHILD&rsin=000000000
   response:
@@ -94,12 +131,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fe035387e-6374-4eb9-b3d1-416294402bae&identificatie=ZAAKTYPE-2020-0000000002&datumGeldigheid=2024-11-09
   response:
@@ -132,8 +167,8 @@ interactions:
 - request:
     body: '{"zaaktype": "http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be",
       "bronorganisatie": "000000000", "verantwoordelijkeOrganisatie": "000000000",
-      "registratiedatum": "2025-12-19", "startdatum": "2025-12-19", "productenOfDiensten":
-      [], "omschrijving": "Form 025", "toelichting": "Aangemaakt door Open Formulieren",
+      "registratiedatum": "2026-03-17", "startdatum": "2026-03-17", "productenOfDiensten":
+      [], "omschrijving": "Form 017", "toelichting": "Aangemaakt door Open Formulieren",
       "betalingsindicatie": "nvt"}'
     headers:
       Accept:
@@ -142,8 +177,6 @@ interactions:
       - EPSG:4326
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Crs:
@@ -153,13 +186,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/zaken
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c","uuid":"23558738-0cc0-4899-ba14-bb68c81dc85c","identificatie":"ZAAK-2025-0000000020","bronorganisatie":"000000000","omschrijving":"Form
-        025","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be","registratiedatum":"2025-12-19","verantwoordelijkeOrganisatie":"000000000","startdatum":"2025-12-19","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"openbaar","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f","uuid":"5e452a57-fe94-4486-9a86-8db010910a5f","identificatie":"ZAAK-2026-0000000008","bronorganisatie":"000000000","omschrijving":"Form
+        017","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be","registratiedatum":"2026-03-17","verantwoordelijkeOrganisatie":"000000000","startdatum":"2026-03-17","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"openbaar","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
         is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
     headers:
       API-version:
@@ -175,7 +208,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c
+      - http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f
       Referrer-Policy:
       - same-origin
       Vary:
@@ -194,12 +227,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=CHILD&rsin=000000000
   response:
@@ -236,12 +267,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fe035387e-6374-4eb9-b3d1-416294402bae&omschrijving=Children+PDF+Informatieobjecttype&datumGeldigheid=2024-11-09
   response:
@@ -278,12 +307,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -317,9 +344,9 @@ interactions:
       message: OK
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/68ce2d9c-fe0f-49cc-a1d6-ddb3d404da35",
-      "bronorganisatie": "000000000", "creatiedatum": "2025-12-19", "titel": "Form
-      025", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
-      "", "status": "definitief", "bestandsnaam": "open-forms-Form 025.pdf", "ontvangstdatum":
+      "bronorganisatie": "000000000", "creatiedatum": "2026-03-17", "titel": "Form
+      017", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
+      "", "status": "definitief", "bestandsnaam": "open-forms-Form 017.pdf", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulier", "indicatieGebruiksrecht": false,
       "bestandsomvang": 0}'
     headers:
@@ -327,8 +354,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Length:
@@ -336,14 +361,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/45cf0243-2a8a-4fe4-98ff-6497722d5ca1","identificatie":"DOCUMENT-2025-0000000025","bronorganisatie":"000000000","creatiedatum":"2025-12-19","titel":"Form
-        025","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2025-12-19T13:14:06.104984Z","bestandsnaam":"open-forms-Form
-        025.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/45cf0243-2a8a-4fe4-98ff-6497722d5ca1/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b95a647e-4c69-48ce-8c4a-bf7ed8c7a6bf","identificatie":"DOCUMENT-2026-0000000008","bronorganisatie":"000000000","creatiedatum":"2026-03-17","titel":"Form
+        017","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2026-03-17T11:41:25.186636Z","bestandsnaam":"open-forms-Form
+        017.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b95a647e-4c69-48ce-8c4a-bf7ed8c7a6bf/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
         formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/68ce2d9c-fe0f-49cc-a1d6-ddb3d404da35","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -357,7 +382,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/45cf0243-2a8a-4fe4-98ff-6497722d5ca1
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b95a647e-4c69-48ce-8c4a-bf7ed8c7a6bf
       Referrer-Policy:
       - same-origin
       Vary:
@@ -370,15 +395,13 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c",
-      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/45cf0243-2a8a-4fe4-98ff-6497722d5ca1"}'
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f",
+      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b95a647e-4c69-48ce-8c4a-bf7ed8c7a6bf"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Length:
@@ -386,13 +409,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/zaakinformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/ab0b6c73-530a-4ccc-a510-3a810fe7cdd9","uuid":"ab0b6c73-530a-4ccc-a510-3a810fe7cdd9","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/45cf0243-2a8a-4fe4-98ff-6497722d5ca1","zaak":"http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c","aardRelatieWeergave":"Hoort
-        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2025-12-19T13:14:06.207274Z","vernietigingsdatum":null,"status":null}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/fd925e2c-9896-4e6c-b80b-b56529d528ee","uuid":"fd925e2c-9896-4e6c-b80b-b56529d528ee","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b95a647e-4c69-48ce-8c4a-bf7ed8c7a6bf","zaak":"http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f","aardRelatieWeergave":"Hoort
+        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2026-03-17T11:41:25.228270Z","vernietigingsdatum":null,"status":null}'
     headers:
       API-version:
       - 1.5.1
@@ -405,7 +428,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/ab0b6c73-530a-4ccc-a510-3a810fe7cdd9
+      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/fd925e2c-9896-4e6c-b80b-b56529d528ee
       Referrer-Policy:
       - same-origin
       Vary:
@@ -424,12 +447,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be&omschrijvingGeneriek=initiator
   response:
@@ -459,32 +480,30 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/c76d3b20-d42c-4c6e-9837-abb1005bba68",
       "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
-      {"inpBsn": "999970094"}}'
+      {"inpBsn": "999970094", "vestigingsNummer": ""}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Length:
-      - '346'
+      - '370'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/5be24063-8361-4175-8684-cd750a5bbe69","uuid":"5be24063-8361-4175-8684-cd750a5bbe69","zaak":"http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/c76d3b20-d42c-4c6e-9837-abb1005bba68","omschrijving":"Children
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/13375551-1734-49b2-8f8f-dfce18ff49f0","uuid":"13375551-1734-49b2-8f8f-dfce18ff49f0","zaak":"http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/c76d3b20-d42c-4c6e-9837-abb1005bba68","omschrijving":"Children
         initiator role type","omschrijvingGeneriek":"initiator","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:06.386857Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970094","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+        formulier","registratiedatum":"2026-03-17T11:41:25.286291Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970094","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
       - 1.5.1
@@ -497,7 +516,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/5be24063-8361-4175-8684-cd750a5bbe69
+      - http://localhost:8003/zaken/api/v1/rollen/13375551-1734-49b2-8f8f-dfce18ff49f0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -516,12 +535,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -552,34 +569,30 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e",
-      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      "roltoelichting": "natuurlijk_persoon", "indicatieMachtiging": "", "betrokkeneIdentificatie":
       {"inpBsn": "999970100", "voorvoegselGeslachtsnaam": "", "voorletters": "O.",
-      "geslachtsnaam": "Oostingh", "voornamen": "Olle", "geboortedatum": "2022-02-02",
-      "roltoelichting": ""}}'
+      "geslachtsnaam": "Oostingh", "voornamen": "Olle", "geboortedatum": "2022-02-02"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Length:
-      - '502'
+      - '480'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/4633c09c-ab76-41ca-b313-6efcc04dd815","uuid":"4633c09c-ab76-41ca-b313-6efcc04dd815","zaak":"http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e","omschrijving":"Children
-        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:06.564827Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970100","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Oostingh","voorvoegselGeslachtsnaam":"","voorletters":"O.","voornamen":"Olle","geslachtsaanduiding":"","geboortedatum":"2022-02-02","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/7742ae5e-6b80-4dd1-bb83-839efc55c7c4","uuid":"7742ae5e-6b80-4dd1-bb83-839efc55c7c4","zaak":"http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e","omschrijving":"Children
+        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"natuurlijk_persoon","registratiedatum":"2026-03-17T11:41:25.347863Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970100","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Oostingh","voorvoegselGeslachtsnaam":"","voorletters":"O.","voornamen":"Olle","geslachtsaanduiding":"","geboortedatum":"2022-02-02","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
       - 1.5.1
@@ -592,7 +605,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/4633c09c-ab76-41ca-b313-6efcc04dd815
+      - http://localhost:8003/zaken/api/v1/rollen/7742ae5e-6b80-4dd1-bb83-839efc55c7c4
       Referrer-Policy:
       - same-origin
       Vary:
@@ -611,12 +624,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -647,34 +658,30 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e",
-      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      "roltoelichting": "natuurlijk_persoon", "indicatieMachtiging": "", "betrokkeneIdentificatie":
       {"inpBsn": "999970112", "voorvoegselGeslachtsnaam": "", "voorletters": "O.",
-      "geslachtsnaam": "Oostingh", "voornamen": "Onne", "geboortedatum": "2022-02-02",
-      "roltoelichting": ""}}'
+      "geslachtsnaam": "Oostingh", "voornamen": "Onne", "geboortedatum": "2022-02-02"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Length:
-      - '502'
+      - '480'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/e7fed559-eaf8-4893-b0b5-5771779219e3","uuid":"e7fed559-eaf8-4893-b0b5-5771779219e3","zaak":"http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e","omschrijving":"Children
-        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:06.742647Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970112","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Oostingh","voorvoegselGeslachtsnaam":"","voorletters":"O.","voornamen":"Onne","geslachtsaanduiding":"","geboortedatum":"2022-02-02","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/dc4904e7-387a-4471-b20a-8131f5e23b31","uuid":"dc4904e7-387a-4471-b20a-8131f5e23b31","zaak":"http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e","omschrijving":"Children
+        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"natuurlijk_persoon","registratiedatum":"2026-03-17T11:41:25.409970Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970112","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Oostingh","voorvoegselGeslachtsnaam":"","voorletters":"O.","voornamen":"Onne","geslachtsaanduiding":"","geboortedatum":"2022-02-02","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
       - 1.5.1
@@ -687,7 +694,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/e7fed559-eaf8-4893-b0b5-5771779219e3
+      - http://localhost:8003/zaken/api/v1/rollen/dc4904e7-387a-4471-b20a-8131f5e23b31
       Referrer-Policy:
       - same-origin
       Vary:
@@ -706,12 +713,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/statustypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -740,17 +745,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f",
       "statustype": "http://localhost:8003/catalogi/api/v1/statustypen/60b6154a-a480-47db-93ab-d8ccc39d4022",
-      "datumStatusGezet": "2025-12-19T13:14:06.846476+00:00", "statustoelichting":
+      "datumStatusGezet": "2026-03-17T11:41:25.450029+00:00", "statustoelichting":
       ""}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NSwiZXhwIjoxNzY2MTkzMjQ1LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.cpasLvA3Tdj7UTJpJ0EFUWR9qMe3gVlk1TUDA_OJ4Ag
       Connection:
       - keep-alive
       Content-Length:
@@ -758,12 +761,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/statussen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/7fed964f-cc56-4aec-b924-6ef5838ebf93","uuid":"7fed964f-cc56-4aec-b924-6ef5838ebf93","zaak":"http://localhost:8003/zaken/api/v1/zaken/23558738-0cc0-4899-ba14-bb68c81dc85c","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/60b6154a-a480-47db-93ab-d8ccc39d4022","datumStatusGezet":"2025-12-19T13:14:06.846476Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/37017fc7-682e-4dcd-acce-5666240c2e5a","uuid":"37017fc7-682e-4dcd-acce-5666240c2e5a","zaak":"http://localhost:8003/zaken/api/v1/zaken/5e452a57-fe94-4486-9a86-8db010910a5f","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/60b6154a-a480-47db-93ab-d8ccc39d4022","datumStatusGezet":"2026-03-17T11:41:25.450029Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
     headers:
       API-version:
       - 1.5.1
@@ -776,7 +779,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/statussen/7fed964f-cc56-4aec-b924-6ef5838ebf93
+      - http://localhost:8003/zaken/api/v1/statussen/37017fc7-682e-4dcd-acce-5666240c2e5a
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_submission_with_children_component_and_selection_enabled.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_submission_with_children_component_and_selection_enabled.yaml
@@ -8,8 +8,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NjYxNTAwNDcsImV4cCI6MTc2NjE5MzI0NywiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.FBQFU2u68CUWCNeKgBT5g3F5A6KGQGFCV106eOpCfMo
       Connection:
       - keep-alive
       Content-Length:
@@ -17,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +37,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:14:07 GMT
+      - Tue, 17 Mar 2026 11:41:25 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970100",
+      "999970112"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970100"},{"burgerservicenummer":"999970112"}]}'
+    headers:
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:41:25 GMT
       Server:
       - Kestrel
     status:
@@ -52,12 +91,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=CHILD&rsin=000000000
   response:
@@ -94,12 +131,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fe035387e-6374-4eb9-b3d1-416294402bae&identificatie=ZAAKTYPE-2020-0000000002&datumGeldigheid=2024-11-09
   response:
@@ -132,8 +167,8 @@ interactions:
 - request:
     body: '{"zaaktype": "http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be",
       "bronorganisatie": "000000000", "verantwoordelijkeOrganisatie": "000000000",
-      "registratiedatum": "2025-12-19", "startdatum": "2025-12-19", "productenOfDiensten":
-      [], "omschrijving": "Form 026", "toelichting": "Aangemaakt door Open Formulieren",
+      "registratiedatum": "2026-03-17", "startdatum": "2026-03-17", "productenOfDiensten":
+      [], "omschrijving": "Form 018", "toelichting": "Aangemaakt door Open Formulieren",
       "betalingsindicatie": "nvt"}'
     headers:
       Accept:
@@ -142,8 +177,6 @@ interactions:
       - EPSG:4326
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       Content-Crs:
@@ -153,13 +186,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/zaken
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293","uuid":"8656b7a3-32be-4cfc-9b57-4c0c65c83293","identificatie":"ZAAK-2025-0000000021","bronorganisatie":"000000000","omschrijving":"Form
-        026","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be","registratiedatum":"2025-12-19","verantwoordelijkeOrganisatie":"000000000","startdatum":"2025-12-19","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"openbaar","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e","uuid":"2881a4f0-b7c2-4a7f-97b1-ed47b55a472e","identificatie":"ZAAK-2026-0000000009","bronorganisatie":"000000000","omschrijving":"Form
+        018","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be","registratiedatum":"2026-03-17","verantwoordelijkeOrganisatie":"000000000","startdatum":"2026-03-17","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"openbaar","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
         is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
     headers:
       API-version:
@@ -175,7 +208,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293
+      - http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -194,12 +227,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=CHILD&rsin=000000000
   response:
@@ -236,12 +267,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fe035387e-6374-4eb9-b3d1-416294402bae&omschrijving=Children+PDF+Informatieobjecttype&datumGeldigheid=2024-11-09
   response:
@@ -278,12 +307,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/zaaktypen/a516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -317,9 +344,9 @@ interactions:
       message: OK
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/68ce2d9c-fe0f-49cc-a1d6-ddb3d404da35",
-      "bronorganisatie": "000000000", "creatiedatum": "2025-12-19", "titel": "Form
-      026", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
-      "", "status": "definitief", "bestandsnaam": "open-forms-Form 026.pdf", "ontvangstdatum":
+      "bronorganisatie": "000000000", "creatiedatum": "2026-03-17", "titel": "Form
+      018", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
+      "", "status": "definitief", "bestandsnaam": "open-forms-Form 018.pdf", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulier", "indicatieGebruiksrecht": false,
       "bestandsomvang": 0}'
     headers:
@@ -327,8 +354,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       Content-Length:
@@ -336,14 +361,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a1942366-27e7-4eb3-90ae-6c247477b4b2","identificatie":"DOCUMENT-2025-0000000026","bronorganisatie":"000000000","creatiedatum":"2025-12-19","titel":"Form
-        026","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2025-12-19T13:14:07.740339Z","bestandsnaam":"open-forms-Form
-        026.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a1942366-27e7-4eb3-90ae-6c247477b4b2/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/78f1450e-6d4b-4d53-968b-43ca4e99f398","identificatie":"DOCUMENT-2026-0000000009","bronorganisatie":"000000000","creatiedatum":"2026-03-17","titel":"Form
+        018","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2026-03-17T11:41:25.995763Z","bestandsnaam":"open-forms-Form
+        018.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/78f1450e-6d4b-4d53-968b-43ca4e99f398/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
         formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/68ce2d9c-fe0f-49cc-a1d6-ddb3d404da35","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -357,7 +382,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a1942366-27e7-4eb3-90ae-6c247477b4b2
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/78f1450e-6d4b-4d53-968b-43ca4e99f398
       Referrer-Policy:
       - same-origin
       Vary:
@@ -370,15 +395,13 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293",
-      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a1942366-27e7-4eb3-90ae-6c247477b4b2"}'
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e",
+      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/78f1450e-6d4b-4d53-968b-43ca4e99f398"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       Content-Length:
@@ -386,13 +409,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/zaakinformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/d9940fbd-cc7c-42b7-9e2a-ec1a7206a32e","uuid":"d9940fbd-cc7c-42b7-9e2a-ec1a7206a32e","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a1942366-27e7-4eb3-90ae-6c247477b4b2","zaak":"http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293","aardRelatieWeergave":"Hoort
-        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2025-12-19T13:14:07.870369Z","vernietigingsdatum":null,"status":null}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/ccc9a34a-c42d-4766-aea2-f7bd2d55ed8a","uuid":"ccc9a34a-c42d-4766-aea2-f7bd2d55ed8a","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/78f1450e-6d4b-4d53-968b-43ca4e99f398","zaak":"http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e","aardRelatieWeergave":"Hoort
+        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2026-03-17T11:41:26.085285Z","vernietigingsdatum":null,"status":null}'
     headers:
       API-version:
       - 1.5.1
@@ -405,7 +428,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/d9940fbd-cc7c-42b7-9e2a-ec1a7206a32e
+      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/ccc9a34a-c42d-4766-aea2-f7bd2d55ed8a
       Referrer-Policy:
       - same-origin
       Vary:
@@ -424,12 +447,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be&omschrijvingGeneriek=initiator
   response:
@@ -459,32 +480,30 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/c76d3b20-d42c-4c6e-9837-abb1005bba68",
       "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
-      {"inpBsn": "999970094"}}'
+      {"inpBsn": "999970094", "vestigingsNummer": ""}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       Content-Length:
-      - '346'
+      - '370'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/bdab500e-83c7-47e1-940c-8c7ec34cbebc","uuid":"bdab500e-83c7-47e1-940c-8c7ec34cbebc","zaak":"http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/c76d3b20-d42c-4c6e-9837-abb1005bba68","omschrijving":"Children
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/f4e5f45f-b249-40e2-8fd3-d932fcf23c6c","uuid":"f4e5f45f-b249-40e2-8fd3-d932fcf23c6c","zaak":"http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/c76d3b20-d42c-4c6e-9837-abb1005bba68","omschrijving":"Children
         initiator role type","omschrijvingGeneriek":"initiator","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:08.059868Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970094","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+        formulier","registratiedatum":"2026-03-17T11:41:26.169480Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970094","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
       - 1.5.1
@@ -497,7 +516,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/bdab500e-83c7-47e1-940c-8c7ec34cbebc
+      - http://localhost:8003/zaken/api/v1/rollen/f4e5f45f-b249-40e2-8fd3-d932fcf23c6c
       Referrer-Policy:
       - same-origin
       Vary:
@@ -516,12 +535,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -552,34 +569,30 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e",
-      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      "roltoelichting": "natuurlijk_persoon", "indicatieMachtiging": "", "betrokkeneIdentificatie":
       {"inpBsn": "999970100", "voorvoegselGeslachtsnaam": "", "voorletters": "O.",
-      "geslachtsnaam": "Oostingh", "voornamen": "Olle", "geboortedatum": "2022-02-02",
-      "roltoelichting": ""}}'
+      "geslachtsnaam": "Oostingh", "voornamen": "Olle", "geboortedatum": "2022-02-02"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       Content-Length:
-      - '502'
+      - '480'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/d161c16c-f8cd-49b3-b810-1b67e5381050","uuid":"d161c16c-f8cd-49b3-b810-1b67e5381050","zaak":"http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e","omschrijving":"Children
-        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:08.252912Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970100","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Oostingh","voorvoegselGeslachtsnaam":"","voorletters":"O.","voornamen":"Olle","geslachtsaanduiding":"","geboortedatum":"2022-02-02","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/7ee02bb7-8d39-4657-abbe-df9e209c9758","uuid":"7ee02bb7-8d39-4657-abbe-df9e209c9758","zaak":"http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/03e330e2-acd6-4e4d-a382-1ed9b71e8a6e","omschrijving":"Children
+        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"natuurlijk_persoon","registratiedatum":"2026-03-17T11:41:26.243379Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999970100","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Oostingh","voorvoegselGeslachtsnaam":"","voorletters":"O.","voornamen":"Olle","geslachtsaanduiding":"","geboortedatum":"2022-02-02","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
       - 1.5.1
@@ -592,7 +605,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/d161c16c-f8cd-49b3-b810-1b67e5381050
+      - http://localhost:8003/zaken/api/v1/rollen/7ee02bb7-8d39-4657-abbe-df9e209c9758
       Referrer-Policy:
       - same-origin
       Vary:
@@ -611,12 +624,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/statustypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Fa516793a-cb5f-446d-bfa3-56077c1897be
   response:
@@ -645,17 +656,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e",
       "statustype": "http://localhost:8003/catalogi/api/v1/statustypen/60b6154a-a480-47db-93ab-d8ccc39d4022",
-      "datumStatusGezet": "2025-12-19T13:14:08.364038+00:00", "statustoelichting":
+      "datumStatusGezet": "2026-03-17T11:41:26.276419+00:00", "statustoelichting":
       ""}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA0NywiZXhwIjoxNzY2MTkzMjQ3LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.UgnQRoh--Xb8-tVtySXoraTfeQe7q0f5NdY9FqKKTMI
       Connection:
       - keep-alive
       Content-Length:
@@ -663,12 +672,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/statussen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/10a8766b-9bce-424e-9626-cbb17b778f5d","uuid":"10a8766b-9bce-424e-9626-cbb17b778f5d","zaak":"http://localhost:8003/zaken/api/v1/zaken/8656b7a3-32be-4cfc-9b57-4c0c65c83293","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/60b6154a-a480-47db-93ab-d8ccc39d4022","datumStatusGezet":"2025-12-19T13:14:08.364038Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/f9abfadf-fd51-415c-ab29-27f9f4737bf8","uuid":"f9abfadf-fd51-415c-ab29-27f9f4737bf8","zaak":"http://localhost:8003/zaken/api/v1/zaken/2881a4f0-b7c2-4a7f-97b1-ed47b55a472e","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/60b6154a-a480-47db-93ab-d8ccc39d4022","datumStatusGezet":"2026-03-17T11:41:26.276419Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
     headers:
       API-version:
       - 1.5.1
@@ -681,7 +690,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/statussen/10a8766b-9bce-424e-9626-cbb17b778f5d
+      - http://localhost:8003/zaken/api/v1/statussen/f9abfadf-fd51-415c-ab29-27f9f4737bf8
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_submission_with_partners_component.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_submission_with_partners_component.yaml
@@ -8,8 +8,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIiLCJpYXQiOjE3NjYxNTAwNTQsImV4cCI6MTc2NjE5MzI1NCwiY2xpZW50X2lkIjoiIiwidXNlcl9pZCI6IiIsInVzZXJfcmVwcmVzZW50YXRpb24iOiIifQ.lxc3C0nqGaYHovKftPWxpB-L4dtpYYwlXxtIcMYst5k
       Connection:
       - keep-alive
       Content-Length:
@@ -17,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -41,7 +39,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 19 Dec 2025 13:14:14 GMT
+      - Tue, 17 Mar 2026 11:40:51 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999995182",
+      "123456782"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.32.5
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999995182"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 17 Mar 2026 11:40:51 GMT
       Server:
       - Kestrel
     status:
@@ -54,12 +93,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=PARTN&rsin=000000000
   response:
@@ -96,12 +133,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2F7575ec62-a5ed-421f-bfc7-f8837066dd10&identificatie=ZAAKTYPE-2020-0000000001&datumGeldigheid=2024-11-09
   response:
@@ -134,8 +169,8 @@ interactions:
 - request:
     body: '{"zaaktype": "http://localhost:8003/catalogi/api/v1/zaaktypen/77543c85-e5cd-4b3e-b7a5-27165e1334b1",
       "bronorganisatie": "000000000", "verantwoordelijkeOrganisatie": "000000000",
-      "registratiedatum": "2025-12-19", "startdatum": "2025-12-19", "productenOfDiensten":
-      [], "omschrijving": "Form 031", "toelichting": "Aangemaakt door Open Formulieren",
+      "registratiedatum": "2026-03-17", "startdatum": "2026-03-17", "productenOfDiensten":
+      [], "omschrijving": "Form 001", "toelichting": "Aangemaakt door Open Formulieren",
       "betalingsindicatie": "nvt"}'
     headers:
       Accept:
@@ -144,8 +179,6 @@ interactions:
       - EPSG:4326
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Crs:
@@ -155,13 +188,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/zaken
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2","uuid":"f59f797d-8628-4598-a62e-6c92e70e0dd2","identificatie":"ZAAK-2025-0000000026","bronorganisatie":"000000000","omschrijving":"Form
-        031","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/77543c85-e5cd-4b3e-b7a5-27165e1334b1","registratiedatum":"2025-12-19","verantwoordelijkeOrganisatie":"000000000","startdatum":"2025-12-19","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"openbaar","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9","uuid":"80777d28-ba5e-4f6e-a156-77eb6aba22f9","identificatie":"ZAAK-2026-0000000007","bronorganisatie":"000000000","omschrijving":"Form
+        001","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/77543c85-e5cd-4b3e-b7a5-27165e1334b1","registratiedatum":"2026-03-17","verantwoordelijkeOrganisatie":"000000000","startdatum":"2026-03-17","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"openbaar","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
         is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
     headers:
       API-version:
@@ -177,7 +210,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2
+      - http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9
       Referrer-Policy:
       - same-origin
       Vary:
@@ -196,12 +229,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=PARTN&rsin=000000000
   response:
@@ -238,12 +269,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2F7575ec62-a5ed-421f-bfc7-f8837066dd10&omschrijving=Partners+PDF+Informatieobjecttype&datumGeldigheid=2024-11-09
   response:
@@ -280,12 +309,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/zaaktypen/77543c85-e5cd-4b3e-b7a5-27165e1334b1
   response:
@@ -319,9 +346,9 @@ interactions:
       message: OK
 - request:
     body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d2ea38b1-5215-402f-a3f5-2977d112bf72",
-      "bronorganisatie": "000000000", "creatiedatum": "2025-12-19", "titel": "Form
-      031", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
-      "", "status": "definitief", "bestandsnaam": "open-forms-Form 031.pdf", "ontvangstdatum":
+      "bronorganisatie": "000000000", "creatiedatum": "2026-03-17", "titel": "Form
+      001", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf", "inhoud":
+      "", "status": "definitief", "bestandsnaam": "open-forms-Form 001.pdf", "ontvangstdatum":
       null, "beschrijving": "Ingezonden formulier", "indicatieGebruiksrecht": false,
       "bestandsomvang": 0}'
     headers:
@@ -329,8 +356,6 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Length:
@@ -338,14 +363,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/29b8f729-5593-4c25-bab9-e6f1aabe7e9b","identificatie":"DOCUMENT-2025-0000000031","bronorganisatie":"000000000","creatiedatum":"2025-12-19","titel":"Form
-        031","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2025-12-19T13:14:15.062915Z","bestandsnaam":"open-forms-Form
-        031.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/29b8f729-5593-4c25-bab9-e6f1aabe7e9b/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a9acad66-c263-4786-a0c4-42567d329a8e","identificatie":"DOCUMENT-2026-0000000007","bronorganisatie":"000000000","creatiedatum":"2026-03-17","titel":"Form
+        001","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2026-03-17T11:40:53.213324Z","bestandsnaam":"open-forms-Form
+        001.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a9acad66-c263-4786-a0c4-42567d329a8e/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
         formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d2ea38b1-5215-402f-a3f5-2977d112bf72","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
     headers:
       API-version:
@@ -359,7 +384,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/29b8f729-5593-4c25-bab9-e6f1aabe7e9b
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a9acad66-c263-4786-a0c4-42567d329a8e
       Referrer-Policy:
       - same-origin
       Vary:
@@ -372,15 +397,13 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2",
-      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/29b8f729-5593-4c25-bab9-e6f1aabe7e9b"}'
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9",
+      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a9acad66-c263-4786-a0c4-42567d329a8e"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Length:
@@ -388,13 +411,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/zaakinformatieobjecten
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/a7ae83ae-be40-4b3b-af52-74fe9370d931","uuid":"a7ae83ae-be40-4b3b-af52-74fe9370d931","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/29b8f729-5593-4c25-bab9-e6f1aabe7e9b","zaak":"http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2","aardRelatieWeergave":"Hoort
-        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2025-12-19T13:14:15.194779Z","vernietigingsdatum":null,"status":null}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/7bf8245c-5fdc-4103-af02-e955939d9be0","uuid":"7bf8245c-5fdc-4103-af02-e955939d9be0","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/a9acad66-c263-4786-a0c4-42567d329a8e","zaak":"http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9","aardRelatieWeergave":"Hoort
+        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2026-03-17T11:40:53.350675Z","vernietigingsdatum":null,"status":null}'
     headers:
       API-version:
       - 1.5.1
@@ -407,7 +430,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/a7ae83ae-be40-4b3b-af52-74fe9370d931
+      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/7bf8245c-5fdc-4103-af02-e955939d9be0
       Referrer-Policy:
       - same-origin
       Vary:
@@ -426,12 +449,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2F77543c85-e5cd-4b3e-b7a5-27165e1334b1&omschrijvingGeneriek=initiator
   response:
@@ -461,32 +482,30 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/eedd2d97-19b1-4d66-821b-307f3f44363e",
       "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
-      {"inpBsn": "000009921"}}'
+      {"inpBsn": "000009921", "vestigingsNummer": ""}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Length:
-      - '346'
+      - '370'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/a509d2be-7ed8-414f-b8eb-48d5b344c314","uuid":"a509d2be-7ed8-414f-b8eb-48d5b344c314","zaak":"http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/eedd2d97-19b1-4d66-821b-307f3f44363e","omschrijving":"Partner
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/0127f704-ea5b-4215-9441-1eae67fdcd44","uuid":"0127f704-ea5b-4215-9441-1eae67fdcd44","zaak":"http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/eedd2d97-19b1-4d66-821b-307f3f44363e","omschrijving":"Partner
         initiator role type","omschrijvingGeneriek":"initiator","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:15.362632Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"000009921","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+        formulier","registratiedatum":"2026-03-17T11:40:53.509167Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"000009921","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
       - 1.5.1
@@ -499,7 +518,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/a509d2be-7ed8-414f-b8eb-48d5b344c314
+      - http://localhost:8003/zaken/api/v1/rollen/0127f704-ea5b-4215-9441-1eae67fdcd44
       Referrer-Policy:
       - same-origin
       Vary:
@@ -518,12 +537,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2F77543c85-e5cd-4b3e-b7a5-27165e1334b1
   response:
@@ -554,34 +571,31 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b",
-      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      "roltoelichting": "natuurlijk_persoon", "indicatieMachtiging": "", "betrokkeneIdentificatie":
       {"inpBsn": "999995182", "voorvoegselGeslachtsnaam": "", "voorletters": "A.M.P.",
       "geslachtsnaam": "Jansma", "voornamen": "Anna Maria Petra", "geboortedatum":
-      "1945-04-18", "roltoelichting": ""}}'
+      "1945-04-18"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Length:
-      - '516'
+      - '494'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/1e0c2563-d5c9-4d12-99c7-0315f3f449ac","uuid":"1e0c2563-d5c9-4d12-99c7-0315f3f449ac","zaak":"http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b","omschrijving":"Partner
-        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:15.528421Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999995182","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Jansma","voorvoegselGeslachtsnaam":"","voorletters":"A.M.P.","voornamen":"Anna
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/6b921b62-a250-4454-8d9c-55d3725d1224","uuid":"6b921b62-a250-4454-8d9c-55d3725d1224","zaak":"http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b","omschrijving":"Partner
+        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"natuurlijk_persoon","registratiedatum":"2026-03-17T11:40:53.615657Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"999995182","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Jansma","voorvoegselGeslachtsnaam":"","voorletters":"A.M.P.","voornamen":"Anna
         Maria Petra","geslachtsaanduiding":"","geboortedatum":"1945-04-18","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
@@ -595,7 +609,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/1e0c2563-d5c9-4d12-99c7-0315f3f449ac
+      - http://localhost:8003/zaken/api/v1/rollen/6b921b62-a250-4454-8d9c-55d3725d1224
       Referrer-Policy:
       - same-origin
       Vary:
@@ -614,12 +628,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2F77543c85-e5cd-4b3e-b7a5-27165e1334b1
   response:
@@ -650,34 +662,31 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9",
       "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b",
-      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      "roltoelichting": "natuurlijk_persoon", "indicatieMachtiging": "", "betrokkeneIdentificatie":
       {"inpBsn": "123456782", "voorvoegselGeslachtsnaam": "", "voorletters": "T.s.p.",
       "geslachtsnaam": "Test", "voornamen": "Test second partner", "geboortedatum":
-      "1945-04-18", "roltoelichting": ""}}'
+      "1945-04-18"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Length:
-      - '517'
+      - '495'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/rollen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/ef097b59-b161-480d-826a-7bebcbba1c5d","uuid":"ef097b59-b161-480d-826a-7bebcbba1c5d","zaak":"http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b","omschrijving":"Partner
-        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"inzender
-        formulier","registratiedatum":"2025-12-19T13:14:15.712838Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"123456782","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Test","voorvoegselGeslachtsnaam":"","voorletters":"T.s.p.","voornamen":"Test
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/d144eef6-aa20-45b8-9cd9-2fc0f84a1498","uuid":"d144eef6-aa20-45b8-9cd9-2fc0f84a1498","zaak":"http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b","omschrijving":"Partner
+        role type","omschrijvingGeneriek":"behandelaar","roltoelichting":"natuurlijk_persoon","registratiedatum":"2026-03-17T11:40:53.692973Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"123456782","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"Test","voorvoegselGeslachtsnaam":"","voorletters":"T.s.p.","voornamen":"Test
         second partner","geslachtsaanduiding":"","geboortedatum":"1945-04-18","verblijfsadres":null,"subVerblijfBuitenland":null}}'
     headers:
       API-version:
@@ -691,7 +700,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/rollen/ef097b59-b161-480d-826a-7bebcbba1c5d
+      - http://localhost:8003/zaken/api/v1/rollen/d144eef6-aa20-45b8-9cd9-2fc0f84a1498
       Referrer-Policy:
       - same-origin
       Vary:
@@ -710,12 +719,10 @@ interactions:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: GET
     uri: http://localhost:8003/catalogi/api/v1/statustypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2F77543c85-e5cd-4b3e-b7a5-27165e1334b1
   response:
@@ -744,17 +751,15 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2",
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9",
       "statustype": "http://localhost:8003/catalogi/api/v1/statustypen/48c43449-1ce2-4db9-a282-3ba86e37b7c3",
-      "datumStatusGezet": "2025-12-19T13:14:15.813587+00:00", "statustoelichting":
+      "datumStatusGezet": "2026-03-17T11:40:53.747863+00:00", "statustoelichting":
       ""}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate, br
-      Authorization:
-      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0X2NsaWVudF9pZCIsImlhdCI6MTc2NjE1MDA1NCwiZXhwIjoxNzY2MTkzMjU0LCJjbGllbnRfaWQiOiJ0ZXN0X2NsaWVudF9pZCIsInVzZXJfaWQiOiIiLCJ1c2VyX3JlcHJlc2VudGF0aW9uIjoiIn0.ul3VWK7zlA3WXfHAbH2QNGyzyi9BU4I4WcCLtLgFqHM
       Connection:
       - keep-alive
       Content-Length:
@@ -762,12 +767,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.4
+      - python-requests/2.32.5
     method: POST
     uri: http://localhost:8003/zaken/api/v1/statussen
   response:
     body:
-      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/cdcd5a11-80c0-4d91-be70-4fb8eb3784b5","uuid":"cdcd5a11-80c0-4d91-be70-4fb8eb3784b5","zaak":"http://localhost:8003/zaken/api/v1/zaken/f59f797d-8628-4598-a62e-6c92e70e0dd2","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/48c43449-1ce2-4db9-a282-3ba86e37b7c3","datumStatusGezet":"2025-12-19T13:14:15.813587Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
+      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/0e097286-80c8-4d6c-9c0f-c720ff3bbde9","uuid":"0e097286-80c8-4d6c-9c0f-c720ff3bbde9","zaak":"http://localhost:8003/zaken/api/v1/zaken/80777d28-ba5e-4f6e-a156-77eb6aba22f9","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/48c43449-1ce2-4db9-a282-3ba86e37b7c3","datumStatusGezet":"2026-03-17T11:40:53.747863Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
     headers:
       API-version:
       - 1.5.1
@@ -780,7 +785,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8003/zaken/api/v1/statussen/cdcd5a11-80c0-4d91-be70-4fb8eb3784b5
+      - http://localhost:8003/zaken/api/v1/statussen/0e097286-80c8-4d6c-9c0f-c720ff3bbde9
       Referrer-Policy:
       - same-origin
       Vary:

--- a/src/stuf/stuf_bg/client.py
+++ b/src/stuf/stuf_bg/client.py
@@ -102,7 +102,7 @@ class Client(BaseClient):
         bsn: str,
         attribute: str,
         relation: Literal["partners", "children"],
-        include_deceased: bool = True,
+        include_deceased: bool = False,
     ) -> list[NaturalPersonDetails]:
         context = {"bsn": bsn}
         response = self.templated_request(


### PR DESCRIPTION
Closes #5857

**Changes**

Changing the default value of the Family members prefill plugin option `include_deceased` to `False`. With that, the Family member prefill plugin tests have also been updated, to reflect the new default situation.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [X] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [X] Commit messages refer to the relevant Github issue
  - [X] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
