### PR TITLE
Remove submission step data

### DIFF
--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -248,6 +248,10 @@ class ComponentNodeTests(TestCase):
         cls.submission = submission
         cls.step = submission.steps[0]
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        cls.step_data = state.get_data(submission_step=cls.step)
+
     def test_generic_node_builder(self):
         """
         Assert that ComponentNode.build_node produces node instances.
@@ -259,7 +263,7 @@ class ComponentNodeTests(TestCase):
         assert component["key"] == "input1"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertIsInstance(component_node, ComponentNode)
@@ -289,7 +293,7 @@ class ComponentNodeTests(TestCase):
 
         with patch("openforms.formio.rendering.registry.register", new=register):
             component_node = ComponentNode.build_node(
-                step_data=self.step.data, component=component, renderer=renderer
+                step_data=self.step_data, component=component, renderer=renderer
             )
 
         self.assertIsInstance(component_node, TextFieldNode)
@@ -306,7 +310,7 @@ class ComponentNodeTests(TestCase):
             assert component["hidden"]
 
             component_node = ComponentNode.build_node(
-                step_data=self.step.data, component=component, renderer=renderer
+                step_data=self.step_data, component=component, renderer=renderer
             )
 
             nodelist = list(component_node)
@@ -324,7 +328,7 @@ class ComponentNodeTests(TestCase):
 
             with patch("openforms.formio.rendering.registry.register", new=register):
                 component_node = ComponentNode.build_node(
-                    step_data=self.step.data, component=fieldset, renderer=renderer
+                    step_data=self.step_data, component=fieldset, renderer=renderer
                 )
 
                 nodelist = list(component_node)
@@ -346,7 +350,7 @@ class ComponentNodeTests(TestCase):
             assert component["hidden"]
 
             component_node = ComponentNode.build_node(
-                step_data=self.step.data, component=component, renderer=renderer
+                step_data=self.step_data, component=component, renderer=renderer
             )
 
             nodelist = list(component_node)
@@ -364,7 +368,7 @@ class ComponentNodeTests(TestCase):
 
             with patch("openforms.formio.rendering.registry.register", new=register):
                 component_node = ComponentNode.build_node(
-                    step_data=self.step.data, component=fieldset, renderer=renderer
+                    step_data=self.step_data, component=fieldset, renderer=renderer
                 )
 
                 nodelist = list(component_node)
@@ -414,7 +418,7 @@ class ComponentNodeTests(TestCase):
             "components"
         ]:
             component_node = ComponentNode.build_node(
-                step_data=self.step.data, component=component, renderer=renderer
+                step_data=self.step_data, component=component, renderer=renderer
             )
             nodelist += list(component_node)
 
@@ -455,7 +459,7 @@ class ComponentNodeTests(TestCase):
                 "components"
             ]:
                 component_node = ComponentNode.build_node(
-                    step_data=self.step.data, component=component, renderer=renderer
+                    step_data=self.step_data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 
@@ -488,7 +492,7 @@ class ComponentNodeTests(TestCase):
                 "components"
             ]:
                 component_node = ComponentNode.build_node(
-                    step_data=self.step.data, component=component, renderer=renderer
+                    step_data=self.step_data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 
@@ -523,7 +527,7 @@ class ComponentNodeTests(TestCase):
                 "components"
             ]:
                 component_node = ComponentNode.build_node(
-                    step_data=self.step.data, component=component, renderer=renderer
+                    step_data=self.step_data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 
@@ -716,12 +720,16 @@ class ComponentNodeTests(TestCase):
         step = submission.steps[0]
         register = Registry()
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         nodelist = []
         with patch("openforms.formio.rendering.registry.register", new=register):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=True)
             for component in step.form_step.form_definition.configuration["components"]:
                 component_node = ComponentNode.build_node(
-                    step_data=step.data, component=component, renderer=renderer
+                    step_data=step_data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 
@@ -937,12 +945,16 @@ class ComponentNodeTests(TestCase):
         step = submission.steps[0]
         register = Registry()
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         nodelist = []
         with patch("openforms.formio.rendering.registry.register", new=register):
             renderer = Renderer(submission, mode=RenderModes.summary, as_html=False)
             for component in step.form_step.form_definition.configuration["components"]:
                 component_node = ComponentNode.build_node(
-                    step_data=step.data, component=component, renderer=renderer
+                    step_data=step_data, component=component, renderer=renderer
                 )
                 nodelist += list(component_node)
 

--- a/src/openforms/formio/rendering/tests/test_custom_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_custom_formio_components.py
@@ -51,9 +51,13 @@ class CustomFormNodeTests(TestCase):
             },
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         renderer = Renderer(submission, mode=RenderModes.summary, as_html=True)
         component_node = ComponentNode.build_node(
-            step_data=step.data, component=component, renderer=renderer
+            step_data=step_data, component=component, renderer=renderer
         )
 
         nodelist = list(component_node)
@@ -128,9 +132,13 @@ class CustomFormNodeTests(TestCase):
             },
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         renderer = Renderer(submission, mode=RenderModes.summary, as_html=True)
         component_node = ComponentNode.build_node(
-            step_data=step.data, component=component, renderer=renderer
+            step_data=step_data, component=component, renderer=renderer
         )
 
         nodelist = list(component_node)

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -201,6 +201,10 @@ class FormNodeTests(TestCase):
         cls.submission = submission
         cls.step = step
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        cls.step_data = state.get_data(submission_step=step)
+
     def test_fieldsets_hidden_if_all_children_hidden(self):
         # we always need a renderer instance
         renderer = Renderer(self.submission, mode=RenderModes.pdf, as_html=False)
@@ -208,7 +212,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "fieldset"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -221,7 +225,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "fieldset"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertTrue(component_node.is_visible)
@@ -237,7 +241,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "fieldset"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -255,7 +259,7 @@ class FormNodeTests(TestCase):
         }
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertEqual(component_node.label, "")
@@ -267,7 +271,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "columns"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -280,7 +284,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "columns"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertTrue(component_node.is_visible)
@@ -296,7 +300,7 @@ class FormNodeTests(TestCase):
         assert component["type"] == "columns"
 
         component_node = ComponentNode.build_node(
-            step_data=self.step.data, component=component, renderer=renderer
+            step_data=self.step_data, component=component, renderer=renderer
         )
 
         self.assertFalse(component_node.is_visible)
@@ -311,7 +315,7 @@ class FormNodeTests(TestCase):
                 renderer = Renderer(self.submission, mode=render_mode, as_html=False)
 
                 component_node = ComponentNode.build_node(
-                    step_data=self.step.data, component=component, renderer=renderer
+                    step_data=self.step_data, component=component, renderer=renderer
                 )
 
                 self.assertEqual(component_node.label, "")
@@ -339,6 +343,11 @@ class FormNodeTests(TestCase):
             submission=submission,
             form_step=submission.form.formstep_set.get(form__name="public name"),
         )
+
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         expected_visibility = {
             RenderModes.confirmation_email: False,
             RenderModes.pdf: True,
@@ -350,7 +359,7 @@ class FormNodeTests(TestCase):
             with self.subTest(render_mode=render_mode):
                 renderer = Renderer(submission, mode=render_mode, as_html=False)
                 component_node = ComponentNode.build_node(
-                    step_data=step.data, component=component, renderer=renderer
+                    step_data=step_data, component=component, renderer=renderer
                 )
 
                 self.assertEqual(component_node.is_visible, is_visible)
@@ -358,7 +367,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=True)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
 
             self.assertEqual(
@@ -368,7 +377,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=False):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=False)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
 
             self.assertEqual(component_node.value, "WYSIWYG with markup")
@@ -395,6 +404,11 @@ class FormNodeTests(TestCase):
             submission=submission,
             form_step=submission.form.formstep_set.get(form__name="public name"),
         )
+
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         expected_visibility = {
             RenderModes.confirmation_email: False,
             RenderModes.pdf: True,
@@ -406,7 +420,7 @@ class FormNodeTests(TestCase):
             with self.subTest(render_mode=render_mode):
                 renderer = Renderer(submission, mode=render_mode, as_html=False)
                 component_node = ComponentNode.build_node(
-                    step_data=step.data, component=component, renderer=renderer
+                    step_data=step_data, component=component, renderer=renderer
                 )
 
                 self.assertEqual(component_node.is_visible, is_visible)
@@ -414,7 +428,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=True)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
 
             self.assertEqual(
@@ -424,7 +438,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=False):
             renderer = Renderer(submission, mode=RenderModes.pdf, as_html=False)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
 
             self.assertEqual(component_node.value, "WYSIWYG with markup")
@@ -476,10 +490,14 @@ class FormNodeTests(TestCase):
             _component_data_path="file",
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step_data=step.data,
+                step_data=step_data,
                 component=component,
                 configuration_path="components.0",
                 renderer=renderer,
@@ -498,7 +516,7 @@ class FormNodeTests(TestCase):
                 submission, mode=RenderModes.registration, as_html=False
             )
             component_node = ComponentNode.build_node(
-                step_data=step.data,
+                step_data=step_data,
                 component=component,
                 configuration_path="components.0",
                 renderer=renderer,
@@ -645,10 +663,14 @@ class FormNodeTests(TestCase):
             submission.submissionvaluevariable_set.filter(key="nested.file").exists()
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             repeating_group_node = ComponentNode.build_node(
-                step_data=step.data,
+                step_data=step_data,
                 component=components[0],
                 renderer=renderer,
                 configuration_path="components.0",
@@ -687,7 +709,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             nested_file_node = ComponentNode.build_node(
-                step_data=step.data,
+                step_data=step_data,
                 component=components[1],
                 renderer=renderer,
                 configuration_path="components.1",
@@ -799,10 +821,14 @@ class FormNodeTests(TestCase):
             _component_data_path="attachment",
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             repeating_group_node = ComponentNode.build_node(
-                step_data=step.data,
+                step_data=step_data,
                 component=components[0],
                 configuration_path="components.0",
                 renderer=renderer,
@@ -827,7 +853,7 @@ class FormNodeTests(TestCase):
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             outside_file_node = ComponentNode.build_node(
-                step_data=step.data,
+                step_data=step_data,
                 component=components[1],
                 configuration_path="components.1",
                 renderer=renderer,
@@ -946,6 +972,10 @@ class FormNodeTests(TestCase):
             _component_data_path="repeatingGroup.0.fileInRepeatingGroup2",
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         self.assertEqual(1, submission.submissionvaluevariable_set.count())
         self.assertTrue(
             submission.submissionvaluevariable_set.filter(key="repeatingGroup").exists()
@@ -953,7 +983,7 @@ class FormNodeTests(TestCase):
 
         renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
         repeating_group_node = ComponentNode.build_node(
-            step_data=step.data,
+            step_data=step_data,
             component=components[0],
             configuration_path="components.0",
             renderer=renderer,
@@ -1001,9 +1031,14 @@ class FormNodeTests(TestCase):
             form_step=submission.form.formstep_set.get(),
             data={},
         )
+
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
         component_node = ComponentNode.build_node(
-            step_data=step.data, component=component, renderer=renderer
+            step_data=step_data, component=component, renderer=renderer
         )
         link = component_node.render()
         self.assertEqual(link, "My File: ")
@@ -1038,10 +1073,14 @@ class FormNodeTests(TestCase):
             },
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
             nodelist = list(component_node)
 
@@ -1085,10 +1124,14 @@ class FormNodeTests(TestCase):
             },
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
             nodelist = list(component_node)
 
@@ -1164,10 +1207,14 @@ class FormNodeTests(TestCase):
             },
         )
 
+        # Get submission data from the state
+        state = submission.load_submission_value_variables_state()
+        step_data = state.get_data(submission_step=step)
+
         with self.subTest(as_html=True):
             renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
             component_node = ComponentNode.build_node(
-                step_data=step.data, component=component, renderer=renderer
+                step_data=step_data, component=component, renderer=renderer
             )
             nodelist = list(component_node)
 

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -310,6 +310,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         ),
     )
     data = FormioDataField(
+        source="_data",
         label=_("data"),
         required=False,
         allow_null=True,
@@ -408,7 +409,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
 
         # Serialize the data to JSON. We can't use a generic JSON encoder here, because
         # we need context from the variable
-        data = instance.unsaved_data if in_form_logic_evaluation else instance.data
+        data = instance.unsaved_data if in_form_logic_evaluation else instance._data
         serialized_data = FormioData()
         state = instance.submission.load_submission_value_variables_state()
         variables = state.get_variables_in_submission_step(instance)

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -17,7 +17,6 @@ from openforms.formio.typing import FormioConfiguration
 
 from .logic.actions import ActionOperation
 from .logic.rules import get_rules_to_evaluate, iter_evaluate_rules
-from .models.submission_step import DirtyData
 
 if TYPE_CHECKING:
     from .models import Submission, SubmissionStep
@@ -199,7 +198,7 @@ def evaluate_form_logic(
     for key, variable in relevant_variables.items():
         if not variable.form_variable or initial_data[key] != data_for_evaluation[key]:
             updated_step_data[key] = data_for_evaluation[key]
-    step.data = DirtyData(updated_step_data)
+    step.unsaved_data = updated_step_data
 
     step._form_logic_evaluated = True
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -30,7 +30,6 @@ from openforms.variables.models import ServiceFetchConfiguration
 from openforms.variables.service import resolve_key
 
 from ..models import Submission, SubmissionStep
-from ..models.submission_step import DirtyData
 from .log_utils import log_errors
 from .service_fetching import perform_service_fetch
 
@@ -336,10 +335,10 @@ class StepNotApplicableAction(ActionOperation):
 
         # This clears data in the database to make sure that saved steps which later become
         # not-applicable don't have old data
-        submission_step_to_modify.data = FormioData()
+        submission_step_to_modify.reset()
         if submission_step_to_modify == step:
             step.is_applicable = False
-            step.data = DirtyData(FormioData())
+            assert step.unsaved_data is None
 
 
 @dataclass

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -1,5 +1,4 @@
 import uuid
-import warnings
 from copy import deepcopy
 
 from django.core import serializers
@@ -183,7 +182,7 @@ class SubmissionStep(models.Model):  # noqa: DJ008
         # TODO: should check that all the data for the form definition is present?
         # and validates?
         # For now - if it's been saved, we assume that was because it was completed
-        return bool(self.pk and self.data is not None)
+        return bool(self.pk)
 
     @property
     def can_submit(self) -> bool:
@@ -204,40 +203,28 @@ class SubmissionStep(models.Model):  # noqa: DJ008
         self._is_applicable = value
 
     def reset(self):
-        self.data = FormioData()
-        self.save()
+        self._data = FormioData()
 
     @property
     def unsaved_data(self) -> FormioData | None:
         return self._unsaved_data
 
-    @property
-    def data(self) -> FormioData:
-        warnings.warn(
-            "Using `SubmissionStep.data` to access submission data is deprecated. "
-            "Please use `SubmissionValueVariablesState.get_data(...)` with the "
-            "relevant flags instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    @unsaved_data.setter
+    def unsaved_data(self, value: FormioData) -> None:
+        self._unsaved_data = value
 
+    @property
+    def _data(self) -> FormioData:
         values_state = self.submission.load_submission_value_variables_state()
         step_data = values_state.get_data(submission_step=self)
         if self._unsaved_data:
             step_data.update(self._unsaved_data)
         return step_data
 
-    @data.setter
-    def data(self, data: FormioData | None) -> None:
-        if isinstance(data, DirtyData):
-            self._unsaved_data = data
-        else:
-            from .submission_value_variable import SubmissionValueVariable
+    @_data.setter
+    def _data(self, data: FormioData) -> None:
+        from .submission_value_variable import SubmissionValueVariable
 
-            SubmissionValueVariable.objects.bulk_create_or_update_from_data(
-                data, self.submission, self, reset_missing_variables=True
-            )
-
-
-class DirtyData(FormioData):
-    pass
+        SubmissionValueVariable.objects.bulk_create_or_update_from_data(
+            data, self.submission, self, reset_missing_variables=True
+        )

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -382,28 +382,67 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
 
     def test_only_changed_data_is_returned_after_submitting_step(self):
         submission = SubmissionFactory.from_components(
-            [{"key": "textfield", "type": "textfield", "label": "Textfield"}]
+            [
+                {"key": "textfield", "type": "textfield", "label": "Textfield"},
+                {
+                    "key": "betterTextfield",
+                    "type": "textfield",
+                    "label": "Better textfield",
+                },
+            ]
+        )
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger={"==": [{"var": "textfield"}, "foo"]},
+            actions=[
+                {
+                    "variable": "betterTextfield",
+                    "action": {
+                        "name": "Set value",
+                        "type": "variable",
+                        "value": "bar",
+                    },
+                }
+            ],
         )
 
-        endpoint = reverse(
+        step_uuid = submission.form.formstep_set.get().uuid
+        check_logic_endpoint = reverse(
             "api:submission-steps-logic-check",
             kwargs={
                 "submission_uuid": submission.uuid,
-                "step_uuid": submission.form.formstep_set.first().uuid,
+                "step_uuid": step_uuid,
+            },
+        )
+        step_detail_endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": step_uuid,
             },
         )
         self._add_submission_to_session(submission)
 
-        response = self.client.post(endpoint, data={"data": {"textfield": "foo"}})
+        response = self.client.post(
+            check_logic_endpoint,
+            data={"data": {"textfield": "foo", "betterTextfield": ""}},
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["step"]["data"], {})
+        # Only returns a data diff of the changed values
+        self.assertEqual(response.json()["step"]["data"], {"betterTextfield": "bar"})
 
-        # Simulate submitting the step (this creates the submission value variables)
-        submission_step = submission.submissionstep_set.first()
-        submission_step.data = {"textfield": "foo"}
+        # Submit the step (this creates the submission value variables)
+        response = self.client.put(
+            step_detail_endpoint,
+            data={"data": {"textfield": "foo", "betterTextfield": "bar"}},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Ensure returned data is still empty after moving back to the submitted step
-        response = self.client.post(endpoint, data={"data": {"textfield": "bar"}})
+        # Move back to the first step and make some changes
+        response = self.client.post(
+            check_logic_endpoint,
+            data={"data": {"textfield": "bar", "betterTextfield": "bar"}},
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # No changes during logic evaluation, so the returned data should be empty
         self.assertEqual(response.json()["step"]["data"], {})
@@ -663,7 +702,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
         submission = SubmissionFactory.create(form=form)
         # We assume the user has already gone through both of the steps, entered some
         # data, and returned to the first step
-        submission_step_1 = SubmissionStepFactory.create(
+        SubmissionStepFactory.create(
             submission=submission,
             form_step=step_1,
             data={"checkbox": True, "textfieldStep1": "some data"},
@@ -725,8 +764,22 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                 response.json()["step"]["data"], {"textfieldStep1": "some data"}
             )
 
-        # Simulate navigating to the next step
-        submission_step_1.data = {"checkbox": False, "textfieldStep1": ""}
+        # There will be another logic call because the textfield is now hidden, so it
+        # won't be included in the data
+        with self.subTest("2nd logic in step 1"):
+            response = self.client.post(endpoint, data={"data": {"checkbox": False}})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["step"]["data"], {})
+
+        with self.subTest("submit the step"):
+            endpoint = reverse(
+                "api:submission-steps-detail",
+                kwargs={
+                    "submission_uuid": submission.uuid,
+                    "step_uuid": step_1.uuid,
+                },
+            )
+            self.client.put(endpoint, data={"data": {"checkbox": False}})
 
         with self.subTest("logic in step 2"):
             endpoint = reverse(

--- a/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
+++ b/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
@@ -137,10 +137,8 @@ class DeterministicEvaluationTests(TestCase):
             evaluate_form_logic(submission, ss1)
 
             state = submission.load_submission_value_variables_state()
-            var_a = state.variables["a"]
-            var_b = state.variables["b"]
-            self.assertEqual(var_a.value, 2)
-            self.assertEqual(var_b.value, 4)
+            data = state.get_data(include_unsaved=True)
+            self.assertEqual({"a": 2, "b": 4, "c": None, "d": None}, data)
 
         with self.subTest("Evaluation not skipped on step 2"):
             ss2 = SubmissionStepFactory.create(
@@ -150,10 +148,8 @@ class DeterministicEvaluationTests(TestCase):
             evaluate_form_logic(submission, ss2)
 
             state = submission.load_submission_value_variables_state()
-            var_c = state.variables["c"]
-            var_d = state.variables["d"]
-            self.assertEqual(var_c.value, 2)
-            self.assertEqual(var_d.value, 6)
+            data = state.get_data(include_unsaved=True)
+            self.assertEqual({"a": 2, "b": 4, "c": 2, "d": 6}, data)
 
         with self.subTest("Evaluation not skipped on step 3"):
             ss3 = SubmissionStepFactory.create(
@@ -163,4 +159,5 @@ class DeterministicEvaluationTests(TestCase):
             evaluate_form_logic(submission, ss3)
 
             state = submission.load_submission_value_variables_state()
-            self.assertEqual(ss3.data, {"d": 6})
+            data = state.get_data(include_unsaved=True)
+            self.assertEqual({"a": 2, "b": 4, "c": 2, "d": 6}, data)

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -167,7 +167,7 @@ class ComponentModificationTests(TestCase):
             ]
         }
         self.assertEqual(configuration, expected)
-        self.assertEqual("", submission_step.data["component2"])
+        self.assertEqual("", submission_step.unsaved_data["component2"])
 
     def test_change_component_to_required(self):
         form = FormFactory.create()
@@ -597,7 +597,9 @@ class ComponentModificationTests(TestCase):
             ]
         }
         self.assertEqual(configuration, expected)
-        self.assertEqual({"step2_textfield1": "some value"}, submission_step_2.data)
+        self.assertEqual(
+            {"step2_textfield1": "some value"}, submission_step_2.unsaved_data
+        )
 
     def test_evaluate_logic_with_empty_data(self):
         """
@@ -855,9 +857,9 @@ class ComponentModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step)
 
-        self.assertEqual(
-            "Some data that must not be cleared!", submission_step.data["textField"]
-        )
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data(submission_step=submission_step, include_unsaved=True)
+        self.assertEqual("Some data that must not be cleared!", data["textField"])
 
     @tag("gh-5520")
     @unittest.expectedFailure
@@ -1014,7 +1016,9 @@ class ComponentModificationTests(TestCase):
             FormioData({"radio": "a", "nested": {"component": "test"}}),
         )
 
-        self.assertEqual(submission_step.data["nested"]["component"], "")
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data(submission_step=submission_step, include_unsaved=True)
+        self.assertEqual("", data["nested"]["component"])
 
     @tag("gh-2838")
     def test_hidden_select_component(self):
@@ -1049,7 +1053,7 @@ class ComponentModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step)
 
-        self.assertNotIn("selectboxes", submission_step.data)
+        self.assertEqual({}, submission_step.unsaved_data)
 
     @tag("gh-3744")
     def test_postcode_component_made_optional(self):

--- a/src/openforms/submissions/tests/form_logic/test_modify_step.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_step.py
@@ -2,8 +2,6 @@ from django.test import TestCase
 
 from freezegun import freeze_time
 
-from openforms.formio.service import FormioData
-from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -294,61 +292,6 @@ class StepModificationTests(TestCase):
             evaluate_form_logic(submission, submission_step)
 
         self.assertFalse(submission_step.can_submit)
-
-    def test_only_diff_data_returned(self):
-        form = FormFactory.create()
-        step = FormStepFactory.create(
-            form=form,
-            form_definition__configuration={
-                "components": [
-                    {
-                        "type": "textfield",
-                        "key": "name",
-                    },
-                    {
-                        "type": "textfield",
-                        "key": "changingKey",
-                    },
-                ]
-            },
-        )
-        FormLogicFactory.create(
-            form=form,
-            json_logic_trigger={
-                "==": [
-                    {"var": "name"},
-                    "john",
-                ]
-            },
-            actions=[
-                {
-                    "variable": "changingKey",
-                    "action": {
-                        "name": "Set value",
-                        "type": LogicActionTypes.variable,
-                        "value": "changed",
-                    },
-                }
-            ],
-        )
-        submission = SubmissionFactory.create(form=form)
-        submission_step = SubmissionStepFactory.create(
-            submission=submission, form_step=step
-        )
-
-        data = FormioData(
-            {
-                "name": "john",
-                "changingKey": "original",
-            }
-        )
-
-        evaluate_form_logic(submission, submission_step, data)
-
-        self.assertEqual(
-            submission_step.data,
-            {"changingKey": "changed"},
-        )
 
     def test_select_boxes_trigger(self):
         form = FormFactory.create()

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 import requests_mock
 from django_camunda.models import CamundaConfig
 
+from openforms.formio.service import FormioData
 from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
@@ -89,7 +90,6 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={},
         )
 
         evaluate_form_logic(submission, submission_step2)
@@ -167,7 +167,6 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={},
         )
 
         evaluate_form_logic(submission, submission_step2)
@@ -245,7 +244,6 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={},
         )
 
         evaluate_form_logic(submission, submission_step2)
@@ -881,7 +879,6 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={},
         )
         evaluate_form_logic(submission, submission_step2)
 
@@ -1013,7 +1010,6 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={},
         )
         evaluate_form_logic(submission, submission_step2)
 
@@ -1145,14 +1141,19 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={
-                "editgrid": [
-                    {"bsn": "999970409", "childName": "Pero"},
-                    {"bsn": "999970173", "childName": "Pelle"},
-                ]
-            },
         )
-        evaluate_form_logic(submission, submission_step2)
+        evaluate_form_logic(
+            submission,
+            submission_step2,
+            FormioData(
+                {
+                    "editgrid": [
+                        {"bsn": "999970409", "childName": "Pero"},
+                        {"bsn": "999970173", "childName": "Pelle"},
+                    ]
+                }
+            ),
+        )
 
         state = submission.load_submission_value_variables_state()
         self.assertEqual(
@@ -1243,7 +1244,6 @@ class VariableModificationTests(TestCase):
         submission_step2 = SubmissionStepFactory.build(
             submission=submission,
             form_step=step2,
-            data={},
         )
         evaluate_form_logic(submission, submission_step2)
 

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -102,8 +102,7 @@ class FormNodeTests(TestCase):
             ],
         )
         # set up data that marks step as not-applicable
-        self.sstep1.data = FormioData({"input1": "disabled-step-2"})
-        self.sstep1.save()
+        self.sstep1._data = FormioData({"input1": "disabled-step-2"})
 
         renderer = Renderer(
             submission=self.submission, mode=RenderModes.pdf, as_html=True

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -102,16 +102,18 @@ class SubmissionTests(TestCase):
             submission.remove_sensitive_data()
 
         submission.refresh_from_db()
-        submission_step.refresh_from_db()
-        submission_step_2.refresh_from_db()
+        state = submission.load_submission_value_variables_state()
 
-        self.assertNotIn("textFieldSensitive", submission_step.data)
-        self.assertEqual(
-            submission_step.data["textFieldNotSensitive"], "this is not sensitive"
+        step_data = state.get_data(
+            submission_step=submission_step, include_unsaved=True
         )
-        self.assertNotIn("textFieldSensitive2", submission_step_2.data)
+        self.assertEqual({"textFieldNotSensitive": "this is not sensitive"}, step_data)
+
+        step_data_2 = state.get_data(
+            submission_step=submission_step_2, include_unsaved=True
+        )
         self.assertEqual(
-            submission_step_2.data["textFieldNotSensitive2"], "this is not sensitive"
+            {"textFieldNotSensitive2": "this is not sensitive"}, step_data_2
         )
         self.assertTrue(submission._is_cleaned)
         self.assertEqual(submission.auth_info.value, "")

--- a/src/openforms/submissions/tests/test_submit_form_step.py
+++ b/src/openforms/submissions/tests/test_submit_form_step.py
@@ -85,7 +85,9 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
                 "requireBackendLogicEvaluation": True,
             },
         )
-        self.assertEqual(submission_step.data, {"test-key": "example data"})
+        state = self.submission.load_submission_value_variables_state()
+        data = state.get_data(submission_step=submission_step, include_unsaved=False)
+        self.assertEqual({"test-key": "example data"}, data)
 
         submission_variables = SubmissionValueVariable.objects.filter(
             submission=self.submission
@@ -176,18 +178,15 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual({"modified": "data", "foo": "bar"}, response.json()["data"])
-        submission_step.refresh_from_db()
-        self.assertEqual(submission_step.data, {"modified": "data", "foo": "bar"})
+
+        state = self.submission.load_submission_value_variables_state(refresh=True)
+        data = state.get_data(submission_step=submission_step, include_unsaved=False)
+        self.assertEqual({"modified": "data", "foo": "bar"}, data)
 
         submission_variables = SubmissionValueVariable.objects.filter(
             submission=self.submission
         )
-
         self.assertEqual(2, submission_variables.count())
-
-        submission_variable = submission_variables.get(key="modified")
-
-        self.assertEqual("data", submission_variable.value)
 
     def test_data_not_underscored(self):
         form_definition = FormDefinitionFactory.create(
@@ -218,11 +217,13 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
         response = self.client.put(endpoint, body)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        saved_data = submission.submissionstep_set.get().data
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data(
+            submission_step=submission.submissionstep_set.get(), include_unsaved=False
+        )
 
         # Check that the data has not been converted to snake case
-        self.assertIn("countryOfResidence", saved_data)
-        self.assertNotIn("country_of_residence", saved_data)
+        self.assertEqual({"countryOfResidence": "Netherlands"}, data)
 
     def test_data_not_camelised(self):
         form_definition = FormDefinitionFactory.create(
@@ -290,11 +291,10 @@ class FormStepSubmissionTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual({"nested": {"key": "some data"}}, response.json()["data"])
-        submission_step.refresh_from_db()
-        self.assertEqual(submission_step.data, {"nested": {"key": "some data"}})
 
-        variable = SubmissionValueVariable.objects.get(key="nested.key")
-        self.assertEqual(variable.value, "some data")
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data(submission_step=submission_step, include_unsaved=False)
+        self.assertEqual({"nested": {"key": "some data"}}, data)
 
     @tag("gh-5757")
     def test_create_step_data_with_fileupload(self):

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -155,7 +155,7 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 3. bulk_create var3 and var4 submission value variables
         # 4. bulk_update var1 and var2 submission value variables
         with self.assertNumQueries(4):
-            submission_step.data = FormioData(
+            submission_step._data = FormioData(
                 {
                     "var1": "test1-modified",
                     "var2": "test2-modified",
@@ -192,7 +192,7 @@ class SubmissionVariablesPerformanceTests(APITestCase):
         # 1. load_variables_state: retrieve form variables
         # 2. load_variables_state: retrieve submission value variables
         with self.assertNumQueries(2):
-            submission_step.data
+            submission_step._data
 
     def test_get_variables_state_no_submission_variables(self):
         form = FormFactory.create()

--- a/src/openforms/submissions/tests/test_variables/test_variable_injection.py
+++ b/src/openforms/submissions/tests/test_variables/test_variable_injection.py
@@ -12,7 +12,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from openforms.formio.service import FormioData
 from openforms.formio.tests.assertions import FormioMixin
 from openforms.forms.tests.factories import FormFactory, FormVariableFactory
 from openforms.variables.constants import FormVariableDataTypes
@@ -135,9 +134,6 @@ class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
 
     def test_detail_endpoint_interpolates_with_submission_data(self):
         self._add_submission_to_session(self.submission)
-        self.submission_step.data = FormioData(
-            {"text1": 'First "textfield"', "checkbox1": True}
-        )
         endpoint = reverse(
             "api:submission-steps-detail",
             kwargs={
@@ -146,8 +142,9 @@ class VariableInjectionTests(SubmissionsMixin, FormioMixin, APITestCase):
             },
         )
 
-        response = self.client.get(endpoint)
-
+        response = self.client.put(
+            endpoint, {"data": {"text1": 'First "textfield"', "checkbox1": True}}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         configuration = response.json()["configuration"]
 


### PR DESCRIPTION
Partly closes #6018 

[skip: e2e]

**Changes**

* `SubmissionStep.data` is no longer public API
* Updated logic and serializer to deal with this
* Updated failing tests

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
