### PR TITLE
Fix crash with frontend logic in fieldset in editgrid

### DIFF
--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -31,7 +31,7 @@ def _get_editgrid_component_map(component: EditGridComponent) -> dict[str, Compo
     Given an edit grid component, return a component map with namespaced keys.
     """
     component_map: dict[str, Component] = {}
-    for nested in iter_components(component, recursive=False):
+    for nested in iter_components(component, recursive=True):
         component_map[f"{component['key']}.{nested['key']}"] = nested
 
         # and this needs to recurse, of course...

--- a/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
@@ -757,3 +757,78 @@ class ConditionalLogicTests(TestCase):
             },
         )
         self.assertEqual(step.unsaved_data, {})
+
+    @tag("gh-6140")
+    def test_fieldset_inside_editgrid(self):
+        """
+        Ensure that items inside a fieldset inside an editgrid are properly handled.
+        """
+        submission = SubmissionFactory.from_components(
+            components_list=[
+                {
+                    "type": "editgrid",
+                    "key": "editgrid",
+                    "label": "Edit grid",
+                    "components": [
+                        {
+                            "type": "fieldset",
+                            "key": "fieldset",
+                            "label": "Fieldset",
+                            "components": [
+                                {
+                                    "type": "selectboxes",
+                                    "key": "trigger",
+                                    "label": "Trigger",
+                                    "values": [
+                                        {"label": "foo", "value": "foo"},
+                                        {"label": "bar", "value": "bar"},
+                                    ],
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "follower",
+                                    "label": "Follower",
+                                    "clearOnHide": True,
+                                    "conditional": {
+                                        "show": True,
+                                        "when": "editgrid.trigger",
+                                        "eq": "foo",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                }
+            ],
+            form__new_renderer_enabled=True,
+        )
+        step = submission.submissionstep_set.get()
+
+        evaluate_form_logic(
+            submission,
+            step,
+            FormioData(
+                {
+                    "editgrid": [
+                        {"trigger": {"foo": True, "bar": False}, "follower": "keep me"},
+                        {
+                            "trigger": {"foo": False, "bar": False},
+                            "follower": "clear me",
+                        },
+                    ]
+                }
+            ),
+        )
+
+        state = submission.variables_state
+        data = state.get_data(include_static_variables=False, include_unsaved=True)
+        self.assertEqual(
+            data,
+            {
+                "editgrid": [
+                    {"trigger": {"foo": True, "bar": False}, "follower": "keep me"},
+                    {"trigger": {"foo": False, "bar": False}, "follower": ""},
+                ]
+            },
+        )
+        self.assertEqual(step.unsaved_data, {})


### PR DESCRIPTION
Closes #6140

[skip: e2e]

**Changes**

* Changed an argument from `False` to `True` :sweat_smile: 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
