### PR TITLE
Extend themes api endpoint response

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -11109,9 +11109,14 @@ components:
           description: An easily recognizable name for the theme, used to identify
             it.
           maxLength: 100
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
       required:
       - name
       - url
+      - uuid
     Time:
       type: object
       properties:

--- a/src/openforms/config/api/serializers.py
+++ b/src/openforms/config/api/serializers.py
@@ -33,7 +33,7 @@ class PrivacyPolicyInfoSerializer(serializers.Serializer):
 class ThemeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = Theme
-        fields = ("url", "name")
+        fields = ("url", "name", "uuid")
         extra_kwargs = {
             "url": {
                 "view_name": "api:themes-detail",

--- a/src/openforms/config/tests/test_api_themes.py
+++ b/src/openforms/config/tests/test_api_themes.py
@@ -65,6 +65,7 @@ class ThemesAPITests(APITestCase):
             data,
             {
                 "url": f"http://testserver{url}",
+                "uuid": str(theme.uuid),
                 "name": "A team",
             },
         )
@@ -81,6 +82,7 @@ class ThemesAPITests(APITestCase):
         self.assertEqual(len(data), 5)
         self.assertIsInstance(data, list)  # no pagination dict
         self.assertIn("url", data[0])
+        self.assertIn("uuid", data[0])
         self.assertIn("name", data[0])
 
     def test_create_form_with_theme(self):


### PR DESCRIPTION
Closes #6080

**Changes**

Added uuid to the response data of the v2 themes api endpoint.

The v3 update form api endpoint expects the `theme` value to be the uuid of a Theme object. The new admin-ui will use the v2 themes api endpoint to provide this information to the frontend. The current response of the v2 themes api is a list of theme names and urls. The urls do contain their uuids, but stripping this information might get messy/prone to bugs.

By adding the uuid to the response data, the frontend can more easily create the UI and pass the correct information back to the backend.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
