### PR TITLE
[#5938] Reuse user cancellation error message for DigiD/eHerkenning OIDC logins

### DIFF
--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/constants.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/constants.py
@@ -1,2 +1,7 @@
 EIDAS_PLUGIN_ID = "eidas_oidc"
 EIDAS_COMPANY_PLUGIN_ID = "eidas_company_oidc"
+
+
+SIGNICAT_ERROR_MAPPING = {
+    "IDP-3200": "access_denied",
+}

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/plugin.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/plugin.py
@@ -40,7 +40,7 @@ from ...constants import (
     AuthAttribute,
     LegalSubjectIdentifierType,
 )
-from .constants import EIDAS_COMPANY_PLUGIN_ID, EIDAS_PLUGIN_ID
+from .constants import EIDAS_COMPANY_PLUGIN_ID, EIDAS_PLUGIN_ID, SIGNICAT_ERROR_MAPPING
 from .oidc_plugins.constants import (
     OIDC_DIGID_IDENTIFIER,
     OIDC_DIGID_MACHTIGEN_IDENTIFIER,
@@ -75,6 +75,15 @@ class DigiDOIDCAuthentication(OIDCAuthentication[DigiDClaims, NoOptions]):
             "value": normalized_claims["bsn_claim"],
             "loa": str(normalized_claims.get("loa_claim", "")),
         }
+
+    def get_error_message_parameters(
+        self, error: str, error_description: str
+    ) -> tuple[str, str]:
+        errors = self.get_error_codes()
+
+        if error_mapping_value := SIGNICAT_ERROR_MAPPING.get(error):
+            return errors[error_mapping_value]
+        return super().get_error_message_parameters(error, error_description)
 
     def get_error_codes(self) -> OIDCErrors:
         return {"access_denied": (DIGID_MESSAGE_PARAMETER, DIGID_LOGIN_CANCELLED)}
@@ -122,6 +131,15 @@ class eHerkenningOIDCAuthentication(OIDCAuthentication[EHClaims, NoOptions]):
         if service_restriction := normalized_claims.get("branch_number_claim", ""):
             form_auth["legal_subject_service_restriction"] = service_restriction
         return form_auth
+
+    def get_error_message_parameters(
+        self, error: str, error_description: str
+    ) -> tuple[str, str]:
+        errors = self.get_error_codes()
+
+        if error_mapping_value := SIGNICAT_ERROR_MAPPING.get(error):
+            return errors[error_mapping_value]
+        return super().get_error_message_parameters(error, error_description)
 
     def get_error_codes(self) -> OIDCErrors:
         eh_message_parameter = EH_MESSAGE_PARAMETER % {

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/test_auth_flow_callbacks.py
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/test_auth_flow_callbacks.py
@@ -159,6 +159,44 @@ class DigiDCallbackTests(IntegrationTestsBase):
         assert BACKEND_OUTAGE_RESPONSE_PARAMETER not in expected_url.args
         self.assertEqual(callback_response.request.url, str(expected_url))
 
+    @tag("gh-5938")
+    def test_digid_error_reported_for_cancelled_login_anon_django_user_signicat(self):
+        OFOIDCClientFactory.create(
+            with_keycloak_provider=True,
+            with_digid=True,
+            oidc_rp_scopes_list=["badscope"],
+        )
+
+        form = FormFactory.create(authentication_backend="digid_oidc")
+        url_helper = URLsHelper(form=form)
+        start_url = url_helper.get_auth_start(plugin_id="digid_oidc")
+        # initialize state, but don't actually log in - we have an invalid config and
+        # keycloak redirects back to our callback URL with error parameters.
+        start_response = self.app.get(start_url)
+        auth_response = requests.get(start_response["Location"], allow_redirects=False)
+        # check out assumptions/expectations before proceeding
+        callback_url = furl(auth_response.headers["Location"])
+        assert callback_url.netloc == "testserver"
+        assert "state" in callback_url.args
+        callback_url.args.update(
+            {
+                "error": "IDP-3200",
+                "error_description": (
+                    "Authentication with IdP 'simulator' was aborted, most likely "
+                    "because the end-user cancelled the authentication.",
+                ),
+            }
+        )
+
+        callback_response = self.app.get(str(callback_url), auto_follow=True)
+
+        self.assertEqual(callback_response.status_code, 200)
+        expected_url = furl(url_helper.frontend_start).add(
+            {"_digid-message": "login-cancelled"}
+        )
+        assert BACKEND_OUTAGE_RESPONSE_PARAMETER not in expected_url.args
+        self.assertEqual(callback_response.request.url, str(expected_url))
+
     @tag("gh-3656", "gh-3692")
     def test_digid_error_reported_for_cancelled_login_with_staff_django_user(self):
         OFOIDCClientFactory.create(
@@ -308,6 +346,53 @@ class EHerkenningCallbackTests(IntegrationTestsBase):
         )
         self.assertEqual(callback_response.request.url, str(expected_url))
         self.assertNotIn(FORM_AUTH_SESSION_KEY, self.app.session)
+
+    @tag("gh-5938")
+    def test_eherkenning_error_reported_for_cancelled_login_anon_django_user_signicat(
+        self,
+    ):
+        OFOIDCClientFactory.create(
+            with_keycloak_provider=True,
+            with_eherkenning=True,
+            oidc_rp_scopes_list=["badscope"],
+        )
+
+        form = FormFactory.create(authentication_backend="eherkenning_oidc")
+        url_helper = URLsHelper(form=form)
+        start_url = url_helper.get_auth_start(plugin_id="eherkenning_oidc")
+        # initialize state, but don't actually log in - we have an invalid config and
+        # keycloak redirects back to our callback URL with error parameters.
+        start_response = self.app.get(start_url)
+        auth_response = requests.get(start_response["Location"], allow_redirects=False)
+        # check out assumptions/expectations before proceeding
+        callback_url = furl(auth_response.headers["Location"])
+        assert callback_url.netloc == "testserver"
+        assert "state" in callback_url.args
+        # modify the error parameters - there doesn't seem to be an obvious way to trigger
+        # this via keycloak itself.
+        # Note: this is an example of a specific provider. It may differ when a
+        # different provider is used. According to
+        # https://openid.net/specs/openid-connect-core-1_0.html#AuthError and
+        # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1 , this is the
+        # error we expect from OIDC.
+        callback_url.args.update(
+            {
+                "error": "IDP-3200",
+                "error_description": (
+                    "Authentication with IdP 'simulator' was aborted, most likely "
+                    "because the end-user cancelled the authentication.",
+                ),
+            }
+        )
+
+        callback_response = self.app.get(str(callback_url), auto_follow=True)
+
+        self.assertEqual(callback_response.status_code, 200)
+        expected_url = furl(url_helper.frontend_start).add(
+            {"_eherkenning-message": "login-cancelled"}
+        )
+        assert BACKEND_OUTAGE_RESPONSE_PARAMETER not in expected_url.args
+        self.assertEqual(callback_response.request.url, str(expected_url))
 
     @tag("gh-3656", "gh-3692")
     def test_eherkenning_error_reported_for_cancelled_login_anon_django_user(self):

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/vcr_cassettes/test_auth_flow_callbacks/DigiDCallbackTests/test_digid_error_reported_for_cancelled_login_anon_django_user_signicat.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/vcr_cassettes/test_auth_flow_callbacks/DigiDCallbackTests/test_digid_error_reported_for_cancelled_login_anon_django_user_signicat.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+  response:
+    body:
+      string: ''
+    headers:
+      Location:
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '0'
+    status:
+      code: 302
+      message: Found
+version: 1

--- a/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/vcr_cassettes/test_auth_flow_callbacks/EHerkenningCallbackTests/test_eherkenning_error_reported_for_cancelled_login_anon_django_user_signicat.yaml
+++ b/src/openforms/authentication/contrib/digid_eherkenning_oidc/tests/vcr_cassettes/test_auth_flow_callbacks/EHerkenningCallbackTests/test_eherkenning_error_reported_for_cancelled_login_anon_django_user_signicat.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: http://localhost:8080/realms/test/protocol/openid-connect/auth?response_type=code&scope=badscope&client_id=testid&redirect_uri=http%3A%2F%2Ftestserver%2Fauth%2Foidc%2Fcallback%2F&state=not-a-random-string&nonce=not-a-random-string
+  response:
+    body:
+      string: ''
+    headers:
+      Location:
+      - http://testserver/auth/oidc/callback/?error=invalid_scope&error_description=Invalid+scopes%3A+badscope&state=not-a-random-string&iss=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '0'
+    status:
+      code: 302
+      message: Found
+version: 1


### PR DESCRIPTION
Closes #5938

**Changes**

Signicat uses [specific "ErrorCode"'s](https://developer.signicat.com/docs/eid-hub/oidc/oidc-error-codes/) for the `error` request query  parameter whenever an error occures after a user tries to login with DigiD (through OIDC). OF previously only knew the `access_denied` error code but this was not used by Signicat. These changes map the Signicat known "ErrorCode"'s to the OF known error codes.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes

See https://docs.maykin.nl/en/docs/development/open-formulieren#local-signicat-environment-openid-connect for the documentation on how to test this locally.
