### PR TITLE
[#5864] Form history shows wrong warning

### DIFF
--- a/src/openforms/js/components/admin/form_versions/FormVersionsTable.js
+++ b/src/openforms/js/components/admin/form_versions/FormVersionsTable.js
@@ -12,14 +12,15 @@ import {FORM_ENDPOINT} from 'components/admin/form_design/constants';
 import {WarningIcon} from 'components/admin/icons';
 import {get, post} from 'utils/fetch';
 
-const checkVersionsCompatible = (version1, version2) => {
+export const checkVersionsCompatible = (version1, version2) => {
   // if any of the versions is empty, we can't reach any conclusions
   if (!version1 || !version2) return true;
   // if we get non-semver versions -> check for strict equality
   if (!semverValid(version1) || !semverValid(version2)) return version1 === version2;
   const diffLevel = semverDiff(version1, version2);
+  // current version should be ok
   // patch releases are backwards compatible
-  return diffLevel === 'patch';
+  return diffLevel === null || diffLevel === 'patch';
 };
 
 const FormVersionsTable = ({formUuid, currentRelease}) => {

--- a/src/openforms/js/components/admin/form_versions/FormVersionsTable.spec.js
+++ b/src/openforms/js/components/admin/form_versions/FormVersionsTable.spec.js
@@ -1,0 +1,14 @@
+import {checkVersionsCompatible} from './FormVersionsTable';
+
+// showing a warning depends on the combination of the app and the current release
+// test same versions and patch, minor and  major versions
+test.each([
+  ['3.3.4', '3.3.4', true],
+  ['3.3.4', '3.3.7', true],
+  ['3.3.4', '3.4.1', false],
+  ['3.3.4', '4.1.0', false],
+])('version compatibility', (appRelease, currentRelease, expected) => {
+  const result = checkVersionsCompatible(appRelease, currentRelease);
+
+  expect(result).toBe(expected);
+});


### PR DESCRIPTION
Closes #5864

**Changes**

- Do not show warning when the application version is the current one. Before that, we were only checking if the two versions  are different in order to show a warning.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
