### PR TITLE
Configure staticfiles storage entry

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -367,6 +367,20 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    # The file storage engine to use when collecting static files with the
+    # collectstatic management command.
+    "staticfiles": {
+        "BACKEND": (
+            "django.contrib.staticfiles.storage."
+            f"{config('STATICFILES_STORAGE_CLASS', default='StaticFilesStorage')}"
+        ),
+    },
+}
+
 MEDIA_ROOT = BASE_DIR / "media"
 
 MEDIA_URL = "/media/"

--- a/src/openforms/conf/production.py
+++ b/src/openforms/conf/production.py
@@ -12,6 +12,7 @@ os.environ.setdefault("ENVIRONMENT", "production")
 os.environ.setdefault("CACHE_DEFAULT", "127.0.0.1:6379/2")
 os.environ.setdefault("CACHE_AXES", "127.0.0.1:6379/4")
 os.environ.setdefault("CACHE_PORTALOCKER", "127.0.0.1:6379/8")
+os.environ.setdefault("STATICFILES_STORAGE_CLASS", "ManifestStaticFilesStorage")
 
 from .base import *  # noqa isort:skip
 
@@ -22,12 +23,6 @@ for db_config in DATABASES.values():
 # Caching sessions.
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
-
-# The file storage engine to use when collecting static files with the
-# collectstatic management command.
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-
-# Production logging facility.
 
 # Production logging facility.
 handlers = ["console"] if LOG_STDOUT else ["django"]


### PR DESCRIPTION
Closes #6110

**Changes**

Django 5.1 deleted the STATICFILES_STORAGE setting in favour of the STORAGES setting. The appropriate configuration is now moved into the new `STORAGES` setting.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
