### PR TITLE
Replace `arg` with `param` in docstrings

### DIFF
--- a/src/openforms/admin/decorators.py
+++ b/src/openforms/admin/decorators.py
@@ -16,7 +16,7 @@ def suppress_requests_errors(model: type[models.Model], fields: list[str]):
     form field that Django would generate by default and append an error message
     for the end-user.
 
-    :arg fields: A list of model field names for which to suppress errors.
+    :param fields: A list of model field names for which to suppress errors.
     """
 
     def fallback(self, db_field, request, *args, **kwargs):

--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -39,16 +39,16 @@ co_sign_authentication_success = Signal()
 Signal a successful co-sign authentication.
 
 Provides:
-    :arg request: the HttpRequest instance
-    :arg plugin: authentication plugin identifier
-    :arg submission: The :class:`Submission` instance being co-signed.
+    :param request: the HttpRequest instance
+    :param plugin: authentication plugin identifier
+    :param submission: The :class:`Submission` instance being co-signed.
 """
 authentication_logout = Signal()
 """
 Signals that a user that had logged in with an authentication plugin logged out.
 
 Provides:
-    :arg request: the HttpRequest instance
+    :param request: the HttpRequest instance
 """
 
 

--- a/src/openforms/conf/utils.py
+++ b/src/openforms/conf/utils.py
@@ -106,7 +106,7 @@ def mute_logging(config: dict) -> None:  # pragma: no cover
     """
     Disable (console) output from logging.
 
-    :arg config: The logging config, typically the django LOGGING setting.
+    :param config: The logging config, typically the django LOGGING setting.
     """
 
     # set up the null handler for all loggers so that nothing gets emitted

--- a/src/openforms/contrib/kvk/client.py
+++ b/src/openforms/contrib/kvk/client.py
@@ -72,7 +72,7 @@ class KVKProfileClient(HALClient):
         """
         Retrieve the profile of a single entity by chamber of commerce number.
 
-        :arg kvk_nummer: a Dutch Chamber of Commerce number consisting of 8 digits.
+        :param kvk_nummer: a Dutch Chamber of Commerce number consisting of 8 digits.
 
         Docs: https://developers.kvk.nl/apis/basisprofiel
         Swagger: https://developers.kvk.nl/documentation/testing/swagger-basisprofiel-api
@@ -96,7 +96,7 @@ class KVKBranchProfileClient(HALClient):
         """
         Retrieve the profile of a single entity by chamber of commerce number.
 
-        :arg branch_number: a brnach number consisting of 12 digits.
+        :param branch_number: a brnach number consisting of 12 digits.
 
         Swagger: https://developers.kvk.nl/documentation/testing/swagger-vestigingsprofiel-api
         """
@@ -121,7 +121,7 @@ class KVKSearchClient(HALClient):
         """
         Perform a search against the KVK zoeken API.
 
-        :arg query_params: a non-empty dictionary of query string parameters for
+        :param query_params: a non-empty dictionary of query string parameters for
           the actual search.
 
         Docs: https://developers.kvk.nl/apis/zoeken

--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -267,7 +267,7 @@ class CatalogiClient(LoggingMixin, NLXClient):
     ) -> Iterator[InformatieObjectType]:
         """List all informatieobjecttypen.
 
-        :arg catalogus: the catalogus URL the informatieobjecttypen should belong to.
+        :param catalogus: the catalogus URL the informatieobjecttypen should belong to.
         """
         params: InformatieObjectTypeListParams = {}
         if catalogus:

--- a/src/openforms/dmn/service.py
+++ b/src/openforms/dmn/service.py
@@ -22,12 +22,12 @@ def evaluate_dmn(
     """
     Evaluate the decision definition using the spefified plugin.
 
-    :arg plugin_id: identifier of the plugin to use for evaluation
-    :arg definition_id: identifier of the decision definition to evaluate
-    :arg version: optional version of the definition to evaluate, if supported. If
+    :param plugin_id: identifier of the plugin to use for evaluation
+    :param definition_id: identifier of the decision definition to evaluate
+    :param version: optional version of the definition to evaluate, if supported. If
       versioning is supported but no version is specified, the latest version should be
       used.
-    :arg input_values: A mapping of variable name -> variable value, used as input
+    :param input_values: A mapping of variable name -> variable value, used as input
       variables for the evaluation.
     :returns: A mapping of name -> value output variables.
     """

--- a/src/openforms/formio/dynamic_config/__init__.py
+++ b/src/openforms/formio/dynamic_config/__init__.py
@@ -26,13 +26,13 @@ def rewrite_formio_components(
     """
     Loop over the formio configuration and mutate components in place.
 
-    :arg configuration_wrapper: Container object holding the Formio form configuration
+    :param configuration_wrapper: Container object holding the Formio form configuration
       to be updated (if applicable). The rewriting loops over all components one-by-one
       and applies the changes.
-    :arg submission: The submission instance for which we are rewriting the
+    :param submission: The submission instance for which we are rewriting the
       configurations. This allows you to inspect state and use convenience methods
       that may not be available in the variables data.
-    :arg data: key-value mapping of variable name to variable value. If a submission
+    :param data: key-value mapping of variable name to variable value. If a submission
       context is available, the variables of the submission are included here.
     """
     data = data or FormioData()  # normalize

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -345,9 +345,9 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         """
         Apply component translations for the provided language code.
 
-        :arg component: Form.io component definition to localize
-        :arg language_code: the language code of the language to translate to
-        :arg enabled: whether translations are enabled or not. If translations are not
+        :param component: Form.io component definition to localize
+        :param language_code: the language code of the language to translate to
+        :param enabled: whether translations are enabled or not. If translations are not
           enabled, the translation information should still be stripped from the
           component definition(s).
         """

--- a/src/openforms/formio/tests/assertions.py
+++ b/src/openforms/formio/tests/assertions.py
@@ -19,9 +19,9 @@ class FormioMixin:
         """
         Assert that the formio component with specified key has the expected properties.
 
-        :arg configuration: Formio form configuration
-        :arg key: the unique key of the component to check
-        :arg properties_map: a mapping of formio property name to expected property
+        :param configuration: Formio form configuration
+        :param key: the unique key of the component to check
+        :param properties_map: a mapping of formio property name to expected property
           value. Note that the dict keys can be dotted paths for nested properties.
         """
         component = _get_component(configuration, key)

--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -77,9 +77,9 @@ def inject_variables(
     component is checked for properties that can be templated. Note that the
     configuration is mutated in the process!
 
-    :arg configuration: A dictionary containing the static Formio configuration (from
+    :param configuration: A dictionary containing the static Formio configuration (from
       the form designer)
-    :arg values: A mapping of variable key to its value (Python native objects)
+    :param values: A mapping of variable key to its value (Python native objects)
     :returns: None - this function mutates the datastructures in place
 
     .. todo:: Support getting non-string based configuration from variables, such as

--- a/src/openforms/forms/migration_operations.py
+++ b/src/openforms/forms/migration_operations.py
@@ -46,9 +46,9 @@ class ConvertComponentsOperation(migrations.RunPython):
     """
     Generate a data migration to apply component conversion.
 
-    :arg component_type: The form.io component type, e.g. "textfield". Only
+    :param component_type: The form.io component type, e.g. "textfield". Only
       components of this type will be targeted.
-    :arg identifier: identifier of the conversion operation, as defined in
+    :param identifier: identifier of the conversion operation, as defined in
       ``CONVERTERS``.
     """
 

--- a/src/openforms/forms/sanitizer.py
+++ b/src/openforms/forms/sanitizer.py
@@ -10,7 +10,7 @@ def sanitize_component(component: Component):
     All tags and attributes that aren't explicitly allowed, are removed from the
     component content.
 
-    :arg component: the component data.
+    :param component: the component data.
     """
     if "tooltip" in component:
         component["tooltip"] = sanitize_html_content(component["tooltip"])

--- a/src/openforms/forms/statistics.py
+++ b/src/openforms/forms/statistics.py
@@ -30,12 +30,12 @@ def export_registration_statistics(
     [start_date, end_date]), optionally filtering them down to a set of forms. Only log
     records for successful registration are considered.
 
-    :arg start_date: include log records starting from this date (midnight, in the local
+    :param start_date: include log records starting from this date (midnight, in the local
       timezone).
-    :arg end_date: include log records until (and including) this date. Log record up to
+    :param end_date: include log records until (and including) this date. Log record up to
       midnight (in the local timezone) the next day are included, i.e.
       ``$date, 23:59:59 999999us``.
-    :arg limit_to_forms: A queryset of forms to limit the export to. If not provided or
+    :param limit_to_forms: A queryset of forms to limit the export to. If not provided or
       ``None`` is given, all forms are included.
     """
     title_mappings = {

--- a/src/openforms/forms/tests/e2e_tests/helpers.py
+++ b/src/openforms/forms/tests/e2e_tests/helpers.py
@@ -17,8 +17,8 @@ async def open_fieldset(page: Page, title: str) -> None:
     """
     Toggle a fieldset from collapsed to open state.
 
-    :arg page: The playwright page to find elements in.
-    :arg title: The heading/title of the fieldset displayed on the page, inside the
+    :param page: The playwright page to find elements in.
+    :param title: The heading/title of the fieldset displayed on the page, inside the
       summary element.
     """
     toggle_summary = page.get_by_role("heading", level=2, name=title)
@@ -68,9 +68,9 @@ async def enter_json_in_editor(
     """
     Put some JSON into a monaca-json-editor instance.
 
-    :arg locator: The locator (`page.locator(".monaco-editor")`) pointing to the
+    :param locator: The locator (`page.locator(".monaco-editor")`) pointing to the
       editor instance.
-    :arg expression: The JSON expression. Will be serialized to JSON before putting it
+    :param expression: The JSON expression. Will be serialized to JSON before putting it
       in the input.
     """
     # copy-and-paste does work on Webkit, but I can't get selecting all editor content

--- a/src/openforms/registrations/contrib/objects_api/handlers/v2.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v2.py
@@ -69,18 +69,18 @@ def process_mapped_variable(
     values are translated before they end up in the Objects API record. Often, these
     transformations are dependent on the component type being processed.
 
-    :arg mapping: The mapping of form variable to destination path, including possible
+    :param mapping: The mapping of form variable to destination path, including possible
       component-specific configuration options that influence the mapping behaviour.
-    :arg value: The raw value of the form variable for the submission being processed.
+    :param value: The raw value of the form variable for the submission being processed.
       The type/shape of the value depends on the variable/component data type being
       processed and even the component configuration (such as multiple True/False).
-    :arg transform_to_list: Component keys in this list will be sent as an array of
+    :param transform_to_list: Component keys in this list will be sent as an array of
       values rather than the default object-shape for selectboxes components.
-    :arg variable: Corresponding submission value variable, will be ``None`` for
+    :param variable: Corresponding submission value variable, will be ``None`` for
       registration variables.
-    :arg component: If the variable corresponds to a Formio component, the component
+    :param component: If the variable corresponds to a Formio component, the component
       definition is provided, otherwise ``None``.
-    :arg attachment_urls: The registration plugin uploads attachments to a Documents API
+    :param attachment_urls: The registration plugin uploads attachments to a Documents API
       and provides the API resource URL for each attachment. Keys are the data paths in
       the (Formio) submission data, e.g. `myAttachment` or ``repeatingGroups.2.file``.
 

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -75,7 +75,7 @@ def _resolve_documenttype(
     """
     Given the registration options, resolve the documenttype URL to use.
 
-    :arg field: for which kind of upload the document type must be resolved.
+    :param field: for which kind of upload the document type must be resolved.
     :return: the resolved document type URL, if any. Empty string means that the upload
       should be skipped.
     """

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -38,8 +38,8 @@ def get_rules_to_evaluate(
     """
     Given a submission, return the logic rules ready for evaluation.
 
-    :arg submission: A submission instance to retrieve the rules for
-    :arg current_step: The (optional) step at which the rules need to be evaluated.
+    :param submission: A submission instance to retrieve the rules for
+    :param current_step: The (optional) step at which the rules need to be evaluated.
     :returns: An iterable of :class`openforms.forms.models.FormLogic` instances. This
       may be a queryset, but could also be a list.
     """
@@ -57,8 +57,8 @@ def get_rules_to_evaluate_old(
 
     As a side-effect, the form logic query results are cached on ``submission.form``.
 
-    :arg submission: A submission instance to retrieve the rules for
-    :arg current_step: The (optional) step at which the rules need to be evaluated. If
+    :param submission: A submission instance to retrieve the rules for
+    :param current_step: The (optional) step at which the rules need to be evaluated. If
       not provided, the step following the last completed step is used, or the first
       step in the form if there are no completed steps.
     :returns: An iterable of :class`openforms.forms.models.FormLogic` instances. This
@@ -105,8 +105,8 @@ def get_rules_to_evaluate_new(
 
     The logic rules are fetched from a many-to-many field on the form step.
 
-    :arg submission: A submission instance to retrieve the rules for
-    :arg current_step: The (optional) step at which the rules need to be evaluated. If
+    :param submission: A submission instance to retrieve the rules for
+    :param current_step: The (optional) step at which the rules need to be evaluated. If
       not provided, the step following the last completed step is used, or the first
       step in the form if there are no completed steps.
     :returns: An iterable of :class`openforms.forms.models.FormLogic` instances. This
@@ -137,7 +137,7 @@ def get_current_step(submission: Submission) -> SubmissionStep | None:
 
     If the last completed step is the last step in the form, then this step is returned.
 
-    :arg submission: The submission instance to get the current step for.
+    :param submission: The submission instance to get the current step for.
     :returns: None if there are no steps in the form, otherwise the first submission
       step that isn't completed.
     """
@@ -177,13 +177,13 @@ def iter_evaluate_rules(
     action operator that updates a variable is processed immediately. The caller is
     responsible for processing (all other) actions accordingly.
 
-    :arg rules: An iterable of form logic rules to evaluate.
-    :arg data: Mapping from variable key to variable value (native Python types), for
+    :param rules: An iterable of form logic rules to evaluate.
+    :param data: Mapping from variable key to variable value (native Python types), for
       all variables present in the :class:`SubmissionValueVariableState`. This data
       structure is updated after every mutation.
-    :arg configuration: Formio configuration wrapper of a step.
-    :arg submission: Submission instance.
-    :arg initial_data: Initial data for clear-on-hide behavior.
+    :param configuration: Formio configuration wrapper of a step.
+    :param submission: Submission instance.
+    :param initial_data: Initial data for clear-on-hide behavior.
     :returns: An iterator yielding :class:`ActionOperation` instances.
     """
     state = submission.load_submission_value_variables_state()

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -341,7 +341,7 @@ class SubmissionValueVariablesState:
         Note: we do not perform any conversions to the native Python types here, this is
         done when fetching the data from the state using ``.get_data()``
 
-        :arg data: mapping of variable key to value.
+        :param data: mapping of variable key to value.
         """
         for key, variable in self.variables.items():
             new_value = data.get(key, default=empty)

--- a/src/openforms/submissions/signals.py
+++ b/src/openforms/submissions/signals.py
@@ -24,9 +24,9 @@ submission_start = Signal()
 Signal creation of a new :class:`openforms.models.Submission` instance.
 
 Provides:
-    :arg instance: The :class:`openforms.models.Submission` instance created.
-    :arg request: the HttpRequest instance (or DRF wrapper around it).
-    :arg anonymous: boolean indicating if the user is logged in or not.
+    :param instance: The :class:`openforms.models.Submission` instance created.
+    :param request: the HttpRequest instance (or DRF wrapper around it).
+    :param anonymous: boolean indicating if the user is logged in or not.
 """
 
 submission_resumed = Signal()
@@ -34,8 +34,8 @@ submission_resumed = Signal()
 Signal resumption of an existing :class:`openforms.models.Submission` instance.
 
 Provides:
-    :arg instance: The :class:`openforms.models.Submission` instance created.
-    :arg request: the HttpRequest instance (or DRF wrapper around it).
+    :param instance: The :class:`openforms.models.Submission` instance created.
+    :param request: the HttpRequest instance (or DRF wrapper around it).
 """
 
 
@@ -44,7 +44,7 @@ submission_complete = Signal()
 Signal completion of a :class:`openforms.models.Submission` instance.
 
 Provides:
-    :arg request: the HttpRequest instance (or DRF wrapper around it).
+    :param request: the HttpRequest instance (or DRF wrapper around it).
 """
 
 submission_cosigned = Signal()
@@ -52,8 +52,8 @@ submission_cosigned = Signal()
 Signal that a :class:`openforms.models.Submission` instance has been co-signed.
 
 Provides:
-    :arg submission: the :class:`openforms.models.Submission` instance.
-    :arg request: the HttpRequest instance (or DRF wrapper around it).
+    :param submission: the :class:`openforms.models.Submission` instance.
+    :param request: the HttpRequest instance (or DRF wrapper around it).
 """
 
 

--- a/src/openforms/template/__init__.py
+++ b/src/openforms/template/__init__.py
@@ -52,11 +52,11 @@ def render_from_string(
     """
     Render a template source string using the provided context.
 
-    :arg source: The template source to render
-    :arg context: The context data for the template to render
-    :arg backend: An optional alternative Django template backend instance to use.
+    :param source: The template source to render
+    :param context: The context data for the template to render
+    :param backend: An optional alternative Django template backend instance to use.
       Defaults to the sandboxed backend.
-    :arg disable_autoescape: Disable escaping of HTML in ``source``.
+    :param disable_autoescape: Disable escaping of HTML in ``source``.
     :raises: :class:`django.template.TemplateSyntaxError` if the template source is
       invalid
     """

--- a/src/openforms/tests/e2e/base.py
+++ b/src/openforms/tests/e2e/base.py
@@ -143,9 +143,9 @@ async def rs_select_option(
     """
     Select the option with specified label in the react-select dropdown.
 
-    :arg dropdown: The react select dropdown, e.g.
+    :param dropdown: The react select dropdown, e.g.
         ``page.get_by_role("combobox", name="<label>")``.
-    :arg option_label: The label text of the option to select.
+    :param option_label: The label text of the option to select.
     """
     page = dropdown.page
     dropdown_root = dropdown.locator("xpath=../../../..")

--- a/src/openforms/tests/e2e/input_validation_base.py
+++ b/src/openforms/tests/e2e/input_validation_base.py
@@ -77,11 +77,11 @@ class ValidationsTestCase(SubmissionsMixin, E2ETestCase):
         cannot handle array/null datatypes etc. so the backend may be stricter to some
         extent.
 
-        :arg component: Given the component definition, create a form instance and use
+        :param component: Given the component definition, create a form instance and use
           this for both the end-to-end test with playwright and the django test client
           assertions to check for validation issues.
-        :arg ui_input: Input to enter in the field with playwright.
-        :arg expected_ui_error: Content of the validation error to be expected in the
+        :param ui_input: Input to enter in the field with playwright.
+        :param expected_ui_error: Content of the validation error to be expected in the
           playwright test.
         """
         form = create_form(component)

--- a/src/openforms/utils/decorators.py
+++ b/src/openforms/utils/decorators.py
@@ -42,7 +42,7 @@ def conditional_search_engine_index(config_attr: str, content="noindex, nofollow
 
     If indexing is not allowed, the X_ROBOTS_TAG_HEADER will be emitted in the response.
 
-    :arg config_attr: Name of the configuration attribute from the
+    :param config_attr: Name of the configuration attribute from the
       :class:`GlobalConfiguration` class.
     """
 

--- a/src/openforms/utils/sanitizer.py
+++ b/src/openforms/utils/sanitizer.py
@@ -188,7 +188,7 @@ def sanitize_svg_file(data: File) -> File:
     The entire file content will be replaced with a sanitized version. All tags and
     attributes that aren't explicitly allowed, are removed from the SVG content.
 
-    :arg data: the uploaded SVG file, opened in binary mode.
+    :param data: the uploaded SVG file, opened in binary mode.
     """
     # Making sure that the file is reset properly
     data.seek(0)
@@ -215,7 +215,7 @@ def sanitize_svg_content(svg_content: str) -> str:
     All tags and attributes that aren't explicitly allowed, are removed from the SVG
     content.
 
-    :arg svg_content: decoded SVG content.
+    :param svg_content: decoded SVG content.
 
     .. warning:: Do not use in security-critical contexts - using nh3 or bleach for
        SVG content sanitizing is best-effort and not what it's made for.
@@ -241,7 +241,7 @@ def sanitize_html_content(html_content: str) -> str:
     The provided string is replaced by a html sanitized version. All tags and attributes
     that aren't explicitly allowed, are removed from the SVG content.
 
-    :arg html_content: the html string to sanitize.
+    :param html_content: the html string to sanitize.
     """
     return nh3.clean(
         html_content,

--- a/src/openforms/utils/urls.py
+++ b/src/openforms/utils/urls.py
@@ -25,9 +25,9 @@ def build_absolute_uri(location: str, request: AnyRequest | None = None):
     If no request argument is provided, the fully qualified URI is constructed via
     :attr:`settings.BASE_URL`.
 
-    :arg location: the path to make absolute, without protocol, netloc or port number.
+    :param location: the path to make absolute, without protocol, netloc or port number.
       Assumed to be an absolute path.
-    :arg request: optionally - the current request object. If provided,
+    :param request: optionally - the current request object. If provided,
       :meth:`request.build_absolute_uri` is called.
     """
     if request:
@@ -80,13 +80,13 @@ def reverse_plus(
     If `make_absolute` is True and no `request` argument is provided, the fully qualified URI is constructed via
     :attr:`settings.BASE_URL`.
 
-    :arg name: the URL name to reverse.
-    :arg args: optionally - arg-argument to reverse().
-    :arg kwargs: optionally - kwargs-argument to reverse().
-    :arg request: optionally - the current request object. If provided,
+    :param name: the URL name to reverse.
+    :param args: optionally - arg-argument to reverse().
+    :param kwargs: optionally - kwargs-argument to reverse().
+    :param request: optionally - the current request object. If provided,
       :meth:`request.build_absolute_uri` is called.
-    :arg query: optionally - add key/values as URL GET parameter
-    :arg make_absolute: optionally - disable absolute URL
+    :param query: optionally - add key/values as URL GET parameter
+    :param make_absolute: optionally - disable absolute URL
     """
     location = reverse(
         name,
@@ -109,7 +109,7 @@ def is_admin_request(request: AnyRequest) -> bool:
     """
     Checks whether a request is made from the admin
 
-    :arg request: the request object to be checked.
+    :param request: the request object to be checked.
     """
     admin_path_prefix = reverse("admin:index")
     if request.path_info.startswith(admin_path_prefix):


### PR DESCRIPTION
For consistency (param is used more frequently)

[skip: e2e]

**Changes**

See title

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
