### PR TITLE
Fix N+1 queries when analyzing/saving logic rules

### DIFF
--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -30,7 +30,8 @@ class FormLogicListSerializer(ListWithChildSerializer):
     )
 
     def validate(self, attrs):
-        if not self.context["form"].new_logic_evaluation_enabled:
+        form = self.context["form"]
+        if not form.new_logic_evaluation_enabled:
             return super().validate(attrs)
 
         # This will only run when the logic rules have passed individual serializer
@@ -44,12 +45,9 @@ class FormLogicListSerializer(ListWithChildSerializer):
             for i, rule_data in enumerate(attrs)
         }
 
-        # Form steps are added to the context dictionary in
-        # `FormViewSet.logic_rules_bulk_update`. It is a mapping from form step UUID to
-        # form step. We rely on it being ordered.
-        first_step: FormStep = next(iter(self.context["form_steps"].values()))
-        # Note that the order will remain 0, even if a form step was deleted.
-        assert first_step.order == 0
+        first_step: FormStep = min(
+            form.form_step_map.values(), key=lambda step: step.order
+        )
         try:
             updated_rules_and_steps = analyze_rules(
                 self.context["form"],

--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -91,11 +91,21 @@ class FormLogicListSerializer(ListWithChildSerializer):
         if not self.context["form"].new_logic_evaluation_enabled:
             return rules
 
-        # Set many-to-many relationship from logic rules to form steps
-        for rule, step_list in zip(
-            rules, self.context["steps_for_each_rule"], strict=True
-        ):
-            rule.form_steps.set(step_list)
+        # the (auto-created) through model
+        FormLogicFormSteps = FormLogic._meta.get_field(
+            "form_steps"
+        ).remote_field.through
+
+        # drop the old relations and create the expected ones.
+        expected_relations = [
+            FormLogicFormSteps(formlogic=rule, formstep=step)
+            for rule, steps in zip(
+                rules, self.context["steps_for_each_rule"], strict=True
+            )
+            for step in steps
+        ]
+        FormLogicFormSteps.objects.filter(formlogic__form=self.context["form"]).delete()
+        FormLogicFormSteps.objects.bulk_create(expected_relations)
 
         return rules
 

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -597,12 +597,7 @@ class FormViewSet(viewsets.ModelViewSet):
                 # context for :class:`openforms.api.fields.RelatedFieldFromContext` lookups
                 "forms": {str(form.uuid): form},
                 "form_variables": FormVariableWrapper(form),
-                # During logic analysis, we may have to fetch the first form step, so
-                # make sure this mapping is ordered accordingly.
-                "form_steps": {
-                    form_step.uuid: form_step
-                    for form_step in form.formstep_set.order_by("order").all()
-                },
+                "form_steps": form.form_step_map,
             },
         )
         serializer.is_valid(raise_exception=True)

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -586,6 +586,8 @@ class FormViewSet(viewsets.ModelViewSet):
         # So we can delete any existing rule because they will be replaced.
         logic_rules.delete()
 
+        prefetch_related_objects([form], "formvariable_set")
+
         serializer = FormLogicSerializer(
             data=request.data,
             many=True,
@@ -606,7 +608,7 @@ class FormViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        prefetch_related_objects(serializer.instance, "form_steps")
+        prefetch_related_objects(serializer.instance, "form_steps", "form_steps__form")
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import uuid as _uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import suppress
 from copy import deepcopy
 from functools import cached_property
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar, Literal
+from uuid import UUID
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -426,6 +427,7 @@ class Form(models.Model):
     get_confirm_text = literal_getter("confirm_text", "form_confirm_text")
 
     _component_to_step: dict[str, FormStep] | None = None
+    _form_step_map: dict[UUID, FormStep] | None = None
     _all_form_variable_keys: set[str] | None = None
 
     class Meta:
@@ -440,6 +442,14 @@ class Form(models.Model):
 
     def get_absolute_url(self):
         return reverse("forms:form-detail", kwargs={"slug": self.slug})
+
+    @property
+    def form_step_map(self) -> Mapping[UUID, FormStep]:
+        """Mapping from form step UUID to form step instance."""
+        if self._form_step_map is None:
+            self._create_form_step_caches()
+        assert self._form_step_map is not None
+        return self._form_step_map
 
     @property
     def is_available(self) -> bool:
@@ -760,10 +770,15 @@ class Form(models.Model):
         :param key: The component key.
         :returns: The corresponding ``FormStep``, or ``None`` if no step could be found.
         """
-        if self._component_to_step is not None:
-            return self._component_to_step.get(key, None)
+        if self._component_to_step is None:
+            self._create_form_step_caches()
 
-        self._component_to_step = {}
+        assert self._component_to_step is not None
+        return self._component_to_step.get(key, None)
+
+    def _create_form_step_caches(self):
+        self._component_to_step: dict[str, FormStep] = {}
+        self._form_step_map: dict[UUID, FormStep] = {}
         for form_step in self.formstep_set.select_related("form_definition"):
             component_list = [
                 component["key"]
@@ -774,8 +789,7 @@ class Form(models.Model):
             self._component_to_step.update(
                 zip(component_list, [form_step] * len(component_list), strict=True)
             )
-
-        return self._component_to_step.get(key, None)
+            self._form_step_map[form_step.uuid] = form_step
 
     @transaction.atomic
     def apply_logic_analysis(self) -> None:

--- a/src/openforms/forms/tests/test_api_form_logic_bulk.py
+++ b/src/openforms/forms/tests/test_api_form_logic_bulk.py
@@ -1297,6 +1297,7 @@ class FormLogicAPITests(APITestCase):
         self.client.force_authenticate(user=user)
         form = FormFactory.create(
             generate_minimal_setup=True,
+            new_logic_evaluation_enabled=True,
             formstep__form_definition__configuration={
                 "components": [
                     {"type": "textfield", "key": "variable1"},
@@ -1335,16 +1336,18 @@ class FormLogicAPITests(APITestCase):
             },
         ]
 
-        # 1. transaction SAVEPOINT
+        # 1. Transaction SAVEPOINT
         # 2. Fetch the form (from UUID param in endpoint)
         # 3. Delete all the existing logic rules (to be replaced)
-        # 4. Look up all the form steps for the form (once)
-        # 5. Look up all the form variables for the form (once)
+        # 4. Look up all the form variables for the form (prefetched in `FormViewSet.logic_rules_bulk_update`)
+        # 5. Look up all the form steps for the form (`form.form_step_map` in `FormViewSet.logic_rules_bulk_update`)
         # 6. Get max order within form (from ordered_model.models.OrderedModelQuerySet.bulk_create)
         # 7. Bulk insert logic rules
-        # 8. Prefetch form steps for all rules
-        # 9. transaction RELEASE SAVEPOINT
-        with self.assertNumQueries(9):
+        # 8. Delete existing `FormLogic.form_steps` relations (`FormLogicListSerializer.create`)
+        # 9. Bulk create new `FormLogic.form_steps` relations (`FormLogicListSerializer.create`)
+        # 10 and 11. Prefetch form steps and `FormStep.form` relation for all rules (`FormViewSet.logic_rules_bulk_update`)
+        # 12. Transaction RELEASE SAVEPOINT
+        with self.assertNumQueries(12):
             response = self.client.put(url, data=form_logic_data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/src/openforms/forms/tests/test_api_form_logic_bulk.py
+++ b/src/openforms/forms/tests/test_api_form_logic_bulk.py
@@ -1353,6 +1353,88 @@ class FormLogicAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(FormLogic.objects.count(), 2)
 
+    @override_settings(MIDDLEWARE=[])  # cut out some irrelevant queries
+    def test_performance_bulk_create_data_with_step_applicable_and_disable_next_actions(
+        self,
+    ):
+        """
+        Assert that a constant number of queries are performed on logic bulk create,
+        specifically for step-(not)-applicable and disable-next actions.
+        """
+        user = SuperUserFactory.create()
+        self.client.force_authenticate(user=user)
+        form = FormFactory.create(new_logic_evaluation_enabled=True)
+        step_1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "variable1"},
+                    {"type": "textfield", "key": "variable2"},
+                    {"type": "textfield", "key": "variable3"},
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "variable4"},
+                    {"type": "textfield", "key": "variable5"},
+                ]
+            },
+        )
+        form_path = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+        url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
+        form_logic_data = [
+            {
+                "form": f"http://testserver{form_path}",
+                "order": 1,
+                "json_logic_trigger": {
+                    "and": [
+                        {"var": "variable1"},
+                        {"var": "variable2"},
+                    ]
+                },
+                # Note that this combination of actions do not make much sense - they
+                # are just used here to test the performance.
+                "actions": [
+                    {
+                        "action": {"type": "step-not-applicable"},
+                        "form_step_uuid": str(step_2.uuid),
+                    },
+                    {
+                        "action": {"type": "step-applicable"},
+                        "form_step_uuid": str(step_2.uuid),
+                    },
+                    {
+                        "action": {"type": "step-not-applicable"},
+                        "form_step_uuid": str(step_2.uuid),
+                    },
+                    {
+                        "action": {"type": "disable-next"},
+                        "form_step_uuid": str(step_1.uuid),
+                    },
+                ],
+            },
+        ]
+
+        # 1. Transaction SAVEPOINT
+        # 2. Fetch the form (from UUID param in endpoint)
+        # 3. Delete all the existing logic rules (to be replaced)
+        # 4. Look up all the form variables for the form (prefetched in `FormViewSet.logic_rules_bulk_update`)
+        # 5. Look up all the form steps for the form (`form.form_step_map` in `FormViewSet.logic_rules_bulk_update`)
+        # 6. Get max order within form (from ordered_model.models.OrderedModelQuerySet.bulk_create)
+        # 7. Bulk insert logic rules
+        # 8. Delete existing `FormLogic.form_steps` relations (`FormLogicListSerializer.create`)
+        # 9. Bulk create new `FormLogic.form_steps` relations (`FormLogicListSerializer.create`)
+        # 10 and 11. Prefetch form steps and `FormStep.form` relation for all rules (`FormViewSet.logic_rules_bulk_update`)
+        # 12. Transaction RELEASE SAVEPOINT
+        with self.assertNumQueries(12):
+            response = self.client.put(url, data=form_logic_data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(FormLogic.objects.count(), 1)
+
     def test_create_rule_with_evaluate_dmn_action(self):
         user = SuperUserFactory.create(username="test", password="test")
         form = FormFactory.create()

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from itertools import chain
 from typing import Any, Self, TypedDict
+from uuid import UUID
 
 from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
@@ -259,7 +260,7 @@ class DisableNextAction(ActionOperation):
 
     @property
     def steps(self) -> set[FormStep]:
-        return {self.rule.form.formstep_set.get(uuid=self.form_step_identifier)}
+        return {self.rule.form.form_step_map[UUID(self.form_step_identifier)]}
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -293,13 +294,13 @@ class StepNotApplicableAction(ActionOperation):
         # Together with detecting "self cycles" in the dependency graph, though, we can
         # detect if the rule uses a field from the current step as input, which would be
         # a weird thing to do.
-        form_step = self.rule.form.formstep_set.get(uuid=self.form_step_identifier)
+        form_step = self.rule.form.form_step_map[UUID(self.form_step_identifier)]
         configuration = form_step.form_definition.configuration_wrapper
         return set(configuration.component_map.keys())
 
     @property
     def steps(self) -> set[FormStep]:
-        return set(self.rule.form.formstep_set.all())
+        return set(self.rule.form.form_step_map.values())
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:
@@ -349,13 +350,13 @@ class StepApplicableAction(ActionOperation):
         # Together with detecting "self cycles" in the dependency graph, though, we can
         # detect if the rule uses a field from the current step as input, which would be
         # a weird thing to do.
-        form_step = self.rule.form.formstep_set.get(uuid=self.form_step_identifier)
+        form_step = self.rule.form.form_step_map[UUID(self.form_step_identifier)]
         configuration = form_step.form_definition.configuration_wrapper
         return set(configuration.component_map.keys())
 
     @property
     def steps(self) -> set[FormStep]:
-        return set(self.rule.form.formstep_set.all())
+        return set(self.rule.form.form_step_map.values())
 
     @classmethod
     def from_action(cls, action: ActionDict) -> Self:


### PR DESCRIPTION
Closes #6136

[skip: e2e]

**Changes**

* Ensured the `FormLogic.form_steps` relations are set in bulk
* Added `Form.form_step_map` cache for quick form-step access for step-(not)-applicable and disable-next actions

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
