### PR TITLE
Fix audit logging of step submission

### DIFF
--- a/src/openforms/logging/adapter.py
+++ b/src/openforms/logging/adapter.py
@@ -110,7 +110,7 @@ def from_structlog(event_dict: EventDict) -> EventDetails:
     from openforms.payments.models import SubmissionPayment
     from openforms.prefill.base import BasePlugin as PrefillBasePlugin
     from openforms.registrations.base import BasePlugin as RegistrationBasePlugin
-    from openforms.submissions.models import Submission, SubmissionStep
+    from openforms.submissions.models import Submission
 
     assert "event" in event_dict
 
@@ -332,18 +332,20 @@ def from_structlog(event_dict: EventDict) -> EventDetails:
 
         case {
             "event": "submission_step_fill" as event,
+            "submission_uuid": str(submission_uuid),
             "step_id": int(step_pk),
+            "step_name": str(step_name),
         }:
-            step = SubmissionStep.objects.select_related(
-                "submission", "form_step__form_definition"
-            ).get(pk=step_pk)
-            assert step.form_step is not None
+            # when a user is submitting the step for the first time, the SubmissionStep
+            # instance is still being created in a transaction and won't be committed
+            # yet, so we can't query by ID.
+            submission = Submission.objects.get(uuid=submission_uuid)
             return EventDetails(
                 event=event,
-                instance=step.submission,
+                instance=submission,
                 tags=[TimelineLogTags.submission_lifecycle],
                 extra_data={
-                    "step": str(step.form_step.form_definition.name),
+                    "step": step_name,
                     "step_id": step_pk,
                 },
             )

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -617,7 +617,13 @@ class SubmissionStepViewSet(
             # serializer
             persist_user_defined_variables(submission)
 
-        audit_logger.info("submission_step_fill", step_id=instance.pk)
+        assert instance.form_step
+        audit_logger.info(
+            "submission_step_fill",
+            submission_uuid=str(submission.uuid),
+            step_id=instance.pk,
+            step_name=str(instance.form_step.form_definition.name),
+        )
         attach_uploads_to_submission_step(instance)
 
         # See #1480 - if there is navigation between steps and original form field values


### PR DESCRIPTION
Closes #6149

**Changes**

Rewrite audit log/event for submission step `PUT` event to not lose data in the audit logs table due to crashes because of uncommitted transactions.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
