### PR TITLE
Fix crash with list comparisons in JSON logic

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -353,7 +353,7 @@ maykin-2fa==2.1.0
     #   maykin-common
 maykin-common==0.18.0
     # via -r requirements/base.in
-maykin-json-logic-py==0.13.0
+maykin-json-logic-py==0.14.0
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
     # via django-digid-eherkenning

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -614,7 +614,7 @@ maykin-common==0.18.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   -r requirements/test-tools.in
-maykin-json-logic-py==0.13.0
+maykin-json-logic-py==0.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -675,7 +675,7 @@ maykin-common==0.18.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-json-logic-py==0.13.0
+maykin-json-logic-py==0.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -572,7 +572,7 @@ maykin-common==0.18.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-json-logic-py==0.13.0
+maykin-json-logic-py==0.14.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -661,7 +661,7 @@ maykin-common==0.18.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-json-logic-py==0.13.0
+maykin-json-logic-py==0.14.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -435,7 +435,7 @@ class VariableAction(ActionOperation):
         data_for_visible_state: FormioData,
     ) -> DataMapping:
         with log_errors(self.value, self.rule):
-            return {self.variable: jsonLogic(self.value, context.data)}
+            return {self.variable: jsonLogic(self.value, context.data)}  # pyright: ignore[reportArgumentType]
 
 
 class DataMappingsConfig(TypedDict):

--- a/src/openforms/utils/json_logic/partial_evaluation.py
+++ b/src/openforms/utils/json_logic/partial_evaluation.py
@@ -40,7 +40,7 @@ def partially_evaluate_json_logic(
       of periods in keys.
     :return: Tuple of the (partially) evaluated JSON logic expression and a flag
       indicating whether the expression was fully resolved. Note that it could return a
-      date or datetime object if the expression was evalutated completely.
+      date or datetime object if the expression was evaluated completely.
     """
     if isinstance(expression, list):
         fully_resolved = True
@@ -83,12 +83,10 @@ def partially_evaluate_json_logic(
                 argument[0], data
             )
             if resolved:
-                return jsonLogic(expression, data), True
+                return jsonLogic(expression, data), True  # pyright: ignore[reportArgumentType, reportReturnType]
             else:
-                # Mismatch between the `JSON` type of `json_logic`, and our own
-                # `JSONValue`
-                argument[0] = var_operation_new  # pyright: ignore[reportCallIssue, reportArgumentType]
-                return expression, False  # pyright: ignore[reportReturnType]
+                argument_new = [var_operation_new, argument[1]]
+                return {operator: argument_new}, False
         case "reduce":
             # The reduce operations has a fixed order of arguments:
             # 1. Variable operation (must be an array)
@@ -103,13 +101,10 @@ def partially_evaluate_json_logic(
                 argument[2], data
             )
             if var_resolved and initializer_resolved:
-                return jsonLogic(expression, data), True
+                return jsonLogic(expression, data), True  # pyright: ignore[reportArgumentType, reportReturnType]
             else:
-                # Mismatch between the `JSON` type of `json_logic`, and our own
-                # `JSONValue`
-                argument[0] = var_operation_new  # pyright: ignore[reportCallIssue, reportArgumentType]
-                argument[2] = initial_value_new  # pyright: ignore[reportCallIssue, reportArgumentType]
-                return expression, False  # pyright: ignore[reportReturnType]
+                argument_new = [var_operation_new, argument[1], initial_value_new]
+                return {operator: argument_new}, False
         case "rdelta":
             assert isinstance(argument, list)
             # The argument of the "rdelta" operator is a list, which can contain
@@ -141,6 +136,6 @@ def partially_evaluate_json_logic(
     argument_new, fully_resolved = partially_evaluate_json_logic(argument, data)
 
     if fully_resolved:
-        return jsonLogic({operator: argument_new}, data, permissive=True), True
+        return jsonLogic({operator: argument_new}, data, permissive=True), True  # pyright: ignore[reportArgumentType, reportReturnType]
     else:
         return {operator: argument_new}, False

--- a/src/openforms/utils/json_logic/partial_evaluation.py
+++ b/src/openforms/utils/json_logic/partial_evaluation.py
@@ -74,24 +74,41 @@ def partially_evaluate_json_logic(
                 return data.get(argument_new[0]), True
             else:
                 return {operator: argument_new}, False
-        case "map" | "reduce":
-            # Map and reduce operations have a fixed order of arguments:
+        case "map":
+            # The map operation has a fixed order of arguments:
             # 1. Variable operation (must be an array)
             # 2. Operation to perform on each array item(s)
-            # 3. Initial value (for reduce only, and cannot be a variable expression)
             assert isinstance(argument, list)
             var_operation_new, resolved = partially_evaluate_json_logic(
                 argument[0], data
             )
-            # Both operations only take a single variable, which we cannot substitute
-            # with the actual value, because `jsonLogic` will see dict array items as
-            # operations. So, we either evaluate the whole expression, or we do nothing.
             if resolved:
                 return jsonLogic(expression, data), True
             else:
                 # Mismatch between the `JSON` type of `json_logic`, and our own
                 # `JSONValue`
                 argument[0] = var_operation_new  # pyright: ignore[reportCallIssue, reportArgumentType]
+                return expression, False  # pyright: ignore[reportReturnType]
+        case "reduce":
+            # The reduce operations has a fixed order of arguments:
+            # 1. Variable operation (must be an array)
+            # 2. Operation to perform on each array item(s)
+            # 3. Initial value (can be a variable expression)
+            assert isinstance(argument, list)
+            var_operation_new, var_resolved = partially_evaluate_json_logic(
+                argument[0], data
+            )
+
+            initial_value_new, initializer_resolved = partially_evaluate_json_logic(
+                argument[2], data
+            )
+            if var_resolved and initializer_resolved:
+                return jsonLogic(expression, data), True
+            else:
+                # Mismatch between the `JSON` type of `json_logic`, and our own
+                # `JSONValue`
+                argument[0] = var_operation_new  # pyright: ignore[reportCallIssue, reportArgumentType]
+                argument[2] = initial_value_new  # pyright: ignore[reportCallIssue, reportArgumentType]
                 return expression, False  # pyright: ignore[reportReturnType]
         case "rdelta":
             assert isinstance(argument, list)

--- a/src/openforms/utils/json_logic/partial_evaluation.py
+++ b/src/openforms/utils/json_logic/partial_evaluation.py
@@ -124,6 +124,6 @@ def partially_evaluate_json_logic(
     argument_new, fully_resolved = partially_evaluate_json_logic(argument, data)
 
     if fully_resolved:
-        return jsonLogic({operator: argument_new}, data), True
+        return jsonLogic({operator: argument_new}, data, permissive=True), True
     else:
         return {operator: argument_new}, False

--- a/src/openforms/utils/tests/test_json_logic.py
+++ b/src/openforms/utils/tests/test_json_logic.py
@@ -5,7 +5,7 @@ from functools import cache
 from typing import Annotated
 from unittest import skipIf
 
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, override_settings, tag
 
 import requests
 from freezegun import freeze_time
@@ -477,6 +477,29 @@ class PartialEvaluationTests(ParametrizedTestCase, SimpleTestCase):
             result, resolved = partially_evaluate_json_logic(expression, data)
             self.assertEqual(result, 15)
             self.assertTrue(resolved)
+
+        with self.subTest("with variable expression as initializer"):
+            expression = {
+                "reduce": [
+                    {"var": "foo"},
+                    {"+": [{"var": "current"}, {"var": "accumulator"}]},
+                    {"var": "bar"},
+                ]
+            }
+            data = {"bar": 5}
+
+            result, resolved = partially_evaluate_json_logic(expression, data)
+            self.assertEqual(
+                result,
+                {
+                    "reduce": [
+                        {"var": ["foo"]},
+                        {"+": [{"var": "current"}, {"var": "accumulator"}]},
+                        5,
+                    ]
+                },
+            )
+            self.assertFalse(resolved)
 
         with self.subTest("with nested-data access"):
             expression = {

--- a/src/openforms/utils/tests/test_json_logic.py
+++ b/src/openforms/utils/tests/test_json_logic.py
@@ -614,3 +614,24 @@ class PartialEvaluationTests(ParametrizedTestCase, SimpleTestCase):
         result, resolved = partially_evaluate_json_logic(expression, data)
         self.assertEqual(result, expected)
         self.assertFalse(resolved)
+
+    @tag("gh-6166")
+    def test_with_list_of_objects_as_data(self):
+        expression = {"==": [{"var": "foo"}, []]}
+        data = {
+            "foo": [
+                {
+                    "affixes": "den",
+                    "bsn": "999994542",
+                    "dateOfBirth": "1968-03-18",
+                    "dateOfBirthPrecision": "date",
+                    "firstNames": "Gerrit",
+                    "initials": "G.",
+                    "lastName": "Braber",
+                }
+            ]
+        }
+
+        result, resolved = partially_evaluate_json_logic(expression, data)
+        self.assertEqual(result, False)
+        self.assertTrue(resolved)

--- a/src/openforms/utils/tests/test_shared_json_logic.py
+++ b/src/openforms/utils/tests/test_shared_json_logic.py
@@ -31,7 +31,7 @@ def name_to_id(arg: str):
 
 
 def evaluate_and_serialize(expression, input_data):
-    result = jsonLogic(expression, input_data)
+    result = jsonLogic(expression, input_data, permissive=True)
     return json.loads(json.dumps(result, cls=DjangoJSONEncoder))
 
 


### PR DESCRIPTION
Closes #6166

[skip: e2e]

**Changes**

- Updated maykin-json-logic-py
- Added `permissive=True` to the relevant `jsonLogic` calls
- Fixed reduce operations not being able to use variable expressions are initial value

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
