### PR TITLE
Remove `completed` and `is_applicable` fields from `SubmissionStepSerializer`

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -10942,12 +10942,6 @@ components:
           type: object
           additionalProperties: {}
           nullable: true
-        isApplicable:
-          type: boolean
-          readOnly: true
-        completed:
-          type: boolean
-          readOnly: true
         canSubmit:
           type: boolean
           readOnly: true
@@ -10976,12 +10970,10 @@ components:
             Will be empty if the backend is required to evaluate form logic.
       required:
       - canSubmit
-      - completed
       - configuration
       - defaultConfiguration
       - formStepUuid
       - id
-      - isApplicable
       - logicRules
       - requireBackendLogicEvaluation
       - slug

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -349,8 +349,6 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             "form_step_uuid",
             "slug",
             "data",
-            "is_applicable",
-            "completed",
             "can_submit",
             "configuration",
             "default_configuration",

--- a/src/openforms/submissions/tests/form_logic/test_side_effects.py
+++ b/src/openforms/submissions/tests/form_logic/test_side_effects.py
@@ -89,10 +89,14 @@ class SideEffectTests(SubmissionsMixin, APITestCase):
             "api:submission-steps-detail",
             kwargs={"submission_uuid": submission.uuid, "step_uuid": step2.uuid},
         )
+        submission_url = reverse(
+            "api:submission-detail",
+            kwargs={"uuid": submission.uuid},
+        )
         with self.subTest("Test setup check"):
-            step2_detail = self.client.get(step2_url)
+            submission_detail = self.client.get(submission_url)
 
-            self.assertTrue(step2_detail.data["is_applicable"])
+            self.assertTrue(submission_detail.data["steps"][1]["is_applicable"])
 
         # now alter the data of step one, triggering the N/A logic
         with self.subTest("Modify step 1 data to trigger logic"):
@@ -110,9 +114,10 @@ class SideEffectTests(SubmissionsMixin, APITestCase):
 
         # check the state of step 2 again
         with self.subTest("Verify step 2 state"):
+            submission_detail = self.client.get(submission_url)
             step2_detail = self.client.get(step2_url)
 
-            self.assertFalse(step2_detail.data["is_applicable"])
+            self.assertFalse(submission_detail.data["steps"][1]["is_applicable"])
             self.assertEqual(step2_detail.data["data"], {})
 
     def test_blocked_submission_is_reset(self):

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -305,7 +305,6 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
 
             data = response.json()
 
-            self.assertTrue(data["completed"])
             self.assertTrue(data["canSubmit"])
 
         with self.subTest("logic step for step 2 should not allow submitting"):

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -113,8 +113,6 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": True,
             "logicRules": [],
@@ -159,8 +157,6 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": True,
             "logicRules": [],
@@ -884,8 +880,6 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": False,
             "logicRules": [],
@@ -929,8 +923,6 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": True,
             "logicRules": [],
@@ -997,8 +989,6 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": False,
             "logicRules": [
@@ -1087,8 +1077,6 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": True,
             "logicRules": [],  # logic rules are not serialized when the backend is required
@@ -1157,8 +1145,6 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
                 ]
             },
             "data": {},
-            "isApplicable": True,
-            "completed": False,
             "canSubmit": True,
             "requireBackendLogicEvaluation": True,
             "logicRules": [],  # logic rules are not serialized when the backend is required

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -80,8 +80,6 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
                 },
                 "defaultConfiguration": None,
                 "data": {"test-key": "example data"},
-                "isApplicable": True,
-                "completed": True,
                 "canSubmit": True,
                 "logicRules": [],
                 "requireBackendLogicEvaluation": True,


### PR DESCRIPTION
Closes #6107

**Changes**

* Removed `completed` and `is_applicable` fields from `SubmissionStepSerializer`
* Updated failing tests

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
