### PR TITLE
[#5932] use profile component email addresses for confirmation email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/cli": "^6.6.1",
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.66.0",
-        "@open-formulieren/formio-builder": "^0.49.0",
+        "@open-formulieren/formio-builder": "^0.50.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -5141,22 +5141,25 @@
       "license": "EUPL-1.2"
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.49.0.tgz",
-      "integrity": "sha512-cjMk4NF97UI3TnO2Qlo2ALXA++ZYZF+eUqtw0ALrh+dX1GovLF51M2AydptlPan/20BrNdA/oRoXZLbD4UY81Q==",
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.1.tgz",
+      "integrity": "sha512-ic8MHnkGzBhkscZ9f5gjW1GH0VB6QKMRHx4Zg393fIjbFq9ApozRuDS+IsqTN1zSv5H5RYhlNVCPrrQaX098ow==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "@floating-ui/react": "^0.26.4",
+        "@formio/vanilla-text-mask": "^5.1.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
-        "@open-formulieren/types": "^1.0.0",
+        "@open-formulieren/types": "^1.1.0",
         "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
+        "dompurify": "^3.3.3",
         "formik": "^2.4.5",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
         "lodash": "^4.17.21",
+        "proj4leaflet": "^1.0.2",
         "react-intl": "^6.3.2",
         "react-leaflet": "^4.2.1",
         "react-leaflet-draw": "^0.20.6",
@@ -5165,7 +5168,6 @@
         "react-signature-canvas": "^1.0.6",
         "react-tabs": "^4.2.1",
         "react-use": "^17.4.0",
-        "sanitize-html": "^2.11.0",
         "zod": "^3.21.4",
         "zod-formik-adapter": "^1.2.0"
       },
@@ -5209,9 +5211,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-pYnLRhyPYIh+Gb1dzF/+aRZ7jFXHQOiZJ0MDS3RY4NI+mh5+pRb5hxHdFc1O3blMu5oPzfGBBhg7bMr7PxwIsQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-ihgy4Lrdk5Wt+uHMT1BfdNvbOCzOvWWoCCmMUQ6ByXVF2Su5AxC6HoMsc8WhhP3jrLACIyCEFqkEQKAQsTmuEA==",
       "license": "EUPL-1.2"
     },
     "node_modules/@react-leaflet/core": {
@@ -9403,6 +9405,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15275,6 +15278,7 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15806,11 +15810,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
-    },
     "node_modules/parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -15977,6 +15976,7 @@
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17563,107 +17563,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "node_modules/sanitize-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sass": {
       "version": "1.69.5",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
@@ -17998,6 +17897,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23888,21 +23788,24 @@
       "integrity": "sha512-zMs6937ostu1b6q7WHYq4yjtKifnExOGAjWNYLMWuc+7ZttnhFnsf5QFXBR6P+YFDkzQNhJSKnGZnmmY1zZPOQ=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.49.0.tgz",
-      "integrity": "sha512-cjMk4NF97UI3TnO2Qlo2ALXA++ZYZF+eUqtw0ALrh+dX1GovLF51M2AydptlPan/20BrNdA/oRoXZLbD4UY81Q==",
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.1.tgz",
+      "integrity": "sha512-ic8MHnkGzBhkscZ9f5gjW1GH0VB6QKMRHx4Zg393fIjbFq9ApozRuDS+IsqTN1zSv5H5RYhlNVCPrrQaX098ow==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "@floating-ui/react": "^0.26.4",
+        "@formio/vanilla-text-mask": "^5.1.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
-        "@open-formulieren/types": "^1.0.0",
+        "@open-formulieren/types": "^1.1.0",
         "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
+        "dompurify": "^3.3.3",
         "formik": "^2.4.5",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
         "lodash": "^4.17.21",
+        "proj4leaflet": "^1.0.2",
         "react-intl": "^6.3.2",
         "react-leaflet": "^4.2.1",
         "react-leaflet-draw": "^0.20.6",
@@ -23911,7 +23814,6 @@
         "react-signature-canvas": "^1.0.6",
         "react-tabs": "^4.2.1",
         "react-use": "^17.4.0",
-        "sanitize-html": "^2.11.0",
         "zod": "^3.21.4",
         "zod-formik-adapter": "^1.2.0"
       },
@@ -23944,9 +23846,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-pYnLRhyPYIh+Gb1dzF/+aRZ7jFXHQOiZJ0MDS3RY4NI+mh5+pRb5hxHdFc1O3blMu5oPzfGBBhg7bMr7PxwIsQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-ihgy4Lrdk5Wt+uHMT1BfdNvbOCzOvWWoCCmMUQ6ByXVF2Su5AxC6HoMsc8WhhP3jrLACIyCEFqkEQKAQsTmuEA=="
     },
     "@react-leaflet/core": {
       "version": "2.1.0",
@@ -27000,7 +26902,8 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true
     },
     "domexception": {
       "version": "4.0.0",
@@ -31108,7 +31011,8 @@
     "nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -31501,11 +31405,6 @@
       "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
       "dev": true
     },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
-    },
     "parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -31614,6 +31513,7 @@
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "dev": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -32736,75 +32636,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sanitize-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
-      "requires": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domhandler": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-          "requires": {
-            "domelementtype": "^2.3.0"
-          }
-        },
-        "domutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.3"
-          }
-        },
-        "entities": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "htmlparser2": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.3",
-            "domutils": "^3.0.1",
-            "entities": "^4.4.0"
-          }
-        },
-        "is-plain-object": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-        }
-      }
-    },
     "sass": {
       "version": "1.69.5",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
@@ -33028,7 +32859,8 @@
     "source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.21",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@formatjs/cli": "^6.6.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.66.0",
-    "@open-formulieren/formio-builder": "^0.49.0",
+    "@open-formulieren/formio-builder": "^0.50.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -801,11 +801,18 @@ class Submission(models.Model):
         state = self.variables_state
         data = state.get_data()
         for key in self.form.get_keys_for_email_confirmation():
-            value = data.get(key)
-            if value:
-                if isinstance(value, str):
-                    recipient_emails.add(value)
-                elif isinstance(value, list):
+            if not (value := data.get(key)):
+                continue
+
+            if isinstance(value, str):
+                recipient_emails.add(value)
+            elif isinstance(value, list):
+                if isinstance(value[0], dict):  # profile component
+                    for entry in value:
+                        entry_type = entry.get("type")
+                        if entry_type == "email" and (email := entry.get("address")):
+                            recipient_emails.add(email)
+                else:
                     recipient_emails.update(value)
 
         return list(recipient_emails)

--- a/src/openforms/submissions/tests/test_tasks_confirmation_emails.py
+++ b/src/openforms/submissions/tests/test_tasks_confirmation_emails.py
@@ -114,6 +114,70 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
         submission.refresh_from_db()
         self.assertTrue(submission.confirmation_email_sent)
 
+    @override_settings(DEFAULT_FROM_EMAIL="info@open-forms.nl")
+    def test_send_confirmation_email_profile_component(self):
+        submission = SubmissionFactory.from_components(
+            completed=True,
+            components_list=[
+                {
+                    "key": "profile",
+                    "type": "customerProfile",
+                    "label": "Profile",
+                    "description": "Foobar",
+                    "digitalAddressTypes": ["email", "phoneNumber"],
+                    "confirmationRecipient": True,
+                }
+            ],
+            submitted_data={
+                "profile": [
+                    {
+                        "type": "email",
+                        "address": "test@example.com",
+                        "preferenceUpdate": "useOnlyOnce",
+                    },
+                    {
+                        "type": "phoneNumber",
+                        "address": "0612345678",
+                        "preferenceUpdate": "useOnlyOnce",
+                    },
+                ]
+            },
+        )
+        # add a second step
+        form_step = FormStepFactory.create(
+            form=submission.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "foo",
+                        "type": "textfield",
+                        "label": "Foo",
+                        "showInEmail": True,
+                    }
+                ],
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step,
+            data={"foo": "bar"},
+        )
+        ConfirmationEmailTemplateFactory.create(
+            form=submission.form,
+            subject="Confirmation mail",
+            content="Information filled in: {{foo}}",
+        )
+
+        # "execute" the celery task
+        with override_settings(CELERY_TASK_ALWAYS_EAGER=True):
+            schedule_emails(submission.id)
+
+        # Verify that email was sent
+        self.assertEqual(len(mail.outbox), 1)
+
+        message = mail.outbox[0]
+        self.assertEqual(message.to, ["test@example.com"])
+
     def test_complete_submission_without_email_recipient(self):
         submission = SubmissionFactory.create(completed=True)
         ConfirmationEmailTemplateFactory.create(


### PR DESCRIPTION
Closes #5932 

**Changes**

This allows the use of all email addresses defined by a profile component to be used for confirmation emails. This requires the "Receives confirmation email" option to be checked for the component.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes

~~Requires https://github.com/open-formulieren/formio-builder/pull/264 to function properly.~~
