### PR TITLE
[#5216] prevent multiple emails being sent after payment status update

### DIFF
--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -237,8 +237,11 @@ class EmailRegistration(BasePlugin[Options]):
 
     def update_payment_status(self, submission: "Submission", options: Options):
         recipients = options.get("payment_emails")
+        config = GlobalConfiguration.get_solo()
 
-        if not recipients:
+        if config.wait_for_payment_to_register and not recipients:
+            return
+        elif not recipients:
             recipients = self.get_recipients(submission, options)
 
         order_ids = submission.payments.get_completed_public_order_ids()

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -693,6 +693,35 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         # check we used the payment_emails
         self.assertEqual(message.to, ["foo@example.com"])
 
+    def test_register_and_update_paid_product_without_payment_email_recipients(self):
+        """
+        Test that whenever the `wait_for_payment_to_register` global configuration option
+        is enabled and no payment emails were configured for the form, no payment
+        update emails were sent.
+        """
+        config = GlobalConfiguration.get_solo()
+        config.wait_for_payment_to_register = True
+        config.save()
+
+        submission = SubmissionFactory.from_data(
+            {"voornaam": "Foo"},
+            form__product__price=Decimal("11.35"),
+            form__payment_backend="demo",
+            registration_success=True,
+            public_registration_reference="XYZ",
+        )
+        assert submission.payment_required
+        email_form_options: Options = {
+            "to_emails": ["foo@bar.nl", "bar@foo.nl"],
+            # payment_emails must override to_emails
+            "payment_emails": [],
+            "attach_files_to_email": None,
+        }
+        plugin = EmailRegistration("email")
+        plugin.update_payment_status(submission, email_form_options)
+
+        self.assertEqual(len(mail.outbox), 0)
+
     @override_settings(DEFAULT_FROM_EMAIL="info@open-forms.nl")
     def test_submission_with_email_backend_export_csv_xlsx(self):
         email_form_options: Options = {


### PR DESCRIPTION
Closes #5216
 
[skip: e2e]

**Changes**

Previously, when `wait_for_payment_to_register` was set to `True` and no payment email addresses were configured (in the email plugin configuration options) for a form, the same email was sent twice to the same email address. The changes in this commit prevent the email plugin from sending the email in these situations.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
