### PR TITLE
don't show "disabled" property for layout fields in actions  

### DIFF
--- a/src/openforms/forms/api/serializers/logic/action_serializers.py
+++ b/src/openforms/forms/api/serializers/logic/action_serializers.py
@@ -330,10 +330,11 @@ class LogicComponentActionSerializer(serializers.Serializer):
 
         # check that "disabled" property is not changed for layout components
         property_component: None | Component = None
-        for formio_component in self.context["form"].iter_components():
-            if formio_component["key"] == component:
-                property_component = formio_component
-                break
+        for form_step in self.context.get("form_steps", {}).values():
+            for formio_component in form_step.iter_components():
+                if formio_component["key"] == component:
+                    property_component = formio_component
+                    break
 
         if property_component:
             is_layout = property_component["type"] in ["fieldset", "columns"]

--- a/src/openforms/forms/api/serializers/logic/action_serializers.py
+++ b/src/openforms/forms/api/serializers/logic/action_serializers.py
@@ -12,6 +12,7 @@ from rest_framework import serializers
 
 from openforms.api.serializers import DummySerializer
 from openforms.formio.api.fields import FormioVariableKeyField
+from openforms.formio.service import holds_submission_data
 from openforms.formio.typing import Component
 from openforms.utils.json_logic.api.validators import JsonLogicValidator
 from openforms.variables.constants import FormVariableDataTypes
@@ -329,18 +330,18 @@ class LogicComponentActionSerializer(serializers.Serializer):
             )
 
         # check that "disabled" property is not changed for layout components
-        property_component: None | Component = None
-        for form_step in self.context.get("form_steps", {}).values():
-            for formio_component in form_step.iter_components():
-                if formio_component["key"] == component:
-                    property_component = formio_component
+        if action_type == LogicActionTypes.property:
+            formio_component: None | Component = None
+            for form_step in self.context.get("form_steps", {}).values():
+                if component in (
+                    wrapper := form_step.form_definition.configuration_wrapper
+                ):
+                    formio_component = wrapper[component]
                     break
 
-        if property_component:
-            is_layout = property_component["type"] in ["fieldset", "columns"]
             if (
-                action_type == LogicActionTypes.property
-                and is_layout
+                formio_component
+                and not holds_submission_data(formio_component)
                 and attrs.get("action", {}).get("property", {}).get("value")
                 == "disabled"
             ):

--- a/src/openforms/forms/api/serializers/logic/action_serializers.py
+++ b/src/openforms/forms/api/serializers/logic/action_serializers.py
@@ -13,7 +13,6 @@ from rest_framework import serializers
 from openforms.api.serializers import DummySerializer
 from openforms.formio.api.fields import FormioVariableKeyField
 from openforms.formio.typing import Component
-from openforms.formio.utils import is_layout_component
 from openforms.utils.json_logic.api.validators import JsonLogicValidator
 from openforms.variables.constants import FormVariableDataTypes
 
@@ -336,19 +335,21 @@ class LogicComponentActionSerializer(serializers.Serializer):
                 property_component = formio_component
                 break
 
-        if (
-            action_type == LogicActionTypes.property
-            and property_component
-            and is_layout_component(property_component)
-            and attrs.get("action", {}).get("property", {}).get("value") == "disabled"
-        ):
-            raise serializers.ValidationError(
-                {
-                    "component": _(
-                        "'disabled' property can't be used for layout components."
-                    )
-                },
-                code="invalid",
-            )
+        if property_component:
+            is_layout = property_component["type"] in ["fieldset", "columns"]
+            if (
+                action_type == LogicActionTypes.property
+                and is_layout
+                and attrs.get("action", {}).get("property", {}).get("value")
+                == "disabled"
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "component": _(
+                            "'disabled' property can't be used for layout components."
+                        )
+                    },
+                    code="invalid",
+                )
 
         return attrs

--- a/src/openforms/forms/api/serializers/logic/action_serializers.py
+++ b/src/openforms/forms/api/serializers/logic/action_serializers.py
@@ -12,6 +12,8 @@ from rest_framework import serializers
 
 from openforms.api.serializers import DummySerializer
 from openforms.formio.api.fields import FormioVariableKeyField
+from openforms.formio.typing import Component
+from openforms.formio.utils import is_layout_component
 from openforms.utils.json_logic.api.validators import JsonLogicValidator
 from openforms.variables.constants import FormVariableDataTypes
 
@@ -325,6 +327,28 @@ class LogicComponentActionSerializer(serializers.Serializer):
                     ]
                 },
                 code="blank",
+            )
+
+        # check that "disabled" property is not changed for layout components
+        property_component: None | Component = None
+        for formio_component in self.context["form"].iter_components():
+            if formio_component["key"] == component:
+                property_component = formio_component
+                break
+
+        if (
+            action_type == LogicActionTypes.property
+            and property_component
+            and is_layout_component(property_component)
+            and attrs.get("action", {}).get("property", {}).get("value") == "disabled"
+        ):
+            raise serializers.ValidationError(
+                {
+                    "component": _(
+                        "'disabled' property can't be used for layout components."
+                    )
+                },
+                code="invalid",
             )
 
         return attrs

--- a/src/openforms/forms/tests/test_api_form_logic_bulk.py
+++ b/src/openforms/forms/tests/test_api_form_logic_bulk.py
@@ -1,6 +1,6 @@
 import uuid
 
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -1691,6 +1691,64 @@ class FormLogicAPITests(APITestCase):
 
         self.assertEqual(data["invalidParams"][6]["code"], "required")
         self.assertEqual(data["invalidParams"][6]["name"], "0.actions.2.action.config")
+
+    @tag("gh-5977")
+    def test_create_rule_with_hidden_property_for_layout(self):
+        user = SuperUserFactory.create()
+        self.client.force_authenticate(user=user)
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "text", "label": "Outer text"},
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "label": "Fieldset",
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "innerText",
+                                "label": "inner text",
+                            },
+                        ],
+                    },
+                ]
+            },
+        )
+
+        form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+        form_logic_data = [
+            {
+                "form": f"http://testserver{form_url}",
+                "order": 0,
+                "json_logic_trigger": {"==": [{"var": "text"}, "hi"]},
+                "actions": [
+                    {
+                        "component": "fieldset",
+                        "action": {
+                            "name": "Disable",
+                            "type": "property",
+                            "property": {"value": "disabled", "type": "bool"},
+                            "state": True,
+                        },
+                    }
+                ],
+            }
+        ]
+        url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
+
+        response = self.client.put(url, data=form_logic_data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            "0.actions.0.component", response.json()["invalidParams"][0]["name"]
+        )
+        self.assertEqual("invalid", response.json()["invalidParams"][0]["code"])
+        self.assertEqual(
+            _("'disabled' property can't be used for layout components."),
+            response.json()["invalidParams"][0]["reason"],
+        )
 
 
 class FormLogicAPIGraphValidationTests(APITestCase):

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -86,7 +86,7 @@ class LogicComponentActionSerializerTest(TestCase):
                     "value": {"var": "anotherDate"},
                 },
             },
-            context={"request": None, "form_variables": form_vars},
+            context={"request": None, "form_variables": form_vars, "form": form},
         )
 
         self.assertTrue(serializer.is_valid())

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2789,6 +2789,12 @@
       "value": "Description (omschrijving) of the ROLTYPE to use for employees filling in a form for a citizen/company."
     }
   ],
+  "K5TkEU": [
+    {
+      "type": 0,
+      "value": "Action state selection"
+    }
+  ],
   "KClY/2": [
     {
       "type": 0,
@@ -2961,6 +2967,12 @@
     {
       "type": 0,
       "value": "Copy"
+    }
+  ],
+  "LOFpy8": [
+    {
+      "type": 0,
+      "value": "Component selection"
     }
   ],
   "LZc4TN": [
@@ -3849,6 +3861,12 @@
     {
       "type": 0,
       "value": "Enable new logic rule evaluation"
+    }
+  ],
+  "TQv+8T": [
+    {
+      "type": 0,
+      "value": "Action property selection"
     }
   ],
   "TR5xSY": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2776,6 +2776,12 @@
       "value": "Omschrijving van het ROLTYPE te gebruiken voor medewerkers die een formulier invullen voor een inwoner/bedrijf."
     }
   ],
+  "K5TkEU": [
+    {
+      "type": 0,
+      "value": "Selecteer actiestatus"
+    }
+  ],
   "KClY/2": [
     {
       "type": 0,
@@ -2948,6 +2954,12 @@
     {
       "type": 0,
       "value": "Kopiëren"
+    }
+  ],
+  "LOFpy8": [
+    {
+      "type": 0,
+      "value": "Selecteer component"
     }
   ],
   "LZc4TN": [
@@ -3832,6 +3844,12 @@
     {
       "type": 0,
       "value": "Gebruik nieuwe logica-evaluatie"
+    }
+  ],
+  "TQv+8T": [
+    {
+      "type": 0,
+      "value": "Selecteer actie-eigenschap"
     }
   ],
   "TR5xSY": [

--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
@@ -409,3 +409,57 @@ export const DisableNext = {
     ],
   },
 };
+
+export const DisabledProperty = {
+  render,
+  name: 'Disabled property',
+
+  args: {
+    prefixText: 'Action',
+
+    action: {
+      component: 'textfield',
+      variable: '',
+      formStepUuid: '8f046d57-ef41-41e0-bb7a-a8dc618b9d43',
+      action: {
+        type: 'property',
+        property: {
+          type: 'bool',
+          value: 'disabled',
+        },
+      },
+    },
+    availableComponents: {
+      textfield: {
+        key: 'textfield',
+        type: 'textfield',
+        label: 'Textfield',
+      },
+      fieldset: {
+        key: 'fieldset',
+        type: 'fieldset',
+        label: 'Fieldset',
+        components: [
+          {
+            key: 'innerTextfield',
+            type: 'textfield',
+            label: 'Inner textfield',
+          },
+        ],
+      },
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    // check that fieldset can't have "hidden" property
+    const componentDropdown = canvasElement.querySelector('select[name="component"]');
+    await userEvent.selectOptions(componentDropdown, 'fieldset');
+
+    const propertyDropdown = canvasElement.querySelector('select[name="action.property"]');
+    const propertyOptions = within(propertyDropdown).getAllByRole('option');
+    expect(propertyOptions).toHaveLength(3);
+    expect(propertyOptions[0]).toHaveValue('');
+    expect(propertyOptions[1]).toHaveValue('validate.required');
+    expect(propertyOptions[2]).toHaveValue('hidden');
+  },
+};

--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
@@ -453,10 +453,10 @@ export const DisabledProperty = {
   play: async ({canvasElement}) => {
     // check that fieldset can't have "hidden" property
     const canvas = within(canvasElement);
-    const componentDropdown = canvas.getByRole('combobox', {name: 'Component selection'});
+    const componentDropdown = canvas.getByRole('combobox', {name: 'Selecteer component'});
     await userEvent.selectOptions(componentDropdown, 'fieldset');
 
-    const propertyDropdown = canvas.getByRole('combobox', {name: 'Action property selection'});
+    const propertyDropdown = canvas.getByRole('combobox', {name: 'Selecteer actie-eigenschap'});
     const propertyOptions = within(propertyDropdown).getAllByRole('option');
     expect(propertyOptions).toHaveLength(3);
     expect(propertyOptions[0]).toHaveValue('');

--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
@@ -452,10 +452,11 @@ export const DisabledProperty = {
 
   play: async ({canvasElement}) => {
     // check that fieldset can't have "hidden" property
-    const componentDropdown = canvasElement.querySelector('select[name="component"]');
+    const canvas = within(canvasElement);
+    const componentDropdown = canvas.getByRole('combobox', {name: 'Component selection'});
     await userEvent.selectOptions(componentDropdown, 'fieldset');
 
-    const propertyDropdown = canvasElement.querySelector('select[name="action.property"]');
+    const propertyDropdown = canvas.getByRole('combobox', {name: 'Action property selection'});
     const propertyOptions = within(propertyDropdown).getAllByRole('option');
     expect(propertyOptions).toHaveLength(3);
     expect(propertyOptions[0]).toHaveValue('');

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -1,4 +1,3 @@
-import FormioUtils from 'formiojs/utils';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import {useContext, useState} from 'react';
@@ -29,7 +28,7 @@ import {ActionError, Action as ActionType} from './types';
 const ActionProperty = ({action, errors, onChange}) => {
   const {components} = useContext(FormContext);
   const isLayout = action.component
-    ? FormioUtils.isLayoutComponent(components[action.component])
+    ? ['columns', 'fieldset'].includes(components[action.component].type)
     : false;
   const modifiablePropertyChoices = Object.entries(MODIFIABLE_PROPERTIES)
     .filter(([, info]) => !isLayout || info.useInLayout)

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -1,3 +1,4 @@
+import FormioUtils from 'formiojs/utils';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import {useContext, useState} from 'react';
@@ -26,10 +27,13 @@ import {SynchronizeVariablesActionConfig} from './synchronize_variable/Synchroni
 import {ActionError, Action as ActionType} from './types';
 
 const ActionProperty = ({action, errors, onChange}) => {
-  const modifiablePropertyChoices = Object.entries(MODIFIABLE_PROPERTIES).map(([key, info]) => [
-    key,
-    info.label,
-  ]);
+  const {components} = useContext(FormContext);
+  const isLayout = action.component
+    ? FormioUtils.isLayoutComponent(components[action.component])
+    : false;
+  const modifiablePropertyChoices = Object.entries(MODIFIABLE_PROPERTIES)
+    .filter(([, info]) => !isLayout || info.useInLayout)
+    .map(([key, info]) => [key, info.label]);
 
   const castValueTypeToString = action => {
     const valueType = action.action.property.type;

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -30,6 +30,7 @@ const holdsSubmissionDataTypes = ['columns', 'fieldset', 'softRequiredErrors', '
 
 const ActionProperty = ({action, errors, onChange}) => {
   const {components} = useContext(FormContext);
+  const intl = useIntl();
   const isLayout = action.component
     ? holdsSubmissionDataTypes.includes(components[action.component].type)
     : false;
@@ -53,7 +54,10 @@ const ActionProperty = ({action, errors, onChange}) => {
       <DSLEditorNode errors={errors.component}>
         <ComponentSelection
           name="component"
-          accessibleLabel="Component selection"
+          accessibleLabel={intl.formatMessage({
+            description: 'Accessible label for component selection',
+            defaultMessage: 'Component selection',
+          })}
           value={action.component}
           onChange={onChange}
         />
@@ -61,7 +65,10 @@ const ActionProperty = ({action, errors, onChange}) => {
       <DSLEditorNode errors={errors.action?.property?.value}>
         <Select
           name="action.property"
-          aria-label="Action property selection"
+          aria-label={intl.formatMessage({
+            description: 'Accessible label for action property selection',
+            defaultMessage: 'Action property selection',
+          })}
           choices={modifiablePropertyChoices}
           translateChoices
           allowBlank
@@ -85,7 +92,10 @@ const ActionProperty = ({action, errors, onChange}) => {
         <DSLEditorNode errors={errors.action?.state}>
           <Select
             name="action.state"
-            aria-label="Action state selection"
+            aria-label={intl.formatMessage({
+              description: 'Accessible label for action state selection',
+              defaultMessage: 'Action state selection',
+            })}
             choices={MODIFIABLE_PROPERTIES[action.action.property.value].options}
             translateChoices
             allowBlank

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -48,11 +48,17 @@ const ActionProperty = ({action, errors, onChange}) => {
   return (
     <>
       <DSLEditorNode errors={errors.component}>
-        <ComponentSelection name="component" value={action.component} onChange={onChange} />
+        <ComponentSelection
+          name="component"
+          accessibleLabel="Component selection"
+          value={action.component}
+          onChange={onChange}
+        />
       </DSLEditorNode>
       <DSLEditorNode errors={errors.action?.property?.value}>
         <Select
           name="action.property"
+          aria-label="Action property selection"
           choices={modifiablePropertyChoices}
           translateChoices
           allowBlank
@@ -76,6 +82,7 @@ const ActionProperty = ({action, errors, onChange}) => {
         <DSLEditorNode errors={errors.action?.state}>
           <Select
             name="action.state"
+            aria-label="Action state selection"
             choices={MODIFIABLE_PROPERTIES[action.action.property.value].options}
             translateChoices
             allowBlank

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -25,10 +25,13 @@ import {detectMappingProblems as detectDMNMappingProblems} from './dmn/utils';
 import {SynchronizeVariablesActionConfig} from './synchronize_variable/SynchronizeVariablesConfigModal';
 import {ActionError, Action as ActionType} from './types';
 
+// frontend counterpart of formio.service.holds_submission_data
+const holdsSubmissionDataTypes = ['columns', 'fieldset', 'softRequiredErrors', 'coSign', 'content'];
+
 const ActionProperty = ({action, errors, onChange}) => {
   const {components} = useContext(FormContext);
   const isLayout = action.component
-    ? ['columns', 'fieldset'].includes(components[action.component].type)
+    ? holdsSubmissionDataTypes.includes(components[action.component].type)
     : false;
   const modifiablePropertyChoices = Object.entries(MODIFIABLE_PROPERTIES)
     .filter(([, info]) => !isLayout || info.useInLayout)

--- a/src/openforms/js/components/admin/form_design/logic/constants.js
+++ b/src/openforms/js/components/admin/form_design/logic/constants.js
@@ -169,6 +169,7 @@ const MODIFIABLE_PROPERTIES = {
     }),
     type: 'bool',
     options: BOOL_OPTIONS,
+    useInLayout: true,
   },
   hidden: {
     label: defineMessage({
@@ -177,6 +178,7 @@ const MODIFIABLE_PROPERTIES = {
     }),
     type: 'bool',
     options: BOOL_OPTIONS,
+    useInLayout: true,
   },
   disabled: {
     label: defineMessage({
@@ -185,6 +187,7 @@ const MODIFIABLE_PROPERTIES = {
     }),
     type: 'bool',
     options: BOOL_OPTIONS,
+    useInLayout: false,
   },
 };
 

--- a/src/openforms/js/components/admin/forms/ComponentSelection.js
+++ b/src/openforms/js/components/admin/forms/ComponentSelection.js
@@ -7,7 +7,7 @@ import Select from './Select';
 
 const allowAny = () => true;
 
-const ComponentSelection = ({name, value, onChange, filter = allowAny}) => {
+const ComponentSelection = ({name, value, onChange, filter = allowAny, accessibleLabel = ''}) => {
   const formContext = useContext(FormContext);
   const allComponents = formContext.components;
   const choices = Object.entries(allComponents)
@@ -16,7 +16,16 @@ const ComponentSelection = ({name, value, onChange, filter = allowAny}) => {
     // apply passed in filter to restrict valid choices
     .filter(([key]) => filter(allComponents[key]));
 
-  return <Select name={name} choices={choices} allowBlank onChange={onChange} value={value} />;
+  return (
+    <Select
+      name={name}
+      aria-label={accessibleLabel || undefined}
+      choices={choices}
+      allowBlank
+      onChange={onChange}
+      value={value}
+    />
+  );
 };
 
 ComponentSelection.propTypes = {
@@ -24,6 +33,7 @@ ComponentSelection.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   filter: PropTypes.func,
+  accessibleLabel: PropTypes.string,
 };
 
 export default ComponentSelection;

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1294,6 +1294,11 @@
     "description": "ZGW-APIs registration options 'medewerkerRoltype' help text",
     "originalDefault": "Description (omschrijving) of the ROLTYPE to use for employees filling in a form for a citizen/company."
   },
+  "K5TkEU": {
+    "defaultMessage": "Action state selection",
+    "description": "Accessible label for action state selection",
+    "originalDefault": "Action state selection"
+  },
   "KClY/2": {
     "defaultMessage": "Processing",
     "description": "Form processing fieldset title",
@@ -1398,6 +1403,11 @@
     "defaultMessage": "Copy",
     "description": "Copy form button",
     "originalDefault": "Copy"
+  },
+  "LOFpy8": {
+    "defaultMessage": "Component selection",
+    "description": "Accessible label for component selection",
+    "originalDefault": "Component selection"
   },
   "LaovNg": {
     "defaultMessage": "Add variable",
@@ -1858,6 +1868,11 @@
     "defaultMessage": "Enable new logic rule evaluation",
     "description": "New logic rule evaluation feature flag label",
     "originalDefault": "Enable new logic rule evaluation"
+  },
+  "TQv+8T": {
+    "defaultMessage": "Action property selection",
+    "description": "Accessible label for action property selection",
+    "originalDefault": "Action property selection"
   },
   "TR5xSY": {
     "defaultMessage": "Are you sure you want to delete this rule?",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1307,6 +1307,11 @@
     "description": "ZGW-APIs registration options 'medewerkerRoltype' help text",
     "originalDefault": "Description (omschrijving) of the ROLTYPE to use for employees filling in a form for a citizen/company."
   },
+  "K5TkEU": {
+    "defaultMessage": "Selecteer actiestatus",
+    "description": "Accessible label for action state selection",
+    "originalDefault": "Action state selection"
+  },
   "KClY/2": {
     "defaultMessage": "Verwerking",
     "description": "Form processing fieldset title",
@@ -1411,6 +1416,11 @@
     "defaultMessage": "Kopiëren",
     "description": "Copy form button",
     "originalDefault": "Copy"
+  },
+  "LOFpy8": {
+    "defaultMessage": "Selecteer component",
+    "description": "Accessible label for component selection",
+    "originalDefault": "Component selection"
   },
   "LaovNg": {
     "defaultMessage": "Variabele toevoegen",
@@ -1877,6 +1887,11 @@
     "defaultMessage": "Gebruik nieuwe logica-evaluatie",
     "description": "New logic rule evaluation feature flag label",
     "originalDefault": "Enable new logic rule evaluation"
+  },
+  "TQv+8T": {
+    "defaultMessage": "Selecteer actie-eigenschap",
+    "description": "Accessible label for action property selection",
+    "originalDefault": "Action property selection"
   },
   "TR5xSY": {
     "defaultMessage": "Weet u zeker dat u deze regel wil verwijderen?",


### PR DESCRIPTION
Closes #5977

**Changes**

* backend: add validation that the action can't set "disabled" property for layout fields
* frontend: don't show "disabled" option in the dropdown for layout fields 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
