### PR TITLE
Replace `is_layout_component` with `holds_submission_data`

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -411,6 +411,9 @@ class NPFamilyMembers(BasePlugin):
     # not actually relevant, as we transform the component into a different type
     formatter = DefaultFormatter
 
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
+
     @staticmethod
     def _get_handler() -> FamilyMembersHandler:
         handlers = {
@@ -1095,6 +1098,9 @@ class CustomerProfile(BasePlugin):
 class SoftRequiredErrors(BasePlugin):
     holds_submission_data = False
 
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
+
     @staticmethod
     def as_json_schema(component: Component) -> None:
         return None
@@ -1103,6 +1109,9 @@ class SoftRequiredErrors(BasePlugin):
 @register("coSign")
 class CoSign(BasePlugin):
     holds_submission_data = False
+
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
 
     @staticmethod
     def as_json_schema(component: Component) -> None:

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1071,6 +1071,12 @@ class LicensePlate(BasePlugin):
 class CustomerProfile(BasePlugin):
     formatter = CustomerProfileFormatter
 
+    def build_serializer_field(
+        self, component: CustomerProfileComponent
+    ) -> serializers.JSONField:
+        required = component.get("validate", {}).get("required", False)
+        return serializers.JSONField(required=required, allow_null=True)
+
     @staticmethod
     def pre_registration_hook(
         component: CustomerProfileComponent, submission: Submission

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -92,6 +92,9 @@ class Default(BasePlugin):
 
     formatter = DefaultFormatter
 
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
+
 
 @register("textfield")
 class TextField(BasePlugin[TextFieldComponent]):
@@ -961,6 +964,9 @@ class Content(BasePlugin):
     formatter = DefaultFormatter
     holds_submission_data = False
 
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
+
     @staticmethod
     def rewrite_for_request(component: ContentComponent, request: Request):
         """
@@ -1194,6 +1200,9 @@ class EditGrid(BasePlugin[EditGridComponent]):
 class Columns(BasePlugin[ColumnsComponent]):
     holds_submission_data = False
 
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
+
     @staticmethod
     def apply_visibility(
         component: ColumnsComponent,
@@ -1238,6 +1247,9 @@ class Columns(BasePlugin[ColumnsComponent]):
 @register("fieldset")
 class Fieldset(BasePlugin[FieldsetComponent]):
     holds_submission_data = False
+
+    def build_serializer_field(self, component: Component) -> serializers.Field:
+        raise NotImplementedError()
 
     @staticmethod
     def apply_visibility(

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -12,7 +12,7 @@ smeared out across the codebase in similar but different implementations, while 
 the public API better defined and smaller.
 """
 
-import warnings
+import abc
 from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
@@ -37,7 +37,6 @@ from openforms.typing import JSONObject, JSONValue, VariableValue
 
 from .datastructures import FormioConfigurationWrapper, FormioData
 from .typing import Component
-from .utils import is_layout_component
 
 if TYPE_CHECKING:
     from openforms.submissions.models import Submission
@@ -69,7 +68,7 @@ class PreRegistrationHookProtocol(Protocol[ComponentT]):
     ) -> ComponentPreRegistrationResult: ...
 
 
-class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
+class BasePlugin(Generic[ComponentT], AbstractBasePlugin, abc.ABC):  # noqa: UP046
     """
     Base class for Formio component plugins.
     """
@@ -113,32 +112,9 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
     def localize(self, component: ComponentT, language_code: str, enabled: bool):
         pass  # noop by default, specific component types can extend the base behaviour
 
+    @abc.abstractmethod
     def build_serializer_field(self, component: ComponentT) -> serializers.Field:
-        # the default implementation is a compatibility shim while we transition to
-        # the new backend validation mechanism.
-        warnings.warn(
-            "Relying on the default/implicit JSONField for component type "
-            f"{component['type']} is deprecated. Instead, define the "
-            "'build_serializer_field' method on the specific component plugin.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        # not considered a layout component (because it doesn't have children)
-        if component["type"] == "content":
-            required = False
-        elif is_layout_component(component):
-            required = False  # they do not hold data, they can never be required
-        else:
-            required = (
-                validate.get("required", False)
-                if (validate := component.get("validate"))
-                else False
-            )
-
-        # Allow anything that is valid JSON, taking into account the 'required'
-        # validation which is common for most components.
-        return serializers.JSONField(required=required, allow_null=True)
+        """Translate a component configuration into a serializer."""
 
     @staticmethod
     def as_json_schema(component: ComponentT) -> JSONObject | list[JSONObject] | None:

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -12,11 +12,10 @@ from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
 
 from ..datastructures import FormioData
-from ..service import format_value
+from ..service import format_value, holds_submission_data
 from ..typing import Component
 from ..utils import (
     get_component_empty_value,
-    is_layout_component,
     is_visible_in_frontend,
     iterate_components_with_configuration_path,
 )
@@ -224,8 +223,8 @@ class ComponentNode(Node):
         if not self.is_visible:
             return
 
-        # in export mode, only emit if the component is not a layout component
-        if self.mode != RenderModes.export or (not is_layout_component(self.component)):
+        # in export mode, only emit if the component holds submission data
+        if self.mode != RenderModes.export or holds_submission_data(self.component):
             yield self
 
         for child in self.get_children():

--- a/src/openforms/formio/rendering/tests/test_component_node.py
+++ b/src/openforms/formio/rendering/tests/test_component_node.py
@@ -211,6 +211,19 @@ class ComponentNodeTests(TestCase):
                     "html": "<p>I am hidden</p>",
                     "label": "Soft required errors",
                 },
+                {
+                    "key": "fieldset",
+                    "type": "fieldset",
+                    "label": "Fieldset",
+                    "components": [
+                        {
+                            "type": "columns",
+                            "key": "columns",
+                            "label": "Columns",
+                            "columns": [{"size": 1, "components": []}],
+                        }
+                    ],
+                },
             ]
         }
         data = {
@@ -463,7 +476,7 @@ class ComponentNodeTests(TestCase):
                 )
                 nodelist += list(component_node)
 
-        self.assertEqual(len(nodelist), 11)
+        self.assertEqual(len(nodelist), 13)
         labels = [node.label for node in nodelist]
         expected_labels = [
             "Input 1",
@@ -477,6 +490,8 @@ class ComponentNodeTests(TestCase):
             "Visible editgrid with hidden children",
             "Input 14",
             "Soft required errors",  # not actually rendered in full render mode
+            "Fieldset",
+            "Columns",
         ]
         self.assertEqual(labels, expected_labels)
 
@@ -511,6 +526,8 @@ class ComponentNodeTests(TestCase):
             "Visible editgrid with hidden children",
             "Input 14",
             "Soft required errors",  # not actually rendered in full render mode
+            "Fieldset",
+            "Columns",
         ]
         self.assertEqual(labels, expected_labels)
 

--- a/src/openforms/formio/serializers.py
+++ b/src/openforms/formio/serializers.py
@@ -19,7 +19,7 @@ from openforms.formio.typing.base import FormioConfiguration
 
 from .datastructures import FormioConfigurationWrapper, FormioData
 from .typing import Component
-from .utils import is_layout_component, iter_components
+from .utils import iter_components
 
 if TYPE_CHECKING:
     from .registry import ComponentRegistry
@@ -31,7 +31,10 @@ type FieldOrNestedFields = serializers.Field | dict[str, "FieldOrNestedFields"]
 
 class StepDataSerializer(serializers.Serializer):
     def apply_hidden_state(
-        self, configuration: FormioConfiguration, fields: dict[str, FieldOrNestedFields]
+        self,
+        configuration: FormioConfiguration,
+        fields: dict[str, FieldOrNestedFields],
+        register: ComponentRegistry,
     ) -> None:
         """
         Apply the hidden/visible state of the formio components to the serializer.
@@ -53,6 +56,11 @@ class StepDataSerializer(serializers.Serializer):
 
         # loop over all components and delegate application to the registry
         for component in iter_components(configuration, recurse_into_editgrid=False):
+            # Components without submission data do not have serializer fields
+            # associated with them.
+            if not register.holds_submission_data(component):
+                continue
+
             # XXX: is_visible_in_frontend does not understand editgrid at all yet, which
             # is a broader issue, but also manifests here.
             is_visible = config_wrapper.is_visible_in_frontend(component["key"], values)
@@ -60,10 +68,6 @@ class StepDataSerializer(serializers.Serializer):
             # we don't have to do anything when the component is visible, regular
             # validation rules apply
             if is_visible:
-                continue
-
-            # Layout components do not have serializer fields associated with them
-            if is_layout_component(component):
                 continue
 
             # when it's not visible, grab the field from the serializer and remove all
@@ -150,12 +154,14 @@ def build_serializer(
 
     config: FormioConfiguration = {"components": components}
     for component in iter_components(config, recurse_into_editgrid=False):
-        if is_layout_component(component):
+        # Components without submission data do not have serializer fields
+        # associated with them.
+        if not register.holds_submission_data(component):
             continue
 
         field = register.build_serializer_field(component)
         assign(obj=fields, path=component["key"], val=field, missing=dict)
 
     serializer = dict_to_serializer(fields, **kwargs)
-    serializer.apply_hidden_state(config, fields)
+    serializer.apply_hidden_state(config, fields, register)
     return serializer

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -59,6 +59,7 @@ __all__ = [
     "process_visibility",
     "get_component_empty_value",
     "get_readable_path_from_configuration_path",
+    "holds_submission_data",
 ]
 
 tracer = trace.get_tracer("openforms.formio.service")

--- a/src/openforms/formio/tests/validation/test_generic.py
+++ b/src/openforms/formio/tests/validation/test_generic.py
@@ -6,10 +6,8 @@ from ...typing import Component
 from .helpers import extract_error, validate_formio_data
 
 
-class FallbackBehaviourTests(SimpleTestCase):
+class ValidateFormioDataTests(SimpleTestCase):
     def test_unknown_component_passthrough(self):
-        # TODO: this should *not* pass when all components are implemented, it's a
-        # temporary compatibility layer
         component: Component = {
             "type": "unknown-i-do-not-exist",
             "key": "foo",
@@ -17,9 +15,8 @@ class FallbackBehaviourTests(SimpleTestCase):
         }
         data: JSONValue = {"value": ["weird", {"data": "structure"}]}
 
-        is_valid, _ = validate_formio_data(component, data)
-
-        self.assertTrue(is_valid)
+        with self.assertRaises(NotImplementedError):
+            validate_formio_data(component, data)
 
     def test_nested_keys_and_fields_being_required(self):
         component: Component = {

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -179,27 +179,6 @@ def get_readable_path_from_configuration_path(
     return " > ".join(keys_path)
 
 
-def is_layout_component(component: Component) -> bool:
-    # Adapted from isLayoutComponent util function in Formio
-    # https://github.com/formio/formio.js/blob/4.13.x/src/utils/formUtils.js#L25
-    # FIXME ideally there would be a cleaner fix for this
-    if component["type"] == "editgrid":
-        return False
-
-    column = component.get("columns")
-    components = component.get("components")
-    rows = component.get("rows")
-
-    if (
-        (column and isinstance(column, list))
-        or (components and isinstance(components, list))
-        or (rows and isinstance(rows, list))
-    ):
-        return True
-
-    return False
-
-
 def get_component_datatype(component: Component):
     component_type = component["type"]
     if component.get("multiple"):

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -14,11 +14,11 @@ import elasticapm
 import structlog
 from opentelemetry import trace
 
+from openforms.formio.service import holds_submission_data
 from openforms.formio.utils import (
     get_component_data_subtype,
     get_component_datatype,
     get_component_default_value,
-    is_layout_component,
     iter_components,
 )
 from openforms.formio.validators import variable_key_validator
@@ -117,9 +117,7 @@ class FormVariableManager(models.Manager["FormVariable"]):
         ):
             # we need to ignore components that don't actually hold any values - there's
             # no point to create variables for those.
-            if is_layout_component(component):
-                continue
-            if component["type"] in ("content", "softRequiredErrors"):
+            if not holds_submission_data(component):
                 continue
 
             # extract options from the component

--- a/src/openforms/forms/tests/variables/test_model.py
+++ b/src/openforms/forms/tests/variables/test_model.py
@@ -935,3 +935,89 @@ class FormVariableManagerTests(TestCase):
                     self.assertEqual(textfield_variable.data_format, "")
                     self.assertFalse(textfield_variable.is_sensitive_data)
                     self.assertEqual(textfield_variable.initial_value, [])
+
+    def test_with_components_which_do_not_hold_submission_data(self):
+        """
+        Assert that no form variables are created for components which do not hold
+        submission data.
+        """
+        fd = FormDefinitionFactory.create(
+            configuration={
+                "components": [
+                    {
+                        "type": "content",
+                        "key": "content",
+                        "label": "Content",
+                        "html": "<p>Some HTML</p>",
+                    },
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "label": "Fieldset",
+                        "components": [
+                            {
+                                "type": "coSign",
+                                "key": "coSign",
+                                "label": "Legacy cosign",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "columns",
+                        "key": "columns",
+                        "label": "Columns",
+                        "columns": [
+                            {
+                                "size": 1,
+                                "components": [
+                                    {
+                                        "key": "softRequiredErrors",
+                                        "type": "softRequiredErrors",
+                                        "html": "<p>Some error</p>",
+                                        "label": "Soft required errors",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+        FormStepFactory.create(form_definition=fd)
+
+        # the factory already implicitly calls the synchronize_for, but let's make it
+        # super explicit
+        FormVariable.objects.synchronize_for(fd)
+        self.assertEqual(0, FormVariable.objects.count())
+
+    def test_with_component_that_holds_submission_data(self):
+        """
+        Assert that fields that holds submission data inside a layout component does
+        have its variable created.
+        """
+        fd = FormDefinitionFactory.create(
+            configuration={
+                "components": [
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "label": "Fieldset",
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "textfield",
+                                "label": "Textfield",
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+        FormStepFactory.create(form_definition=fd)
+        # Note that the factory already implicitly calls the synchronize_for, but let's
+        # make it super explicit
+        FormVariable.objects.synchronize_for(fd)
+
+        form_variables = FormVariable.objects.all()
+        self.assertEqual(1, len(form_variables))
+        self.assertEqual("textfield", form_variables[0].key)

--- a/src/openforms/logging/tests/test_models.py
+++ b/src/openforms/logging/tests/test_models.py
@@ -58,12 +58,17 @@ class TimelineLogProxyTests(TestCase):
     def test_get_formatted_fields(self):
         submission = SubmissionFactory.from_components(
             components_list=[
-                {"key": "email", "type": "textfield", "label": "Email"},
+                {"key": "email", "type": "email", "label": "Email"},
                 {
                     "key": "theBSN",
-                    "type": "textfield",
+                    "type": "bsn",
                     "label": "The BSN",
-                    "prefill": {"attribute": "bsn"},
+                    "prefill": {"plugin": "myplugin", "attribute": "bsn"},
+                },
+                {
+                    "type": "fieldset",
+                    "key": "fieldset",
+                    "label": "Fieldset",
                     "components": [
                         {
                             "key": "theFirstName",
@@ -93,16 +98,17 @@ class TimelineLogProxyTests(TestCase):
     def test_format_fields(self):
         submission = SubmissionFactory.from_components(
             components_list=[
-                {
-                    "key": "email",
-                    "label": "Email",
-                    "type": "textfield",
-                },
+                {"key": "email", "type": "email", "label": "Email"},
                 {
                     "key": "theBSN",
-                    "type": "textfield",
+                    "type": "bsn",
                     "label": "The BSN",
-                    "prefill": {"attribute": "bsn"},
+                    "prefill": {"plugin": "myplugin", "attribute": "bsn"},
+                },
+                {
+                    "type": "fieldset",
+                    "key": "fieldset",
+                    "label": "Fieldset",
                     "components": [
                         {
                             "key": "theFirstName",

--- a/src/openforms/registrations/tests/test_component_pre_registration_tasks.py
+++ b/src/openforms/registrations/tests/test_component_pre_registration_tasks.py
@@ -29,10 +29,15 @@ class HookComponent(Component): ...
 class FailHookComponent(Component): ...
 
 
-class NoHook(BasePlugin[NoHookComponent]): ...
+class NoHook(BasePlugin[NoHookComponent]):
+    def build_serializer_field(self, component):
+        raise NotImplementedError()
 
 
 class Hook(BasePlugin[HookComponent]):
+    def build_serializer_field(self, component):
+        raise NotImplementedError()
+
     @staticmethod
     def pre_registration_hook(
         component: HookComponent, submission: Submission
@@ -41,6 +46,9 @@ class Hook(BasePlugin[HookComponent]):
 
 
 class FailHook(BasePlugin[FailHookComponent]):
+    def build_serializer_field(self, component):
+        raise NotImplementedError()
+
     @staticmethod
     def pre_registration_hook(
         component: HookComponent, submission: Submission

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -140,6 +140,9 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
         class TextField(BasePlugin):
             formatter = TextFieldFormatter
 
+            def build_serializer_field(self, component):
+                raise NotImplementedError()
+
             @staticmethod
             def mutate_config_dynamically(component, submission, data):
                 component["label"] = "Rewritten label"
@@ -698,6 +701,9 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
         @register("testCustomType")
         class CustomType(BasePlugin):
             formatter = TextFieldFormatter
+
+            def build_serializer_field(self, component):
+                raise NotImplementedError()
 
             @staticmethod
             def mutate_config_dynamically(component, submission, data):

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -1,3 +1,4 @@
+from unittest import expectedFailure
 from unittest.mock import patch
 from uuid import UUID
 
@@ -1470,3 +1471,35 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @tag("gh-6155")
+    @expectedFailure
+    def test_validation_of_profile_component_data(self):
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "profile",
+                        "type": "customerProfile",
+                        "digitalAddressTypes": ["email", "phoneNumber"],
+                        "shouldUpdateCustomerData": True,
+                    },
+                ]
+            },
+        )
+        step = submission.form.formstep_set.get()
+        self._add_submission_to_session(submission)
+
+        endpoint = reverse(
+            "api:submission-steps-validate",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": step.uuid,
+            },
+        )
+
+        response = self.client.post(
+            endpoint, {"data": {"profile": "This data makes no sense"}}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Partly closes #6018, #6164

[skip: e2e]

**Changes**

* Added some extra regression tests
* Removed compatibility shim of `build_serializer_fields` for non-registered components
* Replaced `is_layout_component` with `holds_submission_data`
* Removed `is_layout_component` 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes