### PR TITLE
Upgrade formio builder and ckeditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/cli": "^6.6.1",
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.66.0",
-        "@open-formulieren/formio-builder": "^0.48.0",
+        "@open-formulieren/formio-builder": "^0.49.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -2467,286 +2467,919 @@
         "tough-cookie": "^4.1.4"
       }
     },
-    "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-40.2.0.tgz",
-      "integrity": "sha512-OMvOdgEWBzFQbcHLu4CYMe/LONSmn07BxrXQ4Uxd++Wr45U2ElrbkKcJldARa+J97YGEzaaCI3igXDh6g4fkRA==",
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.6.1.tgz",
+      "integrity": "sha512-X4l4KyLgSsmAyRd/YY8R/OArOXR2Ts8NyoW6k+tLtYxEmZOhJsa6ZFSho/OVTole7IqMl+Zo93b9YaAwX23brw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.6.1.tgz",
+      "integrity": "sha512-2u1+Eseelrm5gKKajE9X+gcPchVAIna3AkoJyCw3+Y4dBc6ElWZJEuCO7b6Omv5H7q3lQimbaqJnvIE1Z/nXOA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-40.2.0.tgz",
-      "integrity": "sha512-F3w5k7ti5l6V8U07eSQ3gup3ivltRZQXdtvstBXMmTzDb2ceazNcUDLb6TKSHp5y30ETN0dRGgbhx9xiDL0TXg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.6.1.tgz",
+      "integrity": "sha512-UI3HFyw7VCTM92IhE6hdIh5rp2nqOLL4vnnOFTgp7Lq6dLOVzuwsRJLIEfYxz4Xusy4UKu4zM8QX4FV1nOWsGQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.6.1.tgz",
+      "integrity": "sha512-7om5OHf2hBDi/Md8lVZL6fF7gCBAMVZfg8zsJqTmAW6fwl5gfenD4rggPdSa4GVt+mZXbheZx9EWc0HX1psAew==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-40.2.0.tgz",
-      "integrity": "sha512-P7jYddLnRpaR4zVCqDa8InsZ6YNRHdF0RrX6+Uz81+A1IfyfmSd+5IaiLxxdnFWQ4JlEhJutjy9vMwSmOhZocQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.6.1.tgz",
+      "integrity": "sha512-/8R59UxR/8quK8UmOLOS1xq47GnB+oMNySo8BgLHJl7qepRR5VnWU0hHB239idnFk46IVhuRciXQHjifrJiScQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-40.2.0.tgz",
-      "integrity": "sha512-t03Yp+MeAyQhwdGZqUlkJEx25VSiigpzkIGGOhccSaTIIZ9XcWDkrTevDhwA4Pq4Q9IRQ8Loj3KCVSBuAqkBgw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.6.1.tgz",
+      "integrity": "sha512-wyDLqGrmcDVNlRmHxXTpXg2PKImgB4yIU3UDRofFKVJiuvnZvKKvx/Oh9USVv1G1zOAPoFyoK9AQzqYNOB7AMQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.6.1.tgz",
+      "integrity": "sha512-9HwVudGBEhbqMPkEXQTqSIACGYpOWlES7bOxdG6WfgOUOAdCiTPXFCc5f+HSMFbrwd7XJ40tycPLOa7XK14oEg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-link": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.6.1.tgz",
+      "integrity": "sha512-v083Tnbsx4z1fFW+ghMXlsf5EgB3UaSldjfRsipjIYUiUeatccgRN00Qh6qGMlYz7zZcSdUUtrOfTWL/LYPWDg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "blurhash": "2.0.5",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.6.1.tgz",
+      "integrity": "sha512-ewgqgtQaDDZHQUGby/gg2/840Go280bvx959ExQH8Y7u4fPVw8NEFYAxjcm43W6EXgMnlmsEr8+G8q8g4iKT1w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-40.2.0.tgz",
-      "integrity": "sha512-8/xPH9/i86ukcEiHdmTgNuPVJeYTrivbx5ZYqycPO4Eem7VM99gIbOe7pIYpuV+klr9ymVxIHbGyTJDJ3oUO8A==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.6.1.tgz",
+      "integrity": "sha512-F3KQuCnnCavm8wXvX+d1KN/obh5ux/jT9qC/71QfMKdDvHxEOzi/t3YWa1r3sztlksDQ4LtODU4uWh0vVKUpkg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "@ckeditor/ckeditor5-widget": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.6.1.tgz",
+      "integrity": "sha512-yC9aqornbxjgNhHuUX4gcuvPTLv34sc8CbUOeFYLGbD9ujwoC0fzzjzSB7u5b8fWNg6cAjzriFooJATHBvu40g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.6.1.tgz",
+      "integrity": "sha512-ntZBIEYLoC4/OTUgCkwwmyXwwqDk8QwFcx/1kZN7S4YtwocREZqpDH1wYT+GA2ZmGkjaBRxdTLwSVr/7bf+wqg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-40.2.0.tgz",
-      "integrity": "sha512-0fqIaN+ZhkXXA3mpBN+alycBzPMc8ruO8VrP0OnvCjowqZVS2HXC2AaXNBdxc75xGI3ScXIor7FsgFHxVJIYYQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.6.1.tgz",
+      "integrity": "sha512-6dtnquhjymLkNhdC9T6gk/Mf2bDnHSTZrhkByaXC96CbmQDriCgfcaAVY6pQgDNxBQ6fZrev0TnKBLfTItrMsg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-watchdog": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.6.1.tgz",
+      "integrity": "sha512-hWaqibO1ZUHRIkvvAO7O0qDAIw+GN6UWbdr0wcGNLc4DcSZMUIpAfoXuiyyvE9hQEJPpfTOwA3r0znS6wXtMCg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.6.1.tgz",
+      "integrity": "sha512-geszCykoE9Sja2tBqyMww4etAzAExg4eGnlYbXSGiaUiC7Ks4OqRVeuvw37QsH8Q56J5FQC35ysq95nrLEB+0A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-40.2.0.tgz",
-      "integrity": "sha512-dftfDBxANOgqgQZ4SB3YTsEV/XX1u0g9jopbOBwqIABnVVa8zoGcktgFdGnLUFk51sL65baSx2z8Z1NNYdZcFQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.6.1.tgz",
+      "integrity": "sha512-w2QaF2ieqLqu6i9YldOpPnFezvAsXY/R/vp/c0D1ofvI1CtBRWhQ9/rRwADMoKgpcuyP2320sRG312anT8aiaA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.6.1.tgz",
+      "integrity": "sha512-w047UpjHF106k0NeQLgWY03k29s5vIpS9M6Oj+f+IdKaf4TR7uSzl/CXsS+csfqwZEhtGwGV3LYJVzo35+SifA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.6.1.tgz",
+      "integrity": "sha512-UJQHbMh1nvsHMuiijmRx3y/5ssdxeJTrVjrwDoPlUsI8tfRYjkdIucd9SsRhXnV65Vk31Ah5wiFyaBb5OLXZaA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.6.1.tgz",
+      "integrity": "sha512-Jn55iVT2sg85NSPVe/mThLoiI0FTAEH5r48MXD1MKz1E5K0FkpdLiKyCR4onfdFLozWZW2NvU0faCkyI0BKaZQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.6.1.tgz",
+      "integrity": "sha512-bnnnvRk/eYrvKLLQpJrjSV++Abpm1/8N31BNVaZyeHzaI0pddE6ikS44Ju82u7BQJaqSi2SO2Glx3u3C14rm2g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-mention": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5",
+        "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-40.2.0.tgz",
-      "integrity": "sha512-sgboUX8Ps+LcEgywyT3BeK1nzLHjNVIiZU1qvRxR3ixzIw4w2xRNXCGfESWLW5Y5rv9+ypUCrX61oLnZU64PQQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.6.1.tgz",
+      "integrity": "sha512-Xb398PRhkJqtUuQ1E1pdLXTG1REIOanr7PCIRPpWvpHAIZZAuxTIqyacZC4qVTS9xI+ObxYqosf8yNvFsEtu8w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-40.2.0.tgz",
-      "integrity": "sha512-GjTRaKNX8QEDJ3YYKG3GfPZfGHrcigGBxbo+1WDT7NaOsR2DA/CIZfHlAPfgJDAMV17bhWsT3gy3+oQZsExtnQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.6.1.tgz",
+      "integrity": "sha512-H/d5L8JmZFmb5wYDi3NT4NICYuRueGUwiPgIpaaQ0gb8U3U0YVj4J5WVF/65KGiYdsuP2NupSwRqsdl8TilrdQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-40.2.0.tgz",
-      "integrity": "sha512-7iUUy0Uwiei4yLrn145SOcyzriMeVFVc5ontQkxQE5b9alFdAc/6ZoDPZqwD7V0zi5RQ/2YsoVMRLFa4hbPfNA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.6.1.tgz",
+      "integrity": "sha512-4A9E9GrOudYA/eWCXE9uLqEdw7RLO/OdmeY1KWGAF6B9fubieSCF+S69M3c5hMKS6KJoNjaVJ/iR91KfIyYmtw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-select-all": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.6.1.tgz",
+      "integrity": "sha512-ZbKlNpFYCP0DRICJlhyTLaRlPSwdJ5W9BBrMFjHhGsKNbFJ2KHlPCqTD6nAEWc838heDBZM21jRGTM6O92FLHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-40.2.0.tgz",
-      "integrity": "sha512-k38+eQQF+zfiauVDxcMBHGG1ShRwCNibaJipu5FKzvGY5PJELUsIfor1dsSPsTADWxWMpBi5qEaSO4S4+Lu/JA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.6.1.tgz",
+      "integrity": "sha512-ayMtG44tLbmPBjoEudnF7kFkqX3GUO0Cb1lLd6JR5B4uyoNFuQbN3nyrtx7hMvdu0N4jl0hWcWXjdu6vNL4I6g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.6.1.tgz",
+      "integrity": "sha512-LvA7vzeAkuc/z64kuRu17zm7EIFe0Bqt9xPA5GhfR6T9mBVG4wu62ElqylFUjFJ+macvkjSe68tBYQTAPyUWqg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-40.2.0.tgz",
-      "integrity": "sha512-uDT1sttMy+KrKi90jnqEI43886o1wfKrROWqaMbmKOerTbIi58GNH9LvX04sf1RyHV3+3566RRmB248fsLkYjA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.6.1.tgz",
+      "integrity": "sha512-4kVuMaaAylkxYkJ0PA4hUQCDTARoeokkqKh0dE3DwEZTvvWDZjBEAhIKaSVX116ByeGfImbLkBRAoNCljKNCHQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-paragraph": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
-    "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-40.2.0.tgz",
-      "integrity": "sha512-0Dunw1o5k2+5Q5XiWLDG1r8k9awosfIFuDZwqKJGWtDaNE4QQbJ9+iJSwiiRw2QjcGr7D3JdH7xwJZFra7kYmA==",
+    "node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.6.1.tgz",
+      "integrity": "sha512-hEIAZAImLAGRsz7/d+bbh3k+9s854AxuYoTmCAN2u07muYX/pmrLrLm6cZcazjmi9J/Bow6sP/D5GeoYMWKkLA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.6.1.tgz",
+      "integrity": "sha512-YTSpxdrp8NteaWARH89dA+qUWAf3agw/Q1dRQF+XdiF2kaSXRPQCXJruvmy490H+3xtwUZVs/hSlwX9gT77Skg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.6.1.tgz",
+      "integrity": "sha512-z4iYN6Il/PqpOBm+7OYM1mpXLUCbA7cMjq3MGIAwGwRHNFq8BWq/1by3P8FiF4ozaUyj8YgXXyWoggBC2qQRig==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.6.1.tgz",
+      "integrity": "sha512-F25LY88VYx0gZTrrThmt+kqF2thrwg52ZCIQeRujMd3RIueYEAEn7ZJ0p5iArDvm9qQXtLzsaijEyZr2edstPA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-remove-format": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-icons": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.6.1.tgz",
+      "integrity": "sha512-OEk5hPdMpE5/Cb2lZFtJL2XyMwy/S8xQzuAk2b2P2bJx33rJgU3pk9RUrayxCSa3p+tKqibOzm5GcshLJ7s7Tg==",
+      "license": "SEE LICENSE IN LICENSE.md"
+    },
+    "node_modules/@ckeditor/ckeditor5-image": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.6.1.tgz",
+      "integrity": "sha512-yy7b/7WQqN0c7/VC1Ng5svQU1btXWauBfQjFgVV3AzGa+nVeJ1ZIcV2fAkUa6mB+lCu+5ziv7b7ord22baJYzg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-40.2.0.tgz",
-      "integrity": "sha512-gSlRGoyAslB2OpqghimIY6Oiflf3Z2/MdLBzvFipU5N4X66cL29HuWZc/bOkcFzWwNeDK5LgzfLdvXNzkdv5Xw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.6.1.tgz",
+      "integrity": "sha512-SaokgxUJevRrYfu5PKEMvVrUliybmxpb3Cx/f/JtOnPbyJSFrt05+/mt3XsqsSB0g8LaHH2PXQfD4vncGzE6DQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-integrations-common": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.5.tgz",
+      "integrity": "sha512-CWBlHPfHL+0bfSmdIyfDZ8XLXOar+g55mY74sAFg11twMc5gve4leMHDwDU3My65Wrg7vDj3s35TvYc7sKtnEQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "ckeditor5": ">=42.0.0 || ^0.0.0-nightly"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.6.1.tgz",
+      "integrity": "sha512-YZpySDIa4Y40T9wwKIFsAlDujELkgUtoKw/+4Wl8BHlDnq/40VxXFbOSSXu4TnnVeqVFcnzTjp6Zv8CHtmY3yw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-40.2.0.tgz",
-      "integrity": "sha512-/r4Ti9USdrURBX+qutvyDGOb75sNuSgtXdI8xK503EVfx5yBIi6qsYIYWoFvnGJKkLYkVo+940ilduhwzq0M7g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.6.1.tgz",
+      "integrity": "sha512-A/gjF7e00R/ESUotqR08EeGM91V031DiHiGwYn7b+iZ1bejsdEu3yQK707bZ4U6ByEYBUOMtq1bOMYUtGJl6EA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-40.2.0.tgz",
-      "integrity": "sha512-lsQWSLSFRHRQ2AxA6vgTib9YELjF2J5jpR6H4RDW1gM//dL3FjvLxKPPN/V7rMcp15rrpSiOya+qB99l24DEpQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.6.1.tgz",
+      "integrity": "sha512-k7lXRJpZ8vkMQy0EWoYD8U6rQqYuKEbrTshlIjZSuBOQ9qlAb9llJ80OO0gteYZBOCMde1BJGjCeVxSNAI6eFA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-font": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.6.1.tgz",
+      "integrity": "sha512-bt4UsDKTmq5iyu5TkmxpC/Z5zZEsw8bcCr5egjgNtV5ozJF1E+54iQBjKIYNYIWRdD0PAEEGFE15QoWzSHBtxw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@types/hast": "3.0.4",
+        "ckeditor5": "47.6.1",
+        "hast-util-from-dom": "5.0.1",
+        "hast-util-to-html": "9.0.5",
+        "hast-util-to-mdast": "10.1.2",
+        "hastscript": "9.0.1",
+        "rehype-dom-parse": "5.0.2",
+        "rehype-dom-stringify": "4.0.2",
+        "rehype-remark": "10.0.1",
+        "remark-breaks": "4.0.0",
+        "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "remark-stringify": "11.0.0",
+        "unified": "11.0.5",
+        "unist-util-visit": "5.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-40.2.0.tgz",
-      "integrity": "sha512-ORY7VebL7UTuBG/4++UxzqEKjnlZZKAFqUrIom7xXpQNfo6oJFtZLnKYwESZ6iNk7NBOAeiHEecP2tKWyFQd1g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.6.1.tgz",
+      "integrity": "sha512-G18SeOxXVy+k0SQYHkw1HQtS6/PkqpX2Mv6zM7os9aG3OpPmX8tCqDK+X7TaMx3FRJlDV0ujOy5Qfs71SJrqKA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.6.1.tgz",
+      "integrity": "sha512-/53LFzYqcgvd8pL02XlNBduucfnakDVvY86vC02spDuTsUH5qUMqLaz2FHSo9AH2y3kNVp98KDnqI/QjNZCd+Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.6.1.tgz",
+      "integrity": "sha512-ksKOy4wxzs3pkhfzVtnnsu5rgJxqYHMKM7X8Rkhx9BSshcKFeuNIUVsSh+7QWDQStWKSZ/qAx+0rezdJCm6gvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.6.1.tgz",
+      "integrity": "sha512-KBE1tLsnyIsh0v+S6p0G+WglkvfWvKCkOESmap+gct5xwmOE0HEgRVp6xFFBfHYuGSjSISvgUU4ofdnhseZivA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-40.2.0.tgz",
-      "integrity": "sha512-NotxWP1cKvbJSY1UwdTe/Oy1NnAj9Etsi4Z7XA908EvCsNSnFtzdMhYzLhFZJ18avrQFDa7PpSKSyN3M64CbSA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.6.1.tgz",
+      "integrity": "sha512-6FXs94lSb6n7V7Puwp1c9BMyjycOfsAjdPRSVGTx1THqQBziQZHuZeU9LBxJZBA1mzoQOfmFaC3v+wb8odBgAQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-40.2.0.tgz",
-      "integrity": "sha512-kdk7uJlSa9mvyuNAwmIfV6Kc1tfWI6DbCs19jyseA/F0vySKibb0DsBVSZ7xa5ihcjphfJvwpypWYL0BYdYKLQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.6.1.tgz",
+      "integrity": "sha512-Lt/V8/q59WuPURpwS9Z1UWUU1q5fF7YUbDAapWatzJlK9J/c969nRMG2aXm3z+BjXv3Kdu9qs4Oqngw0sJ0KiA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-react": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-6.2.0.tgz",
-      "integrity": "sha512-i/6OdxJ3iOCU7eiZXS8KYhK645PEAMISs9eFz60c0AFXZX5NTMvNWM68ac/J5sfg+IQ9U6mJ3flSykbJVlf0kA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-11.1.0.tgz",
+      "integrity": "sha512-ac0iQnHg31n+IjMHeUT6xxAEH2l7H0QVT3tEeReDOTXusi4neL5GslLRmsYtz7nPnUQnoXXAaervf0YY1sOLWg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "@ckeditor/ckeditor5-integrations-common": "^2.2.5"
       },
       "peerDependencies": {
-        "@ckeditor/ckeditor5-core": ">=40.1.0",
-        "@ckeditor/ckeditor5-editor-multi-root": ">=40.1.0",
-        "@ckeditor/ckeditor5-engine": ">=40.1.0",
-        "@ckeditor/ckeditor5-utils": ">=40.1.0",
-        "@ckeditor/ckeditor5-watchdog": ">=40.1.0",
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+        "ckeditor5": ">=46.0.0 || ^0.0.0-nightly || ^0.0.0-internal",
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.6.1.tgz",
+      "integrity": "sha512-2lQvT4+OVIFQs67yKh54exnT5UV1rPjEZX7MqyhZ3Dr0rzyEW7b9tpFz7bP/EUOSa2LpFktNoLFOSnIAZnQdyQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.6.1.tgz",
+      "integrity": "sha512-ufWtexBPqBxJNNjjIw9XQe8Q+cnwLV4en6PTvdBX/zXHq87QdjpFk6NRSLCgDTpNmO2GiXnl+FsqUjGJF27zDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-40.2.0.tgz",
-      "integrity": "sha512-yaYCqhdMcoEH3BsilhweNdbOfuO/cexQ1r1/mYoBoW4CypIuAeq8J/3qLpvFaThmCRPzJBn1J7v2Yjs/0UnamA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.6.1.tgz",
+      "integrity": "sha512-NKhujjJ04UdM/pObi45+q6Em0fD6pQ1m+g5qLgTsTyoFUq2rFhMZqeRSPGEXlfuR5dImA7hP8uQtXNtt/GpZ7g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.6.1.tgz",
+      "integrity": "sha512-9MdxI7TjccCOcbdlzX+SBjFvt8CsdxCgyoJxZ2NYut6QJAJ6WPjH0yVxckZXC3LSkqIPzrIOJxHc7e2n+oFFvA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.6.1.tgz",
+      "integrity": "sha512-/NeN6KvgdlvmBzOGH1Uxk26zGti8HvvmBbHLOCzFqfXZRLHB+47BG+GtzOa82t6YnLjK7pvR23opyAApRf6zIA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.6.1.tgz",
+      "integrity": "sha512-O+WRAaDh3m/i3lWF+MaB0G++nBusB/uaB+koN+gwqiIfDHpGJ9HKr+KXrMZZYb0MjiGV0J5gswuwL+YvzNZ6rg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.6.1.tgz",
+      "integrity": "sha512-WD9lzsgIk3sB+Ec/mpgbYIZXr8cRBOcDAjFndfjuSQMZRYM5kCMpIz0qpvjGp1Glz2bmeg7CwfuLDvbZSqZrfA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-html-support": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-40.2.0.tgz",
-      "integrity": "sha512-yODne7az/aJ9lsuI7w476pgGV2QBoH2tOKp3JFh/e2DdHC20637LCVd0cx8sUe3zk61X/eYPY+wOiRJx/mIUqg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.6.1.tgz",
+      "integrity": "sha512-zFJWnqL0PpdlSs8U1m5Mu/gcuoJfi0GSpDqr174dqXLtFcMfIsftVWVTbY5d4f+OKAp8LifxOg3CMvLD1YNSGA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.6.1.tgz",
+      "integrity": "sha512-iaRFqt6ExGAAsOc4AfJNbMyY+jnh//gMzGendqklhQzkwV3RGzN6buRtV0Fps+pKXnpRcbqaVHWv0GOIOaG58Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-40.2.0.tgz",
-      "integrity": "sha512-2E7LkmC4RHdenMUwow0EZDKxlbX00c5UHysUVT51EBGrXiJcN++0cqxQaeJzQ262oTDpk94qE5IZdGXt3ntzrw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.6.1.tgz",
+      "integrity": "sha512-yuMJCK6+KpYyXHxkBKRtVuOF1L42eyhUlCCq4sNFHjoJfD3q3gunmesoGIkdezMZR5RpqpGSfrOapEG9orOBTg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-40.2.0.tgz",
-      "integrity": "sha512-K8oC9zrJokZD5Nl4uQjJMo8Couds0eHmfNI/go6iU4A4OAdDzph+W50QnyMed4etKnMdhvUSbnuZnPtQjnsvFA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.6.1.tgz",
+      "integrity": "sha512-zBEfMSpR26rVPvc9X4KXxQd0wQG42EM+37VHdrfwJL47PFlqXTGlbsZ9BBjlElNM1mpViWSW9zpt5JdE6vtHCQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "lodash-es": "4.17.21",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
         "vanilla-colorful": "0.7.2"
       }
     },
-    "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-40.2.0.tgz",
-      "integrity": "sha512-k2VZS5x4SJtYk3zhdwHYg+D00DgD0iWR0H4qQgcWmQMFRipYvXJRixP3hSLZGJciQanPFeYcjZgxNQ+rU1s8ug==",
+    "node_modules/@ckeditor/ckeditor5-ui/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.6.1.tgz",
+      "integrity": "sha512-kxckLxZHglOTv0yd7cROpZAgOQFR7uJEKy+ehGaPrPy5eMrIhUqHcDWHv4sLNJfNg1IgQrsqYNHeIaTzT38RvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-40.2.0.tgz",
-      "integrity": "sha512-AdJSKvWEQbSSyA/DfxbCHRhFN6S4ew4kuYETO57e6AS3aOuYGLBRdu9Mub7IAQcOyy1LL6ktr9u5WEOoWS2h0w==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.6.1.tgz",
+      "integrity": "sha512-GFMKl6pct+r26EQ4K2D22xokyDQIoRYQZSZFoPl4L04FFPVRuG60pA1YSNtyi7Am+T1fR3qOVBHAuXsANyeL6g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-40.2.0.tgz",
-      "integrity": "sha512-f+kTJBwwk7Y/LXm8pEPxBTXVlJwQrH7Levzye9zxEDB0Jtj7+brGr87o666fPmL/ATQc5M+VPhbvnk2sOv7WKg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.6.1.tgz",
+      "integrity": "sha512-gJl5DikvPjMEsv9DZmEVv6GOZEjHQN3kgaxvaAYpfg4VcT1RENHw46BfvPN/zUHsYwZlh7DxG3+o7h3M8Pzj1w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-40.2.0.tgz",
-      "integrity": "sha512-ets7o2dUR7l23G9o/RAbu+gJzUkc2Ul269E3TEhZnbQXFjshvEGK2kzuay7I+/waL3ADuYe4zuoBqsqdPoAhfg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.6.1.tgz",
+      "integrity": "sha512-mHum5WRT5PKiL80UwNMXiw//s1486smeCO2sgYJKZGrqlz7cSSHDOc8iUi8Cn2YuHvTfjgRjgcZxn0u9uhr1Mw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-40.2.0.tgz",
-      "integrity": "sha512-okeUSwbnu6TUKvwBOl0YdED6Me0/vvs1ybfKZPNEJNwGl989iG0LQO4oYUye8BTCZvzCZ2cBTb1Cvnwr8KRcbg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.6.1.tgz",
+      "integrity": "sha512-rURYZlY9w+qjumkQ+VQ1cO32JJbuxuGoWIPj2lTC3uFjn6kDzYB9KvNItOykBJM/V11R7sEEOWvpKlnsMmlnzg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-enter": "40.2.0",
-        "@ckeditor/ckeditor5-typing": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.6.1.tgz",
+      "integrity": "sha512-q/8jRqtEFQ5SQEY8GsJBtatD7OdQT2f1o7KdKVDcZ4UZTQCo2hi9d2zvHEkQ7drA0LO+D3WJrHNEd+B6wk1slg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@csstools/selector-specificity": {
@@ -4494,32 +5127,6 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
-    "node_modules/@open-formulieren/ckeditor5-build-classic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/ckeditor5-build-classic/-/ckeditor5-build-classic-1.0.1.tgz",
-      "integrity": "sha512-lL9xK4t0PDwzBt6aLVSlrOkFc8ItfSjRQoNUmnh8fVvODepMxWIRTpUlCDhoQ8jv0IYVjTn320fviy/8VfZ6NQ==",
-      "dependencies": {
-        "@ckeditor/ckeditor5-alignment": "40.2.0",
-        "@ckeditor/ckeditor5-autoformat": "40.2.0",
-        "@ckeditor/ckeditor5-basic-styles": "40.2.0",
-        "@ckeditor/ckeditor5-block-quote": "40.2.0",
-        "@ckeditor/ckeditor5-editor-classic": "40.2.0",
-        "@ckeditor/ckeditor5-essentials": "40.2.0",
-        "@ckeditor/ckeditor5-font": "40.2.0",
-        "@ckeditor/ckeditor5-heading": "40.2.0",
-        "@ckeditor/ckeditor5-image": "40.2.0",
-        "@ckeditor/ckeditor5-indent": "40.2.0",
-        "@ckeditor/ckeditor5-link": "40.2.0",
-        "@ckeditor/ckeditor5-list": "40.2.0",
-        "@ckeditor/ckeditor5-media-embed": "40.2.0",
-        "@ckeditor/ckeditor5-paragraph": "40.2.0",
-        "@ckeditor/ckeditor5-paste-from-office": "40.2.0",
-        "@ckeditor/ckeditor5-table": "40.2.0",
-        "@ckeditor/ckeditor5-typing": "40.2.0",
-        "@ckeditor/ckeditor5-undo": "40.2.0",
-        "@ckeditor/ckeditor5-upload": "40.2.0"
-      }
-    },
     "node_modules/@open-formulieren/design-tokens": {
       "version": "0.66.0",
       "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.66.0.tgz",
@@ -4527,17 +5134,17 @@
       "license": "EUPL-1.2"
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.48.0.tgz",
-      "integrity": "sha512-5s6EQeT+MVSH34G6EgnXn2MNmEjKxTKl8darJLplHLP/8f55j4stfbr/fa4j9hitQZYY+NVM1TwQ7/VcSyJtkg==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.49.0.tgz",
+      "integrity": "sha512-cjMk4NF97UI3TnO2Qlo2ALXA++ZYZF+eUqtw0ALrh+dX1GovLF51M2AydptlPan/20BrNdA/oRoXZLbD4UY81Q==",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@ckeditor/ckeditor5-react": "^6.2.0",
+        "@ckeditor/ckeditor5-react": "^11.0.1",
         "@floating-ui/react": "^0.26.4",
-        "@open-formulieren/ckeditor5-build-classic": "^1.0.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@open-formulieren/types": "^1.0.0",
+        "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
         "formik": "^2.4.5",
         "leaflet": "^1.9.4",
@@ -5797,11 +6404,35 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.0"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
+      "license": "MIT"
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -5852,6 +6483,15 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -5920,11 +6560,26 @@
       "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
       "dev": true
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -6004,6 +6659,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/wait-on": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
@@ -6025,6 +6686,12 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@utrecht/components": {
       "version": "7.4.0",
@@ -6932,6 +7599,16 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6976,6 +7653,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/blurhash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -7218,6 +7901,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -7256,6 +7949,36 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -7322,23 +8045,72 @@
       "dev": true
     },
     "node_modules/ckeditor5": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-40.2.0.tgz",
-      "integrity": "sha512-JaFuY/6DX1wbA6yRB2xQVMr+9W1C3HvSX4AT10ccoKBKe9OctIatekDt2ztV+cMaVHLF1wocskS/Ql9XFRy2Eg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.6.1.tgz",
+      "integrity": "sha512-Za7+Dyju3RgfH4TF+zam7lvfOSr+Rd+0tABfR16HEtsARRPEmNBHYgS5nM3PZtNK4+ScliL6Ch3GFk7cd/TiOw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "40.2.0",
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-enter": "40.2.0",
-        "@ckeditor/ckeditor5-paragraph": "40.2.0",
-        "@ckeditor/ckeditor5-select-all": "40.2.0",
-        "@ckeditor/ckeditor5-typing": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-undo": "40.2.0",
-        "@ckeditor/ckeditor5-upload": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "@ckeditor/ckeditor5-watchdog": "40.2.0",
-        "@ckeditor/ckeditor5-widget": "40.2.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "47.6.1",
+        "@ckeditor/ckeditor5-alignment": "47.6.1",
+        "@ckeditor/ckeditor5-autoformat": "47.6.1",
+        "@ckeditor/ckeditor5-autosave": "47.6.1",
+        "@ckeditor/ckeditor5-basic-styles": "47.6.1",
+        "@ckeditor/ckeditor5-block-quote": "47.6.1",
+        "@ckeditor/ckeditor5-bookmark": "47.6.1",
+        "@ckeditor/ckeditor5-ckbox": "47.6.1",
+        "@ckeditor/ckeditor5-ckfinder": "47.6.1",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-code-block": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-easy-image": "47.6.1",
+        "@ckeditor/ckeditor5-editor-balloon": "47.6.1",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.1",
+        "@ckeditor/ckeditor5-editor-inline": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-emoji": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-essentials": "47.6.1",
+        "@ckeditor/ckeditor5-find-and-replace": "47.6.1",
+        "@ckeditor/ckeditor5-font": "47.6.1",
+        "@ckeditor/ckeditor5-fullscreen": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-highlight": "47.6.1",
+        "@ckeditor/ckeditor5-horizontal-line": "47.6.1",
+        "@ckeditor/ckeditor5-html-embed": "47.6.1",
+        "@ckeditor/ckeditor5-html-support": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-indent": "47.6.1",
+        "@ckeditor/ckeditor5-language": "47.6.1",
+        "@ckeditor/ckeditor5-link": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-markdown-gfm": "47.6.1",
+        "@ckeditor/ckeditor5-media-embed": "47.6.1",
+        "@ckeditor/ckeditor5-mention": "47.6.1",
+        "@ckeditor/ckeditor5-minimap": "47.6.1",
+        "@ckeditor/ckeditor5-page-break": "47.6.1",
+        "@ckeditor/ckeditor5-paragraph": "47.6.1",
+        "@ckeditor/ckeditor5-paste-from-office": "47.6.1",
+        "@ckeditor/ckeditor5-remove-format": "47.6.1",
+        "@ckeditor/ckeditor5-restricted-editing": "47.6.1",
+        "@ckeditor/ckeditor5-select-all": "47.6.1",
+        "@ckeditor/ckeditor5-show-blocks": "47.6.1",
+        "@ckeditor/ckeditor5-source-editing": "47.6.1",
+        "@ckeditor/ckeditor5-special-characters": "47.6.1",
+        "@ckeditor/ckeditor5-style": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-watchdog": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "@ckeditor/ckeditor5-word-count": "47.6.1"
       }
     },
     "node_modules/classnames": {
@@ -7513,11 +8285,21 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0"
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/color-string": {
@@ -7551,6 +8333,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -8234,6 +9026,19 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -8353,7 +9158,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8378,6 +9182,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dialog-polyfill": {
@@ -8832,6 +9649,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -9734,6 +10561,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10008,6 +10841,231 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz",
+      "integrity": "sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "property-information": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -10099,6 +11157,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -12895,6 +13963,16 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12990,12 +14068,258 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -13030,6 +14354,569 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
       "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -14736,6 +16623,16 @@
         "react-is": "^16.8.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -15314,6 +17211,59 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-dom-parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz",
+      "integrity": "sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-dom-stringify": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz",
+      "integrity": "sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-dom": "^4.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -15334,6 +17284,87 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/renderkid": {
@@ -15949,6 +17980,16 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -16354,6 +18395,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -16808,6 +18863,36 @@
       "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
       "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ=="
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -16947,6 +19032,119 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -17147,7 +19345,8 @@
     "node_modules/vanilla-colorful": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
-      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==",
+      "license": "MIT"
     },
     "node_modules/vanilla-picker": {
       "version": "2.12.1",
@@ -17155,6 +19354,34 @@
       "integrity": "sha512-2qrEP9VYylKXbyzXKsbu2dferBTvqnlsr29XjHwFE+/MEp0VNj6oEUESLDtKZ7DWzGdSv1x/+ujqFZF+KsO3cg==",
       "dependencies": {
         "@sphinxxxx/color-conversion": "^2.2.2"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -17239,6 +19466,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {
@@ -17865,6 +20102,16 @@
       "peerDependencies": {
         "formik": "^2.2.9",
         "zod": "^3.14.4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   },
@@ -19593,275 +21840,843 @@
         "tough-cookie": "^4.1.4"
       }
     },
-    "@ckeditor/ckeditor5-alignment": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-40.2.0.tgz",
-      "integrity": "sha512-OMvOdgEWBzFQbcHLu4CYMe/LONSmn07BxrXQ4Uxd++Wr45U2ElrbkKcJldARa+J97YGEzaaCI3igXDh6g4fkRA==",
+    "@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-47.6.1.tgz",
+      "integrity": "sha512-X4l4KyLgSsmAyRd/YY8R/OArOXR2Ts8NyoW6k+tLtYxEmZOhJsa6ZFSho/OVTole7IqMl+Zo93b9YaAwX23brw==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-alignment": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-47.6.1.tgz",
+      "integrity": "sha512-2u1+Eseelrm5gKKajE9X+gcPchVAIna3AkoJyCw3+Y4dBc6ElWZJEuCO7b6Omv5H7q3lQimbaqJnvIE1Z/nXOA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-autoformat": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-40.2.0.tgz",
-      "integrity": "sha512-F3w5k7ti5l6V8U07eSQ3gup3ivltRZQXdtvstBXMmTzDb2ceazNcUDLb6TKSHp5y30ETN0dRGgbhx9xiDL0TXg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-47.6.1.tgz",
+      "integrity": "sha512-UI3HFyw7VCTM92IhE6hdIh5rp2nqOLL4vnnOFTgp7Lq6dLOVzuwsRJLIEfYxz4Xusy4UKu4zM8QX4FV1nOWsGQ==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-autosave": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-47.6.1.tgz",
+      "integrity": "sha512-7om5OHf2hBDi/Md8lVZL6fF7gCBAMVZfg8zsJqTmAW6fwl5gfenD4rggPdSa4GVt+mZXbheZx9EWc0HX1psAew==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-basic-styles": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-40.2.0.tgz",
-      "integrity": "sha512-P7jYddLnRpaR4zVCqDa8InsZ6YNRHdF0RrX6+Uz81+A1IfyfmSd+5IaiLxxdnFWQ4JlEhJutjy9vMwSmOhZocQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-47.6.1.tgz",
+      "integrity": "sha512-/8R59UxR/8quK8UmOLOS1xq47GnB+oMNySo8BgLHJl7qepRR5VnWU0hHB239idnFk46IVhuRciXQHjifrJiScQ==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-block-quote": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-40.2.0.tgz",
-      "integrity": "sha512-t03Yp+MeAyQhwdGZqUlkJEx25VSiigpzkIGGOhccSaTIIZ9XcWDkrTevDhwA4Pq4Q9IRQ8Loj3KCVSBuAqkBgw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-47.6.1.tgz",
+      "integrity": "sha512-wyDLqGrmcDVNlRmHxXTpXg2PKImgB4yIU3UDRofFKVJiuvnZvKKvx/Oh9USVv1G1zOAPoFyoK9AQzqYNOB7AMQ==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-bookmark": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-47.6.1.tgz",
+      "integrity": "sha512-9HwVudGBEhbqMPkEXQTqSIACGYpOWlES7bOxdG6WfgOUOAdCiTPXFCc5f+HSMFbrwd7XJ40tycPLOa7XK14oEg==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-link": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-ckbox": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-47.6.1.tgz",
+      "integrity": "sha512-v083Tnbsx4z1fFW+ghMXlsf5EgB3UaSldjfRsipjIYUiUeatccgRN00Qh6qGMlYz7zZcSdUUtrOfTWL/LYPWDg==",
+      "requires": {
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "blurhash": "2.0.5",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-ckfinder": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-47.6.1.tgz",
+      "integrity": "sha512-ewgqgtQaDDZHQUGby/gg2/840Go280bvx959ExQH8Y7u4fPVw8NEFYAxjcm43W6EXgMnlmsEr8+G8q8g4iKT1w==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-clipboard": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-40.2.0.tgz",
-      "integrity": "sha512-8/xPH9/i86ukcEiHdmTgNuPVJeYTrivbx5ZYqycPO4Eem7VM99gIbOe7pIYpuV+klr9ymVxIHbGyTJDJ3oUO8A==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-47.6.1.tgz",
+      "integrity": "sha512-F3KQuCnnCavm8wXvX+d1KN/obh5ux/jT9qC/71QfMKdDvHxEOzi/t3YWa1r3sztlksDQ4LtODU4uWh0vVKUpkg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "@ckeditor/ckeditor5-widget": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-cloud-services": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-47.6.1.tgz",
+      "integrity": "sha512-yC9aqornbxjgNhHuUX4gcuvPTLv34sc8CbUOeFYLGbD9ujwoC0fzzjzSB7u5b8fWNg6cAjzriFooJATHBvu40g==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-code-block": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-47.6.1.tgz",
+      "integrity": "sha512-ntZBIEYLoC4/OTUgCkwwmyXwwqDk8QwFcx/1kZN7S4YtwocREZqpDH1wYT+GA2ZmGkjaBRxdTLwSVr/7bf+wqg==",
+      "requires": {
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-core": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-40.2.0.tgz",
-      "integrity": "sha512-0fqIaN+ZhkXXA3mpBN+alycBzPMc8ruO8VrP0OnvCjowqZVS2HXC2AaXNBdxc75xGI3ScXIor7FsgFHxVJIYYQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-47.6.1.tgz",
+      "integrity": "sha512-6dtnquhjymLkNhdC9T6gk/Mf2bDnHSTZrhkByaXC96CbmQDriCgfcaAVY6pQgDNxBQ6fZrev0TnKBLfTItrMsg==",
       "requires": {
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-watchdog": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-easy-image": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-47.6.1.tgz",
+      "integrity": "sha512-hWaqibO1ZUHRIkvvAO7O0qDAIw+GN6UWbdr0wcGNLc4DcSZMUIpAfoXuiyyvE9hQEJPpfTOwA3r0znS6wXtMCg==",
+      "requires": {
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-balloon": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-47.6.1.tgz",
+      "integrity": "sha512-geszCykoE9Sja2tBqyMww4etAzAExg4eGnlYbXSGiaUiC7Ks4OqRVeuvw37QsH8Q56J5FQC35ysq95nrLEB+0A==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-editor-classic": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-40.2.0.tgz",
-      "integrity": "sha512-dftfDBxANOgqgQZ4SB3YTsEV/XX1u0g9jopbOBwqIABnVVa8zoGcktgFdGnLUFk51sL65baSx2z8Z1NNYdZcFQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-47.6.1.tgz",
+      "integrity": "sha512-w2QaF2ieqLqu6i9YldOpPnFezvAsXY/R/vp/c0D1ofvI1CtBRWhQ9/rRwADMoKgpcuyP2320sRG312anT8aiaA==",
       "requires": {
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-47.6.1.tgz",
+      "integrity": "sha512-w047UpjHF106k0NeQLgWY03k29s5vIpS9M6Oj+f+IdKaf4TR7uSzl/CXsS+csfqwZEhtGwGV3LYJVzo35+SifA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-inline": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-47.6.1.tgz",
+      "integrity": "sha512-UJQHbMh1nvsHMuiijmRx3y/5ssdxeJTrVjrwDoPlUsI8tfRYjkdIucd9SsRhXnV65Vk31Ah5wiFyaBb5OLXZaA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-47.6.1.tgz",
+      "integrity": "sha512-Jn55iVT2sg85NSPVe/mThLoiI0FTAEH5r48MXD1MKz1E5K0FkpdLiKyCR4onfdFLozWZW2NvU0faCkyI0BKaZQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-emoji": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-47.6.1.tgz",
+      "integrity": "sha512-bnnnvRk/eYrvKLLQpJrjSV++Abpm1/8N31BNVaZyeHzaI0pddE6ikS44Ju82u7BQJaqSi2SO2Glx3u3C14rm2g==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-mention": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5",
+        "fuzzysort": "3.1.0"
       }
     },
     "@ckeditor/ckeditor5-engine": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-40.2.0.tgz",
-      "integrity": "sha512-sgboUX8Ps+LcEgywyT3BeK1nzLHjNVIiZU1qvRxR3ixzIw4w2xRNXCGfESWLW5Y5rv9+ypUCrX61oLnZU64PQQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-47.6.1.tgz",
+      "integrity": "sha512-Xb398PRhkJqtUuQ1E1pdLXTG1REIOanr7PCIRPpWvpHAIZZAuxTIqyacZC4qVTS9xI+ObxYqosf8yNvFsEtu8w==",
       "requires": {
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-enter": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-40.2.0.tgz",
-      "integrity": "sha512-GjTRaKNX8QEDJ3YYKG3GfPZfGHrcigGBxbo+1WDT7NaOsR2DA/CIZfHlAPfgJDAMV17bhWsT3gy3+oQZsExtnQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-47.6.1.tgz",
+      "integrity": "sha512-H/d5L8JmZFmb5wYDi3NT4NICYuRueGUwiPgIpaaQ0gb8U3U0YVj4J5WVF/65KGiYdsuP2NupSwRqsdl8TilrdQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-essentials": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-40.2.0.tgz",
-      "integrity": "sha512-7iUUy0Uwiei4yLrn145SOcyzriMeVFVc5ontQkxQE5b9alFdAc/6ZoDPZqwD7V0zi5RQ/2YsoVMRLFa4hbPfNA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-47.6.1.tgz",
+      "integrity": "sha512-4A9E9GrOudYA/eWCXE9uLqEdw7RLO/OdmeY1KWGAF6B9fubieSCF+S69M3c5hMKS6KJoNjaVJ/iR91KfIyYmtw==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-select-all": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-find-and-replace": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-47.6.1.tgz",
+      "integrity": "sha512-ZbKlNpFYCP0DRICJlhyTLaRlPSwdJ5W9BBrMFjHhGsKNbFJ2KHlPCqTD6nAEWc838heDBZM21jRGTM6O92FLHA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-font": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-40.2.0.tgz",
-      "integrity": "sha512-k38+eQQF+zfiauVDxcMBHGG1ShRwCNibaJipu5FKzvGY5PJELUsIfor1dsSPsTADWxWMpBi5qEaSO4S4+Lu/JA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-47.6.1.tgz",
+      "integrity": "sha512-ayMtG44tLbmPBjoEudnF7kFkqX3GUO0Cb1lLd6JR5B4uyoNFuQbN3nyrtx7hMvdu0N4jl0hWcWXjdu6vNL4I6g==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-fullscreen": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-47.6.1.tgz",
+      "integrity": "sha512-LvA7vzeAkuc/z64kuRu17zm7EIFe0Bqt9xPA5GhfR6T9mBVG4wu62ElqylFUjFJ+macvkjSe68tBYQTAPyUWqg==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-heading": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-40.2.0.tgz",
-      "integrity": "sha512-uDT1sttMy+KrKi90jnqEI43886o1wfKrROWqaMbmKOerTbIi58GNH9LvX04sf1RyHV3+3566RRmB248fsLkYjA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-47.6.1.tgz",
+      "integrity": "sha512-4kVuMaaAylkxYkJ0PA4hUQCDTARoeokkqKh0dE3DwEZTvvWDZjBEAhIKaSVX116ByeGfImbLkBRAoNCljKNCHQ==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-paragraph": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
-    "@ckeditor/ckeditor5-image": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-40.2.0.tgz",
-      "integrity": "sha512-0Dunw1o5k2+5Q5XiWLDG1r8k9awosfIFuDZwqKJGWtDaNE4QQbJ9+iJSwiiRw2QjcGr7D3JdH7xwJZFra7kYmA==",
+    "@ckeditor/ckeditor5-highlight": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-47.6.1.tgz",
+      "integrity": "sha512-hEIAZAImLAGRsz7/d+bbh3k+9s854AxuYoTmCAN2u07muYX/pmrLrLm6cZcazjmi9J/Bow6sP/D5GeoYMWKkLA==",
       "requires": {
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-horizontal-line": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-47.6.1.tgz",
+      "integrity": "sha512-YTSpxdrp8NteaWARH89dA+qUWAf3agw/Q1dRQF+XdiF2kaSXRPQCXJruvmy490H+3xtwUZVs/hSlwX9gT77Skg==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-html-embed": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-47.6.1.tgz",
+      "integrity": "sha512-z4iYN6Il/PqpOBm+7OYM1mpXLUCbA7cMjq3MGIAwGwRHNFq8BWq/1by3P8FiF4ozaUyj8YgXXyWoggBC2qQRig==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-html-support": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-47.6.1.tgz",
+      "integrity": "sha512-F25LY88VYx0gZTrrThmt+kqF2thrwg52ZCIQeRujMd3RIueYEAEn7ZJ0p5iArDvm9qQXtLzsaijEyZr2edstPA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-remove-format": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-icons": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-47.6.1.tgz",
+      "integrity": "sha512-OEk5hPdMpE5/Cb2lZFtJL2XyMwy/S8xQzuAk2b2P2bJx33rJgU3pk9RUrayxCSa3p+tKqibOzm5GcshLJ7s7Tg=="
+    },
+    "@ckeditor/ckeditor5-image": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-47.6.1.tgz",
+      "integrity": "sha512-yy7b/7WQqN0c7/VC1Ng5svQU1btXWauBfQjFgVV3AzGa+nVeJ1ZIcV2fAkUa6mB+lCu+5ziv7b7ord22baJYzg==",
+      "requires": {
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-indent": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-40.2.0.tgz",
-      "integrity": "sha512-gSlRGoyAslB2OpqghimIY6Oiflf3Z2/MdLBzvFipU5N4X66cL29HuWZc/bOkcFzWwNeDK5LgzfLdvXNzkdv5Xw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-47.6.1.tgz",
+      "integrity": "sha512-SaokgxUJevRrYfu5PKEMvVrUliybmxpb3Cx/f/JtOnPbyJSFrt05+/mt3XsqsSB0g8LaHH2PXQfD4vncGzE6DQ==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-integrations-common": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.5.tgz",
+      "integrity": "sha512-CWBlHPfHL+0bfSmdIyfDZ8XLXOar+g55mY74sAFg11twMc5gve4leMHDwDU3My65Wrg7vDj3s35TvYc7sKtnEQ=="
+    },
+    "@ckeditor/ckeditor5-language": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-47.6.1.tgz",
+      "integrity": "sha512-YZpySDIa4Y40T9wwKIFsAlDujELkgUtoKw/+4Wl8BHlDnq/40VxXFbOSSXu4TnnVeqVFcnzTjp6Zv8CHtmY3yw==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-link": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-40.2.0.tgz",
-      "integrity": "sha512-/r4Ti9USdrURBX+qutvyDGOb75sNuSgtXdI8xK503EVfx5yBIi6qsYIYWoFvnGJKkLYkVo+940ilduhwzq0M7g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-47.6.1.tgz",
+      "integrity": "sha512-A/gjF7e00R/ESUotqR08EeGM91V031DiHiGwYn7b+iZ1bejsdEu3yQK707bZ4U6ByEYBUOMtq1bOMYUtGJl6EA==",
       "requires": {
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-list": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-40.2.0.tgz",
-      "integrity": "sha512-lsQWSLSFRHRQ2AxA6vgTib9YELjF2J5jpR6H4RDW1gM//dL3FjvLxKPPN/V7rMcp15rrpSiOya+qB99l24DEpQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-47.6.1.tgz",
+      "integrity": "sha512-k7lXRJpZ8vkMQy0EWoYD8U6rQqYuKEbrTshlIjZSuBOQ9qlAb9llJ80OO0gteYZBOCMde1BJGjCeVxSNAI6eFA==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-font": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-47.6.1.tgz",
+      "integrity": "sha512-bt4UsDKTmq5iyu5TkmxpC/Z5zZEsw8bcCr5egjgNtV5ozJF1E+54iQBjKIYNYIWRdD0PAEEGFE15QoWzSHBtxw==",
+      "requires": {
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@types/hast": "3.0.4",
+        "ckeditor5": "47.6.1",
+        "hast-util-from-dom": "5.0.1",
+        "hast-util-to-html": "9.0.5",
+        "hast-util-to-mdast": "10.1.2",
+        "hastscript": "9.0.1",
+        "rehype-dom-parse": "5.0.2",
+        "rehype-dom-stringify": "4.0.2",
+        "rehype-remark": "10.0.1",
+        "remark-breaks": "4.0.0",
+        "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "remark-stringify": "11.0.0",
+        "unified": "11.0.5",
+        "unist-util-visit": "5.0.0"
       }
     },
     "@ckeditor/ckeditor5-media-embed": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-40.2.0.tgz",
-      "integrity": "sha512-ORY7VebL7UTuBG/4++UxzqEKjnlZZKAFqUrIom7xXpQNfo6oJFtZLnKYwESZ6iNk7NBOAeiHEecP2tKWyFQd1g==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-47.6.1.tgz",
+      "integrity": "sha512-G18SeOxXVy+k0SQYHkw1HQtS6/PkqpX2Mv6zM7os9aG3OpPmX8tCqDK+X7TaMx3FRJlDV0ujOy5Qfs71SJrqKA==",
       "requires": {
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-mention": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-47.6.1.tgz",
+      "integrity": "sha512-/53LFzYqcgvd8pL02XlNBduucfnakDVvY86vC02spDuTsUH5qUMqLaz2FHSo9AH2y3kNVp98KDnqI/QjNZCd+Q==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-minimap": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-47.6.1.tgz",
+      "integrity": "sha512-ksKOy4wxzs3pkhfzVtnnsu5rgJxqYHMKM7X8Rkhx9BSshcKFeuNIUVsSh+7QWDQStWKSZ/qAx+0rezdJCm6gvQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-page-break": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-47.6.1.tgz",
+      "integrity": "sha512-KBE1tLsnyIsh0v+S6p0G+WglkvfWvKCkOESmap+gct5xwmOE0HEgRVp6xFFBfHYuGSjSISvgUU4ofdnhseZivA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-paragraph": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-40.2.0.tgz",
-      "integrity": "sha512-NotxWP1cKvbJSY1UwdTe/Oy1NnAj9Etsi4Z7XA908EvCsNSnFtzdMhYzLhFZJ18avrQFDa7PpSKSyN3M64CbSA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-47.6.1.tgz",
+      "integrity": "sha512-6FXs94lSb6n7V7Puwp1c9BMyjycOfsAjdPRSVGTx1THqQBziQZHuZeU9LBxJZBA1mzoQOfmFaC3v+wb8odBgAQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-paste-from-office": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-40.2.0.tgz",
-      "integrity": "sha512-kdk7uJlSa9mvyuNAwmIfV6Kc1tfWI6DbCs19jyseA/F0vySKibb0DsBVSZ7xa5ihcjphfJvwpypWYL0BYdYKLQ==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-47.6.1.tgz",
+      "integrity": "sha512-Lt/V8/q59WuPURpwS9Z1UWUU1q5fF7YUbDAapWatzJlK9J/c969nRMG2aXm3z+BjXv3Kdu9qs4Oqngw0sJ0KiA==",
       "requires": {
-        "ckeditor5": "40.2.0"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-react": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-6.2.0.tgz",
-      "integrity": "sha512-i/6OdxJ3iOCU7eiZXS8KYhK645PEAMISs9eFz60c0AFXZX5NTMvNWM68ac/J5sfg+IQ9U6mJ3flSykbJVlf0kA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-11.1.0.tgz",
+      "integrity": "sha512-ac0iQnHg31n+IjMHeUT6xxAEH2l7H0QVT3tEeReDOTXusi4neL5GslLRmsYtz7nPnUQnoXXAaervf0YY1sOLWg==",
       "requires": {
-        "prop-types": "^15.7.2"
+        "@ckeditor/ckeditor5-integrations-common": "^2.2.5"
+      }
+    },
+    "@ckeditor/ckeditor5-remove-format": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-47.6.1.tgz",
+      "integrity": "sha512-2lQvT4+OVIFQs67yKh54exnT5UV1rPjEZX7MqyhZ3Dr0rzyEW7b9tpFz7bP/EUOSa2LpFktNoLFOSnIAZnQdyQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-restricted-editing": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-47.6.1.tgz",
+      "integrity": "sha512-ufWtexBPqBxJNNjjIw9XQe8Q+cnwLV4en6PTvdBX/zXHq87QdjpFk6NRSLCgDTpNmO2GiXnl+FsqUjGJF27zDQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-select-all": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-40.2.0.tgz",
-      "integrity": "sha512-yaYCqhdMcoEH3BsilhweNdbOfuO/cexQ1r1/mYoBoW4CypIuAeq8J/3qLpvFaThmCRPzJBn1J7v2Yjs/0UnamA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-47.6.1.tgz",
+      "integrity": "sha512-NKhujjJ04UdM/pObi45+q6Em0fD6pQ1m+g5qLgTsTyoFUq2rFhMZqeRSPGEXlfuR5dImA7hP8uQtXNtt/GpZ7g==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-show-blocks": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-47.6.1.tgz",
+      "integrity": "sha512-9MdxI7TjccCOcbdlzX+SBjFvt8CsdxCgyoJxZ2NYut6QJAJ6WPjH0yVxckZXC3LSkqIPzrIOJxHc7e2n+oFFvA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-source-editing": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-47.6.1.tgz",
+      "integrity": "sha512-/NeN6KvgdlvmBzOGH1Uxk26zGti8HvvmBbHLOCzFqfXZRLHB+47BG+GtzOa82t6YnLjK7pvR23opyAApRf6zIA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-special-characters": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-47.6.1.tgz",
+      "integrity": "sha512-O+WRAaDh3m/i3lWF+MaB0G++nBusB/uaB+koN+gwqiIfDHpGJ9HKr+KXrMZZYb0MjiGV0J5gswuwL+YvzNZ6rg==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1"
+      }
+    },
+    "@ckeditor/ckeditor5-style": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-47.6.1.tgz",
+      "integrity": "sha512-WD9lzsgIk3sB+Ec/mpgbYIZXr8cRBOcDAjFndfjuSQMZRYM5kCMpIz0qpvjGp1Glz2bmeg7CwfuLDvbZSqZrfA==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-html-support": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-table": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-40.2.0.tgz",
-      "integrity": "sha512-yODne7az/aJ9lsuI7w476pgGV2QBoH2tOKp3JFh/e2DdHC20637LCVd0cx8sUe3zk61X/eYPY+wOiRJx/mIUqg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-47.6.1.tgz",
+      "integrity": "sha512-zFJWnqL0PpdlSs8U1m5Mu/gcuoJfi0GSpDqr174dqXLtFcMfIsftVWVTbY5d4f+OKAp8LifxOg3CMvLD1YNSGA==",
       "requires": {
-        "ckeditor5": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-theme-lark": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-47.6.1.tgz",
+      "integrity": "sha512-iaRFqt6ExGAAsOc4AfJNbMyY+jnh//gMzGendqklhQzkwV3RGzN6buRtV0Fps+pKXnpRcbqaVHWv0GOIOaG58Q==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-typing": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-40.2.0.tgz",
-      "integrity": "sha512-2E7LkmC4RHdenMUwow0EZDKxlbX00c5UHysUVT51EBGrXiJcN++0cqxQaeJzQ262oTDpk94qE5IZdGXt3ntzrw==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-47.6.1.tgz",
+      "integrity": "sha512-yuMJCK6+KpYyXHxkBKRtVuOF1L42eyhUlCCq4sNFHjoJfD3q3gunmesoGIkdezMZR5RpqpGSfrOapEG9orOBTg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-ui": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-40.2.0.tgz",
-      "integrity": "sha512-K8oC9zrJokZD5Nl4uQjJMo8Couds0eHmfNI/go6iU4A4OAdDzph+W50QnyMed4etKnMdhvUSbnuZnPtQjnsvFA==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-47.6.1.tgz",
+      "integrity": "sha512-zBEfMSpR26rVPvc9X4KXxQd0wQG42EM+37VHdrfwJL47PFlqXTGlbsZ9BBjlElNM1mpViWSW9zpt5JdE6vtHCQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "lodash-es": "4.17.21",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
         "vanilla-colorful": "0.7.2"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+          "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+          "requires": {
+            "color-name": "^2.0.0"
+          }
+        },
+        "color-name": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+          "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="
+        }
       }
     },
     "@ckeditor/ckeditor5-undo": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-40.2.0.tgz",
-      "integrity": "sha512-k2VZS5x4SJtYk3zhdwHYg+D00DgD0iWR0H4qQgcWmQMFRipYvXJRixP3hSLZGJciQanPFeYcjZgxNQ+rU1s8ug==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-47.6.1.tgz",
+      "integrity": "sha512-kxckLxZHglOTv0yd7cROpZAgOQFR7uJEKy+ehGaPrPy5eMrIhUqHcDWHv4sLNJfNg1IgQrsqYNHeIaTzT38RvQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-upload": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-40.2.0.tgz",
-      "integrity": "sha512-AdJSKvWEQbSSyA/DfxbCHRhFN6S4ew4kuYETO57e6AS3aOuYGLBRdu9Mub7IAQcOyy1LL6ktr9u5WEOoWS2h0w==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-47.6.1.tgz",
+      "integrity": "sha512-GFMKl6pct+r26EQ4K2D22xokyDQIoRYQZSZFoPl4L04FFPVRuG60pA1YSNtyi7Am+T1fR3qOVBHAuXsANyeL6g==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1"
       }
     },
     "@ckeditor/ckeditor5-utils": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-40.2.0.tgz",
-      "integrity": "sha512-f+kTJBwwk7Y/LXm8pEPxBTXVlJwQrH7Levzye9zxEDB0Jtj7+brGr87o666fPmL/ATQc5M+VPhbvnk2sOv7WKg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-47.6.1.tgz",
+      "integrity": "sha512-gJl5DikvPjMEsv9DZmEVv6GOZEjHQN3kgaxvaAYpfg4VcT1RENHw46BfvPN/zUHsYwZlh7DxG3+o7h3M8Pzj1w==",
       "requires": {
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-watchdog": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-40.2.0.tgz",
-      "integrity": "sha512-ets7o2dUR7l23G9o/RAbu+gJzUkc2Ul269E3TEhZnbQXFjshvEGK2kzuay7I+/waL3ADuYe4zuoBqsqdPoAhfg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-47.6.1.tgz",
+      "integrity": "sha512-mHum5WRT5PKiL80UwNMXiw//s1486smeCO2sgYJKZGrqlz7cSSHDOc8iUi8Cn2YuHvTfjgRjgcZxn0u9uhr1Mw==",
       "requires": {
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@ckeditor/ckeditor5-widget": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-40.2.0.tgz",
-      "integrity": "sha512-okeUSwbnu6TUKvwBOl0YdED6Me0/vvs1ybfKZPNEJNwGl989iG0LQO4oYUye8BTCZvzCZ2cBTb1Cvnwr8KRcbg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-47.6.1.tgz",
+      "integrity": "sha512-rURYZlY9w+qjumkQ+VQ1cO32JJbuxuGoWIPj2lTC3uFjn6kDzYB9KvNItOykBJM/V11R7sEEOWvpKlnsMmlnzg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-enter": "40.2.0",
-        "@ckeditor/ckeditor5-typing": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "@ckeditor/ckeditor5-word-count": {
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-47.6.1.tgz",
+      "integrity": "sha512-q/8jRqtEFQ5SQEY8GsJBtatD7OdQT2f1o7KdKVDcZ4UZTQCo2hi9d2zvHEkQ7drA0LO+D3WJrHNEd+B6wk1slg==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "ckeditor5": "47.6.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "@csstools/selector-specificity": {
@@ -21021,48 +23836,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
-    "@open-formulieren/ckeditor5-build-classic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/ckeditor5-build-classic/-/ckeditor5-build-classic-1.0.1.tgz",
-      "integrity": "sha512-lL9xK4t0PDwzBt6aLVSlrOkFc8ItfSjRQoNUmnh8fVvODepMxWIRTpUlCDhoQ8jv0IYVjTn320fviy/8VfZ6NQ==",
-      "requires": {
-        "@ckeditor/ckeditor5-alignment": "40.2.0",
-        "@ckeditor/ckeditor5-autoformat": "40.2.0",
-        "@ckeditor/ckeditor5-basic-styles": "40.2.0",
-        "@ckeditor/ckeditor5-block-quote": "40.2.0",
-        "@ckeditor/ckeditor5-editor-classic": "40.2.0",
-        "@ckeditor/ckeditor5-essentials": "40.2.0",
-        "@ckeditor/ckeditor5-font": "40.2.0",
-        "@ckeditor/ckeditor5-heading": "40.2.0",
-        "@ckeditor/ckeditor5-image": "40.2.0",
-        "@ckeditor/ckeditor5-indent": "40.2.0",
-        "@ckeditor/ckeditor5-link": "40.2.0",
-        "@ckeditor/ckeditor5-list": "40.2.0",
-        "@ckeditor/ckeditor5-media-embed": "40.2.0",
-        "@ckeditor/ckeditor5-paragraph": "40.2.0",
-        "@ckeditor/ckeditor5-paste-from-office": "40.2.0",
-        "@ckeditor/ckeditor5-table": "40.2.0",
-        "@ckeditor/ckeditor5-typing": "40.2.0",
-        "@ckeditor/ckeditor5-undo": "40.2.0",
-        "@ckeditor/ckeditor5-upload": "40.2.0"
-      }
-    },
     "@open-formulieren/design-tokens": {
       "version": "0.66.0",
       "resolved": "https://registry.npmjs.org/@open-formulieren/design-tokens/-/design-tokens-0.66.0.tgz",
       "integrity": "sha512-zMs6937ostu1b6q7WHYq4yjtKifnExOGAjWNYLMWuc+7ZttnhFnsf5QFXBR6P+YFDkzQNhJSKnGZnmmY1zZPOQ=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.48.0.tgz",
-      "integrity": "sha512-5s6EQeT+MVSH34G6EgnXn2MNmEjKxTKl8darJLplHLP/8f55j4stfbr/fa4j9hitQZYY+NVM1TwQ7/VcSyJtkg==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.49.0.tgz",
+      "integrity": "sha512-cjMk4NF97UI3TnO2Qlo2ALXA++ZYZF+eUqtw0ALrh+dX1GovLF51M2AydptlPan/20BrNdA/oRoXZLbD4UY81Q==",
       "requires": {
-        "@ckeditor/ckeditor5-react": "^6.2.0",
+        "@ckeditor/ckeditor5-react": "^11.0.1",
         "@floating-ui/react": "^0.26.4",
-        "@open-formulieren/ckeditor5-build-classic": "^1.0.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@open-formulieren/types": "^1.0.0",
+        "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
         "formik": "^2.4.5",
         "leaflet": "^1.9.4",
@@ -21874,11 +24663,32 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "@types/color-convert": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
+      "requires": {
+        "@types/color-name": "^1.1.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg=="
+    },
     "@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true
+    },
+    "@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "requires": {
+        "@types/ms": "*"
+      }
     },
     "@types/deep-eql": {
       "version": "4.0.2",
@@ -21924,6 +24734,14 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "requires": {
+        "@types/unist": "*"
       }
     },
     "@types/hoist-non-react-statics": {
@@ -21990,11 +24808,24 @@
       "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
       "dev": true
     },
+    "@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/mdx": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "dev": true
+    },
+    "@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "@types/node": {
       "version": "14.17.9",
@@ -22070,6 +24901,11 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "optional": true
     },
+    "@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
     "@types/wait-on": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
@@ -22091,6 +24927,11 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
+    },
+    "@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "@utrecht/components": {
       "version": "7.4.0",
@@ -22789,6 +25630,11 @@
         }
       }
     },
+    "bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -22819,6 +25665,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "blurhash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w=="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -22979,6 +25830,11 @@
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==",
       "dev": true
     },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+    },
     "chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -23008,6 +25864,21 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+    },
+    "character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
+    },
+    "character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
     },
     "check-error": {
       "version": "2.1.3",
@@ -23049,23 +25920,71 @@
       "dev": true
     },
     "ckeditor5": {
-      "version": "40.2.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-40.2.0.tgz",
-      "integrity": "sha512-JaFuY/6DX1wbA6yRB2xQVMr+9W1C3HvSX4AT10ccoKBKe9OctIatekDt2ztV+cMaVHLF1wocskS/Ql9XFRy2Eg==",
+      "version": "47.6.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-47.6.1.tgz",
+      "integrity": "sha512-Za7+Dyju3RgfH4TF+zam7lvfOSr+Rd+0tABfR16HEtsARRPEmNBHYgS5nM3PZtNK4+ScliL6Ch3GFk7cd/TiOw==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "40.2.0",
-        "@ckeditor/ckeditor5-core": "40.2.0",
-        "@ckeditor/ckeditor5-engine": "40.2.0",
-        "@ckeditor/ckeditor5-enter": "40.2.0",
-        "@ckeditor/ckeditor5-paragraph": "40.2.0",
-        "@ckeditor/ckeditor5-select-all": "40.2.0",
-        "@ckeditor/ckeditor5-typing": "40.2.0",
-        "@ckeditor/ckeditor5-ui": "40.2.0",
-        "@ckeditor/ckeditor5-undo": "40.2.0",
-        "@ckeditor/ckeditor5-upload": "40.2.0",
-        "@ckeditor/ckeditor5-utils": "40.2.0",
-        "@ckeditor/ckeditor5-watchdog": "40.2.0",
-        "@ckeditor/ckeditor5-widget": "40.2.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "47.6.1",
+        "@ckeditor/ckeditor5-alignment": "47.6.1",
+        "@ckeditor/ckeditor5-autoformat": "47.6.1",
+        "@ckeditor/ckeditor5-autosave": "47.6.1",
+        "@ckeditor/ckeditor5-basic-styles": "47.6.1",
+        "@ckeditor/ckeditor5-block-quote": "47.6.1",
+        "@ckeditor/ckeditor5-bookmark": "47.6.1",
+        "@ckeditor/ckeditor5-ckbox": "47.6.1",
+        "@ckeditor/ckeditor5-ckfinder": "47.6.1",
+        "@ckeditor/ckeditor5-clipboard": "47.6.1",
+        "@ckeditor/ckeditor5-cloud-services": "47.6.1",
+        "@ckeditor/ckeditor5-code-block": "47.6.1",
+        "@ckeditor/ckeditor5-core": "47.6.1",
+        "@ckeditor/ckeditor5-easy-image": "47.6.1",
+        "@ckeditor/ckeditor5-editor-balloon": "47.6.1",
+        "@ckeditor/ckeditor5-editor-classic": "47.6.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "47.6.1",
+        "@ckeditor/ckeditor5-editor-inline": "47.6.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "47.6.1",
+        "@ckeditor/ckeditor5-emoji": "47.6.1",
+        "@ckeditor/ckeditor5-engine": "47.6.1",
+        "@ckeditor/ckeditor5-enter": "47.6.1",
+        "@ckeditor/ckeditor5-essentials": "47.6.1",
+        "@ckeditor/ckeditor5-find-and-replace": "47.6.1",
+        "@ckeditor/ckeditor5-font": "47.6.1",
+        "@ckeditor/ckeditor5-fullscreen": "47.6.1",
+        "@ckeditor/ckeditor5-heading": "47.6.1",
+        "@ckeditor/ckeditor5-highlight": "47.6.1",
+        "@ckeditor/ckeditor5-horizontal-line": "47.6.1",
+        "@ckeditor/ckeditor5-html-embed": "47.6.1",
+        "@ckeditor/ckeditor5-html-support": "47.6.1",
+        "@ckeditor/ckeditor5-icons": "47.6.1",
+        "@ckeditor/ckeditor5-image": "47.6.1",
+        "@ckeditor/ckeditor5-indent": "47.6.1",
+        "@ckeditor/ckeditor5-language": "47.6.1",
+        "@ckeditor/ckeditor5-link": "47.6.1",
+        "@ckeditor/ckeditor5-list": "47.6.1",
+        "@ckeditor/ckeditor5-markdown-gfm": "47.6.1",
+        "@ckeditor/ckeditor5-media-embed": "47.6.1",
+        "@ckeditor/ckeditor5-mention": "47.6.1",
+        "@ckeditor/ckeditor5-minimap": "47.6.1",
+        "@ckeditor/ckeditor5-page-break": "47.6.1",
+        "@ckeditor/ckeditor5-paragraph": "47.6.1",
+        "@ckeditor/ckeditor5-paste-from-office": "47.6.1",
+        "@ckeditor/ckeditor5-remove-format": "47.6.1",
+        "@ckeditor/ckeditor5-restricted-editing": "47.6.1",
+        "@ckeditor/ckeditor5-select-all": "47.6.1",
+        "@ckeditor/ckeditor5-show-blocks": "47.6.1",
+        "@ckeditor/ckeditor5-source-editing": "47.6.1",
+        "@ckeditor/ckeditor5-special-characters": "47.6.1",
+        "@ckeditor/ckeditor5-style": "47.6.1",
+        "@ckeditor/ckeditor5-table": "47.6.1",
+        "@ckeditor/ckeditor5-theme-lark": "47.6.1",
+        "@ckeditor/ckeditor5-typing": "47.6.1",
+        "@ckeditor/ckeditor5-ui": "47.6.1",
+        "@ckeditor/ckeditor5-undo": "47.6.1",
+        "@ckeditor/ckeditor5-upload": "47.6.1",
+        "@ckeditor/ckeditor5-utils": "47.6.1",
+        "@ckeditor/ckeditor5-watchdog": "47.6.1",
+        "@ckeditor/ckeditor5-widget": "47.6.1",
+        "@ckeditor/ckeditor5-word-count": "47.6.1"
       }
     },
     "classnames": {
@@ -23198,11 +26117,18 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "^2.0.0"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+          "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="
+        }
       }
     },
     "color-string": {
@@ -23234,6 +26160,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
     "commander": {
       "version": "8.3.0",
@@ -23734,6 +26665,14 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
+    "decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "requires": {
+        "character-entities": "^2.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -23816,8 +26755,7 @@
     "dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "design-token-editor": {
       "version": "0.6.0",
@@ -23833,6 +26771,14 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "requires": {
+        "dequal": "^2.0.0"
+      }
     },
     "dialog-polyfill": {
       "version": "0.5.6",
@@ -24203,6 +27149,11 @@
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
       }
+    },
+    "es-toolkit": {
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ=="
     },
     "es6-error": {
       "version": "4.1.1",
@@ -24854,6 +27805,11 @@
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
       "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw=="
     },
+    "fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -25042,6 +27998,161 @@
         "function-bind": "^1.1.2"
       }
     },
+    "hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      }
+    },
+    "hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      }
+    },
+    "hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
+    "hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
+    "hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
+    "hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
+    "hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      }
+    },
+    "hast-util-to-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz",
+      "integrity": "sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "property-information": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      }
+    },
+    "hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      }
+    },
+    "hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      }
+    },
+    "hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "requires": {
+        "@types/hast": "^3.0.0"
+      }
+    },
+    "hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -25106,6 +28217,11 @@
         "relateurl": "^0.2.7",
         "terser": "^5.10.0"
       }
+    },
+    "html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
     },
     "html-webpack-plugin": {
       "version": "5.6.6",
@@ -27121,6 +30237,11 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -27197,10 +30318,181 @@
         "tmpl": "1.0.5"
       }
     },
+    "markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
+      }
+    },
+    "mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      }
+    },
+    "mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "requires": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      }
+    },
+    "mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      }
+    },
+    "mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      }
+    },
+    "mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      }
+    },
+    "mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      }
+    },
+    "mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      }
+    },
+    "mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      }
+    },
+    "mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      }
+    },
+    "mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "requires": {
+        "@types/mdast": "^4.0.0"
+      }
     },
     "mdn-data": {
       "version": "2.0.14",
@@ -27230,6 +30522,303 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
       "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
+    },
+    "micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "requires": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "requires": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "requires": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "requires": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "requires": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="
+    },
+    "micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "requires": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "requires": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "requires": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "requires": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="
+    },
+    "micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="
     },
     "micromatch": {
       "version": "4.0.8",
@@ -28388,6 +31977,11 @@
         "react-is": "^16.8.1"
       }
     },
+    "property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
+    },
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -28834,6 +32428,47 @@
         }
       }
     },
+    "rehype-dom-parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz",
+      "integrity": "sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "rehype-dom-stringify": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz",
+      "integrity": "sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-dom": "^4.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      }
+    },
+    "rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -28847,6 +32482,62 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      }
+    },
+    "remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       }
     },
     "renderkid": {
@@ -29285,6 +32976,11 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
+    "space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+    },
     "spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -29588,6 +33284,15 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
       }
     },
     "strip-ansi": {
@@ -29903,6 +33608,21 @@
       "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
       "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ=="
     },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
+    },
+    "trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg=="
+    },
+    "trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+    },
     "ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -29998,6 +33718,79 @@
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
       "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
       "dev": true
+    },
+    "unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        }
+      }
+    },
+    "unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "requires": {
+        "@types/unist": "^3.0.0"
+      }
+    },
+    "unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      }
     },
     "universalify": {
       "version": "2.0.1",
@@ -30137,6 +33930,24 @@
         "@sphinxxxx/color-conversion": "^2.2.2"
       }
     },
+    "vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "requires": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      }
+    },
     "w3c-xmlserializer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -30203,6 +34014,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -30646,6 +34462,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/zod-formik-adapter/-/zod-formik-adapter-1.2.0.tgz",
       "integrity": "sha512-62U+Mf8U05pvLsIMUTC1H6d4K5SmsrXM+YgiZhCpPin5GNhnVuXCGySmJCs0FHuTJCBy7Et5Z1i8KF5ffuLttg=="
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@formatjs/cli": "^6.6.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.66.0",
-    "@open-formulieren/formio-builder": "^0.48.0",
+    "@open-formulieren/formio-builder": "^0.49.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "UNLICENSED",
   "homepage": "https://maykinmedia.nl",
   "dependencies": {
+    "@formatjs/cli": "^6.6.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.66.0",
     "@open-formulieren/formio-builder": "^0.48.0",
@@ -51,7 +52,6 @@
     "microscope-sass": "^2.0.0",
     "paper-css": "^0.4.1",
     "prop-types": "^15.7.2",
-    "@formatjs/cli": "^6.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-formio": "^4.3.0",
@@ -86,6 +86,7 @@
     "@babel/core": "^7.12.16",
     "@babel/preset-env": "^7.12.16",
     "@babel/preset-react": "^7.13.13",
+    "@storybook/addon-docs": "9.1.19",
     "@storybook/addon-links": "9.1.19",
     "@storybook/addon-webpack5-compiler-babel": "^3.0.5",
     "@storybook/react-webpack5": "9.1.19",
@@ -120,8 +121,7 @@
     "url-loader": "^4.1.1",
     "webpack": "^5.70.0",
     "webpack-cli": "^4.9.2",
-    "yargs": "^17.3.1",
-    "@storybook/addon-docs": "9.1.19"
+    "yargs": "^17.3.1"
   },
   "msw": {
     "workerDirectory": "public"

--- a/src/openforms/js/index.js
+++ b/src/openforms/js/index.js
@@ -1,5 +1,4 @@
-// via @open-formulieren/formio-builder
-import ClassicEditor from '@open-formulieren/ckeditor5-build-classic';
+import ClassicEditor from '@open-formulieren/formio-builder/esm/components/CKEditor';
 import cssHasPseudo from 'css-has-pseudo/browser';
 import {Formio} from 'react-formio';
 


### PR DESCRIPTION
No ticket - follow up of dependabot alerts

**Changes**

formio-builder 0.49.0 replaced the custom ckeditor-classic-build that was based on v40.x with the plain npm package variant for ckeditor 47. The installation mechanism changed somewhere between those versions, making it easier to bundle it.

The breaking changes don't impact us.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
