### PR TITLE
[#5924] skip non-applicable form steps during validation

### DIFF
--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -83,6 +83,9 @@ class SubmissionCompletionSerializer(serializers.Serializer):
 
         state = submission.variables_state
         data = state.get_data()
+        applicable_steps: int = len(
+            [step for step in submission.steps if step.is_applicable]
+        )
 
         for step in submission.steps:
             form_step = step.form_step
@@ -90,6 +93,13 @@ class SubmissionCompletionSerializer(serializers.Serializer):
             form_definition = form_step.form_definition
             assert isinstance(form_definition, FormDefinition)
             step_name: str = form_definition.name
+
+            # Omit validation errors for non-applicable form steps so that the
+            # front-end can determine the failing submission steps correctly.
+            # The front-end currently does not process non-applicable form steps.
+            # See the `SubmissionSummary` React component for more details.
+            if not step.is_applicable:
+                continue
 
             step_errors = {}  # we must add *something* to the array
 
@@ -131,7 +141,7 @@ class SubmissionCompletionSerializer(serializers.Serializer):
 
             all_step_errors.append(step_errors)
 
-        assert len(all_step_errors) == len(submission.steps), (
+        assert len(all_step_errors) == applicable_steps, (
             "Detected a mismatch in validation errors list with actual submission steps."
         )
 

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -218,6 +218,143 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
 
         self.assertTrue(submission.is_completed)
 
+    @tag("gh-5924")
+    def test_submission_validation_including_non_applicable_steps(self):
+        """
+        Test that non-applicable form steps are not processed during validation of
+        submission completion.
+        """
+        form = FormFactory.create()
+        step_1 = FormStepFactory.create(
+            form=form,
+            is_applicable=True,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "age",
+                    }
+                ]
+            },
+        )
+        FormStepFactory.create(  # non-applicable step 2
+            form=form,
+            is_applicable=False,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "age",
+                    }
+                ]
+            },
+        )
+        step_3 = FormStepFactory.create(
+            form=form,
+            is_applicable=True,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "questionInput",
+                        "values": [
+                            {"label": "Yes", "value": "yes"},
+                            {
+                                "label": "No",
+                                "value": "no",
+                                "openForms": {"translations": {}},
+                            },
+                        ],
+                    },
+                    {
+                        "type": "textfield",
+                        "hidden": True,
+                        "key": "driverId",
+                        "validate": {
+                            "required": True,
+                        },
+                    },
+                ]
+            },
+        )
+        FormStepFactory.create(  # non-applicable step 4
+            form=form,
+            is_applicable=False,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "driverId",
+                    }
+                ]
+            },
+        )
+        step_5 = FormStepFactory.create(
+            form=form,
+            is_applicable=True,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "driverId",
+                    }
+                ]
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "questionInput"}, "yes"]},
+            actions=[
+                {
+                    "component": "driverId",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "hidden", "type": "bool"},
+                        "state": False,
+                    },
+                }
+            ],
+        )
+        submission = SubmissionFactory.create(form=form)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step_1,
+            data={
+                "age": 18,
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step_3,
+            data={
+                "questionInput": "yes",
+                "driverId": "",
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=step_5,
+            data={
+                "driverId": "0001",
+            },
+        )
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint, {"privacy_policy_accepted": True})
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
+        errors = response.json()["invalidParams"]
+        self.assertEqual(len(errors), 1)
+        # Non-applicable steps should not be taken into account for validation errors,
+        # hence the offending step is index number 1 (step 3 in this test).
+        self.assertEqual(errors[0]["name"], "steps.1.data.driverId")
+        self.assertEqual(errors[0]["code"], "blank")
+
+        submission.refresh_from_db()
+        self.assertFalse(submission.is_completed)
+
     @override_settings(LANGUAGE_CODE="en")
     def test_submit_form_with_submission_disabled_with_overview(self):
         submission = SubmissionFactory.create(


### PR DESCRIPTION
Closes #5924 

**Changes**

Removes the empty validation errors dictionaries for non-applicable form steps so that the front-end can determine the failing submission steps correctly.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
