### PR TITLE
Fix missing outgoing request logs in Celery workers

### DIFF
--- a/bin/celery_worker.sh
+++ b/bin/celery_worker.sh
@@ -13,7 +13,10 @@ export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-openforms-worker-"${QUEUE}"}"
 
 echo "Starting celery worker $WORKER_NAME with queue $QUEUE"
 # unset this if NOT using a process pool
-export _OTEL_DEFER_SETUP="true" _TIMELINE_LOGGER_DEFER_LISTENER="true"
+export \
+    _OTEL_DEFER_SETUP="true" \
+    _TIMELINE_LOGGER_DEFER_LISTENER="true" \
+    _LOG_OUTGOING_REQUESTS_LOGGER_DEFER_LISTENER="true"
 exec celery --workdir src --app openforms.celery worker \
     -Q $QUEUE \
     -n $WORKER_NAME \

--- a/src/openforms/celery/logging.py
+++ b/src/openforms/celery/logging.py
@@ -1,10 +1,14 @@
 import logging  # noqa: TID251 - correct use to replace stdlib logging
 import logging.config  # noqa: TID251 - correct use to replace stdlib logging
 
+from django.conf import settings
+
 import structlog
+from log_outgoing_requests.structlog import ExtractRequestAndResponseDetails
 from maykin_common.config import config
 
 from openforms.logging.adapter import from_structlog
+from openforms.logging.processors import add_open_telemetry_spans
 
 
 def receiver_setup_logging(
@@ -24,6 +28,8 @@ def receiver_setup_logging(
                         structlog.processors.TimeStamper(fmt="iso"),
                         structlog.stdlib.add_logger_name,
                         structlog.stdlib.add_log_level,
+                        ExtractRequestAndResponseDetails(expand_headers=False),
+                        add_open_telemetry_spans,
                         structlog.stdlib.PositionalArgumentsFormatter(),
                     ],
                 },
@@ -35,6 +41,8 @@ def receiver_setup_logging(
                         structlog.processors.TimeStamper(fmt="iso"),
                         structlog.stdlib.add_logger_name,
                         structlog.stdlib.add_log_level,
+                        ExtractRequestAndResponseDetails(expand_headers=True),
+                        add_open_telemetry_spans,
                         structlog.stdlib.PositionalArgumentsFormatter(),
                     ],
                 },
@@ -48,6 +56,12 @@ def receiver_setup_logging(
                     "()": "openforms.logging.factories.audit_handler_factory",
                     "adapter": from_structlog,
                     "buffer_size": 5,
+                    "flush_interval": 15.0,
+                },
+                "save_outgoing_requests": {
+                    "level": "DEBUG",
+                    "()": "log_outgoing_requests.handlers.outgoing_requests_handler_factory",
+                    "buffer_size": 3,
                     "flush_interval": 15.0,
                 },
             },
@@ -71,6 +85,15 @@ def receiver_setup_logging(
                 "maykin_common": {
                     "handlers": ["console"],
                     "level": "INFO",
+                },
+                "log_outgoing_requests": {
+                    "handlers": (
+                        ["console", "save_outgoing_requests"]
+                        if settings.LOG_OUTGOING_REQUESTS
+                        else []
+                    ),
+                    "level": "DEBUG",
+                    "propagate": False,
                 },
             },
         }


### PR DESCRIPTION
Reported via Slack by Laurens

[skip: e2e]

**Changes**

* Add missing logger in Celery logging config
* Add missing envvar to defer background thread starting of workers
* Add missing OTel trace info for celery task logs

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
