### PR TITLE
Capture TraceID and SpanID from OTel for Sentry events

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -27,7 +27,7 @@ from openforms.logging.processors import (
     drop_user_agent_in_dev,
 )
 
-from .utils import Filesize, get_sentry_integrations
+from .utils import Filesize, get_sentry_integrations, sentry_before_send
 
 # Build paths inside the project, so further paths can be defined relative to
 # the code root. Gets the abspath to src/openforms
@@ -974,7 +974,10 @@ if SENTRY_DSN:
     }
 
     sentry_sdk.init(
-        **SENTRY_CONFIG, integrations=get_sentry_integrations(), send_default_pii=True
+        **SENTRY_CONFIG,
+        integrations=get_sentry_integrations(),
+        send_default_pii=True,
+        before_send=sentry_before_send,
     )
 
 # Sentry for the Open-Forms SDK

--- a/src/openforms/conf/utils.py
+++ b/src/openforms/conf/utils.py
@@ -3,8 +3,10 @@ import re
 from collections.abc import Callable, MutableMapping
 from typing import ClassVar
 
+from opentelemetry import trace
 from sentry_sdk.integrations import DidNotEnable, django, redis
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.types import Event, Hint
 
 type ConverterMapping = MutableMapping[str, Callable[[int], int]]
 
@@ -100,6 +102,21 @@ def get_sentry_integrations() -> list:
         extra.append(celery.CeleryIntegration())
 
     return [*default, *extra]
+
+
+def sentry_before_send(event: Event, hint: Hint) -> Event | None:
+    span = trace.get_current_span()
+    if span.is_recording():
+        ctx = span.get_span_context()
+        if "extra" not in event:  # type checker doesn't like setdefault
+            event["extra"] = {}
+        event["extra"].update(
+            {
+                "otel.span_id": format(ctx.span_id, "016x"),
+                "otel.trace_id": format(ctx.trace_id, "032x"),
+            }
+        )
+    return event
 
 
 def mute_logging(config: dict) -> None:  # pragma: no cover


### PR DESCRIPTION
Allowing correlation between Sentry events and traces/logs in Grafana.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
