### PR TITLE
[#6119] Fix min length of steps in FormSerializer v3

### DIFF
--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -61,7 +61,7 @@ class FormSerializer(serializers.ModelSerializer):
         slug_field="uuid",
     )
 
-    steps = FormStepSerializer(many=True, source="formstep_set", min_length=1)  # pyright: ignore[reportCallIssue]
+    steps = FormStepSerializer(many=True, source="formstep_set")
 
     payment = FormPaymentSerializer(required=False, source="*")
 
@@ -306,6 +306,31 @@ class FormSerializer(serializers.ModelSerializer):
             )
 
         return value
+
+    def validate(self, attrs):
+        steps = attrs.get("formstep_set")
+
+        # validate is called multiple times because of the nested serializer fileds and
+        # this means that steps will not exist at every call
+
+        if steps is None:
+            return attrs
+
+        is_appointment = attrs.get("is_appointment")
+
+        # regular form should have at least one step
+        if not is_appointment and len(steps) == 0:
+            raise serializers.ValidationError(
+                _("At least one form step is required in a regular form.")
+            )
+
+        # appointment form should not have any steps
+        if is_appointment and len(steps) > 0:
+            raise serializers.ValidationError(
+                _("Form steps are not allowed in an appointment form.")
+            )
+
+        return attrs
 
     @transaction.atomic()
     def save(self, **kwargs):

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -35,7 +35,7 @@ from ....models import (
     FormStep,
     FormVariable,
 )
-from ..typing import FormStepData, FormValidatedData
+from ..typing import FormStepData, FormValidatedData, NewFormValidatedData
 from .form_step import FormStepSerializer
 from .payment import FormPaymentSerializer
 
@@ -61,7 +61,7 @@ class FormSerializer(serializers.ModelSerializer):
         slug_field="uuid",
     )
 
-    steps = FormStepSerializer(many=True, source="formstep_set")
+    steps = FormStepSerializer(many=True, required=True, source="formstep_set")
 
     payment = FormPaymentSerializer(required=False, source="*")
 
@@ -142,7 +142,7 @@ class FormSerializer(serializers.ModelSerializer):
         }
 
     @transaction.atomic()
-    def create(self, validated_data: FormValidatedData) -> Form:
+    def create(self, validated_data: NewFormValidatedData) -> Form:
         instance = super().create(
             {k: v for k, v in validated_data.items() if k not in self._nested_fields}
         )
@@ -307,12 +307,13 @@ class FormSerializer(serializers.ModelSerializer):
 
         return value
 
-    def validate(self, attrs):
+    def validate(self, attrs: FormValidatedData | NewFormValidatedData):
+        # validate is called multiple times because of the nested serializer fields.
+        # For example ModelTranslationsSerializer is calling it 2 times (current amount
+        # of languages) but at this point the attrs contain only the related data (child).
+        # Fixing/updating ModelTranslationsSerializer can be tricky (it's used a lot in
+        # the project), so that's why we do the check here.
         steps = attrs.get("formstep_set")
-
-        # validate is called multiple times because of the nested serializer fileds and
-        # this means that steps will not exist at every call
-
         if steps is None:
             return attrs
 

--- a/src/openforms/forms/api/v3/typing.py
+++ b/src/openforms/forms/api/v3/typing.py
@@ -92,8 +92,7 @@ class PaymentData(TypedDict):
     payment_backend_options: dict
 
 
-class FormValidatedData(TypedDict):
-    uuid: UUID
+class NewFormValidatedData(TypedDict):
     name: str
     internal_name: NotRequired[str]
     internal_remarks: NotRequired[str]
@@ -139,3 +138,7 @@ class FormValidatedData(TypedDict):
     new_logic_evaluation_enabled: NotRequired[bool]
 
     translations: NotRequired[FormTranslationsData]
+
+
+class FormValidatedData(NewFormValidatedData):
+    uuid: UUID

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -128,7 +128,7 @@ class FormEndpointTests(APITestCase):
                 },
             },
             "appointmentOptions": {
-                "isAppointment": True,
+                "isAppointment": False,
             },
             "literals": {
                 "beginText": {"value": "Different Begin Text"},
@@ -258,7 +258,7 @@ class FormEndpointTests(APITestCase):
         self.assertTrue(form.login_required)
         self.assertTrue(form.translation_enabled)
 
-        self.assertTrue(form.is_appointment)
+        self.assertFalse(form.is_appointment)
         self.assertEqual(form.slug, "create-form")
 
         # product
@@ -726,7 +726,7 @@ class FormEndpointTests(APITestCase):
             "steps.0.formDefinition.configuration.components.0",
         )
 
-    def test_create_form_requires_one_step(self):
+    def test_create_regular_form_requires_one_step(self):
         url = reverse(
             "api:v3:form-detail",
             kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
@@ -734,7 +734,66 @@ class FormEndpointTests(APITestCase):
         data = {
             "name": "Create form",
             "slug": "create-form",
+            "appointmentOptions": {
+                "isAppointment": False,
+            },
             "steps": [],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        assert "invalidParams" in response_data and response_data["invalidParams"]
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["invalidParams"][0]["code"], "invalid")
+        self.assertEqual(response_data["invalidParams"][0]["name"], "nonFieldErrors")
+        self.assertEqual(
+            response_data["invalidParams"][0]["reason"],
+            _("At least one form step is required in a regular form."),
+        )
+
+    def test_create_appointment_form_requires_zero_steps(self):
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "appointmentOptions": {
+                "isAppointment": True,
+            },
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": uuid4(),
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                }
+            ],
         }
         response = self.client.put(url, data=data)
         response_data = response.json()
@@ -742,15 +801,11 @@ class FormEndpointTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert "invalidParams" in response_data and response_data["invalidParams"]
         self.assertEqual(len(response_data["invalidParams"]), 1)
-        self.assertEqual(response_data["invalidParams"][0]["code"], "min_length")
-        self.assertEqual(
-            response_data["invalidParams"][0]["name"], "steps.nonFieldErrors"
-        )
+        self.assertEqual(response_data["invalidParams"][0]["code"], "invalid")
+        self.assertEqual(response_data["invalidParams"][0]["name"], "nonFieldErrors")
         self.assertEqual(
             response_data["invalidParams"][0]["reason"],
-            _("Ensure this field has at least {min_length} elements.").format(
-                min_length=1
-            ),
+            _("Form steps are not allowed in an appointment form."),
         )
 
     def test_incorrect_payment_backend_options(self):


### PR DESCRIPTION
Closes #6119

**Changes**

The previous min_length=1 was ok for regular forms but does not work for the appointment forms where no steps are defined. We explicitly remove all the steps in the frontend. This is now done in the validate method where we can access both the is_appointment and the formstep_set.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
