### PR TITLE
Remove submission data

### DIFF
--- a/src/openforms/appointments/api/views.py
+++ b/src/openforms/appointments/api/views.py
@@ -385,7 +385,7 @@ class CancelAppointmentView(GenericAPIView):
                 audit_logger.warning("appointment_cancel_failure", exc_info=exc)
                 raise
 
-            emails = submission.get_email_confirmation_recipients(submission.data)
+            emails = submission.get_email_confirmation_recipients()
 
             # The user must enter the email address they used when creating
             # the appointment which we validate here

--- a/src/openforms/contrib/customer_interactions/update.py
+++ b/src/openforms/contrib/customer_interactions/update.py
@@ -87,7 +87,7 @@ def update_customer_interaction_data(
     """
 
     # submission profile data
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     profile_submission_data: list[DigitalAddress] = state.get_data()[profile_key]  # pyright: ignore[reportAssignmentType]
 
     # prefill config

--- a/src/openforms/contrib/haal_centraal/tests/test_integration.py
+++ b/src/openforms/contrib/haal_centraal/tests/test_integration.py
@@ -114,7 +114,7 @@ class BRPIntegrationTest(OFVCRMixin, TransactionTestCase):
             service.server_certificate.save()
 
         prefill_variables(submission=self.submission)
-        state = self.submission.load_submission_value_variables_state()
+        state = self.submission.variables_state
 
         self.assertPrefillVariableValues(state.variables["address"].value)
 
@@ -140,6 +140,6 @@ class BRPIntegrationTest(OFVCRMixin, TransactionTestCase):
         )
 
         prefill_variables(submission=self.submission)
-        state = self.submission.load_submission_value_variables_state()
+        state = self.submission.variables_state
 
         self.assertPrefillVariableValues(state.variables["address"].value)

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -737,7 +737,7 @@ class PartnerListField(serializers.Field):
     def validate_list(self, partners):
         component_key = self.component["key"]
         submission = self.context["submission"]
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         prefill_data = state.get_prefilled_data()
 
         fm_immutable_variable = FormVariable.objects.filter(
@@ -861,7 +861,7 @@ class ChildListField(serializers.Field):
     def validate_list(self, children):
         component_key = self.component["key"]
         submission = self.context["submission"]
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         prefill_data = state.get_prefilled_data()
 
         fm_immutable_variable = FormVariable.objects.filter(

--- a/src/openforms/formio/formatters/tests/test_kitchensink.py
+++ b/src/openforms/formio/formatters/tests/test_kitchensink.py
@@ -24,11 +24,12 @@ def filter_printable(components: Iterable[Component]) -> Iterable[Component]:
 
 def _get_printable_data(submission: Submission) -> list[tuple[str, Any]]:
     printable_data: list[tuple[str, Any]] = []
-    merged_data = submission.data
+    state = submission.load_submission_value_variables_state()
+    data = state.get_data()
 
     for component in filter_printable(submission.form.iter_components(recursive=True)):
         key = component["key"]
-        value = format_value(component, merged_data.get(key), as_html=False)
+        value = format_value(component, data.get(key), as_html=False)
         printable_data.append((component.get("label", key), value))
 
     return printable_data

--- a/src/openforms/formio/formatters/tests/test_kitchensink.py
+++ b/src/openforms/formio/formatters/tests/test_kitchensink.py
@@ -24,7 +24,7 @@ def filter_printable(components: Iterable[Component]) -> Iterable[Component]:
 
 def _get_printable_data(submission: Submission) -> list[tuple[str, Any]]:
     printable_data: list[tuple[str, Any]] = []
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     data = state.get_data()
 
     for component in filter_printable(submission.form.iter_components(recursive=True)):

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -289,7 +289,7 @@ class FormioNode(Node):
         assert self.step.form_step  # nosec: intended use of B101
         configuration = self.step.form_step.form_definition.configuration
 
-        state = self.step.submission.load_submission_value_variables_state()
+        state = self.step.submission.variables_state
         data = state.get_data(include_unsaved=True, submission_step=self.step)
         for configuration_path, component in iterate_components_with_configuration_path(
             configuration, recursive=False

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -1282,10 +1282,12 @@ class FormNodeTests(TestCase):
                 ]
             },
         )
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
 
         renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)
         component_node = ComponentNode.build_node(
-            step_data=submission.data, component=component, renderer=renderer
+            step_data=data, component=component, renderer=renderer
         )
         nodelist = list(component_node)
 

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -1282,7 +1282,7 @@ class FormNodeTests(TestCase):
                 ]
             },
         )
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
 
         renderer = Renderer(submission, mode=RenderModes.registration, as_html=True)

--- a/src/openforms/forms/json_schema.py
+++ b/src/openforms/forms/json_schema.py
@@ -72,7 +72,7 @@ def generate_json_schema(
 
     # Update the total configuration to add options to components that (possibly) use
     # another variable as a data source (radio, select, and selectboxes).
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     new_configuration = rewrite_formio_components(
         submission.total_configuration_wrapper,
         submission,

--- a/src/openforms/prefill/contrib/customer_interactions/api/views.py
+++ b/src/openforms/prefill/contrib/customer_interactions/api/views.py
@@ -63,7 +63,7 @@ class CommunicationPreferencesView(ListMixin[VariableValue], views.APIView):
             # it's possible to use profile component without prefill, so no warning
             return []
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         value = state.get_data()[form_variable.key]
         assert isinstance(value, Sequence)
         return value

--- a/src/openforms/prefill/contrib/customer_interactions/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/customer_interactions/tests/test_plugin.py
@@ -63,7 +63,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected = [
             {
@@ -118,7 +118,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         self.assertEqual(state.variables["communication-preferences"].value, [])
 
@@ -157,7 +157,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected = [
             {
@@ -208,7 +208,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         self.assertEqual(state.variables["communication-preferences"].value, [])
 
@@ -243,7 +243,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert not submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         self.assertEqual(state.variables["communication-preferences"].value, [])
 
@@ -282,7 +282,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected = [
             {
@@ -332,7 +332,7 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected = [
             {
@@ -377,6 +377,6 @@ class CommunicationPreferencesTests(OFVCRMixin, TestCase):
         assert submission.is_authenticated
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         self.assertEqual(state.variables["empty-preferences"].value, [])

--- a/src/openforms/prefill/contrib/eidas/tests/test_plugins.py
+++ b/src/openforms/prefill/contrib/eidas/tests/test_plugins.py
@@ -61,7 +61,7 @@ class EIDASCitizenTests(TransactionTestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         # assert that nothing was prefilled
         values = state.get_data()
@@ -85,7 +85,7 @@ class EIDASCitizenTests(TransactionTestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         # assert that nothing was prefilled
         values = state.get_data()
@@ -166,7 +166,7 @@ class EIDASCompanyPrefillTests(TransactionTestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         # assert that nothing was prefilled
         values = state.get_data()
@@ -191,7 +191,7 @@ class EIDASCompanyPrefillTests(TransactionTestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         # assert that nothing was prefilled
         values = state.get_data()

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -90,7 +90,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -138,7 +138,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -206,7 +206,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         with freeze_time("2025-04-25T18:00:00+01:00"):
             prefill_variables(submission=submission)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -257,7 +257,7 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         with freeze_time("2025-04-25T18:00:00+01:00"):
             prefill_variables(submission=submission)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -445,7 +445,7 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
         # validate request
         self.assertSoapBodyIsValid(request_body)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -512,7 +512,7 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
         # validate request
         self.assertSoapBodyIsValid(request_body)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         expected_data = [
             {
                 "bsn": "456789123",
@@ -597,7 +597,7 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
         # validate request
         self.assertSoapBodyIsValid(request_body)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -787,7 +787,7 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
         # validate request
         self.assertSoapBodyIsValid(request_body)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {
@@ -891,7 +891,7 @@ class FamilyMembersPrefillPluginStufBgTests(StUFBGAssertionsMixin, TestCase):
         # validate request
         self.assertSoapBodyIsValid(request_body)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expected_data = [
             {

--- a/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
+++ b/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
@@ -85,7 +85,7 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         self.assertEqual(TimelineLogProxy.objects.count(), 2)
         ownership_check_log, prefill_log = TimelineLogProxy.objects.all()
@@ -137,7 +137,7 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
 
         with self.assertRaises(PermissionDenied):
             prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
 
         self.assertEqual(TimelineLogProxy.objects.count(), 1)
@@ -192,7 +192,7 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         )
 
         prefill_variables(submission=submission)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
 
         self.assertEqual(TimelineLogProxy.objects.count(), 2)

--- a/src/openforms/prefill/service.py
+++ b/src/openforms/prefill/service.py
@@ -74,7 +74,7 @@ def inject_prefill(
     The prefill values are looped over by key: value, and for each value the matching
     component is looked up to normalize it in the context of the component.
     """
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     prefilled_data = state.get_prefilled_data()
     for key, variable in state.prefilled_variables.items():
         prefill_value = prefilled_data[key]
@@ -123,7 +123,7 @@ def prefill_variables(submission: Submission, register: Registry | None = None) 
     """
     register = register or default_register
 
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
 
     variables_with_attribute: list[SubmissionValueVariable] = []
     variables_with_options: list[SubmissionValueVariable] = []

--- a/src/openforms/prefill/tests/test_prefill_variables.py
+++ b/src/openforms/prefill/tests/test_prefill_variables.py
@@ -76,9 +76,7 @@ class PrefillVariablesTests(TestCase):
 
         prefill_variables(submission=submission_step.submission)
 
-        submission_value_variables_state = (
-            submission_step.submission.load_submission_value_variables_state()
-        )
+        submission_value_variables_state = submission_step.submission.variables_state
 
         self.assertEqual(2, len(submission_value_variables_state.variables))
 
@@ -111,9 +109,7 @@ class PrefillVariablesTests(TestCase):
 
         prefill_variables(submission=submission)
 
-        submission_value_variables_state = (
-            submission.load_submission_value_variables_state()
-        )
+        submission_value_variables_state = submission.variables_state
 
         self.assertEqual(1, len(submission_value_variables_state.variables))
 
@@ -219,7 +215,7 @@ class PrefillVariablesTests(TestCase):
         assert "defaultValue" in component_date
         self.assertEqual(component_date["defaultValue"], "1999-06-15")
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(
             state.get_prefilled_data().data,
             {
@@ -237,9 +233,7 @@ class PrefillVariablesTests(TestCase):
             data={"voornamen": "", "age": None},
         )
 
-        submission_value_variables_state = (
-            submission_step.submission.load_submission_value_variables_state()
-        )
+        submission_value_variables_state = submission_step.submission.variables_state
 
         FormVariable.objects.all().delete()
 
@@ -524,7 +518,7 @@ class PrefillVariablesFromOptionsTests(TestCase):
 
         prefill_variables(submission=submission, register=prefill_from_options_register)
 
-        variables_state = submission.load_submission_value_variables_state()
+        variables_state = submission.variables_state
         self.assertEqual(variables_state.get_data()["voornamen"], "foo, bar")
 
     @patch("openforms.plugins.plugin.GlobalConfiguration.get_solo")
@@ -559,7 +553,7 @@ class PrefillVariablesFromOptionsTests(TestCase):
 
         prefill_variables(submission=submission, register=prefill_from_options_register)
 
-        variables_state = submission.load_submission_value_variables_state()
+        variables_state = submission.variables_state
 
         self.assertEqual(variables_state.get_data(), {})
 
@@ -591,7 +585,7 @@ class PrefillVariablesFromOptionsTests(TestCase):
 
         prefill_variables(submission=submission, register=prefill_from_options_register)
 
-        variables_state = submission.load_submission_value_variables_state()
+        variables_state = submission.variables_state
 
         self.assertEqual(variables_state.get_data(), {})
 
@@ -623,7 +617,7 @@ class PrefillVariablesFromOptionsTests(TestCase):
 
         prefill_variables(submission=submission, register=prefill_from_options_register)
 
-        variables_state = submission.load_submission_value_variables_state()
+        variables_state = submission.variables_state
 
         self.assertEqual(variables_state.get_data(), {})
 

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -49,18 +49,18 @@ def get_process_variables(
         ]
     )
 
-    merged_data = submission.data
+    state = submission.load_submission_value_variables_state()
+    data = state.get_data()
     for component in submission.form.iter_components(recursive=True):
         if (key := component.get("key")) not in simple_mappings:
             continue
 
-        value = merged_data.get(key, None)
+        value = data.get(key, None)
         alias = simple_mappings[key]
         variables[alias] = to_python(component, value)
 
     complex_variables = get_complex_process_variables(
-        options.get("complex_process_variables", []),
-        merged_data,
+        options.get("complex_process_variables", []), data
     )
 
     if intersection := set(complex_variables).intersection(set(variables)):

--- a/src/openforms/registrations/contrib/camunda/plugin.py
+++ b/src/openforms/registrations/contrib/camunda/plugin.py
@@ -49,7 +49,7 @@ def get_process_variables(
         ]
     )
 
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     data = state.get_data()
     for component in submission.form.iter_components(recursive=True):
         if (key := component.get("key")) not in simple_mappings:

--- a/src/openforms/registrations/contrib/email/plugin.py
+++ b/src/openforms/registrations/contrib/email/plugin.py
@@ -59,7 +59,7 @@ class EmailRegistration(BasePlugin[Options]):
         log = logger.bind(
             submission_uuid=str(submission.uuid), form_uuid=str(submission.form.uuid)
         )
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         # ensure we have a fallback
         recipients: list[str] = options["to_emails"]
 

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -423,8 +423,10 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             "to_emails": ["foo@bar.nl", "bar@foo.nl"],
             "attach_files_to_email": None,
         }
-        submission = SubmissionFactory.from_data(
-            {"foo": "https://someurl.com"}, completed=True
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "foo", "label": "Link"}],
+            submitted_data={"foo": "https://someurl.com"},
+            completed=True,
         )
         plugin = EmailRegistration("email")
         plugin.register_submission(submission, email_form_options)
@@ -446,8 +448,10 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             "to_emails": ["foo@bar.nl", "bar@foo.nl"],
             "attach_files_to_email": None,
         }
-        submission = SubmissionFactory.from_data(
-            {"foo": "https://allowed.com"}, completed=True
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "foo", "label": "Link"}],
+            submitted_data={"foo": "https://allowed.com"},
+            completed=True,
         )
         plugin = EmailRegistration("email")
         plugin.register_submission(submission, email_form_options)
@@ -606,8 +610,9 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         self.assertEqual(pdf_export[2], "application/pdf")
 
     def test_register_and_update_paid_product_with_payment_email_recipient(self):
-        submission = SubmissionFactory.from_data(
-            {"voornaam": "Foo"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "voornaam", "label": "Voornaam"}],
+            submitted_data={"voornaam": "Foo"},
             form__product__price=Decimal("11.35"),
             form__payment_backend="demo",
             registration_success=True,
@@ -632,8 +637,9 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
     def test_register_and_update_paid_product_with_payment_email_recipient_and_variable_email_recipient(
         self,
     ):
-        submission = SubmissionFactory.from_data(
-            {"voornaam": "Foo"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "voornaam", "label": "Voornaam"}],
+            submitted_data={"voornaam": "Foo"},
             form__product__price=Decimal("11.35"),
             form__payment_backend="demo",
             registration_success=True,
@@ -665,8 +671,9 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
     def test_register_and_update_paid_product_with_variable_email_recipient(
         self,
     ):
-        submission = SubmissionFactory.from_data(
-            {"voornaam": "Foo"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "voornaam", "label": "Voornaam"}],
+            submitted_data={"voornaam": "Foo"},
             form__product__price=Decimal("11.35"),
             form__payment_backend="demo",
             registration_success=True,
@@ -703,8 +710,9 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
         config.wait_for_payment_to_register = True
         config.save()
 
-        submission = SubmissionFactory.from_data(
-            {"voornaam": "Foo"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "voornaam", "label": "Voornaam"}],
+            submitted_data={"voornaam": "Foo"},
             form__product__price=Decimal("11.35"),
             form__payment_backend="demo",
             registration_success=True,
@@ -1372,8 +1380,9 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             "to_emails": ["recipient@example.com"],
             "attach_files_to_email": None,
         }
-        submission = SubmissionFactory.from_data(
-            {"whatever": "156/Silence"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "whatever", "label": "Whatever"}],
+            submitted_data={"whatever": "156/Silence"},
             completed_not_preregistered=True,
             initial_data_reference="some-reference",
             form__registration_backend=PLUGIN_ID,

--- a/src/openforms/registrations/contrib/generic_json/plugin.py
+++ b/src/openforms/registrations/contrib/generic_json/plugin.py
@@ -41,7 +41,7 @@ class GenericJSONRegistration(BasePlugin):
     def register_submission(
         self, submission: Submission, options: GenericJSONOptions
     ) -> dict:
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         all_values = state.get_data(include_static_variables=True)
         all_values.update(state.get_static_data(other_registry=variables_registry))
@@ -242,7 +242,7 @@ def post_process(
     if transform_to_list is None:
         transform_to_list = []
 
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     configuration_wrapper = submission.total_configuration_wrapper
 
     # Create attachment mapping from key or component data path to attachment list

--- a/src/openforms/registrations/contrib/microsoft_graph/plugin.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/plugin.py
@@ -70,7 +70,7 @@ class MSGraphRegistration(BasePlugin[MicrosoftGraphOptions]):
             submission_report.content, folder_name / "report.pdf"
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
         data["__metadata__"] = {"submission_language": submission.language_code}
         uploader.upload_data_as_json(data.data, folder_name / "data.json")

--- a/src/openforms/registrations/contrib/microsoft_graph/plugin.py
+++ b/src/openforms/registrations/contrib/microsoft_graph/plugin.py
@@ -70,7 +70,8 @@ class MSGraphRegistration(BasePlugin[MicrosoftGraphOptions]):
             submission_report.content, folder_name / "report.pdf"
         )
 
-        data = submission.data
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
         data["__metadata__"] = {"submission_language": submission.language_code}
         uploader.upload_data_as_json(data.data, folder_name / "data.json")
 

--- a/src/openforms/registrations/contrib/objects_api/handlers/v1.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v1.py
@@ -90,7 +90,7 @@ def _get_variables_for_context(submission: Submission) -> dict[str, VariableValu
     that returns JSON values instead (for the submission data). The static variables
     are still date-related objects.
     """
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
 
     data = FormioData()
     # Loop over the saved variables here to mimic the exact behaviour of the original

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -450,7 +450,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
         self, submission: Submission, options: RegistrationOptionsV2
     ) -> Record:
         log = logger.bind(submission_uuid=str(submission.uuid))
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         all_values = state.get_data(
             include_static_variables=True,
@@ -549,7 +549,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
     def get_update_payment_status_data(
         self, submission: Submission, options: RegistrationOptionsV2
     ) -> Record:
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         # we only consider the payment variables for payment update status data
         registration_values = FormioData(
             state.get_static_data(other_registry=variables_registry)

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -819,7 +819,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
 
@@ -937,7 +937,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
         assert isinstance(children_data[0], dict)
@@ -1446,7 +1446,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
             completed=True,
             submitted_data={},
         )
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         assert not state.saved_variables
         v2_options: RegistrationOptionsV2 = {
             "version": 2,

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -819,7 +819,8 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        children_data = submission.data["children"]
+        state = submission.load_submission_value_variables_state()
+        children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
 
         for child in children_data:
@@ -936,7 +937,8 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        children_data = submission.data["children"]
+        state = submission.load_submission_value_variables_state()
+        children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
         assert isinstance(children_data[0], dict)
         assert isinstance(children_data[1], dict)

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -173,7 +173,7 @@ def _get_extra_variables_mapping(submission: Submission, options: RegistrationOp
         if variable.key in key_mapping
     }
 
-    state_variables_data = submission.load_submission_value_variables_state().get_data(
+    state_variables_data = submission.variables_state.get_data(
         include_static_variables=True
     )
 
@@ -295,7 +295,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
 
                 # xml file generation depends on whether the variable was prefilled or not
                 # (authentiek)
-                state = submission.load_submission_value_variables_state()
+                state = submission.variables_state
                 submission_variable = state.get_variable(fm_immutable_variable.key)
 
                 # update the zaak data with the information needed for the xml request

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -4432,7 +4432,8 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        childrenKey_data = submission.data["childrenKey"]
+        state = submission.load_submission_value_variables_state()
+        childrenKey_data = state.get_data()["childrenKey"]
         assert isinstance(childrenKey_data, list)
 
         for child in childrenKey_data:
@@ -4531,7 +4532,8 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        childrenKey_data = submission.data["childrenKey"]
+        state = submission.load_submission_value_variables_state()
+        childrenKey_data = state.get_data()["childrenKey"]
         assert isinstance(childrenKey_data, list)
         assert isinstance(childrenKey_data[0], dict)
         assert isinstance(childrenKey_data[1], dict)
@@ -4866,7 +4868,8 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        childrenKey_data = submission.data["childrenKey"]
+        state = submission.load_submission_value_variables_state()
+        childrenKey_data = state.get_data()["childrenKey"]
         assert isinstance(childrenKey_data, list)
 
         for child in childrenKey_data:

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -4432,7 +4432,7 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         childrenKey_data = state.get_data()["childrenKey"]
         assert isinstance(childrenKey_data, list)
 
@@ -4532,7 +4532,7 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         childrenKey_data = state.get_data()["childrenKey"]
         assert isinstance(childrenKey_data, list)
         assert isinstance(childrenKey_data[0], dict)
@@ -4868,7 +4868,7 @@ class StufZDSPluginChildrenComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         childrenKey_data = state.get_data()["childrenKey"]
         assert isinstance(childrenKey_data, list)
 

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -68,7 +68,7 @@ def get_property_mappings_from_submission(
     simple_mappings = {
         mapping["component_key"]: mapping["eigenschap"] for mapping in mappings
     }
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     data = state.get_data()
 
     property_mappings = {

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -68,12 +68,11 @@ def get_property_mappings_from_submission(
     simple_mappings = {
         mapping["component_key"]: mapping["eigenschap"] for mapping in mappings
     }
-    variable_values = submission.data
+    state = submission.load_submission_value_variables_state()
+    data = state.get_data()
 
     property_mappings = {
-        simple_mappings[key]: variable_values[key]
-        for key in simple_mappings
-        if key in variable_values
+        simple_mappings[key]: data[key] for key in simple_mappings if key in data
     }
 
     return property_mappings

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -1309,8 +1309,9 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
         )
 
     def test_register_and_update_paid_product(self):
-        submission = SubmissionFactory.from_data(
-            {"voornaam": "Foo"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "voornaam", "label": "Voornaam"}],
+            submitted_data={"voornaam": "Foo"},
             bsn="111222333",
             # setup payment although at this level of testing it is not needed
             form__product__price=Decimal("11.35"),

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -2268,7 +2268,8 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        children_data = submission.data["children"]
+        state = submission.load_submission_value_variables_state()
+        children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
 
         for child in children_data:
@@ -2412,7 +2413,8 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        children_data = submission.data["children"]
+        state = submission.load_submission_value_variables_state()
+        children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
         assert isinstance(children_data[0], dict)
         assert isinstance(children_data[1], dict)

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -2268,7 +2268,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
 
@@ -2413,7 +2413,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
         # the submitted data needs extra handling because frontend adds some extra field
         # to it which is not happenning here, so we have to update it manually in order
         # to mimic the frontend behaviour
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         children_data = state.get_data()["children"]
         assert isinstance(children_data, list)
         assert isinstance(children_data[0], dict)

--- a/src/openforms/registrations/tasks.py
+++ b/src/openforms/registrations/tasks.py
@@ -440,7 +440,7 @@ def execute_component_pre_registration(
     )
     audit_log.info("component_pre_registration_start")
 
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     component_var = state.get_variable(component_key)
 
     # if it's already completed

--- a/src/openforms/registrations/tests/test_component_pre_registration_tasks.py
+++ b/src/openforms/registrations/tests/test_component_pre_registration_tasks.py
@@ -78,7 +78,7 @@ class PreRegistrationTaskTests(TestCase):
             component=hook_component, submission_id=submission.pk
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         component_var = state.variables["withHook"]
 
         self.assertEqual(
@@ -103,7 +103,7 @@ class PreRegistrationTaskTests(TestCase):
             component=failed_hook_component, submission_id=submission.pk
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         component_var = state.variables["failedHook"]
 
         self.assertEqual(
@@ -123,7 +123,7 @@ class PreRegistrationTaskTests(TestCase):
             [hook_component],
             {"withHook": "foo"},
         )
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         component_var = state.variables["withHook"]
         component_var.pre_registration_status = ComponentPreRegistrationStatuses.success
         component_var.save()
@@ -162,7 +162,7 @@ class PreRegistrationTaskTests(TestCase):
 
         execute_component_pre_registration_group.delay(submission_id=submission.pk)  # pyright: ignore[reportFunctionMemberAccess]
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         no_hook_var = state.variables["withoutHook"]
         hook_var = state.variables["withHook"]
 
@@ -198,7 +198,7 @@ class PreRegistrationTaskTests(TestCase):
 
         execute_component_pre_registration_group.delay(submission_id=submission.pk)  # pyright: ignore[reportFunctionMemberAccess]
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         no_hook_var = state.variables["withoutHook"]
         failed_hook_var = state.variables["failedHook"]
 
@@ -235,7 +235,7 @@ class PreRegistrationTaskTests(TestCase):
 
         execute_component_pre_registration_group.delay(submission_id=submission.pk)  # pyright: ignore[reportFunctionMemberAccess]
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         hook_var = state.variables["withHook"]
         failed_hook_var = state.variables["failedHook"]
 
@@ -271,7 +271,7 @@ class PreRegistrationTaskTests(TestCase):
             mock_hook.side_effect = ValueError("something went wrong")
             execute_component_pre_registration_group.delay(submission_id=submission.pk)  # pyright: ignore[reportFunctionMemberAccess]
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         hook_var = state.variables["withHook"]
 
         self.assertEqual(
@@ -303,7 +303,7 @@ class PreRegistrationTaskTests(TestCase):
         )
         assert submission.needs_on_completion_retry is False
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         hook_var = state.variables["withHook"]
         hook_var.pre_registration_status = ComponentPreRegistrationStatuses.success
         hook_var.save()
@@ -326,7 +326,7 @@ class PreRegistrationTaskTests(TestCase):
             {"failedHook": "bar"},
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         failed_hook_var = state.variables["failedHook"]
         failed_hook_var.pre_registration_status = (
             ComponentPreRegistrationStatuses.failed
@@ -356,7 +356,7 @@ class PreRegistrationTaskTests(TestCase):
             {"withHook": "foo", "failedHook": "bar"},
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         hook_var = state.variables["withHook"]
         hook_var.pre_registration_status = ComponentPreRegistrationStatuses.success
         hook_var.save()

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -262,7 +262,7 @@ class FormLogicFrontendSerializer(OrderedModelSerializer):
 
     def to_representation(self, instance):
         step: SubmissionStep = self.context["submission_step"]
-        state = step.submission.load_submission_value_variables_state()
+        state = step.submission.variables_state
         # We include all data, to make sure we have a (empty) value for every variable.
         # Component variables of the current step need to be excluded, though, as these
         # are subject to change with user input. If variables from future steps are not
@@ -419,7 +419,7 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         # we need context from the variable
         data = instance.unsaved_data if in_form_logic_evaluation else instance._data
         serialized_data = FormioData()
-        state = instance.submission.load_submission_value_variables_state()
+        state = instance.submission.variables_state
         variables = state.get_variables_in_submission_step(instance)
         for key, variable in variables.items():
             if key not in data:

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -81,7 +81,7 @@ class SubmissionCompletionSerializer(serializers.Serializer):
         all_step_errors: list[StepValidationErrors] = []
         step_errors: StepValidationErrors
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
 
         for step in submission.steps:

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -81,7 +81,8 @@ class SubmissionCompletionSerializer(serializers.Serializer):
         all_step_errors: list[StepValidationErrors] = []
         step_errors: StepValidationErrors
 
-        data = submission.data
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
 
         for step in submission.steps:
             form_step = step.form_step

--- a/src/openforms/submissions/api/validators.py
+++ b/src/openforms/submissions/api/validators.py
@@ -33,7 +33,7 @@ class ValidatePrefillData:
         # user input is used to perform this flip, the end-user can manipulate this
         # value too and force the logic evaluation to mark the component as not
         # readonly, which beats the point of performing this check.
-        state = instance.submission.load_submission_value_variables_state()
+        state = instance.submission.variables_state
         original_data = state.get_data(include_unsaved=True)
         original_configuration = deepcopy(
             instance.form_step.form_definition.configuration

--- a/src/openforms/submissions/attachments.py
+++ b/src/openforms/submissions/attachments.py
@@ -110,7 +110,7 @@ def iter_step_uploads(
     Yield every uploaded file and its context within the form step for further
     processing.
     """
-    state = submission_step.submission.load_submission_value_variables_state()
+    state = submission_step.submission.variables_state
     data = state.get_data(submission_step=submission_step, include_unsaved=False)
     uploads = resolve_uploads_from_data(
         submission_step.form_step.form_definition.configuration, data
@@ -139,7 +139,7 @@ def attach_uploads_to_submission_step(
 
     submission: Submission = submission_step.submission
     execution_state = submission.load_execution_state()
-    variable_state = submission.load_submission_value_variables_state()
+    variable_state = submission.variables_state
     step_variables = variable_state.get_variables_in_submission_step(submission_step)
     assert submission_step.form_step is not None
 

--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -118,7 +118,7 @@ class CosignState:
                 # we can't just blindly return the component, as it may be conditionally
                 # displayed, which is equivalent to "cosign not relevant". See
                 # https://github.com/open-formulieren/open-forms/issues/3901
-                state = self.submission.load_submission_value_variables_state()
+                state = self.submission.variables_state
                 visible = configuration_wrapper.is_visible_in_frontend(
                     component["key"], values=state.get_data(include_unsaved=True)
                 )
@@ -187,7 +187,7 @@ class CosignState:
             "You can only look up the email in forms that have a cosign component"
         )
 
-        variables_state = self.submission.load_submission_value_variables_state()
+        variables_state = self.submission.variables_state
         values = variables_state.get_data()
         # detect inconsistent state - the component may be added after the submission
         # was completed

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -95,7 +95,7 @@ def evaluate_form_logic(
         return config_wrapper.configuration
 
     # 3. Load the (variables) state
-    submission_variables_state = submission.load_submission_value_variables_state()
+    submission_variables_state = submission.variables_state
 
     # 4. Apply the (dirty) data to the variable state.
     # We need to get the initial data for clear on hide first, as we don't want it to
@@ -222,7 +222,7 @@ def _get_initial_data_for_clear_on_hide(step: SubmissionStep) -> FormioData:
     :param step: Submission step.
     :returns: Initial data in a ``FormioData`` instance.
     """
-    state = step.submission.load_submission_value_variables_state()
+    state = step.submission.variables_state
     saved_data = state.get_data(submission_step=step, include_unsaved=False)
 
     initial_data = FormioData()
@@ -299,7 +299,7 @@ def check_submission_logic(
     rules = get_rules_to_evaluate(submission, current_step)
 
     # load the data state and all variables
-    submission_variables_state = submission.load_submission_value_variables_state()
+    submission_variables_state = submission.variables_state
     data_for_evaluation = submission_variables_state.get_data(
         include_unsaved=True, include_static_variables=True
     )

--- a/src/openforms/submissions/json_logic.py
+++ b/src/openforms/submissions/json_logic.py
@@ -49,7 +49,7 @@ def add_data_type_information(
     For example (consider a form with a date component "dateField"):
     >>> expression = {"==": [{"var": "dateField"}, {"date": "2026-03-10"}]}
     >>> result = add_data_type_information(
-    ...     expression, submission.load_submission_value_variables_state()
+    ...     expression, submission.variables_state
     ... )
     >>> print(result)
     {"==" [{"date": [{"var": ["dateField"]}]}, {"date": ["2026-03-10"]}]}

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -186,7 +186,7 @@ def iter_evaluate_rules(
     :param initial_data: Initial data for clear-on-hide behavior.
     :returns: An iterator yielding :class:`ActionOperation` instances.
     """
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
 
     # keep a copy of the start data that is not affected by the mutations applied by
     # logic. Due to the instant processing of clearOnHide side-effects and multiple

--- a/src/openforms/submissions/mapping.py
+++ b/src/openforms/submissions/mapping.py
@@ -98,7 +98,7 @@ def apply_data_mapping[T: MutableMapping[str, Any]](
             attr_key_lookup[attribute] = key
 
     # grab submitted data
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     data = state.get_data()
 
     for target_path, conf in mapping_config.items():
@@ -139,7 +139,7 @@ def get_unmapped_data(
     """
     companion to apply_data_mapping() returns data not mapped to RegistrationAttributes
     """
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     data = state.get_data()
 
     attr_key_lookup = dict()

--- a/src/openforms/submissions/mapping.py
+++ b/src/openforms/submissions/mapping.py
@@ -98,7 +98,8 @@ def apply_data_mapping[T: MutableMapping[str, Any]](
             attr_key_lookup[attribute] = key
 
     # grab submitted data
-    data = submission.data
+    state = submission.load_submission_value_variables_state()
+    data = state.get_data()
 
     for target_path, conf in mapping_config.items():
         if isinstance(conf, str):
@@ -138,7 +139,8 @@ def get_unmapped_data(
     """
     companion to apply_data_mapping() returns data not mapped to RegistrationAttributes
     """
-    data = submission.data
+    state = submission.load_submission_value_variables_state()
+    data = state.get_data()
 
     attr_key_lookup = dict()
 

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -531,6 +531,10 @@ class Submission(models.Model):
     def suspension_allowed(self) -> bool:
         return self.form.suspension_allowed and not self.is_completed
 
+    @property
+    def variables_state(self) -> SubmissionValueVariablesState:
+        return self.load_submission_value_variables_state()
+
     @transaction.atomic()
     def remove_sensitive_data(self):
         from .submission_files import SubmissionFileAttachment
@@ -794,7 +798,7 @@ class Submission(models.Model):
             return emails
 
         recipient_emails = set()
-        state = self.load_submission_value_variables_state()
+        state = self.variables_state
         data = state.get_data()
         for key in self.form.get_keys_for_email_confirmation():
             value = data.get(key)

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -785,7 +785,7 @@ class Submission(models.Model):
             self._merged_attachments = self.get_attachments().as_form_dict()
         return self._merged_attachments
 
-    def get_email_confirmation_recipients(self, submitted_data: dict) -> list[str]:
+    def get_email_confirmation_recipients(self) -> list[str]:
         from openforms.appointments.service import get_email_confirmation_recipients
 
         # first check if there are any recipients because it's an appointment form, as that
@@ -794,8 +794,10 @@ class Submission(models.Model):
             return emails
 
         recipient_emails = set()
+        state = self.load_submission_value_variables_state()
+        data = state.get_data()
         for key in self.form.get_keys_for_email_confirmation():
-            value = submitted_data.get(key)
+            value = data.get(key)
             if value:
                 if isinstance(value, str):
                     recipient_emails.add(value)

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-import warnings
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
@@ -25,7 +24,7 @@ from opentelemetry import trace
 
 from openforms.appointments.models import AppointmentInfo
 from openforms.config.models import GlobalConfiguration
-from openforms.formio.service import FormioConfigurationWrapper, FormioData
+from openforms.formio.service import FormioConfigurationWrapper
 from openforms.forms.models import FormRegistrationBackend, FormStep
 from openforms.logging import audit_logger
 from openforms.payments.constants import PaymentStatus
@@ -741,28 +740,6 @@ class Submission(models.Model):
         """
         submission_state = self.load_execution_state()
         return submission_state.get_last_completed_step()
-
-    @property
-    def data(self) -> FormioData:
-        """The filled-in data of the submission.
-
-        This is a mapping between variable keys and their corresponding values.
-
-        .. note::
-
-            Keys containing dots (``.``) will be nested under another mapping.
-            Static variables values are *not* included.
-        """
-        warnings.warn(
-            "Using `Submission.data` to access submission data is deprecated. Please "
-            "use `SubmissionValueVariablesState.get_data(...)` with the relevant flags "
-            "instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        values_state = self.load_submission_value_variables_state()
-        return values_state.get_data()
 
     def get_co_signer(self) -> str | SubmissionCosignData:
         # Legacy cosign returns an empty string, cosign v2 returns SubmissionCosignData

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -215,7 +215,7 @@ class SubmissionStep(models.Model):  # noqa: DJ008
 
     @property
     def _data(self) -> FormioData:
-        values_state = self.submission.load_submission_value_variables_state()
+        values_state = self.submission.variables_state
         step_data = values_state.get_data(submission_step=self)
         if self._unsaved_data:
             step_data.update(self._unsaved_data)

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -402,7 +402,7 @@ class SubmissionValueVariableManager(models.Manager):
           the database (if present). The variable instances in the state will be reset
           to their unsaved version (no primary key, and reset to the initial value).
         """
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         variables = (
             state.variables
             if submission_step is None

--- a/src/openforms/submissions/pricing.py
+++ b/src/openforms/submissions/pricing.py
@@ -84,7 +84,7 @@ def _price_from_variable(submission: Submission) -> Decimal | None:
     if not (var_key := submission.form.price_variable_key):
         return None
 
-    values_state = submission.load_submission_value_variables_state()
+    values_state = submission.variables_state
     data = values_state.get_data(include_unsaved=True)
     if var_key not in data:
         # Discussed with DH - it's better to crash hard than the possibly make them

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -286,20 +286,6 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
         submission.load_submission_value_variables_state(refresh=True)
         return submission
 
-    @staticmethod
-    def from_data(data_dict: dict, **kwargs):
-        components = [
-            {
-                "key": key,
-            }
-            for key in data_dict
-        ]
-        return SubmissionFactory.from_components(
-            components,
-            data_dict,
-            **kwargs,
-        )
-
 
 class SubmissionStepFactory(factory.django.DjangoModelFactory):
     submission = factory.SubFactory(SubmissionFactory)

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -190,7 +190,7 @@ class SubmissionFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def prefill_data(obj, create, extracted, **kwargs):
-        state = obj.load_submission_value_variables_state()
+        state = obj.variables_state
         if extracted:
             state.save_prefill_data(extracted)
         return extracted

--- a/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
@@ -50,7 +50,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -130,7 +130,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -201,7 +201,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -283,7 +283,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -353,7 +353,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -432,7 +432,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -533,7 +533,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -592,7 +592,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -661,7 +661,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,
@@ -700,7 +700,7 @@ class ConditionalLogicTests(TestCase):
 
         evaluate_form_logic(submission, step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(data["file"], [])
         self.assertEqual(step.unsaved_data, {})
@@ -747,7 +747,7 @@ class ConditionalLogicTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_static_variables=False, include_unsaved=True)
         self.assertEqual(
             data,

--- a/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
+++ b/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
@@ -61,7 +61,7 @@ class DeterministicEvaluationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         variable = state.variables["a"]
         self.assertEqual(variable.value, 8)  # ( 3 x 2 ) + 2
 
@@ -136,7 +136,7 @@ class DeterministicEvaluationTests(TestCase):
         with self.subTest("Evaluation skipped on step 1"):
             evaluate_form_logic(submission, ss1)
 
-            state = submission.load_submission_value_variables_state()
+            state = submission.variables_state
             data = state.get_data(include_unsaved=True)
             self.assertEqual({"a": 2, "b": 4, "c": None, "d": None}, data)
 
@@ -147,7 +147,7 @@ class DeterministicEvaluationTests(TestCase):
 
             evaluate_form_logic(submission, ss2)
 
-            state = submission.load_submission_value_variables_state()
+            state = submission.variables_state
             data = state.get_data(include_unsaved=True)
             self.assertEqual({"a": 2, "b": 4, "c": 2, "d": 6}, data)
 
@@ -158,6 +158,6 @@ class DeterministicEvaluationTests(TestCase):
 
             evaluate_form_logic(submission, ss3)
 
-            state = submission.load_submission_value_variables_state()
+            state = submission.variables_state
             data = state.get_data(include_unsaved=True)
             self.assertEqual({"a": 2, "b": 4, "c": 2, "d": 6}, data)

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -909,7 +909,7 @@ class ComponentModificationTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
 
         self.assertEqual(data["textField"], "Some data that must not be cleared!")
@@ -1207,7 +1207,7 @@ class ComponentModificationTests(TestCase):
             submission_step,
             FormioData({"checkbox": True, "container": {"textfield": "clear me"}}),
         )
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
         self.assertEqual(data["container.textfield"], "")
 
@@ -1324,7 +1324,7 @@ class ComponentModificationTests(TestCase):
         evaluate_form_logic(submission, submission_step, data)
 
         # Check the data
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
         self.assertEqual(
             data["editgridHiddenByDefault.0"],
@@ -1403,7 +1403,7 @@ class ComponentModificationTests(TestCase):
 
         # The rule with the hidden action was never triggered, so the field must have
         # the value set by the variable action.
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
         self.assertEqual("foo", data["textfield"])
 

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -94,7 +94,7 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step2)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(state.get_data(include_unsaved=True)["nTotalBoxes"], 7)
 
     def test_modify_variable_related_to_another_step_than_the_one_being_edited(self):
@@ -171,7 +171,7 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step2)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(state.get_data(include_unsaved=True)["nTotalBoxes"], 7)
 
     def test_modify_variable_not_related_to_a_step(self):
@@ -248,7 +248,7 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step2)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(state.get_data(include_unsaved=True)["nTotalBoxes"], 7)
 
     def test_logic_with_repeating_groups(self):
@@ -350,7 +350,7 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
         self.assertEqual(2, data["numberOfCars"])
         self.assertEqual(5000, data["totalPrice"])
@@ -399,7 +399,7 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(state.get_data(include_unsaved=True)["timedelta"], "P368D")
 
     @requests_mock.Mocker()
@@ -493,7 +493,7 @@ class VariableModificationTests(TestCase):
         ):
             evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertTrue(state.get_data(include_unsaved=True)["canApply"])
 
     @requests_mock.Mocker()
@@ -605,7 +605,7 @@ class VariableModificationTests(TestCase):
         ):
             evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertFalse(state.get_data(include_unsaved=True)["yo.im.nested.canApply"])
 
     @requests_mock.Mocker()
@@ -703,7 +703,7 @@ class VariableModificationTests(TestCase):
         ):
             evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertTrue(state.get_data(include_unsaved=True)["canApply"])
 
     def test_two_actions_on_the_same_variable(self):
@@ -751,7 +751,7 @@ class VariableModificationTests(TestCase):
 
         evaluate_form_logic(submission, submission_step)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(
             str(state.get_data(include_unsaved=True)["date"]), "2025-07-06"
         )
@@ -882,7 +882,7 @@ class VariableModificationTests(TestCase):
         )
         evaluate_form_logic(submission, submission_step2)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(
             state.get_data(include_unsaved=True)["editgrid"],
             [
@@ -1013,7 +1013,7 @@ class VariableModificationTests(TestCase):
         )
         evaluate_form_logic(submission, submission_step2)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(
             state.get_data(include_unsaved=True)["editgrid"],
             [
@@ -1155,7 +1155,7 @@ class VariableModificationTests(TestCase):
             ),
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(
             state.get_data(include_unsaved=True)["editgrid"],
             [
@@ -1247,5 +1247,5 @@ class VariableModificationTests(TestCase):
         )
         evaluate_form_logic(submission, submission_step2)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         self.assertEqual(state.get_data(include_unsaved=True)["editgrid"], [])

--- a/src/openforms/submissions/tests/form_logic/test_modifying_registration_backend.py
+++ b/src/openforms/submissions/tests/form_logic/test_modifying_registration_backend.py
@@ -14,10 +14,9 @@ class RegistrationBackendModificationTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.submission = SubmissionFactory.from_data(
-            {
-                "firstname": "Foo",
-            },
+        cls.submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "firstname", "Label": "First name"}],
+            submitted_data={"firstname": "Foo"},
         )
         FormRegistrationBackendFactory.create(
             form=cls.submission.form,

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -580,7 +580,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         )
         self._add_submission_to_session(submission)
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         with freeze_time("2015-10-10"):
             response = self.client.post(endpoint, {"data": state.get_data()})
 

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -580,8 +580,9 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
         )
         self._add_submission_to_session(submission)
 
+        state = submission.load_submission_value_variables_state()
         with freeze_time("2015-10-10"):
-            response = self.client.post(endpoint, {"data": submission.data})
+            response = self.client.post(endpoint, {"data": state.get_data()})
 
         submission_details = response.json()
 

--- a/src/openforms/submissions/tests/test_factories.py
+++ b/src/openforms/submissions/tests/test_factories.py
@@ -3,7 +3,6 @@ from django.utils.translation import override as override_language
 
 from privates.test import temp_private_root
 
-from openforms.authentication.service import AuthAttribute
 from openforms.submissions.tests.factories import SubmissionFactory
 
 
@@ -85,43 +84,6 @@ class SubmissionFactoryTests(TestCase):
         )
 
         self.assertEqual(submission.form.name, "MyForm")
-        self.assertEqual(submission.auth_info.value, "111222333")
-
-    def test_from_data__simple(self):
-        submission = SubmissionFactory.from_data(
-            {
-                "foo": 1,
-                "bar": 2,
-            }
-        )
-
-        state = submission.variables_state
-        actual = state.get_data()
-        expected = {
-            "foo": 1,
-            "bar": 2,
-        }
-        self.assertEqual(actual, expected)
-
-    def test_from_data__kwargs(self):
-        submission = SubmissionFactory.from_data(
-            {
-                "foo": 1,
-                "bar": 2,
-            },
-            form__name="MyForm",
-            kvk="111222333",
-        )
-
-        state = submission.variables_state
-        actual = state.get_data()
-        expected = {
-            "foo": 1,
-            "bar": 2,
-        }
-        self.assertEqual(actual, expected)
-        self.assertEqual(submission.form.name, "MyForm")
-        self.assertEqual(submission.auth_info.attribute, AuthAttribute.kvk)
         self.assertEqual(submission.auth_info.value, "111222333")
 
     def test_passing_a_language_code_sets__form_translation_enabled(self):

--- a/src/openforms/submissions/tests/test_factories.py
+++ b/src/openforms/submissions/tests/test_factories.py
@@ -63,7 +63,7 @@ class SubmissionFactoryTests(TestCase):
             },
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         actual = state.get_data()
         expected = {"foo": 1, "bar": 2}
         self.assertEqual(actual, expected)
@@ -95,7 +95,7 @@ class SubmissionFactoryTests(TestCase):
             }
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         actual = state.get_data()
         expected = {
             "foo": 1,
@@ -113,7 +113,7 @@ class SubmissionFactoryTests(TestCase):
             kvk="111222333",
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         actual = state.get_data()
         expected = {
             "foo": 1,

--- a/src/openforms/submissions/tests/test_factories.py
+++ b/src/openforms/submissions/tests/test_factories.py
@@ -63,7 +63,8 @@ class SubmissionFactoryTests(TestCase):
             },
         )
 
-        actual = submission.data
+        state = submission.load_submission_value_variables_state()
+        actual = state.get_data()
         expected = {"foo": 1, "bar": 2}
         self.assertEqual(actual, expected)
 
@@ -94,7 +95,8 @@ class SubmissionFactoryTests(TestCase):
             }
         )
 
-        actual = submission.data
+        state = submission.load_submission_value_variables_state()
+        actual = state.get_data()
         expected = {
             "foo": 1,
             "bar": 2,
@@ -111,7 +113,8 @@ class SubmissionFactoryTests(TestCase):
             kvk="111222333",
         )
 
-        actual = submission.data
+        state = submission.load_submission_value_variables_state()
+        actual = state.get_data()
         expected = {
             "foo": 1,
             "bar": 2,

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -402,8 +402,9 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
     maxDiff = None
 
     def test_it_only_translates_appropriate_string_properties(self):
-        submission = SubmissionFactory.from_data(
-            {"bar": "Korova Milk Bar"},
+        submission = SubmissionFactory.from_components(
+            [{"type": "textfield", "key": "bar", "label": "Bar"}],
+            submitted_data={"bar": "Korova Milk Bar"},
             language_code="de",
         )
         form_step = submission.steps[0].form_step

--- a/src/openforms/submissions/tests/test_json_logic.py
+++ b/src/openforms/submissions/tests/test_json_logic.py
@@ -33,7 +33,7 @@ class AddDataTypeInformationTests(TestCase):
             },
         )
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expressions = [
             {"==": [{"var": "date"}, {"var": "today"}]},  # today is static variable
@@ -111,7 +111,7 @@ class AddDataTypeInformationTests(TestCase):
             },
         )
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expressions = [
             {"==": [{"var": "date.0"}, {"date": "2026-03-06"}]},
@@ -157,7 +157,7 @@ class AddDataTypeInformationTests(TestCase):
             },
         )
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expressions = [
             {"==": [{"var": "children.0.dateOfBirth"}, {"date": "2026-03-06"}]},
@@ -215,7 +215,7 @@ class AddDataTypeInformationTests(TestCase):
             },
         )
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expressions = [
             {
@@ -322,7 +322,7 @@ class AddDataTypeInformationTests(TestCase):
     def test_array_operations_without_component(self):
         form = FormFactory.create(generate_minimal_setup=True)
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expressions = [
             {"map": [[1, 2, 3, 4], {">": [{"var": ""}, 3]}]},
@@ -397,7 +397,7 @@ class AddDataTypeInformationTests(TestCase):
             },
         )
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         expressions = [
             {

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -346,6 +346,8 @@ class SubmissionTests(TestCase):
             },
         )
 
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
         self.assertEqual(
             {
                 "person": {
@@ -358,7 +360,7 @@ class SubmissionTests(TestCase):
                     },
                 }
             },
-            submission.data,
+            data,
         )
 
     def test_form_login_required(self):

--- a/src/openforms/submissions/tests/test_models.py
+++ b/src/openforms/submissions/tests/test_models.py
@@ -346,7 +346,7 @@ class SubmissionTests(TestCase):
             },
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
         self.assertEqual(
             {

--- a/src/openforms/submissions/tests/test_regressions.py
+++ b/src/openforms/submissions/tests/test_regressions.py
@@ -80,9 +80,11 @@ class SubmissionStepDeletedRegressionTests(TestCase):
             form_step=step2,
             data={"step2": "ik ben een alien"},
         )
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
         with self.subTest("check initial data setup"):
             self.assertEqual(
-                submission.data,
+                data,
                 {
                     "step1": "stippenlift",
                     "step2": "ik ben een alien",
@@ -111,8 +113,10 @@ class SubmissionStepDeletedRegressionTests(TestCase):
 
         # reload submission as fresh data object so we don't have any cached states
         submission = Submission.objects.get(pk=submission.pk)
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
         self.assertEqual(
-            submission.data,
+            data,
             {
                 "step1": "stippenlift",
                 "step2": "ik ben een alien",
@@ -187,8 +191,10 @@ class SubmissionStepDeletedRegressionTests(TestCase):
 
         # reload submission as fresh data object so we don't have any cached states
         submission = Submission.objects.get(pk=submission.pk)
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
         self.assertEqual(
-            submission.data,
+            data,
             {
                 "step1": "stippenlift",
                 "step2": "ik ben een alien",
@@ -253,8 +259,10 @@ class SubmissionStepDeletedRegressionTests(TestCase):
 
         # reload submission as fresh data object so we don't have any cached states
         submission = Submission.objects.get(pk=submission.pk)
+        state = submission.load_submission_value_variables_state()
+        data = state.get_data()
         self.assertEqual(
-            submission.data,
+            data,
             {
                 "step1": "stippenlift",
                 "step2": "ik ben een alien",

--- a/src/openforms/submissions/tests/test_regressions.py
+++ b/src/openforms/submissions/tests/test_regressions.py
@@ -80,7 +80,7 @@ class SubmissionStepDeletedRegressionTests(TestCase):
             form_step=step2,
             data={"step2": "ik ben een alien"},
         )
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
         with self.subTest("check initial data setup"):
             self.assertEqual(
@@ -113,7 +113,7 @@ class SubmissionStepDeletedRegressionTests(TestCase):
 
         # reload submission as fresh data object so we don't have any cached states
         submission = Submission.objects.get(pk=submission.pk)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
         self.assertEqual(
             data,
@@ -191,7 +191,7 @@ class SubmissionStepDeletedRegressionTests(TestCase):
 
         # reload submission as fresh data object so we don't have any cached states
         submission = Submission.objects.get(pk=submission.pk)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
         self.assertEqual(
             data,
@@ -259,7 +259,7 @@ class SubmissionStepDeletedRegressionTests(TestCase):
 
         # reload submission as fresh data object so we don't have any cached states
         submission = Submission.objects.get(pk=submission.pk)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data()
         self.assertEqual(
             data,

--- a/src/openforms/submissions/tests/test_serializers.py
+++ b/src/openforms/submissions/tests/test_serializers.py
@@ -77,7 +77,7 @@ class SubmissionStepSerializerTests(TestCase):
         self.assertTrue(is_valid)
 
         # Ensure state and configuration are not mutated in an unexpected way.
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         data = state.get_data(include_unsaved=True)
         self.assertEqual(
             {"textfield": "foo", "number": 42, "user_defined": "Initial value"},

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -955,7 +955,10 @@ class SetRegistrationBackendTests(SubmissionsMixin, APITestCase):
         self.monkeypatch = patch_registry(backend_field, mock_register)
 
     def test_single_backend_needs_no_logic(self):
-        submission = SubmissionFactory.from_data({"foo": 1})
+        submission = SubmissionFactory.from_components(
+            [{"type": "number", "key": "foo", "label": "Foo"}],
+            submitted_data={"foo": 1},
+        )
         FormRegistrationBackendFactory.create(
             form=submission.form,
             backend="mock",
@@ -977,7 +980,10 @@ class SetRegistrationBackendTests(SubmissionsMixin, APITestCase):
         )
 
     def test_multi_backend_no_logic(self):
-        submission = SubmissionFactory.from_data({"foo": 1})
+        submission = SubmissionFactory.from_components(
+            [{"type": "number", "key": "foo", "label": "Foo"}],
+            submitted_data={"foo": 1},
+        )
         FormRegistrationBackendFactory.create(
             form=submission.form,
             key="M",
@@ -1021,7 +1027,10 @@ class SetRegistrationBackendTests(SubmissionsMixin, APITestCase):
         )
 
     def test_setting_backend_with_logic(self):
-        submission = SubmissionFactory.from_data({"foo": 1})
+        submission = SubmissionFactory.from_components(
+            [{"type": "number", "key": "foo", "label": "Foo"}],
+            submitted_data={"foo": 1},
+        )
         FormRegistrationBackendFactory.create(
             form=submission.form,
             backend="mock",
@@ -1062,7 +1071,10 @@ class SetRegistrationBackendTests(SubmissionsMixin, APITestCase):
         )
 
     def test_setting_faulty_backend_with_logic(self):
-        submission = SubmissionFactory.from_data({"foo": 1})
+        submission = SubmissionFactory.from_components(
+            [{"type": "number", "key": "foo", "label": "Foo"}],
+            submitted_data={"foo": 1},
+        )
         FormRegistrationBackendFactory.create(
             form=submission.form,
             key="M",

--- a/src/openforms/submissions/tests/test_submission_confirmation.py
+++ b/src/openforms/submissions/tests/test_submission_confirmation.py
@@ -145,7 +145,13 @@ class SubmissionConfirmationPageTests(APITestCase):
         config.submission_confirmation_template = "See http://example.com/bla"
         config.save()
 
-        submission = SubmissionFactory.from_data({"name": "john", "last_name": "doe"})
+        submission = SubmissionFactory.from_components(
+            [
+                {"type": "textfield", "key": "name", "label": "Name"},
+                {"type": "textfield", "key": "last_name", "label": "Last name"},
+            ],
+            submitted_data={"name": "john", "last_name": "doe"},
+        )
         confirmation_page_content = submission.render_confirmation_page()
 
         self.assertEqual(

--- a/src/openforms/submissions/tests/test_variables/test_fetch_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_fetch_with_logic.py
@@ -53,7 +53,7 @@ class ServiceFetchWithActionsTest(TestCase):
 
         evaluate_form_logic(submission, submission.submissionstep_set.first())
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         variable = state.get_variable("someVariable")
 

--- a/src/openforms/submissions/tests/test_variables/test_model.py
+++ b/src/openforms/submissions/tests/test_variables/test_model.py
@@ -417,9 +417,7 @@ class SubmissionValueVariableModelTests(ParametrizedTestCase, TestCase):
             form_step=form_step,
         )
 
-        submission_value_variables_state = (
-            submission_step.submission.load_submission_value_variables_state()
-        )
+        submission_value_variables_state = submission_step.submission.variables_state
         variables = submission_value_variables_state.variables
 
         self.assertEqual(2, len(variables))
@@ -633,7 +631,7 @@ class SubmissionValueVariableManagerTests(TestCase):
             },
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         for key in ("textfield", "email", "date"):
             with self.subTest(f"Initial state: {key}"):
                 variable = state.variables[key]
@@ -690,7 +688,7 @@ class SubmissionValueVariableManagerTests(TestCase):
             },
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         for key in ("textfield", "date"):
             with self.subTest(f"Initial state: {key}"):
                 variable = state.variables[key]
@@ -733,7 +731,7 @@ class SubmissionValueVariableManagerTests(TestCase):
             },
         )
 
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
         with self.subTest("Initial state"):
             variable = state.variables["textfield"]
             # Variable is present in the state, but not in the database (yet)
@@ -776,7 +774,7 @@ class SubmissionValueVariableManagerTests(TestCase):
             initial_value="",
         )
         submission = SubmissionFactory.create(form=form)
-        state = submission.load_submission_value_variables_state()
+        state = submission.variables_state
 
         # Create variables
         data = {"textfield": "foo", "date": "2025-12-05", "user_defined": "bar"}

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -166,7 +166,7 @@ def send_confirmation_email(submission: Submission) -> None:
 
     subject_template, content_template = get_confirmation_email_templates(submission)
 
-    to_emails = submission.get_email_confirmation_recipients(submission.data)
+    to_emails = submission.get_email_confirmation_recipients()
     if not to_emails:
         audit_log.warning(
             "confirmation_email_skip",

--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -235,7 +235,7 @@ def send_confirmation_email(submission: Submission) -> None:
 
 
 def initialise_user_defined_variables(submission: Submission):
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     SubmissionValueVariable.objects.bulk_create(
         [
             variable
@@ -246,7 +246,7 @@ def initialise_user_defined_variables(submission: Submission):
 
 
 def persist_user_defined_variables(submission: Submission) -> None:
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     user_defined_vars_data = FormioData(
         {
             variable.key: variable.value

--- a/src/openforms/tests/test_registrator_prefill.py
+++ b/src/openforms/tests/test_registrator_prefill.py
@@ -163,7 +163,7 @@ class OIDCRegistratorSubjectHaalCentraalPrefillIntegrationTest(
 
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             submission = Submission.objects.get()
-            state = submission.load_submission_value_variables_state()
+            state = submission.variables_state
 
             data = state.get_prefilled_data()
             self.assertEqual(len(data), 1)

--- a/src/openforms/variables/rendering/nodes.py
+++ b/src/openforms/variables/rendering/nodes.py
@@ -32,7 +32,7 @@ class VariablesNode(Node):
     @property
     def variables(self):
         if not self._variables:
-            variables_state = self.submission.load_submission_value_variables_state()
+            variables_state = self.submission.variables_state
             relevant_vars = [
                 variable
                 for variable in variables_state.variables.values()

--- a/src/openforms/variables/utils.py
+++ b/src/openforms/variables/utils.py
@@ -48,7 +48,7 @@ def get_variables_for_context(
     Note that depending on when it is called, the 'auth' static variables (auth_bsn,
     auth_kvk...) can be already hashed.
     """
-    state = submission.load_submission_value_variables_state()
+    state = submission.variables_state
     data = state.get_data(
         include_static_variables=True,
         include_unsaved=True,


### PR DESCRIPTION
Partly closes #6018

[skip: e2e]

**Changes**

* Removed `Submission.data`
* Added `Submission.variables_state` property
* Removed `SubmissionFactory.from_data`  

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes