### PR TITLE
[#5691] Add limit to number of products in appointments

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7253,7 +7253,16 @@ components:
         description:
           type: string
           description: Product extra description
+        amountLimit:
+          type: integer
+          minimum: 0
+          readOnly: true
+          default: 0
+          title: Product amount limit
+          description: The maximum number of times a user can request this appointment.
+            Defaults to 0 (unlimited) if the plugin does not specify this.
       required:
+      - amountLimit
       - code
       - description
       - identifier

--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -61,6 +61,16 @@ class ProductSerializer(serializers.Serializer):
         help_text=_("Product extra description"),
         allow_blank=True,
     )
+    amount_limit = serializers.IntegerField(
+        label=_("Product amount limit"),
+        min_value=0,
+        default=0,
+        read_only=True,
+        help_text=_(
+            "The maximum number of times a user can request this appointment. "
+            "Defaults to 0 (unlimited) if the plugin does not specify this."
+        ),
+    )
 
     class Meta:
         ref_name = "AppointmentProduct"
@@ -221,7 +231,7 @@ class AppointmentSerializer(serializers.HyperlinkedModelSerializer):
         plugin = get_plugin()
         # normalize to data class instances to call plugin methods
         products = [
-            Product(identifier=product["product_id"], name="")
+            Product(identifier=product["product_id"], name="", amount=product["amount"])
             for product in attrs["products"]
         ]
 
@@ -241,16 +251,28 @@ class AppointmentSerializer(serializers.HyperlinkedModelSerializer):
         available_products = plugin.get_available_products(
             location_id=config.limit_to_location
         )
-        available_product_ids = set(p.identifier for p in available_products)
+        available_products = {p.identifier: p for p in available_products}
 
         product_errors = []
         for product in products:
-            valid_product = product.identifier in available_product_ids
-            product_errors.append(
-                {}
-                if valid_product
-                else {"product_id": _("Product is unknown in the appointment backend.")}
-            )
+            if product.identifier not in available_products:
+                product_errors.append(
+                    {"product_id": _("Product is unknown in the appointment backend.")}
+                )
+                break
+
+            if (limit := available_products[product.identifier].amount_limit) > 0:
+                valid_amount_of_products = product.amount <= limit
+                product_errors.append(
+                    {}
+                    if valid_amount_of_products
+                    else {
+                        "amount": _(
+                            "The product supports up to {limit} persons."
+                        ).format(limit=limit)
+                    }
+                )
+
         if any(err != {} for err in product_errors):
             raise serializers.ValidationError({"products": product_errors})
 

--- a/src/openforms/appointments/base.py
+++ b/src/openforms/appointments/base.py
@@ -29,6 +29,7 @@ class Product:
     name: str
     code: str = ""
     amount: int = 1
+    amount_limit: int = 0
     description: str = ""
 
     def __str__(self):

--- a/src/openforms/appointments/contrib/demo/plugin.py
+++ b/src/openforms/appointments/contrib/demo/plugin.py
@@ -38,6 +38,7 @@ class DemoAppointment(BasePlugin[CustomerFields]):
         return [
             Product(identifier="1", name="Test product 1"),
             Product(identifier="2", name="Test product 2"),
+            Product(identifier="3", name="Test product 3", amount_limit=3),
         ]
 
     def get_locations(self, products=None):
@@ -96,6 +97,7 @@ class DemoAppointment(BasePlugin[CustomerFields]):
             products=[
                 Product(identifier="1", name="Test product 1"),
                 Product(identifier="2", name="Test product 2"),
+                Product(identifier="3", name="Test product 3", amount_limit=3),
             ],
             location=Location(
                 identifier="1", name="Test location", address="Test address"

--- a/src/openforms/appointments/contrib/demo/tests/test_endpoints.py
+++ b/src/openforms/appointments/contrib/demo/tests/test_endpoints.py
@@ -41,7 +41,7 @@ class DemoPluginTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         products = response.json()
-        self.assertEqual(len(products), 2)
+        self.assertEqual(len(products), 3)
 
     def test_location_list(self):
         endpoint = reverse("api:appointments-locations-list")

--- a/src/openforms/appointments/contrib/jcc_rest/plugin.py
+++ b/src/openforms/appointments/contrib/jcc_rest/plugin.py
@@ -109,6 +109,7 @@ class JccRestPlugin(BasePlugin):
                 identifier=product["id"],
                 name=product.get("description", ""),
                 description=product.get("necessities", ""),
+                amount_limit=product.get("maxCountForEvent", 0),
             )
             for product in data
         ]

--- a/src/openforms/appointments/tests/test_api_appointment_create.py
+++ b/src/openforms/appointments/tests/test_api_appointment_create.py
@@ -950,3 +950,33 @@ class AppointmentCreateValidationErrorTests(
         response = self.client.post(ENDPOINT, data)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_amount_exceeded(self):
+        appointment_datetime = timezone.make_aware(
+            datetime.combine(TODAY, time(15, 15))
+        )
+        base = {
+            "submission": reverse(
+                "api:submission-detail", kwargs={"uuid": self.submission.uuid}
+            ),
+            "location": "1",
+            "date": TODAY.isoformat(),
+            "datetime": appointment_datetime.isoformat(),
+            "contactDetails": {
+                "lastName": "Periwinkle",
+                "email": "user@example.com",
+            },
+            "privacyPolicyAccepted": True,
+        }
+
+        data = {
+            **base,
+            "products": [{"productId": "3", "amount": 4}],
+        }
+
+        response = self.client.post(ENDPOINT, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        invalid_params = response.json()["invalidParams"]
+        self.assertEqual(len(invalid_params), 1)
+        self.assertEqual(invalid_params[0]["name"], "products.0.amount")


### PR DESCRIPTION
Closes #5691 partly

**Changes**

- Introduce a new limit for the number of appointments. A user cannot request more than that if this is defined in the plugin.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
