### PR TITLE
[#5716] api documentation doesnt mentions location header

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+©: 3.0.3
 info:
   title: Open Forms API
   version: 3.5.0
@@ -1042,12 +1042,11 @@ paths:
       - cookieAuth: []
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FormDefinition'
-          description: ''
           headers:
+            Location:
+              schema:
+                type: string
+              description: URL of the newly created resource.
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
             X-CSRFToken:
@@ -1056,6 +1055,11 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormDefinition'
+          description: ''
   /api/v2/form-definitions/{uuid}:
     get:
       operationId: form_definitions_retrieve
@@ -1452,12 +1456,11 @@ paths:
       - cookieAuth: []
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Form'
-          description: ''
           headers:
+            Location:
+              schema:
+                type: string
+              description: URL of the newly created resource.
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
             X-CSRFToken:
@@ -1466,6 +1469,11 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Form'
+          description: ''
   /api/v2/forms-import:
     post:
       operationId: forms_import_create
@@ -1576,12 +1584,11 @@ paths:
       - cookieAuth: []
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FormStep'
-          description: ''
           headers:
+            Location:
+              schema:
+                type: string
+              description: URL of the newly created resource.
             X-Session-Expires-In:
               $ref: '#/components/headers/X-Session-Expires-In'
             X-CSRFToken:
@@ -1590,6 +1597,11 @@ paths:
               $ref: '#/components/headers/X-Is-Form-Designer'
             Content-Language:
               $ref: '#/components/headers/Content-Language'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormStep'
+          description: ''
   /api/v2/forms/{form_uuid_or_slug}/steps/{uuid}:
     get:
       operationId: forms_steps_retrieve

--- a/src/openforms/api/schema.py
+++ b/src/openforms/api/schema.py
@@ -1,7 +1,42 @@
+from django.utils.translation import gettext_lazy as _
+
 from drf_spectacular.openapi import AutoSchema as _AutoSchema
+from drf_spectacular.plumbing import force_instance
+from drf_spectacular.utils import OpenApiParameter
+from rest_framework import status
+from rest_framework.settings import api_settings
 
 
 class AutoSchema(_AutoSchema):
     # Subclassed because we often end up hooking into the schema generator. This
     # provides the plumbing.
-    pass
+
+    def get_override_parameters(self):
+        params = super().get_override_parameters()
+
+        if self._is_create_operation() and self._serializer_has_url_field():
+            params = params + [
+                OpenApiParameter(
+                    name="Location",
+                    type=str,
+                    location=OpenApiParameter.HEADER,
+                    description=_("URL of the newly created resource."),
+                    response=[status.HTTP_201_CREATED],
+                    required=False,
+                )
+            ]
+
+        return params
+
+    def _serializer_has_url_field(self) -> bool:
+        from rest_framework.serializers import ListSerializer, Serializer
+
+        serializer = force_instance(self.get_response_serializers())
+        # Only plain Serializer instances have a fields mapping; ListSerializer,
+        # BaseSerializer and Field subclasses do not.
+        if not isinstance(serializer, Serializer) or isinstance(
+            serializer, ListSerializer
+        ):
+            return False
+        fields: dict = getattr(serializer, "fields", {})
+        return api_settings.URL_FIELD_NAME in fields

--- a/src/openforms/api/schema.py
+++ b/src/openforms/api/schema.py
@@ -1,7 +1,12 @@
+from collections.abc import Mapping
+
+from django.utils.translation import gettext_lazy as _
+
 from drf_spectacular.openapi import AutoSchema as _AutoSchema
 from drf_spectacular.plumbing import force_instance
 from drf_spectacular.utils import OpenApiParameter
-from rest_framework import status
+from rest_framework import serializers, status
+from rest_framework.serializers import ListSerializer, Serializer
 from rest_framework.settings import api_settings
 
 
@@ -12,27 +17,23 @@ class AutoSchema(_AutoSchema):
     def get_override_parameters(self):
         params = super().get_override_parameters()
 
-        if self._is_create_operation() and self._serializer_has_url_field():
+        if self._is_create_operation() and self.serializer_has_url_field():
             params = params + [
                 OpenApiParameter(
                     name="Location",
                     type=str,
                     location=OpenApiParameter.HEADER,
-                    description="URL of the newly created resource.",
+                    description=_("URL of the newly created resource."),
                     response=[status.HTTP_201_CREATED],
-                    required=False,
+                    required=True,
                 )
             ]
 
         return params
 
-    def _serializer_has_url_field(self) -> bool:
-        from rest_framework.serializers import ListSerializer, Serializer
-
+    def serializer_has_url_field(self) -> bool:
         serializer = force_instance(self.get_response_serializers())
-        if not isinstance(serializer, Serializer) or isinstance(
-            serializer, ListSerializer
-        ):
+        if not isinstance(serializer, Serializer | ListSerializer):
             return False
-        fields: dict = getattr(serializer, "fields", {})
+        fields: Mapping[str, serializers.Field] = serializer.fields
         return api_settings.URL_FIELD_NAME in fields

--- a/src/openforms/api/schema.py
+++ b/src/openforms/api/schema.py
@@ -1,5 +1,3 @@
-from django.utils.translation import gettext_lazy as _
-
 from drf_spectacular.openapi import AutoSchema as _AutoSchema
 from drf_spectacular.plumbing import force_instance
 from drf_spectacular.utils import OpenApiParameter
@@ -20,7 +18,7 @@ class AutoSchema(_AutoSchema):
                     name="Location",
                     type=str,
                     location=OpenApiParameter.HEADER,
-                    description=_("URL of the newly created resource."),
+                    description="URL of the newly created resource.",
                     response=[status.HTTP_201_CREATED],
                     required=False,
                 )
@@ -32,8 +30,6 @@ class AutoSchema(_AutoSchema):
         from rest_framework.serializers import ListSerializer, Serializer
 
         serializer = force_instance(self.get_response_serializers())
-        # Only plain Serializer instances have a fields mapping; ListSerializer,
-        # BaseSerializer and Field subclasses do not.
         if not isinstance(serializer, Serializer) or isinstance(
             serializer, ListSerializer
         ):

--- a/src/openforms/api/tests/test_location_header_in_schema.py
+++ b/src/openforms/api/tests/test_location_header_in_schema.py
@@ -69,9 +69,7 @@ class GetOverrideParametersTests(TestCase):
         schema.view = MagicMock()
         schema.method = "POST" if is_create else "GET"
         with (
-            patch.object(
-                schema, "_is_create_operation", return_value=is_create
-            ),
+            patch.object(schema, "_is_create_operation", return_value=is_create),
             patch.object(
                 schema, "_serializer_has_url_field", return_value=has_url_field
             ),
@@ -108,7 +106,9 @@ class LocationHeaderSchemaIntegrationTests(TestCase):
         list_create = paths["/form-definitions/"]
         detail = paths["/form-definitions/{uuid}/"]
 
-        self.assertIn("Location", list_create["post"]["responses"]["201"].get("headers", {}))
+        self.assertIn(
+            "Location", list_create["post"]["responses"]["201"].get("headers", {})
+        )
 
         for method, responses in [
             ("get", list_create["get"]["responses"]),

--- a/src/openforms/api/tests/test_location_header_in_schema.py
+++ b/src/openforms/api/tests/test_location_header_in_schema.py
@@ -2,122 +2,100 @@
 
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
+from django.urls import path
 
 from drf_spectacular.generators import SchemaGenerator
-from rest_framework import routers, serializers
+from rest_framework import serializers
+from rest_framework.generics import CreateAPIView
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from openforms.api.schema import AutoSchema
 
 
-def generate_schema(route, viewset):
-    router = routers.SimpleRouter()
-    router.register(route, viewset, basename=route)
-    generator = SchemaGenerator(patterns=router.urls)
+def generate_schema(urlpatterns):
+    generator = SchemaGenerator(patterns=urlpatterns)
     return generator.get_schema(request=None, public=True)
 
 
-class _WithUrlSerializer(serializers.Serializer):
+class WithUrlSerializer(serializers.Serializer):
     url = serializers.URLField()
     name = serializers.CharField()
 
 
-class _WithoutUrlSerializer(serializers.Serializer):
+class WithoutUrlSerializer(serializers.Serializer):
     name = serializers.CharField()
 
 
-class SerializerHasUrlFieldTests(TestCase):
-    """Unit tests for AutoSchema._serializer_has_url_field."""
+class DummyCreateView(CreateAPIView):
+    serializer_class = WithUrlSerializer
+    schema = AutoSchema()
 
-    def _make_schema(self, serializer):
+
+class DummyPlainView(APIView):
+    schema = AutoSchema()
+
+    def post(self, request):
+        return Response({"url": "", "name": ""}, status=201)
+
+
+class SerializerHasUrlFieldTests(SimpleTestCase):
+    """Unit tests for AutoSchema.serializer_has_url_field."""
+
+    def check_schema_has_url_field(self, serializer) -> bool:
         schema = AutoSchema()
         schema.view = MagicMock()
         schema.method = "POST"
         with patch.object(schema, "get_response_serializers", return_value=serializer):
-            return schema._serializer_has_url_field()
+            return schema.serializer_has_url_field()
 
     def test_serializer_with_url_field(self):
-        self.assertTrue(self._make_schema(_WithUrlSerializer()))
+        self.assertTrue(self.check_schema_has_url_field(WithUrlSerializer()))
 
     def test_serializer_without_url_field(self):
-        self.assertFalse(self._make_schema(_WithoutUrlSerializer()))
+        self.assertFalse(self.check_schema_has_url_field(WithoutUrlSerializer()))
 
     def test_list_serializer_is_excluded(self):
         # ListSerializer wraps a child — should return False even if child has url
-        list_ser = serializers.ListSerializer(child=_WithUrlSerializer())
-        self.assertFalse(self._make_schema(list_ser))
+        list_ser = serializers.ListSerializer(child=WithUrlSerializer())
+        self.assertFalse(self.check_schema_has_url_field(list_ser))
 
     def test_base_serializer_is_excluded(self):
         # BaseSerializer has no .fields — should return False
         base_ser = serializers.BaseSerializer()
-        self.assertFalse(self._make_schema(base_ser))
+        self.assertFalse(self.check_schema_has_url_field(base_ser))
 
     def test_serializer_class_accepted(self):
         # force_instance should instantiate the class; class with url → True
-        self.assertTrue(self._make_schema(_WithUrlSerializer))
+        self.assertTrue(self.check_schema_has_url_field(WithUrlSerializer))
 
     def test_none_response_serializer(self):
         # Some views return no serializer
-        self.assertFalse(self._make_schema(None))
+        self.assertFalse(self.check_schema_has_url_field(None))
 
 
-class GetOverrideParametersTests(TestCase):
-    """Unit tests for the Location header injection in get_override_parameters."""
-
-    def _get_location_param(self, is_create, has_url_field):
-        schema = AutoSchema()
-        schema.view = MagicMock()
-        schema.method = "POST" if is_create else "GET"
-        with (
-            patch.object(schema, "_is_create_operation", return_value=is_create),
-            patch.object(
-                schema, "_serializer_has_url_field", return_value=has_url_field
-            ),
-        ):
-            params = schema.get_override_parameters()
-        return [p for p in params if getattr(p, "name", None) == "Location"]
-
-    def test_location_added_for_create_with_url_field(self):
-        location_params = self._get_location_param(is_create=True, has_url_field=True)
-        self.assertEqual(len(location_params), 1)
-
-    def test_no_location_for_create_without_url_field(self):
-        location_params = self._get_location_param(is_create=True, has_url_field=False)
-        self.assertEqual(len(location_params), 0)
-
-    def test_no_location_for_non_create_with_url_field(self):
-        location_params = self._get_location_param(is_create=False, has_url_field=True)
-        self.assertEqual(len(location_params), 0)
-
-
-class LocationHeaderSchemaIntegrationTests(TestCase):
-    """Verify Location header presence/absence using a schema built from FormDefinitionViewSet."""
+class LocationHeaderSchemaIntegrationTests(SimpleTestCase):
+    """Verify Location header targets CreateModelMixin, not plain APIViews."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        from openforms.forms.api.viewsets import FormDefinitionViewSet
+        urlpatterns = [
+            path("create/", DummyCreateView.as_view(), name="dummy-create"),
+            path("plain/", DummyPlainView.as_view(), name="dummy-plain"),
+        ]
+        cls.schema = generate_schema(urlpatterns)
 
-        cls.schema = generate_schema("form-definitions", FormDefinitionViewSet)
+    def test_create_view_has_location_header(self):
+        create_op = self.schema["paths"]["/create/"]["post"]
+        self.assertIn("Location", create_op["responses"]["201"].get("headers", {}))
 
-    def test_location_header_only_on_create_responses(self):
-        # POST (create) → Location in 201; GET/PUT/PATCH → absent
-        paths = self.schema["paths"]
-        list_create = paths["/form-definitions/"]
-        detail = paths["/form-definitions/{uuid}/"]
-
-        self.assertIn(
-            "Location", list_create["post"]["responses"]["201"].get("headers", {})
-        )
-
-        for method, responses in [
-            ("get", list_create["get"]["responses"]),
-            ("put", detail.get("put", {}).get("responses", {})),
-            ("patch", detail.get("patch", {}).get("responses", {})),
-        ]:
-            for code, resp in responses.items():
-                self.assertNotIn(
-                    "Location",
-                    resp.get("headers", {}),
-                    f"{method.upper()} {code} should not have Location header",
-                )
+    def test_plain_view_has_no_location_header(self):
+        plain_op = self.schema["paths"]["/plain/"]["post"]
+        for code, resp in plain_op["responses"].items():
+            self.assertNotIn(
+                "Location",
+                resp.get("headers", {}),
+                f"POST {code} on plain APIView should not have Location header",
+            )

--- a/src/openforms/api/tests/test_location_header_in_schema.py
+++ b/src/openforms/api/tests/test_location_header_in_schema.py
@@ -1,0 +1,123 @@
+"""Tests for AutoSchema Location header detection on create operations."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from drf_spectacular.generators import SchemaGenerator
+from rest_framework import routers, serializers
+
+from openforms.api.schema import AutoSchema
+
+
+def generate_schema(route, viewset):
+    router = routers.SimpleRouter()
+    router.register(route, viewset, basename=route)
+    generator = SchemaGenerator(patterns=router.urls)
+    return generator.get_schema(request=None, public=True)
+
+
+class _WithUrlSerializer(serializers.Serializer):
+    url = serializers.URLField()
+    name = serializers.CharField()
+
+
+class _WithoutUrlSerializer(serializers.Serializer):
+    name = serializers.CharField()
+
+
+class SerializerHasUrlFieldTests(TestCase):
+    """Unit tests for AutoSchema._serializer_has_url_field."""
+
+    def _make_schema(self, serializer):
+        schema = AutoSchema()
+        schema.view = MagicMock()
+        schema.method = "POST"
+        with patch.object(schema, "get_response_serializers", return_value=serializer):
+            return schema._serializer_has_url_field()
+
+    def test_serializer_with_url_field(self):
+        self.assertTrue(self._make_schema(_WithUrlSerializer()))
+
+    def test_serializer_without_url_field(self):
+        self.assertFalse(self._make_schema(_WithoutUrlSerializer()))
+
+    def test_list_serializer_is_excluded(self):
+        # ListSerializer wraps a child — should return False even if child has url
+        list_ser = serializers.ListSerializer(child=_WithUrlSerializer())
+        self.assertFalse(self._make_schema(list_ser))
+
+    def test_base_serializer_is_excluded(self):
+        # BaseSerializer has no .fields — should return False
+        base_ser = serializers.BaseSerializer()
+        self.assertFalse(self._make_schema(base_ser))
+
+    def test_serializer_class_accepted(self):
+        # force_instance should instantiate the class; class with url → True
+        self.assertTrue(self._make_schema(_WithUrlSerializer))
+
+    def test_none_response_serializer(self):
+        # Some views return no serializer
+        self.assertFalse(self._make_schema(None))
+
+
+class GetOverrideParametersTests(TestCase):
+    """Unit tests for the Location header injection in get_override_parameters."""
+
+    def _get_location_param(self, is_create, has_url_field):
+        schema = AutoSchema()
+        schema.view = MagicMock()
+        schema.method = "POST" if is_create else "GET"
+        with (
+            patch.object(
+                schema, "_is_create_operation", return_value=is_create
+            ),
+            patch.object(
+                schema, "_serializer_has_url_field", return_value=has_url_field
+            ),
+        ):
+            params = schema.get_override_parameters()
+        return [p for p in params if getattr(p, "name", None) == "Location"]
+
+    def test_location_added_for_create_with_url_field(self):
+        location_params = self._get_location_param(is_create=True, has_url_field=True)
+        self.assertEqual(len(location_params), 1)
+
+    def test_no_location_for_create_without_url_field(self):
+        location_params = self._get_location_param(is_create=True, has_url_field=False)
+        self.assertEqual(len(location_params), 0)
+
+    def test_no_location_for_non_create_with_url_field(self):
+        location_params = self._get_location_param(is_create=False, has_url_field=True)
+        self.assertEqual(len(location_params), 0)
+
+
+class LocationHeaderSchemaIntegrationTests(TestCase):
+    """Verify Location header presence/absence using a schema built from FormDefinitionViewSet."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from openforms.forms.api.viewsets import FormDefinitionViewSet
+
+        cls.schema = generate_schema("form-definitions", FormDefinitionViewSet)
+
+    def test_location_header_only_on_create_responses(self):
+        # POST (create) → Location in 201; GET/PUT/PATCH → absent
+        paths = self.schema["paths"]
+        list_create = paths["/form-definitions/"]
+        detail = paths["/form-definitions/{uuid}/"]
+
+        self.assertIn("Location", list_create["post"]["responses"]["201"].get("headers", {}))
+
+        for method, responses in [
+            ("get", list_create["get"]["responses"]),
+            ("put", detail.get("put", {}).get("responses", {})),
+            ("patch", detail.get("patch", {}).get("responses", {})),
+        ]:
+            for code, resp in responses.items():
+                self.assertNotIn(
+                    "Location",
+                    resp.get("headers", {}),
+                    f"{method.upper()} {code} should not have Location header",
+                )


### PR DESCRIPTION
Closes #5716

**Changes**

Extend `AutoSchema` - Location header is auto-documented for `create` operations

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
