### PR TITLE
Fix admin-index border not stretching full width

### DIFF
--- a/src/openforms/scss/admin/_admin_theme.scss
+++ b/src/openforms/scss/admin/_admin_theme.scss
@@ -23,7 +23,7 @@ body {
   }
 }
 
-div#header {
+header#header {
   // some admin pages (form definitions, form designer) include bootstrap which is
   // just a massive PITA and we need these overrides because of the CSS reset that's
   // loaded.


### PR DESCRIPTION
The Django 5.2 changed the div into a header element, which broke our earlier fix.

[skip: e2e]