### PR TITLE
[#4746] Add a way to identify the environemnt in daily report digest email subject

### DIFF
--- a/src/openforms/emails/tasks.py
+++ b/src/openforms/emails/tasks.py
@@ -77,8 +77,16 @@ def send_email_digest() -> None:
     if not content:
         return
 
+    environment = settings.ENVIRONMENT_LABEL
+    if environment:
+        subject = _(
+            "[Open Forms] Daily summary of detected problems from: %(environment)s"
+        ) % {"environment": environment}
+    else:
+        subject = _("[Open Forms] Daily summary of detected problems")
+
     send_mail_html(
-        _("[Open Forms] Daily summary of detected problems"),
+        subject,
         content,
         settings.DEFAULT_FROM_EMAIL,
         recipients,

--- a/src/openforms/emails/tests/test_tasks_integration.py
+++ b/src/openforms/emails/tests/test_tasks_integration.py
@@ -66,6 +66,7 @@ class EmailDigestTaskIntegrationTests(TestCase):
 
         self.addCleanup(GlobalConfiguration.clear_cache)
 
+    @override_settings(ENVIRONMENT_LABEL="")
     def test_that_repeated_failures_are_not_mentioned_multiple_times(self):
         submission = SubmissionFactory.create()
         audit_log = audit_logger.bind(
@@ -99,6 +100,28 @@ class EmailDigestTaskIntegrationTests(TestCase):
             sent_email.recipients(), ["tralala@test.nl", "trblblb@test.nl"]
         )
         self.assertEqual(submission_occurencies, 1)
+
+    @override_settings(ENVIRONMENT_LABEL="test-env")
+    def test_subject_includes_environment_label(self):
+        submission = SubmissionFactory.create()
+
+        with freeze_time("2023-01-02T12:30:00+01:00"):
+            audit_logger.info(
+                "email_status_change",
+                submission_uuid=str(submission.uuid),
+                email_event="registration",
+                new_status=Message.STATUS_FAILED,
+                status_label="Failed",
+            )
+
+        with freeze_time("2023-01-03T01:00:00+01:00"):
+            send_email_digest()
+
+        sent_email = mail.outbox[0]
+        self.assertEqual(
+            sent_email.subject,
+            "[Open Forms] Daily summary of detected problems from: test-env",
+        )
 
     def test_no_email_sent_if_no_logs(self):
         send_email_digest()


### PR DESCRIPTION
Closes #4746 

[skip: e2e]

**Changes**

Adds ENVIRONMENT_LABEL to email subject of Daily report digest

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
