### PR TITLE
Add logic rules to submission step serializer 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Extract SDK version info
         id: sdk-vars
         uses: ./.github/actions/extract-sdk-version
+        with:
+          backend-version: ${{ steps.vars.outputs.version }}
 
   tests:
     name: Run the Django test suite

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7617,19 +7617,6 @@ components:
             %}' instructions. Additionally, you can use the '{% confirmation_summary
             %}' instruction and some additional variables - see the documentation
             for details.
-    ContextAwareFormStep:
-      type: object
-      properties:
-        index:
-          type: integer
-          readOnly: true
-        configuration:
-          type: object
-          additionalProperties: {}
-          readOnly: true
-      required:
-      - configuration
-      - index
     DMNEvaluateAction:
       type: object
       properties:
@@ -8693,6 +8680,24 @@ components:
       - order
       - url
       - uuid
+    FormLogicFrontend:
+      type: object
+      description: Represent logic rules which can be executed in the frontend.
+      properties:
+        jsonLogicTrigger:
+          readOnly: true
+          description: The trigger expression to determine if the actions should execute.
+            Will be (partially) evaluated based on available data.
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogicComponentAction'
+          readOnly: true
+          description: Actions triggered when the trigger expression evaluates to
+            'truthy'.
+      required:
+      - actions
+      - jsonLogicTrigger
     FormModelTranslations:
       type: object
       description: |-
@@ -9763,6 +9768,11 @@ components:
         isApplicable:
           type: boolean
           readOnly: true
+        defaultIsApplicable:
+          type: boolean
+          readOnly: true
+          title: Default 'is applicable' flag
+          description: This flag is directly fetched from the form step.
         completed:
           type: boolean
           readOnly: true
@@ -9772,6 +9782,7 @@ components:
       required:
       - canSubmit
       - completed
+      - defaultIsApplicable
       - formStep
       - id
       - isApplicable
@@ -10919,14 +10930,14 @@ components:
           readOnly: true
           nullable: true
           title: UUID
+        formStepUuid:
+          type: string
+          format: uuid
+          readOnly: true
         slug:
           type: string
           readOnly: true
           pattern: ^[-a-zA-Z0-9_]+$
-        formStep:
-          allOf:
-          - $ref: '#/components/schemas/ContextAwareFormStep'
-          readOnly: true
         data:
           type: object
           additionalProperties: {}
@@ -10940,12 +10951,39 @@ components:
         canSubmit:
           type: boolean
           readOnly: true
+        configuration:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+          description: Form configuration of the corresponding form step, (possibly)
+            mutated by form logic.
+        defaultConfiguration:
+          readOnly: true
+          nullable: true
+          description: Default form configuration of the corresponding form step.
+        requireBackendLogicEvaluation:
+          type: boolean
+          readOnly: true
+          description: Indicates whether the backend is required to execute form logic.
+        logicRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormLogicFrontend'
+          readOnly: true
+          description: Logic rules of the corresponding form step. The JSON logic
+            triggers are partially evaluated with data from user-defined variables,
+            and variables of components from the steps other than the current one.
+            Will be empty if the backend is required to evaluate form logic.
       required:
       - canSubmit
       - completed
-      - formStep
+      - configuration
+      - defaultConfiguration
+      - formStepUuid
       - id
       - isApplicable
+      - logicRules
+      - requireBackendLogicEvaluation
       - slug
     SubmissionStepSummary:
       type: object

--- a/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
@@ -824,7 +824,7 @@ class TestDynamicConfigAddingOptionsForRequest(SubmissionsMixin, APITestCase):
         self.client.force_authenticate(user=user)
 
         response = self.client.get(endpoint, HTTP_X_CSP_NONCE="dGvsa==")
-        formio_components = response.json()["formStep"]["configuration"]["components"]
+        formio_components = response.json()["configuration"]["components"]
 
         with self.subTest("HTML of content component with inline style"):
             component1 = next(

--- a/src/openforms/forms/api/serializers/__init__.py
+++ b/src/openforms/forms/api/serializers/__init__.py
@@ -4,9 +4,11 @@ from .form_definition import FormDefinitionDetailSerializer, FormDefinitionSeria
 from .form_step import FormStepLiteralsSerializer, FormStepSerializer
 from .form_variable import FormVariableListSerializer, FormVariableSerializer
 from .form_version import FormVersionSerializer
+from .logic.action_serializers import LogicComponentActionSerializer
 from .logic.form_logic import FormLogicSerializer
 
 __all__ = [
+    "LogicComponentActionSerializer",
     "FormLogicSerializer",
     "FormSerializer",
     "FormExportSerializer",

--- a/src/openforms/js/components/admin/form_design/FormLogic.stories.js
+++ b/src/openforms/js/components/admin/form_design/FormLogic.stories.js
@@ -375,6 +375,19 @@ export const WithLogicRuleAnalysis = {
           },
         ],
       },
+      {
+        uuid: 'baz',
+        _generatedId: 'baz',
+        _logicType: 'simple',
+        form: 'http://localhost:8000/api/v2/forms/ae26e20c-f059-4fdf-bb82-afc377869bb5',
+        description: 'New logic rule',
+        _mayGenerateDescription: false,
+        order: 2,
+        jsonLogicTrigger: {},
+        isAdvanced: true,
+        formSteps: [],
+        actions: [],
+      },
     ],
 
     availableFormVariables: AVAILABLE_FORM_VARIABLES,
@@ -390,5 +403,6 @@ export const WithLogicRuleAnalysis = {
     expect(
       await canvas.findByText('Deze regel wordt uitgevoerd in stap(pen): Step 1, Step 2')
     ).toBeVisible();
+    expect(canvas.getByDisplayValue('New logic rule')).toBeVisible();
   },
 };

--- a/src/openforms/js/components/admin/form_design/StepSelection.js
+++ b/src/openforms/js/components/admin/form_design/StepSelection.js
@@ -54,12 +54,11 @@ const useFormStep = (identifier = '') => {
  * Look up multiple form steps in the form context by identifiers.
  *
  * @param  {Array[string]} identifiers  Array of URL for persisted steps or generated ID for non-persisted steps.
- * @return {Array[Object]|null}  Array of objects with the step instances from the context, or null if no identifiers were provided.
+ * @return {Array[Object]}  Array of objects with the step instances from the context, empty if no identifiers were provided.
  */
 const useFormSteps = (identifiers = []) => {
   const formContext = useContext(FormContext);
   const formSteps = formContext.formSteps;
-  if (identifiers.length === 0) return null;
 
   const steps = [];
   for (const identifier of identifiers) {

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -87,6 +87,12 @@ class NestedSubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             "form_uuid_or_slug": "submission__form__uuid",
         },
     )
+    default_is_applicable = serializers.BooleanField(
+        source="form_step.is_applicable",
+        label=_("Default 'is applicable' flag"),
+        help_text=_("This flag is directly fetched from the form step."),
+        read_only=True,
+    )
 
     class Meta:
         model = SubmissionStep
@@ -96,6 +102,7 @@ class NestedSubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             "url",
             "form_step",
             "is_applicable",
+            "default_is_applicable",
             "completed",
             "can_submit",
         )

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -27,7 +27,6 @@ from openforms.formio.service import FormioData, build_serializer
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
 from openforms.forms.constants import SubmissionAllowedChoices
-from openforms.forms.models import FormStep
 from openforms.forms.validators import validate_not_deleted
 from openforms.utils.urls import build_absolute_uri
 
@@ -211,36 +210,8 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer[Submission]):
         return super().to_representation(instance)
 
 
-class ContextAwareFormStepSerializer(serializers.ModelSerializer):
-    configuration = serializers.SerializerMethodField()
-
-    class Meta:
-        model = FormStep
-        fields = ("index", "configuration")
-        extra_kwargs = {
-            "index": {"source": "order"},
-        }
-
-    @tracer.start_as_current_span(
-        name="get-configuration",
-        attributes={
-            "span.type": "app",
-            "span.subtype": "api",
-            "span.action": "serialization",
-        },
-    )
-    @elasticapm.capture_span(span_type="app.api.serialization")
-    def get_configuration(self, instance) -> dict:
-        submission = self.root.instance.submission
-        serializer = FormDefinitionSerializer(
-            instance=instance.form_definition,
-            context={**self.context, "submission": submission},
-        )
-        return serializer.data["configuration"]
-
-
 class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
-    form_step = ContextAwareFormStepSerializer(read_only=True)
+    configuration = serializers.SerializerMethodField()
     slug = serializers.SlugField(source="form_step.slug", read_only=True)
     data = FormioDataField(  # type: ignore
         label=_("data"),
@@ -260,11 +231,11 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         fields = (
             "id",
             "slug",
-            "form_step",
             "data",
             "is_applicable",
             "completed",
             "can_submit",
+            "configuration",
         )
 
         extra_kwargs = {
@@ -311,6 +282,21 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         representation["data"] = serialized_data.data
 
         return representation
+
+    @tracer.start_as_current_span(
+        name="get-configuration",
+        attributes={
+            "span.type": "app",
+            "span.subtype": "api",
+            "span.action": "serialization",
+        },
+    )
+    @elasticapm.capture_span(span_type="app.api.serialization")
+    def get_configuration(self, instance) -> dict:
+        serializer = FormDefinitionSerializer(
+            instance=instance.form_step.form_definition, context=self.context
+        )
+        return serializer.data["configuration"]
 
     def validate_data(self, data: FormioData):
         self._run_formio_validation(data)

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -1,5 +1,6 @@
+from copy import deepcopy
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import date, datetime, time, timedelta
 from typing import TypedDict
 
 from django.conf import settings
@@ -13,6 +14,7 @@ import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from opentelemetry import trace
+from ordered_model.serializers import OrderedModelSerializer
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -23,15 +25,26 @@ from openforms.api.utils import mark_experimental
 from openforms.config.models import GlobalConfiguration
 from openforms.emails.utils import render_email_template, send_mail_html
 from openforms.formio.api.fields import FormioDataField
-from openforms.formio.service import FormioData, build_serializer
+from openforms.formio.service import (
+    FormioData,
+    build_serializer,
+    rewrite_formio_components_for_request,
+)
 from openforms.formio.utils import iter_components
-from openforms.forms.api.serializers import FormDefinitionSerializer
+from openforms.forms.api.serializers import (
+    FormDefinitionSerializer,
+    LogicComponentActionSerializer,
+)
 from openforms.forms.constants import SubmissionAllowedChoices
+from openforms.forms.models import FormLogic
 from openforms.forms.validators import validate_not_deleted
+from openforms.typing import JSONValue, VariableValue
+from openforms.utils.json_logic import partially_evaluate_json_logic
 from openforms.utils.urls import build_absolute_uri
 
 from ..constants import SUBMISSIONS_SESSION_KEY, ProcessingResults, ProcessingStatuses
 from ..form_logic import check_submission_logic, evaluate_form_logic
+from ..json_logic import add_data_type_information
 from ..models import EmailVerification, Submission, SubmissionStep
 from ..tokens import submission_resume_token_generator
 from ..utils import get_report_download_url
@@ -210,14 +223,110 @@ class SubmissionSerializer(serializers.HyperlinkedModelSerializer[Submission]):
         return super().to_representation(instance)
 
 
+def _to_json(value: VariableValue) -> JSONValue:
+    match value:
+        case dict():
+            return {k: _to_json(v) for k, v in value.items()}
+        case list():
+            return [_to_json(v) for v in value]
+        case date() | datetime() | time():
+            return value.isoformat()
+        case _:
+            return value
+
+
+class FormLogicFrontendSerializer(OrderedModelSerializer):
+    """Represent logic rules which can be executed in the frontend."""
+
+    actions = LogicComponentActionSerializer(
+        read_only=True,
+        many=True,
+        label=_("Actions"),
+        help_text=_(
+            "Actions triggered when the trigger expression evaluates to 'truthy'."
+        ),
+    )
+    json_logic_trigger = serializers.SerializerMethodField(
+        label=_("JSON Logic Trigger"),
+        help_text=_(
+            "The trigger expression to determine if the actions should execute. Will "
+            "be (partially) evaluated based on available data."
+        ),
+    )
+
+    class Meta:
+        model = FormLogic
+        fields = (
+            "json_logic_trigger",
+            "actions",
+        )
+
+    @extend_schema_field(serializers.JSONField)
+    def get_json_logic_trigger(self, instance) -> JSONValue:
+        step = self.context["submission_step"]
+        state = step.submission.load_submission_value_variables_state()
+        # We include all data, to make sure we have a (empty) value for every variable.
+        # Component variables of the current step need to be excluded, though, as these
+        # are subject to change with user input. If variables from future steps are not
+        # included here, form designers have to take into account that a value can be
+        # `None`, in addition to an empty value. `None` (or `null` in JS) is the value
+        # that will be used by JSON logic if the variable is not present in the data.
+        data = state.get_data(include_unsaved=True, include_static_variables=True)
+        for key in state.get_variables_in_submission_step(step).keys():
+            data.pop(key)
+
+        # Add data type information before partially evaluating - otherwise we lose
+        # the variable context.
+        json_logic_trigger = add_data_type_information(
+            instance.json_logic_trigger, state
+        )
+        json_logic_trigger, _ = partially_evaluate_json_logic(json_logic_trigger, data)
+
+        return _to_json(json_logic_trigger)
+
+
 class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
-    configuration = serializers.SerializerMethodField()
     slug = serializers.SlugField(source="form_step.slug", read_only=True)
-    data = FormioDataField(  # type: ignore
+    form_step_uuid = serializers.UUIDField(source="form_step.uuid", read_only=True)
+    # Note that this field is set in the `to_representation` method.
+    default_configuration = serializers.JSONField(
+        label=_("Default configuration"),
+        help_text=_("Default form configuration of the corresponding form step."),
+        allow_null=True,
+        read_only=True,
+    )
+    configuration = serializers.SerializerMethodField(
+        label=_("Configuration"),
+        help_text=_(
+            "Form configuration of the corresponding form step, (possibly) mutated by "
+            "form logic."
+        ),
+    )
+    data = FormioDataField(
         label=_("data"),
         required=False,
         allow_null=True,
         validators=[ValidatePrefillData()],
+    )
+    # Note that this field is set in the `to_representation` method.
+    require_backend_logic_evaluation = serializers.BooleanField(
+        label=_("Require backend logic evaluation"),
+        help_text=_("Indicates whether the backend is required to execute form logic."),
+        read_only=True,
+    )
+    # Note that this field is set in the `to_representation` method.
+    logic_rules = FormLogicFrontendSerializer(
+        many=True,
+        label=_("Logic rules"),
+        help_text=_(
+            "Logic rules of the corresponding form step. The JSON logic triggers are "
+            "partially evaluated with data from user-defined variables, and variables "
+            "of components from the steps other than the current one. Will be empty if "
+            "the backend is required to evaluate form logic."
+        ),
+        read_only=True,
+        allow_empty=True,
+        default=list,
     )
 
     parent_lookup_kwargs = {
@@ -230,12 +339,16 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         model = SubmissionStep
         fields = (
             "id",
+            "form_step_uuid",
             "slug",
             "data",
             "is_applicable",
             "completed",
             "can_submit",
             "configuration",
+            "default_configuration",
+            "require_backend_logic_evaluation",
+            "logic_rules",
         )
 
         extra_kwargs = {
@@ -256,7 +369,29 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
     )
     @elasticapm.capture_span(span_type="app.api.serialization")
     def to_representation(self, instance):
-        # invoke the configured form logic to dynamically update the Formio.js configuration
+        in_form_logic_evaluation = self.context.get("in_form_logic_evaluation", False)
+
+        # Before evaluating logic, we need to ensure we determine the "require backend"
+        # flag and save the default configuration, to avoid doing this on a mutated
+        # configuration.
+        logic_rules = list(instance.form_step.logic_rules.all())
+        require_backend = (
+            not instance.form_step.form.new_logic_evaluation_enabled  # backend is always required if the feature flag is disabled
+            or in_form_logic_evaluation  # not relevant for the check-logic endpoint
+            or instance.form_step.is_backend_logic_evaluation_required
+            or any(rule.is_backend_logic_evaluation_required for rule in logic_rules)
+        )
+
+        default_configuration = None
+        if not in_form_logic_evaluation:  # not relevant for the check-logic endpoint
+            wrapper = deepcopy(instance.form_step.form_definition.configuration_wrapper)
+            rewrite_formio_components_for_request(
+                wrapper, request=self.context["request"]
+            )
+            default_configuration = wrapper.configuration
+
+        # invoke the configured form logic to dynamically update the Formio.js
+        # configuration
         new_configuration = evaluate_form_logic(instance.submission, instance)
 
         # update the config for serialization
@@ -266,11 +401,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
 
         # Serialize the data to JSON. We can't use a generic JSON encoder here, because
         # we need context from the variable
-        data = (
-            instance.unsaved_data
-            if self.context.get("unsaved_data_only", False)
-            else instance.data
-        )
+        data = instance.unsaved_data if in_form_logic_evaluation else instance.data
         serialized_data = FormioData()
         state = instance.submission.load_submission_value_variables_state()
         variables = state.get_variables_in_submission_step(instance)
@@ -279,7 +410,18 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
                 continue
             serialized_data[key] = variable.to_json(data[key])
 
+        # Add relevant data
         representation["data"] = serialized_data.data
+        representation["require_backend_logic_evaluation"] = require_backend
+        representation["default_configuration"] = default_configuration
+
+        if not require_backend:
+            # Serializing logic rules is only useful if we do not require the backend
+            # for logic evaluation.
+            logic_rules_serializer = FormLogicFrontendSerializer(
+                many=True, instance=logic_rules, context={"submission_step": instance}
+            )
+            representation["logic_rules"] = logic_rules_serializer.data
 
         return representation
 

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -390,7 +390,9 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         )
 
         default_configuration = None
-        if not in_form_logic_evaluation:  # not relevant for the check-logic endpoint
+        if not require_backend:
+            # Creating a default configuration is only useful if we do not require the
+            # backend for logic evaluation.
             wrapper = deepcopy(instance.form_step.form_definition.configuration_wrapper)
             rewrite_formio_components_for_request(
                 wrapper, request=self.context["request"]

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -725,7 +725,7 @@ class SubmissionStepViewSet(
             context={
                 "request": request,
                 "current_step": submission_step,
-                "unsaved_data_only": True,
+                "in_form_logic_evaluation": True,
             },
         )
         return Response(submission_state_logic_serializer.data)

--- a/src/openforms/submissions/json_logic.py
+++ b/src/openforms/submissions/json_logic.py
@@ -142,12 +142,17 @@ def add_data_type_information(
                     parent = var_expression["var"][0]
 
             item_expression = add_data_type_information(argument[1], state, parent)
-            return {
-                operator: [var_expression, item_expression],
-            }
+            return {operator: [var_expression, item_expression]}
         case "date" | "datetime":
-            # It already contains a date operator.
-            return normalized  # pyright: ignore[reportReturnType]
+            # Date operations only take a single argument
+            assert len(argument) == 1
+            arg = argument[0]
+            # If the argument is a (ISO-8601) string or a variable expression, we don't
+            # have to do anything. If it is something else, e.g. a subtraction
+            # operation, we do need to process it further to ensure data-type
+            # information is added to any nested variable expressions.
+            if isinstance(arg, str) or (isinstance(arg, dict) and "var" in arg):
+                return normalized  # pyright: ignore[reportReturnType]
         case _:
             pass
 

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -1223,3 +1223,45 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
         )
         # Logic rule should be triggered
         self.assertEqual(step_data["canSubmit"], False)
+
+    def test_step_data_with_new_logic_evaluation_flag_enabled(self):
+        form = FormFactory.create(new_logic_evaluation_enabled=True)
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"}
+                ]
+            },
+        )
+        rule = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "textfield"}, "foo"]},
+            actions=[
+                {
+                    "form_step_uuid": str(step.uuid),
+                    "action": {
+                        "name": "Disable next",
+                        "type": "disable-next",
+                    },
+                }
+            ],
+        )
+        rule.form_steps.set([step])
+
+        submission = SubmissionFactory.create(form=form)
+        endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+
+        # Perform logic check
+        response = self.client.post(endpoint, data={"data": {"textfield": "foo"}})
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        step_data = response.json()["step"]
+        # Ensure some data is not serialized: default configuration and logic rules are
+        # not relevant in the context of the check-logic call.
+        self.assertIsNone(step_data["defaultConfiguration"])
+        self.assertEqual([], step_data["logicRules"])

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -474,7 +474,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         data = response.json()
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertFalse(
-            data["step"]["formStep"]["configuration"]["components"][0]["hidden"],
+            data["step"]["configuration"]["components"][0]["hidden"],
         )
 
         response = self.client.post(
@@ -485,7 +485,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual({"textfield": ""}, data["step"]["data"])
         self.assertTrue(
-            data["step"]["formStep"]["configuration"]["components"][0]["hidden"],
+            data["step"]["configuration"]["components"][0]["hidden"],
         )
 
     @tag("gh-5151")
@@ -681,7 +681,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             response = self.client.get(endpoint)
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            configuration = response.json()["formStep"]["configuration"]
+            configuration = response.json()["configuration"]
             self.assertEqual(
                 configuration["components"][1],
                 {
@@ -703,7 +703,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             response = self.client.post(logic_check_endpoint, {"data": {"hide": False}})
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            configuration = response.json()["step"]["formStep"]["configuration"]
+            configuration = response.json()["step"]["configuration"]
             self.assertEqual(
                 configuration["components"][1],
                 {
@@ -725,7 +725,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             response = self.client.post(logic_check_endpoint, {"data": {"hide": True}})
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            configuration = response.json()["step"]["formStep"]["configuration"]
+            configuration = response.json()["step"]["configuration"]
             self.assertEqual(
                 configuration["components"][1],
                 {
@@ -1227,9 +1227,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             self.assertEqual(data["step"]["data"], {})
 
         with self.subTest("evaluated content template"):
-            content_component = data["step"]["formStep"]["configuration"]["components"][
-                2
-            ]
+            content_component = data["step"]["configuration"]["components"][2]
             self.assertEqual(
                 content_component["html"],
                 textwrap.dedent("""
@@ -1336,9 +1334,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 },
             )
 
-            textfield, editgrid = step_data["formStep"]["configuration"]["components"][
-                0:2
-            ]
+            textfield, editgrid = step_data["configuration"]["components"][0:2]
             self.assertTrue(textfield["hidden"])
             self.assertTrue(editgrid["hidden"])
 
@@ -1362,9 +1358,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             # loop
             self.assertEqual(step_data["data"], {})
 
-            textfield, editgrid = step_data["formStep"]["configuration"]["components"][
-                0:2
-            ]
+            textfield, editgrid = step_data["configuration"]["components"][0:2]
             self.assertTrue(textfield["hidden"])
             self.assertTrue(editgrid["hidden"])
 
@@ -1440,9 +1434,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        self.assertFalse(
-            data["step"]["formStep"]["configuration"]["components"][1]["hidden"]
-        )
+        self.assertFalse(data["step"]["configuration"]["components"][1]["hidden"])
         self.assertEqual(data["step"]["data"], {})
 
     def test_second_rule_triggers_first_does_not_must_not_clear_value(self):
@@ -1509,9 +1501,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        self.assertFalse(
-            data["step"]["formStep"]["configuration"]["components"][1]["hidden"]
-        )
+        self.assertFalse(data["step"]["configuration"]["components"][1]["hidden"])
         self.assertEqual(data["step"]["data"], {})
 
     def test_rules_flip_from_hidden_to_visible_state_should_not_clear_value(self):
@@ -1636,16 +1626,12 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         data = response.json()
 
         with self.subTest("textfield"):
-            textfield_component = data["step"]["formStep"]["configuration"][
-                "components"
-            ][2]
+            textfield_component = data["step"]["configuration"]["components"][2]
             self.assertFalse(textfield_component["hidden"])
             self.assertTrue(textfield_component["validate"]["required"])
 
         with self.subTest("fieldset"):
-            fieldset_component = data["step"]["formStep"]["configuration"][
-                "components"
-            ][3]
+            fieldset_component = data["step"]["configuration"]["components"][3]
             self.assertFalse(fieldset_component["hidden"])
             self.assertFalse(fieldset_component["components"][0]["hidden"])
 
@@ -1776,16 +1762,12 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
         data = response.json()
 
         with self.subTest("textfield"):
-            textfield_component = data["step"]["formStep"]["configuration"][
-                "components"
-            ][2]
+            textfield_component = data["step"]["configuration"]["components"][2]
             self.assertFalse(textfield_component["hidden"])
             self.assertTrue(textfield_component["validate"]["required"])
 
         with self.subTest("fieldset"):
-            fieldset_component = data["step"]["formStep"]["configuration"][
-                "components"
-            ][3]
+            fieldset_component = data["step"]["configuration"]["components"][3]
             self.assertFalse(fieldset_component["hidden"])
             self.assertFalse(fieldset_component["components"][0]["hidden"])
 
@@ -1859,7 +1841,7 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase, HypothesisTestC
         response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        configuration = response.json()["formStep"]["configuration"]
+        configuration = response.json()["configuration"]
         self.assertEqual(
             configuration["components"][1],
             {

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -1321,3 +1321,52 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
         data = response.json()
         self.assertFalse(data["requireBackendLogicEvaluation"])
         self.assertEqual(expected, data["logicRules"][0])
+
+    @freeze_time("2026-03-18")
+    def test_with_date_trigger_that_could_be_partially_resolved(self):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                ]
+            },
+        )
+        # This is an actual logic rule used by municipalities!
+        rule = FormLogicFactory.create(
+            form=step.form,
+            json_logic_trigger={
+                ">": [
+                    {"date": {"var": "dateOfBirth"}},
+                    {"date": {"-": [{"var": "today"}, {"duration": "P24Y"}]}},
+                ]
+            },
+            actions=[
+                {
+                    "action": {"type": "disable-next"},
+                    "form_step_uuid": str(step.uuid),
+                }
+            ],
+        )
+        rule.form_steps.set([step])
+
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        # Even though the second part of the comparison could be evaluated to a date
+        # already, we would lose typing information if it was. The date object would
+        # be serialized to an ISO string in this case, without any remaining date
+        # operation being present.
+        expected = {
+            ">": [
+                {"date": [{"var": ["dateOfBirth"]}]},
+                {"date": [{"-": [{"date": ["2026-03-18"]}, {"duration": ["P24Y"]}]}]},
+            ]
+        }
+        self.assertEqual(expected, response.json()["logicRules"][0]["jsonLogicTrigger"])

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -91,23 +91,20 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
         expected = {
             "id": None,  # there is no submission step created yet
             "slug": self.step.slug,
-            "formStep": {
-                "index": 0,
-                "configuration": {
-                    "components": [
-                        {
-                            "label": "Some field",
-                            "key": "someField",
-                            "type": "textfield",
-                        },
-                        {
-                            "label": "Other field",
-                            "key": "otherField",
-                            "type": "selectboxes",
-                            "inputType": "checkbox",
-                        },
-                    ]
-                },
+            "configuration": {
+                "components": [
+                    {
+                        "label": "Some field",
+                        "key": "someField",
+                        "type": "textfield",
+                    },
+                    {
+                        "label": "Other field",
+                        "key": "otherField",
+                        "type": "selectboxes",
+                        "inputType": "checkbox",
+                    },
+                ]
             },
             "data": {},
             "isApplicable": True,
@@ -137,23 +134,20 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
         expected = {
             "id": None,  # there is no submission step created yet
             "slug": self.step.slug,
-            "formStep": {
-                "index": 0,
-                "configuration": {
-                    "components": [
-                        {
-                            "label": "Rewritten label",
-                            "key": "someField",
-                            "type": "textfield",
-                        },
-                        {
-                            "label": "Other field",
-                            "type": "selectboxes",
-                            "key": "otherField",
-                            "inputType": "checkbox",
-                        },
-                    ]
-                },
+            "configuration": {
+                "components": [
+                    {
+                        "label": "Rewritten label",
+                        "key": "someField",
+                        "type": "textfield",
+                    },
+                    {
+                        "label": "Other field",
+                        "type": "selectboxes",
+                        "key": "otherField",
+                        "inputType": "checkbox",
+                    },
+                ]
             },
             "data": {},
             "isApplicable": True,
@@ -226,7 +220,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        component = data["formStep"]["configuration"]["components"][0]
+        component = data["configuration"]["components"][0]
         self.assertEqual(component["key"], "file")
         self.assertEqual(component["type"], "file")
         self.assertEqual(component["url"], "http://testserver/api/v2/formio/fileupload")
@@ -416,9 +410,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             },
         )
 
-        textfield = self.client.get(endpoint).json()["formStep"]["configuration"][
-            "components"
-        ][0]
+        textfield = self.client.get(endpoint).json()["configuration"]["components"][0]
 
         self.assertEqual(textfield["key"], "bar")
         self.assertEqual(textfield["label"], "Kneipe")
@@ -519,7 +511,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             },
         )
 
-        configuration = self.client.get(endpoint).json()["formStep"]["configuration"]
+        configuration = self.client.get(endpoint).json()["configuration"]
 
         wrapped_configuration = FormioConfigurationWrapper(configuration)
         expected = {
@@ -605,7 +597,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
         response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        date2 = response.json()["formStep"]["configuration"]["components"][1]
+        date2 = response.json()["configuration"]["components"][1]
 
         self.assertEqual(date2["datePicker"]["minDate"], "2022-09-20T00:00:00+02:00")
         self.assertEqual(date2["datePicker"]["maxDate"], "2022-12-31T00:00:00+01:00")
@@ -654,7 +646,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
         response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        date2 = response.json()["formStep"]["configuration"]["components"][1]
+        date2 = response.json()["configuration"]["components"][1]
 
         self.assertEqual(date2["datePicker"]["minDate"], "2022-09-20T00:00:00+02:00")
 
@@ -737,7 +729,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        components = response.data["form_step"]["configuration"]["components"]
+        components = response.data["configuration"]["components"]
         expected = [
             {
                 "type": "textfield",

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -97,20 +97,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
             "id": None,  # there is no submission step created yet
             "formStepUuid": str(self.step.uuid),
             "slug": self.step.slug,
-            "defaultConfiguration": {
-                "components": [
-                    {
-                        "label": "Some field",
-                        "key": "someField",
-                        "type": "textfield",
-                    },
-                    {
-                        "label": "Other field",
-                        "key": "otherField",
-                        "type": "selectboxes",
-                    },
-                ]
-            },
+            "defaultConfiguration": None,
             "configuration": {
                 "components": [
                     {
@@ -156,20 +143,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
             "id": None,  # there is no submission step created yet
             "formStepUuid": str(self.step.uuid),
             "slug": self.step.slug,
-            "defaultConfiguration": {
-                "components": [
-                    {
-                        "label": "Some field",
-                        "key": "someField",
-                        "type": "textfield",
-                    },
-                    {
-                        "label": "Other field",
-                        "key": "otherField",
-                        "type": "selectboxes",
-                    },
-                ]
-            },
+            "defaultConfiguration": None,
             "configuration": {
                 "components": [
                     {
@@ -948,11 +922,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             "id": None,  # there is no submission step created yet
             "formStepUuid": str(step.uuid),
             "slug": step.slug,
-            "defaultConfiguration": {
-                "components": [
-                    {"type": "textfield", "key": "textfield", "label": "{{ foo }}"},
-                ]
-            },
+            "defaultConfiguration": None,
             "configuration": {
                 "components": [
                     {"type": "textfield", "key": "textfield", "label": "I am a label!"},
@@ -1104,12 +1074,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             "id": None,  # there is no submission step created yet
             "formStepUuid": str(step.uuid),
             "slug": step.slug,
-            "defaultConfiguration": {
-                "components": [
-                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
-                    {"type": "textfield", "key": "textfield", "label": "{{ foo }}"},
-                ]
-            },
+            "defaultConfiguration": None,
             "configuration": {
                 "components": [
                     {
@@ -1179,12 +1144,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             "id": None,  # there is no submission step created yet
             "formStepUuid": str(step.uuid),
             "slug": step.slug,
-            "defaultConfiguration": {
-                "components": [
-                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
-                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
-                ]
-            },
+            "defaultConfiguration": None,
             "configuration": {
                 "components": [
                     {

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -13,7 +13,9 @@ import uuid
 from unittest.mock import patch
 
 from django.test import tag
+from django.utils.translation import gettext_lazy as _
 
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -27,9 +29,11 @@ from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
     FormStepFactory,
+    FormVariableFactory,
 )
 from openforms.variables.constants import FormVariableDataTypes
 
+from ...config.models import GlobalConfiguration
 from ..models import Submission
 from .factories import (
     SubmissionFactory,
@@ -40,6 +44,8 @@ from .mixins import SubmissionsMixin
 
 
 class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -56,7 +62,6 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                     "label": "Other field",
                     "key": "otherField",
                     "type": "selectboxes",
-                    "inputType": "checkbox",
                 },
             ]
         }
@@ -90,7 +95,22 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected = {
             "id": None,  # there is no submission step created yet
+            "formStepUuid": str(self.step.uuid),
             "slug": self.step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {
+                        "label": "Some field",
+                        "key": "someField",
+                        "type": "textfield",
+                    },
+                    {
+                        "label": "Other field",
+                        "key": "otherField",
+                        "type": "selectboxes",
+                    },
+                ]
+            },
             "configuration": {
                 "components": [
                     {
@@ -102,7 +122,6 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                         "label": "Other field",
                         "key": "otherField",
                         "type": "selectboxes",
-                        "inputType": "checkbox",
                     },
                 ]
             },
@@ -110,6 +129,8 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
             "isApplicable": True,
             "completed": False,
             "canSubmit": True,
+            "requireBackendLogicEvaluation": True,
+            "logicRules": [],
         }
         self.assertEqual(response.json(), expected)
 
@@ -133,7 +154,22 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected = {
             "id": None,  # there is no submission step created yet
+            "formStepUuid": str(self.step.uuid),
             "slug": self.step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {
+                        "label": "Some field",
+                        "key": "someField",
+                        "type": "textfield",
+                    },
+                    {
+                        "label": "Other field",
+                        "key": "otherField",
+                        "type": "selectboxes",
+                    },
+                ]
+            },
             "configuration": {
                 "components": [
                     {
@@ -143,9 +179,8 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                     },
                     {
                         "label": "Other field",
-                        "type": "selectboxes",
                         "key": "otherField",
-                        "inputType": "checkbox",
+                        "type": "selectboxes",
                     },
                 ]
             },
@@ -153,6 +188,8 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
             "isApplicable": True,
             "completed": False,
             "canSubmit": True,
+            "requireBackendLogicEvaluation": True,
+            "logicRules": [],
         }
         self.assertEqual(response.json(), expected)
 
@@ -227,6 +264,8 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
 
 
 class GetSubmissionStepTests(SubmissionsMixin, APITestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -389,6 +428,8 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
     """
     Integration tests where various subsystems come together.
     """
+
+    maxDiff = None
 
     def test_it_only_translates_appropriate_string_properties(self):
         submission = SubmissionFactory.from_data(
@@ -787,3 +828,496 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             response.json()["data"],
             {"date": "", "time": "", "datetime": ""},
         )
+
+    @patch(
+        "openforms.formio.components.vanilla.GlobalConfiguration.get_solo",
+        return_value=GlobalConfiguration(
+            form_upload_default_file_types=["image/png", "application/pdf"]
+        ),
+    )
+    def test_default_configuration_has_components_rewritten_for_request(
+        self, m_get_solo
+    ):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "file",
+                        "key": "file",
+                        "label": "File",
+                        "useConfigFiletypes": True,
+                        "filePattern": "*",
+                        "url": "",
+                        "file": {"allowedTypesLabels": []},
+                    }
+                ]
+            },
+        )
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "type": "file",
+            "key": "file",
+            "label": "File",
+            "useConfigFiletypes": True,
+            "filePattern": "image/png,application/pdf",
+            "url": "http://testserver/api/v2/formio/fileupload",
+            "file": {"allowedTypesLabels": [".png", ".pdf"]},
+        }
+        self.assertEqual(
+            expected, response.json()["defaultConfiguration"]["components"][0]
+        )
+
+    def test_without_logic_rules_and_without_dynamic_configuration(self):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"}
+                ]
+            },
+        )
+
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "id": None,  # there is no submission step created yet
+            "formStepUuid": str(step.uuid),
+            "slug": step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+            "configuration": {
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+            "data": {},
+            "isApplicable": True,
+            "completed": False,
+            "canSubmit": True,
+            "requireBackendLogicEvaluation": False,
+            "logicRules": [],
+        }
+        self.assertEqual(expected, response.json())
+
+    def test_without_logic_rules_but_with_dynamic_configuration(self):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "{{ foo }}"}
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=step.form,
+            key="foo",
+            data_type=FormVariableDataTypes.string,
+            user_defined=True,
+            initial_value="I am a label!",
+        )
+
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "id": None,  # there is no submission step created yet
+            "formStepUuid": str(step.uuid),
+            "slug": step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "{{ foo }}"},
+                ]
+            },
+            "configuration": {
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "I am a label!"},
+                ]
+            },
+            "data": {},
+            "isApplicable": True,
+            "completed": False,
+            "canSubmit": True,
+            "requireBackendLogicEvaluation": True,
+            "logicRules": [],
+        }
+        self.assertEqual(expected, response.json())
+
+    @freeze_time("2026-03-18")
+    def test_with_logic_rule_that_does_not_require_backend(self):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+        )
+        rule = FormLogicFactory.create(
+            form=step.form,
+            json_logic_trigger={"==": [{"var": "dateOfBirth"}, {"var": "today"}]},
+            actions=[
+                {
+                    "action": {
+                        "type": "variable",
+                        "value": "foo",
+                    },
+                    "variable": "textfield",
+                    "uuid": "3798727a-ae54-4661-93ad-37d873c4d5fc",
+                }
+            ],
+        )
+        # This step will be assigned during logic rule analysis, because the action
+        # affects the "textfield" variable on the first (and only) step.
+        rule.form_steps.set([step])
+
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "id": None,  # there is no submission step created yet
+            "formStepUuid": str(step.uuid),
+            "slug": step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+            "configuration": {
+                "components": [
+                    {
+                        "type": "date",
+                        "key": "dateOfBirth",
+                        "label": "Date of birth",
+                        "placeholder": _("dd-mm-yyyy"),
+                    },
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+            "data": {},
+            "isApplicable": True,
+            "completed": False,
+            "canSubmit": True,
+            "requireBackendLogicEvaluation": False,
+            "logicRules": [
+                {
+                    # Note the partially evaluated rule with added data-type
+                    # information.
+                    "jsonLogicTrigger": {
+                        "==": [
+                            {"date": [{"var": ["dateOfBirth"]}]},
+                            {"date": ["2026-03-18"]},
+                        ]
+                    },
+                    "actions": [
+                        {
+                            "uuid": "3798727a-ae54-4661-93ad-37d873c4d5fc",
+                            "formStepUuid": None,
+                            "action": {"type": "variable", "value": "foo"},
+                            "variable": "textfield",
+                        }
+                    ],
+                }
+            ],
+        }
+        self.assertEqual(expected, response.json())
+
+    def test_with_logic_rule_that_does_not_require_backend_but_with_dynamic_configuration(
+        self,
+    ):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {"type": "textfield", "key": "textfield", "label": "{{ foo }}"},
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=step.form,
+            key="foo",
+            data_type=FormVariableDataTypes.string,
+            user_defined=True,
+            initial_value="I am a label!",
+        )
+        rule = FormLogicFactory.create(
+            form=step.form,
+            json_logic_trigger={"==": [{"var": "dateOfBirth"}, {"var": "today"}]},
+            actions=[
+                {
+                    "action": {
+                        "type": "variable",
+                        "value": "foo",
+                    },
+                    "variable": "textfield",
+                    "uuid": "3798727a-ae54-4661-93ad-37d873c4d5fc",
+                }
+            ],
+        )
+        # This step will be assigned during logic rule analysis, because the action
+        # affects the "textfield" variable on the first (and only) step.
+        rule.form_steps.set([step])
+
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "id": None,  # there is no submission step created yet
+            "formStepUuid": str(step.uuid),
+            "slug": step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {"type": "textfield", "key": "textfield", "label": "{{ foo }}"},
+                ]
+            },
+            "configuration": {
+                "components": [
+                    {
+                        "type": "date",
+                        "key": "dateOfBirth",
+                        "label": "Date of birth",
+                        "placeholder": _("dd-mm-yyyy"),
+                    },
+                    {"type": "textfield", "key": "textfield", "label": "I am a label!"},
+                ]
+            },
+            "data": {},
+            "isApplicable": True,
+            "completed": False,
+            "canSubmit": True,
+            "requireBackendLogicEvaluation": True,
+            "logicRules": [],  # logic rules are not serialized when the backend is required
+        }
+        self.assertEqual(expected, response.json())
+
+    def test_with_logic_rule_that_requires_backend(self):
+        step = FormStepFactory.create(
+            form__new_logic_evaluation_enabled=True,
+            form_definition__configuration={
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=step.form,
+            key="foo",
+            data_type=FormVariableDataTypes.string,
+            user_defined=True,
+            initial_value="",
+        )
+        # Note that user-defined variables cannot be set in the frontend
+        rule = FormLogicFactory.create(
+            form=step.form,
+            json_logic_trigger={"==": [{"var": "dateOfBirth"}, {"var": "today"}]},
+            actions=[
+                {
+                    "action": {
+                        "type": "variable",
+                        "value": "bar",
+                    },
+                    "variable": "foo",
+                    "uuid": "3798727a-ae54-4661-93ad-37d873c4d5fc",
+                }
+            ],
+        )
+        # This step will be assigned during logic rule analysis, because the action sets
+        # a user-defined variable -> the first (and only) step is assigned.
+        rule.form_steps.set([step])
+
+        submission = SubmissionFactory.create(form=step.form)
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "id": None,  # there is no submission step created yet
+            "formStepUuid": str(step.uuid),
+            "slug": step.slug,
+            "defaultConfiguration": {
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+            "configuration": {
+                "components": [
+                    {
+                        "type": "date",
+                        "key": "dateOfBirth",
+                        "label": "Date of birth",
+                        "placeholder": _("dd-mm-yyyy"),
+                    },
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+            "data": {},
+            "isApplicable": True,
+            "completed": False,
+            "canSubmit": True,
+            "requireBackendLogicEvaluation": True,
+            "logicRules": [],  # logic rules are not serialized when the backend is required
+        }
+        self.assertEqual(expected, response.json())
+
+    @freeze_time("2026-03-18")
+    def test_logic_rule_is_serialized_properly(self):
+        form = FormFactory.create(new_logic_evaluation_enabled=True)
+        step_1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "number", "key": "number", "label": "Number"},
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
+                    {
+                        "type": "content",
+                        "key": "content",
+                        "html": "I am some content!",
+                        "hidden": False,
+                    },
+                ]
+            },
+        )
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="foo",
+            data_type=FormVariableDataTypes.string,
+            user_defined=True,
+            initial_value="",
+        )
+        rule = FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "and": [
+                    {"==": [{"var": "number"}, 42]},
+                    {"==": [{"var": "dateOfBirth"}, {"var": "today"}]},
+                    # This is a weird trigger because a field from a future step (3)
+                    # affects something on the current step (2), but it demonstrates the
+                    # principle of partial evaluation with unsaved variables.
+                    {"==": [{"var": "textfield"}, ""]},
+                ]
+            },
+            actions=[
+                {
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "hidden", "type": "bool"},
+                        "state": False,
+                    },
+                    "component": "content",
+                    "uuid": "3798727a-ae54-4661-93ad-37d873c4d5fc",
+                }
+            ],
+        )
+        # This step will be assigned during logic rule analysis, because the action
+        # affects the "content" component on step 2.
+        rule.form_steps.set([step_2])
+
+        # Simulate submitting step 1
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step_1,
+            data={"number": 42},
+        )
+
+        url = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step_2.uuid},
+        )
+        self._add_submission_to_session(submission)
+        response = self.client.get(url)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        expected = {
+            "jsonLogicTrigger": {
+                "and": [
+                    # {"==": [{"var": "number"}, 42]} evaluates to True with the already submitted data
+                    True,
+                    # data-type information is added and static variables are substituted
+                    {
+                        "==": [
+                            {"date": [{"var": ["dateOfBirth"]}]},
+                            {"date": ["2026-03-18"]},
+                        ]
+                    },
+                    # {"==": [{"var": "textfield"}, ""]} evaluates to True with the empty value
+                    True,
+                ]
+            },
+            "actions": [
+                {
+                    "action": {
+                        "property": {"type": "bool", "value": "hidden"},
+                        "state": False,
+                        "type": "property",
+                    },
+                    "component": "content",
+                    "formStepUuid": None,
+                    "uuid": "3798727a-ae54-4661-93ad-37d873c4d5fc",
+                }
+            ],
+        }
+        data = response.json()
+        self.assertFalse(data["requireBackendLogicEvaluation"])
+        self.assertEqual(expected, data["logicRules"][0])

--- a/src/openforms/submissions/tests/test_json_logic.py
+++ b/src/openforms/submissions/tests/test_json_logic.py
@@ -37,6 +37,12 @@ class AddDataTypeInformationTests(TestCase):
 
         expressions = [
             {"==": [{"var": "date"}, {"var": "today"}]},  # today is static variable
+            {
+                ">": [
+                    {"date": "2010-04-26"},
+                    {"date": {"-": [{"var": "today"}, {"duration": "P24Y"}]}},
+                ]
+            },
             {"==": [{"datetime": "2026-03-06T15:37:00"}, {"var": "datetime"}]},
             {"==": [{"var": "textfield"}, "foo"]},
         ]
@@ -45,6 +51,21 @@ class AddDataTypeInformationTests(TestCase):
                 "==": [
                     {"date": [{"var": ["date"]}]},
                     {"date": [{"var": ["today"]}]},
+                ]
+            },
+            {
+                ">": [
+                    {"date": ["2010-04-26"]},
+                    {
+                        "date": [
+                            {
+                                "-": [
+                                    {"date": [{"var": ["today"]}]},
+                                    {"duration": ["P24Y"]},
+                                ]
+                            }
+                        ]
+                    },
                 ]
             },
             {

--- a/src/openforms/submissions/tests/test_list_submissions.py
+++ b/src/openforms/submissions/tests/test_list_submissions.py
@@ -88,6 +88,7 @@ class SubmissionListTests(SubmissionsMixin, APITestCase):
                     "url": f"http://testserver{submission_step_path}",
                     "formStep": f"http://testserver{form_step_path}",
                     "isApplicable": True,
+                    "defaultIsApplicable": True,
                     "completed": False,
                     "name": "Select product",
                     "canSubmit": True,

--- a/src/openforms/submissions/tests/test_read_submission.py
+++ b/src/openforms/submissions/tests/test_read_submission.py
@@ -99,6 +99,7 @@ class SubmissionReadTests(SubmissionsMixin, APITestCase):
                         "url": f"http://testserver{submission_step_path}",
                         "formStep": f"http://testserver{form_step_path}",
                         "isApplicable": True,
+                        "defaultIsApplicable": True,
                         "completed": False,
                         "name": "Select product",
                         "canSubmit": True,

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -511,7 +511,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(
             "invalid_time",
-            response.json()["formStep"]["configuration"]["components"][0]["errors"],
+            response.json()["configuration"]["components"][0]["errors"],
         )
 
     @tag("gh-4143")
@@ -632,7 +632,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
         with self.subTest("check valid configuration items expression"):
             resp = self.client.get(endpoint)
 
-            values = resp.json()["formStep"]["configuration"]["components"][0]["values"]
+            values = resp.json()["configuration"]["components"][0]["values"]
             self.assertEqual(len(values), 5)
 
         with self.subTest("valid data"):

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -74,11 +74,8 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
             {
                 "id": str(submission_step.uuid),
                 "slug": self.step1.slug,
-                "formStep": {
-                    "index": 0,
-                    "configuration": {
-                        "components": [{"type": "textfield", "key": "test-key"}]
-                    },
+                "configuration": {
+                    "components": [{"type": "textfield", "key": "test-key"}]
                 },
                 "data": {
                     "test-key": "example data",
@@ -183,14 +180,11 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
             {
                 "id": str(submission_step.uuid),
                 "slug": step2.slug,
-                "formStep": {
-                    "index": 1,
-                    "configuration": {
-                        "components": [
-                            {"key": "foo", "type": "textfield"},
-                            {"key": "modified", "type": "textfield"},
-                        ]
-                    },
+                "configuration": {
+                    "components": [
+                        {"key": "foo", "type": "textfield"},
+                        {"key": "modified", "type": "textfield"},
+                    ]
                 },
                 "data": {"modified": "data", "foo": "bar"},
                 "isApplicable": True,
@@ -316,13 +310,10 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
             {
                 "id": str(submission_step.uuid),
                 "slug": step.slug,
-                "formStep": {
-                    "index": 0,
-                    "configuration": {
-                        "components": [
-                            {"key": "nested.key", "type": "textfield"},
-                        ]
-                    },
+                "configuration": {
+                    "components": [
+                        {"key": "nested.key", "type": "textfield"},
+                    ]
                 },
                 "data": {"nested": {"key": "some data"}},
                 "isApplicable": True,

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -78,9 +78,7 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
                 "configuration": {
                     "components": [{"type": "textfield", "key": "test-key"}]
                 },
-                "defaultConfiguration": {
-                    "components": [{"type": "textfield", "key": "test-key"}]
-                },
+                "defaultConfiguration": None,
                 "data": {"test-key": "example data"},
                 "isApplicable": True,
                 "completed": True,

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -74,15 +74,19 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
             {
                 "id": str(submission_step.uuid),
                 "slug": self.step1.slug,
+                "formStepUuid": str(self.step1.uuid),
                 "configuration": {
                     "components": [{"type": "textfield", "key": "test-key"}]
                 },
-                "data": {
-                    "test-key": "example data",
+                "defaultConfiguration": {
+                    "components": [{"type": "textfield", "key": "test-key"}]
                 },
+                "data": {"test-key": "example data"},
                 "isApplicable": True,
                 "completed": True,
                 "canSubmit": True,
+                "logicRules": [],
+                "requireBackendLogicEvaluation": True,
             },
         )
         self.assertEqual(submission_step.data, {"test-key": "example data"})
@@ -175,23 +179,7 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
         response = self.client.put(endpoint, body)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {
-                "id": str(submission_step.uuid),
-                "slug": step2.slug,
-                "configuration": {
-                    "components": [
-                        {"key": "foo", "type": "textfield"},
-                        {"key": "modified", "type": "textfield"},
-                    ]
-                },
-                "data": {"modified": "data", "foo": "bar"},
-                "isApplicable": True,
-                "completed": True,
-                "canSubmit": True,
-            },
-        )
+        self.assertEqual({"modified": "data", "foo": "bar"}, response.json()["data"])
         submission_step.refresh_from_db()
         self.assertEqual(submission_step.data, {"modified": "data", "foo": "bar"})
 
@@ -305,22 +293,7 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
         response = self.client.put(endpoint, body)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {
-                "id": str(submission_step.uuid),
-                "slug": step.slug,
-                "configuration": {
-                    "components": [
-                        {"key": "nested.key", "type": "textfield"},
-                    ]
-                },
-                "data": {"nested": {"key": "some data"}},
-                "isApplicable": True,
-                "completed": True,
-                "canSubmit": True,
-            },
-        )
+        self.assertEqual({"nested": {"key": "some data"}}, response.json()["data"])
         submission_step.refresh_from_db()
         self.assertEqual(submission_step.data, {"nested": {"key": "some data"}})
 

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -67,9 +67,7 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response_data = response.json()
-        content_field = response_data["formStep"]["configuration"]["components"][0][
-            "html"
-        ]
+        content_field = response_data["configuration"]["components"][0]["html"]
         data = response_data["data"]
 
         # The static variable is used in the dynamic configuration ...

--- a/src/openforms/submissions/tests/test_variables/test_variable_injection.py
+++ b/src/openforms/submissions/tests/test_variables/test_variable_injection.py
@@ -101,7 +101,7 @@ class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
         response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        configuration = response.json()["formStep"]["configuration"]
+        configuration = response.json()["configuration"]
 
         with self.subTest(component="group1"):
             self.assertFormioComponent(
@@ -149,7 +149,7 @@ class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
         response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        configuration = response.json()["formStep"]["configuration"]
+        configuration = response.json()["configuration"]
 
         with self.subTest(component="group1"):
             self.assertFormioComponent(
@@ -194,7 +194,7 @@ class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
         response = self.client.post(endpoint, {"data": {"text1": "some input"}})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        configuration = response.json()["step"]["formStep"]["configuration"]
+        configuration = response.json()["step"]["configuration"]
 
         with self.subTest(component="group1"):
             self.assertFormioComponent(
@@ -313,7 +313,7 @@ class VariableInjectionI18NTests(SubmissionsMixin, FormioMixin, APITestCase):
 
         step_json = self.client.get(endpoint).json()
         components_by_key = {
-            c["key"]: c for c in step_json["formStep"]["configuration"]["components"]
+            c["key"]: c for c in step_json["configuration"]["components"]
         }
 
         c = components_by_key.get
@@ -353,8 +353,7 @@ class VariableInjectionI18NTests(SubmissionsMixin, FormioMixin, APITestCase):
         ).json()
 
         components_by_key = {
-            c["key"]: c
-            for c in check_json["step"]["formStep"]["configuration"]["components"]
+            c["key"]: c for c in check_json["step"]["configuration"]["components"]
         }
 
         c = components_by_key.get

--- a/src/openforms/utils/json_logic/partial_evaluation.py
+++ b/src/openforms/utils/json_logic/partial_evaluation.py
@@ -107,11 +107,10 @@ def partially_evaluate_json_logic(
                 fully_resolved = fully_resolved and resolved
             return {operator: argument_new}, fully_resolved
         case "date" | "datetime" | "duration":
-            # These operators should not be evaluated directly, but only if the entire
-            # expression was resolved at the end. Their arguments could still contain
-            # variable expressions, though.
-            argument_new, resolved = partially_evaluate_json_logic(argument, data)
-            return {operator: argument_new}, resolved
+            # These operators should not be evaluated directly, because we might lose
+            # data type information if part of the expression was already evaluated.
+            argument_new, _ = partially_evaluate_json_logic(argument, data)
+            return {operator: argument_new}, False
         case "today":
             # For the "today" operator, the arguments are ignored, so we just return an
             # unchanged expression, which can be evaluated at the end.

--- a/src/openforms/utils/tests/test_json_logic.py
+++ b/src/openforms/utils/tests/test_json_logic.py
@@ -349,28 +349,6 @@ class PartialEvaluationTests(ParametrizedTestCase, SimpleTestCase):
             self.assertEqual(result, {"!": [{"==": [{"var": ["foo"]}, "a"]}]})
             self.assertFalse(resolved)
 
-    @parametrize(
-        ("expression", "data", "expected"),
-        [
-            param(
-                {"+": [{"date": "2026-01-01"}, {"duration": "P1M"}]},
-                {},
-                "2026-02-01",
-                id="no_variables",
-            ),
-            param(
-                {"+": [{"date": {"var": "foo"}}, {"duration": {"var": "bar"}}]},
-                {"foo": "2026-01-01", "bar": "P1M"},
-                "2026-02-01",
-                id="all_variables",
-            ),
-        ],
-    )
-    def test_date_operators_resolves(self, expression, data, expected):
-        result, resolved = partially_evaluate_json_logic(expression, data)
-        self.assertEqual(result.isoformat(), expected)
-        self.assertTrue(resolved)
-
     def test_date_operators_do_not_resolve(self):
         with self.subTest("variable in duration missing"):
             expression = {"+": [{"date": {"var": "foo"}}, {"duration": {"var": "bar"}}]}
@@ -415,8 +393,16 @@ class PartialEvaluationTests(ParametrizedTestCase, SimpleTestCase):
 
             with freeze_time("2024-01-01T12:00:00"):
                 result, resolved = partially_evaluate_json_logic(expression, data)
-            self.assertTrue(result)
-            self.assertTrue(resolved)
+            self.assertEqual(
+                result,
+                {
+                    ">": [
+                        {"date": ["2002-01-01"]},
+                        {"date": [{"-": [{"today": ""}, {"duration": ["P24Y"]}]}]},
+                    ]
+                },
+            )
+            self.assertFalse(resolved)
 
         with self.subTest("with conditional and missing variable"):
             expression = {
@@ -443,28 +429,35 @@ class PartialEvaluationTests(ParametrizedTestCase, SimpleTestCase):
             )
             self.assertFalse(resolved)
 
-        with self.subTest("with the second part of the conditional resolving"):
+        with self.subTest("with the second part of the conditional possibly resolving"):
+            # Note that "today" is a static variable that will have a date operation
+            # added to it before it will be partially evaluated.
             expression = {
                 ">": [
                     {"date": {"var": "dateOfBirth"}},
-                    {"-": [{"var": "today"}, {"duration": "P24Y"}]},
+                    {"date": {"-": [{"date": {"var": "today"}}, {"duration": "P24Y"}]}},
                 ]
             }
             data = {"today": date(2026, 2, 23)}
 
-            # TODO-5962: this will result in a problem when pushing the rule to the
-            #  frontend, because the date object will be serialized into an ISO string.
-            #  We then try to compare a date object to a string, it will always fail.
-            #  It shows that we need to wrap all date-related variables with a date
-            #  operator (or detect date-related objects and wrap them), BEFORE partially
-            #  evaluating logic.
             result, resolved = partially_evaluate_json_logic(expression, data)
+            # Even though we could evaluate the second part of the greater-than
+            # expression, we would lose data type information if we did.
             self.assertEqual(
                 result,
                 {
                     ">": [
                         {"date": [{"var": ["dateOfBirth"]}]},
-                        date(2002, 2, 23),
+                        {
+                            "date": [
+                                {
+                                    "-": [
+                                        {"date": [date(2026, 2, 23)]},
+                                        {"duration": ["P24Y"]},
+                                    ]
+                                }
+                            ]
+                        },
                     ]
                 },
             )


### PR DESCRIPTION
Partly closes #5962

**Changes**

* Removed context aware form step serializer
* Added logic rules to submission step serializer
* Fixed bug when partially evaluating expressions with dates
* Fixed logic rule crashing in admin when adding a new one

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
