### PR TITLE
[#5959] add support for variables to v3 form endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -9033,6 +9033,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FormRegistrationBackend'
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormVariableV3'
         payment:
           $ref: '#/components/schemas/FormPayment'
         appointmentOptions:
@@ -9276,6 +9280,85 @@ components:
       required:
       - dataType
       - form
+      - key
+      - name
+      - source
+    FormVariableV3:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the variable
+        key:
+          type: string
+          description: Key of the variable, should be unique with the form.
+          pattern: ^(\w|\w[\w.\-]*\w)$
+        source:
+          allOf:
+          - $ref: '#/components/schemas/SourceEnum'
+          description: |-
+            Where will the data that will be associated with this variable come from
+
+            * `component` - Component
+            * `user_defined` - User defined
+        serviceFetchConfiguration:
+          allOf:
+          - $ref: '#/components/schemas/ServiceFetchConfigurationV3'
+          nullable: true
+        formDefinition:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        prefillPlugin:
+          type: string
+          description: Which, if any, prefill plugin should be used
+          maxLength: 50
+        prefillAttribute:
+          type: string
+          description: Which attribute from the prefill response should be used to
+            fill this variable
+          maxLength: 200
+        prefillIdentifierRole:
+          allOf:
+          - $ref: '#/components/schemas/PrefillIdentifierRoleEnum'
+          description: |-
+            In case that multiple identifiers are returned (in the case of eHerkenning bewindvoering and DigiD Machtigen), should the prefill data related to the main identifier be used, or that related to the authorised person?
+
+            * `main` - Main
+            * `authorizee` - Authorizee
+        prefillOptions: {}
+        dataType:
+          allOf:
+          - $ref: '#/components/schemas/DataTypeEnum'
+          description: |-
+            The type of the value that will be associated with this variable
+
+            * `string` - String
+            * `boolean` - Boolean
+            * `object` - Object
+            * `array` - Array
+            * `int` - Integer
+            * `float` - Float
+            * `datetime` - Datetime
+            * `time` - Time
+            * `date` - Date
+            * `partners` - Partners
+            * `children` - Children
+            * `editgrid` - Edit Grid
+        dataFormat:
+          type: string
+          description: The format of the value that will be associated with this variable
+          maxLength: 250
+        isSensitiveData:
+          type: boolean
+          description: Will this variable be associated with sensitive data?
+        initialValue:
+          nullable: true
+          description: The initial value for this field
+      required:
+      - dataType
+      - formDefinition
       - key
       - name
       - source
@@ -10685,6 +10768,68 @@ components:
             the cached responses will expire after the timeout (in seconds).
       required:
       - id
+      - name
+      - service
+    ServiceFetchConfigurationV3:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: human readable name for the configuration
+          maxLength: 250
+        service:
+          type: string
+          format: uuid
+        path:
+          type: string
+          description: path relative to the Service API root
+          maxLength: 250
+        method:
+          allOf:
+          - $ref: '#/components/schemas/MethodEnum'
+          title: HTTP method
+          description: |-
+            POST is allowed, but should not be used to mutate data
+
+            * `GET` - GET
+            * `POST` - POST
+        headers:
+          type: object
+          additionalProperties: {}
+          title: HTTP request headers
+          description: Additions and overrides for the HTTP request headers as defined
+            in the Service.
+        queryParams:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          title: HTTP query string
+        body:
+          nullable: true
+          title: HTTP request body
+          description: Request body for POST requests (only "application/json" is
+            supported)
+        dataMappingType:
+          title: Mapping expression language
+          oneOf:
+          - $ref: '#/components/schemas/DataMappingTypeEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        mappingExpression:
+          nullable: true
+          description: For jq, pass a string containing the filter expression
+        cacheTimeout:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: The responses for service fetch are cached to prevent repeating
+            the same request multiple times when performing the logic check. If specified,
+            the cached responses will expire after the timeout (in seconds).
+      required:
       - name
       - service
     SourceEnum:

--- a/src/openforms/emails/digest.py
+++ b/src/openforms/emails/digest.py
@@ -509,7 +509,7 @@ def collect_invalid_logic_rules() -> list[InvalidLogicRule]:
                 "source": form_variable.source,
                 "type": form_variable.data_type,
             }
-            for form_variable in form.formvariable_set.all()  # pyright: ignore[reportAttributeAccessIssue]
+            for form_variable in form.formvariable_set.all()
         }
 
         all_keys = list(static_variables) + list(form_variables)

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -1,4 +1,4 @@
-from collections import Counter
+from collections import Counter, defaultdict
 from uuid import UUID
 
 from django.db import transaction
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from openforms.appointments.api.serializers import AppointmentOptionsSerializer
 from openforms.config.models import Theme
@@ -18,9 +18,16 @@ from openforms.formio.service import (
     FormioConfigurationWrapper,
     get_readable_path_from_configuration_path,
 )
+from openforms.formio.typing.base import Component
+from openforms.prefill.contrib.customer_interactions.constants import (
+    PLUGIN_IDENTIFIER as COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+)
 from openforms.products.models import Product
 from openforms.translations.api.serializers import ModelTranslationsSerializer
 from openforms.typing import StrOrPromise
+from openforms.variables.constants import FormVariableSources
+from openforms.variables.models import ServiceFetchConfiguration
+from openforms.variables.service import get_static_variables
 
 from ....api.serializers.form import (
     FormLiteralsSerializer,
@@ -37,9 +44,10 @@ from ....models import (
     FormVariable,
 )
 from ...validators import RequireAppointmentsPlugin
-from ..typing import FormStepData, FormValidatedData
+from ..typing import FormStepData, FormValidatedData, FormVariableData
 from .form_step import FormStepSerializer
 from .payment import FormPaymentSerializer
+from .variables import FormVariableSerializer
 
 
 @extend_schema_serializer(component_name="FormV3Serializer")
@@ -64,6 +72,9 @@ class FormSerializer(serializers.ModelSerializer):
     )
 
     steps = FormStepSerializer(many=True, required=True, source="formstep_set")
+    variables = FormVariableSerializer(
+        many=True, source="formvariable_set", required=False
+    )
 
     payment = FormPaymentSerializer(required=False, source="*")
 
@@ -91,8 +102,11 @@ class FormSerializer(serializers.ModelSerializer):
     _nested_fields = (
         "confirmation_email_template",
         "formstep_set",
+        "formvariable_set",
         "registration_backends",
     )
+
+    form_definition_configurations: dict[UUID, FormioConfigurationWrapper]
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = Form
@@ -104,6 +118,7 @@ class FormSerializer(serializers.ModelSerializer):
             "login_required",
             "translation_enabled",
             "registration_backends",
+            "variables",
             "payment",
             "appointment_options",
             "literals",
@@ -165,12 +180,14 @@ class FormSerializer(serializers.ModelSerializer):
         )
         # fmt:on
         len(form_definitions)  # Evaluate the queryset to acquire the locks.
+        form_definitions_created: dict[UUID, FormDefinition] = {}
         for index, step_data in enumerate(form_step_data):
             form_definition_data = step_data["form_definition"]
             form_definition, _ = form_definitions.update_or_create(
                 uuid=form_definition_data["uuid"],
                 defaults={k: v for k, v in form_definition_data.items() if k != "uuid"},
             )
+            form_definitions_created[form_definition_data["uuid"]] = form_definition
 
             FormStep.objects.create(
                 **{**step_data, "form_definition": form_definition},
@@ -178,11 +195,43 @@ class FormSerializer(serializers.ModelSerializer):
                 form=instance,
             )
 
+        # These calls are required to create the corresponding component form variables
+        # from the form definitions.
+        for form_definition in form_definitions_created.values():
+            FormVariable.objects.synchronize_for(form_definition)
+
         registration_backends = validated_data.get("registration_backends", [])
         FormRegistrationBackend.objects.bulk_create(
             FormRegistrationBackend(form=instance, **backend)
             for backend in registration_backends
         )
+
+        form_variables_data = validated_data.get("formvariable_set", [])
+        form_variables: list[FormVariable] = []
+        for variable_data in form_variables_data:
+            service_fetch_configuration = None
+            if service_configuration_data := variable_data.pop(
+                "service_fetch_configuration", None
+            ):
+                service_fetch_configuration_id = service_configuration_data.pop(
+                    "id", None
+                )
+                service_fetch_configuration, __ = (
+                    ServiceFetchConfiguration.objects.update_or_create(
+                        id=service_fetch_configuration_id,
+                        defaults=service_configuration_data,
+                    )
+                )
+
+            variable_kwargs = dict(variable_data)
+            form_variable = FormVariable(
+                form=instance,
+                service_fetch_configuration=service_fetch_configuration,
+                **variable_kwargs,
+            )
+            form_variable.check_data_type_and_initial_value()
+            form_variables.append(form_variable)
+        FormVariable.objects.bulk_create(form_variables)
 
         return instance
 
@@ -210,12 +259,14 @@ class FormSerializer(serializers.ModelSerializer):
         )
         # fmt:on
         len(form_definitions)  # Evaluate the queryset to acquire the locks.
+        form_definitions_created: dict[UUID, FormDefinition] = {}
         for index, step_data in enumerate(form_step_data):
             form_definition_data = step_data["form_definition"]
             form_definition, _ = form_definitions.update_or_create(
                 uuid=form_definition_data["uuid"],
                 defaults={k: v for k, v in form_definition_data.items() if k != "uuid"},
             )
+            form_definitions_created[form_definition.uuid] = form_definition
 
             step = FormStep(  # TODO: use update_or_create (nice to have)
                 **{**step_data, "form_definition": form_definition},
@@ -224,16 +275,30 @@ class FormSerializer(serializers.ModelSerializer):
             )
             assigned_steps.append(step)
 
+        # Remove the form steps not that are not part of the request along with their
+        # form definitions when applicable.
         steps_to_delete = instance.formstep_set.exclude(
             pk__in=(step.pk for step in assigned_steps)
         )
-        for step in steps_to_delete:
-            step.delete()  # Removes the form definition when applicable by calling `.delete`.
+        form_definitions_to_delete = [
+            step.form_definition.pk
+            for step in steps_to_delete
+            if not step.form_definition.is_reusable
+            and step.form_definition.uuid not in form_definitions_created
+        ]
+        # Use query manager delete methods to bypass model defined `delete` methods.
+        steps_to_delete.delete()
+        FormDefinition.objects.filter(pk__in=form_definitions_to_delete).delete()
 
         # Generate form steps after deleting existings steps, to allow correct calculation of
         # the `order` field.
         for step in sorted(assigned_steps, key=lambda step: step.order):
             step.save()
+
+        # These calls are required to create the corresponding component form variables
+        # from the form definitions.
+        for form_definition in form_definitions_created.values():
+            FormVariable.objects.synchronize_for(form_definition)
 
         registration_backends = validated_data.get("registration_backends", None)
         if registration_backends is not None:
@@ -242,6 +307,35 @@ class FormSerializer(serializers.ModelSerializer):
                 FormRegistrationBackend(form=instance, **backend)
                 for backend in registration_backends
             )
+
+        form_variables_data = validated_data.get("formvariable_set", [])
+        form_variables: list[FormVariable] = []
+        for variable_data in form_variables_data:
+            service_fetch_configuration = None
+            if service_configuration_data := variable_data.pop(
+                "service_fetch_configuration", None
+            ):
+                service_fetch_configuration_id = service_configuration_data.pop(
+                    "id", None
+                )
+                service_fetch_configuration, __ = (
+                    ServiceFetchConfiguration.objects.update_or_create(
+                        id=service_fetch_configuration_id,
+                        defaults=service_configuration_data,
+                    )
+                )
+
+            variable_kwargs = dict(variable_data)
+            form_variable = FormVariable(
+                form=instance,
+                service_fetch_configuration=service_fetch_configuration,
+                **variable_kwargs,
+            )
+            form_variable.check_data_type_and_initial_value()
+            form_variables.append(form_variable)
+        # Remove the stale variables that were not part of the request.
+        instance.formvariable_set.exclude(source=FormVariableSources.component).delete()
+        FormVariable.objects.bulk_create(form_variables)
 
         return instance
 
@@ -260,6 +354,8 @@ class FormSerializer(serializers.ModelSerializer):
             )
             for step in value
         }
+        # Required for the variable validation.
+        self.form_definition_configurations = configurations
 
         all_keys: list[str] = []
         for form_definition, configuration in configurations.items():
@@ -311,6 +407,137 @@ class FormSerializer(serializers.ModelSerializer):
 
         return value
 
+    def validate_variable_profile_options(
+        self,
+        index: int,
+        variable_data: FormVariableData,
+        errors: dict[str, list[ErrorDetail]],
+        existing_profile_form_vars: list[str],
+    ) -> None:
+        prefill_options = variable_data.get("prefill_options", {})
+        if not (
+            profile_form_variable_key := prefill_options.get("profile_form_variable")
+        ):
+            return
+
+        component: Component | None = None
+        for form_configuration in self.form_definition_configurations.values():
+            if profile_form_variable_key not in form_configuration:
+                continue
+            component = form_configuration[profile_form_variable_key]
+            break
+        else:
+            error_message = ErrorDetail(
+                f"Unknown component key '{profile_form_variable_key}' specified for profile form variable",
+                code="invalid",
+            )
+            errors[f"variables.{index}"].append(error_message)
+
+        if component and component["type"] != "customerProfile":
+            error_message = ErrorDetail(
+                _(  # pyright: ignore[reportArgumentType]
+                    "Only variables of 'profile' components are allowed as "
+                    "profile form variable."
+                ),
+                code="invalid",
+            )
+            errors[f"variables.{index}"].append(error_message)
+
+        prefill_plugin = variable_data.get("prefill_plugin")
+        if prefill_plugin == COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER or any(
+            (prefill_options, profile_form_variable_key)
+        ):
+            if profile_form_variable_key:
+                if profile_form_variable_key in existing_profile_form_vars:
+                    error_message = ErrorDetail(
+                        _(  # pyright: ignore[reportArgumentType]
+                            "This profile form variable is already used in another "
+                            "communication preferences prefill plugin."
+                        ),
+                        code="unique",
+                    )
+                    errors[f"variables.{index}"].append(error_message)
+
+                existing_profile_form_vars.append(profile_form_variable_key)
+
+    def validate_variable_prefill_data(
+        self, index: int, attrs: FormVariableData, errors: dict[str, list[ErrorDetail]]
+    ) -> None:
+        prefill_plugin = attrs.get("prefill_plugin") or ""
+        prefill_attribute = attrs.get("prefill_attribute") or ""
+        prefill_options = attrs.get("prefill_options")
+
+        if prefill_plugin and prefill_options and prefill_attribute:
+            error_message = ErrorDetail(
+                _(  # pyright: ignore[reportArgumentType]
+                    "Prefill plugin, attribute and options can not be specified at the same time."
+                ),
+                code="invalid",
+            )
+            errors[f"variables.{index}"].append(error_message)
+
+        if (prefill_plugin and not (prefill_attribute or prefill_options)) or (
+            not prefill_plugin and (prefill_attribute or prefill_options)
+        ):
+            error_message = ErrorDetail(
+                _(  # pyright: ignore[reportArgumentType]
+                    "Prefill plugin must be specified with either prefill attribute or prefill options."
+                ),
+                code="invalid",
+            )
+            errors[f"variables.{index}"].append(error_message)
+
+    def validate_variable_data(self, attrs: FormValidatedData) -> None:
+        if not (variables_data := attrs.get("formvariable_set", [])):
+            return
+
+        static_keys = [item.key for item in get_static_variables()]
+        component_keys = [
+            component["key"]
+            for configuration in self.form_definition_configurations.values()
+            for component in configuration
+        ]
+        existing_profile_form_vars: list[str] = []
+        errors: dict[str, list[ErrorDetail]] = defaultdict(list)
+        variables: list[FormVariableData] = []
+        for index, variable_data in enumerate(variables_data):
+            # To have a smooth transition in the front-end from v2 to v3, only user-defined
+            # variables will be processed/saved from the request. Component variable
+            # are automagically created/updated when the form gets saved.
+            if variable_data["source"] == FormVariableSources.component:
+                continue
+
+            if variable_data["key"] in static_keys:
+                error_message = ErrorDetail(
+                    (
+                        "The variable key cannot be equal to any of the "
+                        "following static variable keys: {static_keys}."
+                    ).format(static_keys=", ".join(static_keys)),
+                    code="unique",
+                )
+                errors[f"variables.{index}"].append(error_message)
+            elif variable_data["key"] in component_keys:
+                error_message = ErrorDetail(
+                    (
+                        "The variable key cannot be equal to any of the "
+                        "following component variable keys: {component_keys}."
+                    ).format(component_keys=", ".join(component_keys)),
+                    code="unique",
+                )
+                errors[f"variables.{index}"].append(error_message)
+
+            self.validate_variable_prefill_data(index, variable_data, errors)
+            self.validate_variable_profile_options(
+                index, variable_data, errors, existing_profile_form_vars
+            )
+
+            variables.append(variable_data)
+
+        if errors:
+            raise ValidationError(errors)
+
+        attrs["formvariable_set"] = variables
+
     def validate_amount_of_steps(self, attrs: FormValidatedData) -> None:
         # validate is called multiple times because of the nested serializer fields.
         # For example ModelTranslationsSerializer is calling it 2 times (current amount
@@ -343,14 +570,10 @@ class FormSerializer(serializers.ModelSerializer):
     def validate(self, attrs: FormValidatedData) -> FormValidatedData:
         self.validate_amount_of_steps(attrs)
 
+        # validate variables after validation of the form definitions were ran
+        self.validate_variable_data(attrs)
         return attrs
 
-    @transaction.atomic()
     def save(self, **kwargs):
         instance = super().save(**kwargs, uuid=self.context["form_uuid"])
-
-        for step in instance.formstep_set.all():
-            # call this synchronously so that it's part of the same DB transaction.
-            FormVariable.objects.synchronize_for(step.form_definition)
-
         return instance

--- a/src/openforms/forms/api/v3/serializers/service_fetch_config.py
+++ b/src/openforms/forms/api/v3/serializers/service_fetch_config.py
@@ -1,0 +1,54 @@
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+from zgw_consumers.models import Service
+
+from openforms.api.validators import ModelValidator
+from openforms.variables.models import ServiceFetchConfiguration
+from openforms.variables.validators import (
+    validate_mapping_expression,
+    validate_request_body,
+)
+
+
+@extend_schema_serializer(component_name="ServiceFetchConfigurationV3Serializer")
+class ServiceFetchConfigurationSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(required=False)
+
+    headers = serializers.DictField(
+        label=_("HTTP request headers"),
+        help_text=_(
+            "Additions and overrides for the HTTP request headers as defined in the Service."
+        ),
+        required=False,
+    )
+    query_params = serializers.DictField(
+        child=serializers.ListField(child=serializers.CharField()),
+        label=_("HTTP query string"),
+        required=False,
+    )
+
+    service = serializers.SlugRelatedField(
+        slug_field="uuid", queryset=Service.objects.all()
+    )
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = ServiceFetchConfiguration
+        fields = (
+            "id",
+            "name",
+            "service",
+            "path",
+            "method",
+            "headers",
+            "query_params",
+            "body",
+            "data_mapping_type",
+            "mapping_expression",
+            "cache_timeout",
+        )
+        validators = [
+            ModelValidator[ServiceFetchConfiguration](validate_mapping_expression),
+            ModelValidator[ServiceFetchConfiguration](validate_request_body),
+        ]

--- a/src/openforms/forms/api/v3/serializers/variables.py
+++ b/src/openforms/forms/api/v3/serializers/variables.py
@@ -1,0 +1,35 @@
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+from openforms.forms.models import FormVariable
+
+from .service_fetch_config import ServiceFetchConfigurationSerializer
+
+
+@extend_schema_serializer(component_name="FormVariableV3Serializer")
+class FormVariableSerializer(serializers.ModelSerializer):
+    form_definition = serializers.UUIDField(
+        required=False, allow_null=True, source="form_definition.uuid", read_only=True
+    )
+    service_fetch_configuration = ServiceFetchConfigurationSerializer(
+        required=False, allow_null=True
+    )
+    prefill_options = serializers.JSONField(required=False)
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = FormVariable
+        fields = (
+            "name",
+            "key",
+            "source",
+            "service_fetch_configuration",
+            "form_definition",
+            "prefill_plugin",
+            "prefill_attribute",
+            "prefill_identifier_role",
+            "prefill_options",
+            "data_type",
+            "data_format",
+            "is_sensitive_data",
+            "initial_value",
+        )

--- a/src/openforms/forms/api/v3/typing.py
+++ b/src/openforms/forms/api/v3/typing.py
@@ -7,6 +7,13 @@ from openforms.config.models import Theme
 from openforms.data_removal.constants import RemovalMethods
 from openforms.emails.typing import ConfirmationEmailTemplateTranslatedData
 from openforms.formio.typing import FormioConfiguration
+from openforms.prefill.constants import IdentifierRoles
+from openforms.variables.constants import (
+    DataMappingTypes,
+    FormVariableDataTypes,
+    FormVariableSources,
+    ServiceFetchMethods,
+)
 
 from ...constants import FormTypeChoices, StatementCheckboxChoices
 from ...models import Category
@@ -92,6 +99,47 @@ class PaymentData(TypedDict):
     payment_backend_options: dict
 
 
+class ServiceFetchConfigurationData(TypedDict):
+    id: NotRequired[int]
+    name: str
+    service: UUID
+
+    path: NotRequired[str]
+    method: NotRequired[ServiceFetchMethods]
+    headers: NotRequired[dict]
+    query_params: NotRequired[dict]
+    body: NotRequired[dict | None]
+
+    data_mapping_type: NotRequired[DataMappingTypes]
+
+    mapping_expression: NotRequired[str | None]
+
+    cache_timeout: NotRequired[int | None]
+
+
+class FormVariableData(TypedDict):
+    name: str
+    key: str
+    source: FormVariableSources
+    is_sensitive_data: NotRequired[bool]
+
+    form_definition: NotRequired[UUID | None]
+
+    data_type: FormVariableDataTypes
+    data_subtype: NotRequired[FormVariableDataTypes]
+
+    data_format: NotRequired[str]
+
+    prefill_plugin: NotRequired[str]
+    prefill_attribute: NotRequired[str]
+    prefill_identifier_role: NotRequired[IdentifierRoles]
+    prefill_options: NotRequired[dict]
+
+    initial_value: NotRequired[dict | None]
+
+    service_fetch_configuration: NotRequired[ServiceFetchConfigurationData | None]
+
+
 class FormValidatedData(TypedDict):
     uuid: UUID
     name: str
@@ -107,6 +155,8 @@ class FormValidatedData(TypedDict):
     theme: NotRequired[Theme]
     formstep_set: list[FormStepData]
     payment: NotRequired[PaymentData]
+
+    formvariable_set: list[FormVariableData]
 
     show_progress_indicator: NotRequired[bool]
     show_summary_progress: NotRequired[bool]

--- a/src/openforms/forms/json_schema.py
+++ b/src/openforms/forms/json_schema.py
@@ -36,7 +36,7 @@ def _iter_form_variables(
             variables_registry=additional_variables_registry
         )
     # Handle form variables holding dynamic data (component and user defined)
-    yield from form.formvariable_set.all()  # pyright: ignore[reportAttributeAccessIssue]
+    yield from form.formvariable_set.all()
 
 
 def generate_json_schema(

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
         FormLogic,
         FormRegistrationBackend,
         FormStep,
+        FormVariable,
     )
 
 
@@ -422,6 +423,7 @@ class Form(models.Model):
         FormManager
     ] = FormManager()
     formstep_set: models.Manager[FormStep]
+    formvariable_set: models.Manager[FormVariable]
     auth_backends: Manager[FormAuthenticationBackend]
     registration_backends: Manager[FormRegistrationBackend]
     formlogic_set: Manager[FormLogic]

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -12,18 +12,31 @@ from djangorestframework_camel_case.util import underscoreize
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient, APITestCase, APITransactionTestCase
+from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.accounts.models import User
 from openforms.accounts.tests.factories import UserFactory
 from openforms.appointments.models import AppointmentsConfig
 from openforms.config.tests.factories import ThemeFactory
+from openforms.contrib.customer_interactions.tests.factories import (
+    CustomerInteractionsAPIGroupConfigFactory,
+)
 from openforms.data_removal.constants import RemovalMethods
 from openforms.payments.contrib.worldline.tests.factories import (
     WorldlineMerchantFactory,
 )
+from openforms.prefill.contrib.customer_interactions.constants import (
+    PLUGIN_IDENTIFIER as COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+)
 from openforms.products.tests.factories import ProductFactory
 from openforms.typing import JSONObject
 from openforms.utils.tests.feature_flags import enable_feature_flag
+from openforms.variables.constants import (
+    FormVariableDataTypes,
+    FormVariableSources,
+    ServiceFetchMethods,
+)
+from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
 from ...constants import (
     FormTypeChoices,
@@ -52,6 +65,7 @@ class FormEndpointTests(APITestCase):
         self.client.force_authenticate(user=self.admin_user)
 
     def test_create_minimal_form(self):
+        form_definition_uuid = uuid4()
         url = reverse(
             "api:v3:form-detail",
             kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
@@ -63,7 +77,7 @@ class FormEndpointTests(APITestCase):
                 {
                     "slug": "step-1",
                     "formDefinition": {
-                        "uuid": str(uuid4()),
+                        "uuid": form_definition_uuid,
                         "configuration": {
                             "components": [
                                 {
@@ -180,6 +194,20 @@ class FormEndpointTests(APITestCase):
                         },
                     },
                 }
+            ],
+            "variables": [
+                {
+                    "name": "extra_var",
+                    "key": "extra_var",
+                    "source": FormVariableSources.user_defined,
+                    "data_type": FormVariableDataTypes.string,
+                },
+                {
+                    "name": "extra_var_2",
+                    "key": "extra_var_2",
+                    "source": FormVariableSources.user_defined,
+                    "data_type": FormVariableDataTypes.string,
+                },
             ],
             "maintenanceMode": True,
             "active": True,
@@ -304,6 +332,34 @@ class FormEndpointTests(APITestCase):
                 ],
             },
         )
+
+        # variables
+        variables = form.formvariable_set.order_by("source", "key")
+        self.assertEqual(variables.count(), 4)
+
+        ## Component variables
+        self.assertEqual(variables[0].name, "component1")
+        self.assertEqual(variables[0].key, "component1")
+        self.assertEqual(variables[0].form_definition, form_definition)
+        self.assertEqual(variables[0].data_type, FormVariableDataTypes.string)
+        self.assertEqual(variables[0].source, FormVariableSources.component)
+        self.assertEqual(variables[1].name, "component2")
+        self.assertEqual(variables[1].key, "component2")
+        self.assertEqual(variables[1].form_definition, form_definition)
+        self.assertEqual(variables[1].data_type, FormVariableDataTypes.string)
+        self.assertEqual(variables[1].source, FormVariableSources.component)
+
+        ## User defined variables
+        self.assertEqual(variables[2].name, "extra_var")
+        self.assertEqual(variables[2].key, "extra_var")
+        self.assertIsNone(variables[2].form_definition)
+        self.assertEqual(variables[2].data_type, FormVariableDataTypes.string)
+        self.assertEqual(variables[2].source, FormVariableSources.user_defined)
+        self.assertEqual(variables[3].name, "extra_var_2")
+        self.assertEqual(variables[3].key, "extra_var_2")
+        self.assertIsNone(variables[3].form_definition)
+        self.assertEqual(variables[3].data_type, FormVariableDataTypes.string)
+        self.assertEqual(variables[3].source, FormVariableSources.user_defined)
 
         # registration backends
         registration_backend = FormRegistrationBackend.objects.get()
@@ -1768,6 +1824,1397 @@ class FormEndpointTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(Form.objects.count(), 0)
+
+
+class FormEndpointVariableTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+
+        cls.admin_user = UserFactory.create(
+            is_staff=True, user_permissions=("forms.change_form",)
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.client.force_authenticate(user=self.admin_user)
+
+    def test_user_defined_variables(self):
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "extra_var",
+                    "key": "extra_var",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": None,
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+        variables = form.formvariable_set.order_by("name")
+
+        # component variable, generated for the form step (based on the form defintion)
+        self.assertEqual(variables[0].name, "component1")
+        self.assertEqual(variables[0].key, "component1")
+        self.assertEqual(variables[0].source, FormVariableSources.component)
+        self.assertEqual(variables[0].form_definition.uuid, form_definition_uuid)
+        self.assertEqual(variables[0].data_type, FormVariableDataTypes.string)
+
+        # user defined variable, from the request body
+        self.assertEqual(variables[1].name, "extra_var")
+        self.assertEqual(variables[1].key, "extra_var")
+        self.assertEqual(variables[1].source, FormVariableSources.user_defined)
+        self.assertIsNone(variables[1].form_definition)
+        self.assertEqual(variables[1].data_type, FormVariableDataTypes.string)
+
+    def test_user_defined_profile_form_variable(self):
+        customer_interactions_api = CustomerInteractionsAPIGroupConfigFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "customerProfile",
+                                    "key": "profile",
+                                    "name": "Profile",
+                                    "digitalAddressTypes": ["email"],
+                                    "shouldUpdateCustomerData": True,
+                                }
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "profile-prefill",
+                    "key": "profilePrefill",
+                    "formDefinition": None,
+                    "source": FormVariableSources.user_defined,
+                    "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                    "prefillAttribute": "",
+                    "prefillIdentifierRole": "main",
+                    "prefillOptions": {
+                        "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                        "profileFormVariable": "profile",
+                    },
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+        variables = form.formvariable_set.order_by("name")
+
+        # component variable, generated for the form step (based on the form defintion)
+        self.assertEqual(variables[0].name, "profile")
+        self.assertEqual(variables[0].key, "profile")
+        self.assertEqual(variables[0].source, FormVariableSources.component)
+        self.assertEqual(variables[0].form_definition.uuid, form_definition_uuid)
+        self.assertEqual(variables[0].data_type, FormVariableDataTypes.array)
+
+        # user defined variable, from the request body
+        self.assertEqual(variables[1].name, "profile-prefill")
+        self.assertEqual(variables[1].key, "profilePrefill")
+        self.assertEqual(variables[1].source, FormVariableSources.user_defined)
+        self.assertIsNone(variables[1].form_definition)
+        self.assertEqual(variables[1].data_type, FormVariableDataTypes.string)
+
+    def test_service_configuration(self):
+        form_definition_uuid = uuid4()
+        service = ServiceFactory.create()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+
+        with self.subTest("Create form"):
+            data = {
+                "name": "Create form",
+                "slug": "create-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "component1",
+                                        "hidden": False,
+                                        "clearOnHide": True,
+                                    },
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                "variables": [
+                    {
+                        "name": "extra_var",
+                        "key": "extra_var",
+                        "source": FormVariableSources.user_defined,
+                        "formDefinition": None,
+                        "dataType": FormVariableDataTypes.string,
+                        "serviceFetchConfiguration": {
+                            "name": "Service fetch configuration 1",
+                            "service": service.uuid,
+                            "path": "/foobar",
+                            "method": ServiceFetchMethods.get,
+                            "headers": {
+                                "Foo": "Bar",
+                            },
+                            "queryParams": {
+                                "Bar": ["Foo"],
+                            },
+                            "body": None,
+                            "dataMappingType": "",
+                            "mappingExpression": None,
+                            "cacheTimeout": None,
+                        },
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(Form.objects.count(), 1)
+            form = Form.objects.get()
+            variables = form.formvariable_set.order_by("source", "name")
+            assert len(variables) == 2
+
+            service_fetch_configuration = variables[1].service_fetch_configuration
+            assert service_fetch_configuration
+            self.assertEqual(
+                service_fetch_configuration.name, "Service fetch configuration 1"
+            )
+            self.assertEqual(service_fetch_configuration.service, service)
+            self.assertEqual(service_fetch_configuration.path, "/foobar")
+            self.assertEqual(
+                service_fetch_configuration.method, ServiceFetchMethods.get
+            )
+            self.assertEqual(service_fetch_configuration.headers, {"_foo": "Bar"})
+            self.assertEqual(
+                service_fetch_configuration.query_params, {"_bar": ["Foo"]}
+            )
+            self.assertIsNone(service_fetch_configuration.body)
+            self.assertEqual(service_fetch_configuration.data_mapping_type, "")
+            self.assertIsNone(service_fetch_configuration.mapping_expression)
+            self.assertIsNone(service_fetch_configuration.cache_timeout)
+
+        with self.subTest("Update form"):
+            data = {
+                "name": "Update form",
+                "slug": "update-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "component1",
+                                        "hidden": False,
+                                        "clearOnHide": True,
+                                    },
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                "variables": [
+                    {
+                        "name": "extra_var",
+                        "key": "extra_var",
+                        "source": FormVariableSources.user_defined,
+                        "formDefinition": None,
+                        "dataType": FormVariableDataTypes.string,
+                        "serviceFetchConfiguration": {
+                            "name": "Service fetch configuration 1",
+                            "service": service.uuid,
+                            "path": "/foobar",
+                            "method": ServiceFetchMethods.get,
+                            "headers": {
+                                "Foo": "Bar",
+                            },
+                            "queryParams": {
+                                "Bar": ["Foo"],
+                            },
+                            "body": None,
+                            "dataMappingType": "",
+                            "mappingExpression": None,
+                            "cacheTimeout": None,
+                        },
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(Form.objects.count(), 1)
+            form = Form.objects.get()
+            variables = form.formvariable_set.order_by("source", "name")
+            assert len(variables) == 2
+
+            service_fetch_configuration = variables[1].service_fetch_configuration
+            assert service_fetch_configuration
+            self.assertEqual(
+                service_fetch_configuration.name, "Service fetch configuration 1"
+            )
+            self.assertEqual(service_fetch_configuration.service, service)
+            self.assertEqual(service_fetch_configuration.path, "/foobar")
+            self.assertEqual(
+                service_fetch_configuration.method, ServiceFetchMethods.get
+            )
+            self.assertEqual(service_fetch_configuration.headers, {"_foo": "Bar"})
+            self.assertEqual(
+                service_fetch_configuration.query_params, {"_bar": ["Foo"]}
+            )
+            self.assertIsNone(service_fetch_configuration.body)
+            self.assertEqual(service_fetch_configuration.data_mapping_type, "")
+            self.assertIsNone(service_fetch_configuration.mapping_expression)
+            self.assertIsNone(service_fetch_configuration.cache_timeout)
+
+    def test_reuse_service_fetch_configuration(self):
+        service = ServiceFactory.create()
+        initial_service_fetch_configuration = ServiceFetchConfigurationFactory.create(
+            name="Service fetch configuration foo", service=service
+        )
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+
+        with self.subTest("Create form"):
+            data = {
+                "name": "Create form",
+                "slug": "create-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "component1",
+                                        "hidden": False,
+                                        "clearOnHide": True,
+                                    },
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                "variables": [
+                    {
+                        "name": "extra_var",
+                        "key": "extra_var",
+                        "source": FormVariableSources.user_defined,
+                        "formDefinition": None,
+                        "dataType": FormVariableDataTypes.string,
+                        "serviceFetchConfiguration": {
+                            "id": initial_service_fetch_configuration.pk,
+                            "name": "Service fetch configuration 1",
+                            "service": service.uuid,
+                            "path": "/foobar",
+                            "method": ServiceFetchMethods.get,
+                            "headers": {
+                                "Foo": "Bar",
+                            },
+                            "queryParams": {
+                                "Bar": ["Foo"],
+                            },
+                            "body": None,
+                            "dataMappingType": "",
+                            "mappingExpression": None,
+                            "cacheTimeout": None,
+                        },
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(Form.objects.count(), 1)
+            form = Form.objects.get()
+            variables = form.formvariable_set.order_by("source", "name")
+            assert len(variables) == 2
+
+            service_fetch_configuration = variables[1].service_fetch_configuration
+            assert service_fetch_configuration
+            self.assertEqual(
+                initial_service_fetch_configuration, service_fetch_configuration
+            )
+            self.assertEqual(
+                service_fetch_configuration.name, "Service fetch configuration 1"
+            )
+
+        with self.subTest("Update form"):
+            data = {
+                "name": "Update form",
+                "slug": "update-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "component1",
+                                        "hidden": False,
+                                        "clearOnHide": True,
+                                    },
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                "variables": [
+                    {
+                        "name": "extra_var",
+                        "key": "extra_var",
+                        "source": FormVariableSources.user_defined,
+                        "formDefinition": None,
+                        "dataType": FormVariableDataTypes.string,
+                        "serviceFetchConfiguration": {
+                            "id": initial_service_fetch_configuration.pk,
+                            "name": "Service fetch configuration 2",
+                            "service": service.uuid,
+                            "path": "/foobar",
+                            "method": ServiceFetchMethods.get,
+                            "headers": {
+                                "Foo": "Bar",
+                            },
+                            "queryParams": {
+                                "Bar": ["Foo"],
+                            },
+                            "body": None,
+                            "dataMappingType": "",
+                            "mappingExpression": None,
+                            "cacheTimeout": None,
+                        },
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(Form.objects.count(), 1)
+            form = Form.objects.get()
+            variables = form.formvariable_set.order_by("source", "name")
+            assert len(variables) == 2
+
+            service_fetch_configuration = variables[1].service_fetch_configuration
+            assert service_fetch_configuration
+            self.assertEqual(
+                initial_service_fetch_configuration, service_fetch_configuration
+            )
+            self.assertEqual(
+                service_fetch_configuration.name, "Service fetch configuration 2"
+            )
+
+    def test_update_recreates_variables(self):
+        form = FormFactory.create()
+        form_step_1_definition_uuid = UUID("7284fcde-0cde-4cb4-b2e5-1e472fceccfb")
+        FormStepFactory.create(
+            form=form,
+            form_definition__uuid=form_step_1_definition_uuid,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "name",
+                    },
+                    {
+                        "type": "number",
+                        "key": "age",
+                    },
+                ]
+            },
+        )
+        form_step_2_definition_uuid = UUID("3ab6da26-7407-4a39-a77c-8fd846ab6d8d")
+        FormStepFactory.create(
+            form=form,
+            form_definition__uuid=form_step_2_definition_uuid,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "nLargeBoxes",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nGiganticBoxes",
+                    },
+                ]
+            },
+        )
+
+        form_step_3_definition_uuid = UUID("0d4a67fb-1aa3-4568-a5b3-a374842c048d")
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_step_1_definition_uuid,
+                        "isReusable": False,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "number",
+                                    "key": "age",
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "email",
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+                {
+                    "slug": "step-2",
+                    "formDefinition": {
+                        "uuid": form_step_2_definition_uuid,
+                        "isReusable": False,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "city",
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 2",
+                                "internalName": "Form configuration 2",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 2",
+                                "internalName": "Form configuratie 2",
+                            },
+                        },
+                    },
+                },
+                {
+                    "slug": "step-3",
+                    "formDefinition": {
+                        "uuid": form_step_3_definition_uuid,
+                        "isReusable": False,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "streetname",
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 3",
+                                "internalName": "Form configuration 3",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 3",
+                                "internalName": "Form configuratie 3",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "extra_var",
+                    "key": "extra_var",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": None,
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+        variables = form.formvariable_set.order_by("source", "name")
+
+        self.assertEqual(variables.count(), 5)
+
+        # component variables, generated for the form step (based on the form defintion)
+        self.assertEqual(variables[0].name, "age")
+        self.assertEqual(variables[0].key, "age")
+        self.assertEqual(variables[0].source, FormVariableSources.component)
+        self.assertEqual(variables[0].form_definition.uuid, form_step_1_definition_uuid)
+        self.assertEqual(variables[0].data_type, FormVariableDataTypes.float)
+        self.assertEqual(variables[1].name, "city")
+        self.assertEqual(variables[1].key, "city")
+        self.assertEqual(variables[1].source, FormVariableSources.component)
+        self.assertEqual(variables[1].form_definition.uuid, form_step_2_definition_uuid)
+        self.assertEqual(variables[1].data_type, FormVariableDataTypes.string)
+        self.assertEqual(variables[2].name, "email")
+        self.assertEqual(variables[2].key, "email")
+        self.assertEqual(variables[2].source, FormVariableSources.component)
+        self.assertEqual(variables[2].form_definition.uuid, form_step_1_definition_uuid)
+        self.assertEqual(variables[2].data_type, FormVariableDataTypes.string)
+        self.assertEqual(variables[3].name, "streetname")
+        self.assertEqual(variables[3].key, "streetname")
+        self.assertEqual(variables[3].source, FormVariableSources.component)
+        self.assertEqual(variables[3].form_definition.uuid, form_step_3_definition_uuid)
+        self.assertEqual(variables[3].data_type, FormVariableDataTypes.string)
+
+        # user defined variable, from the request body
+        self.assertEqual(variables[4].name, "extra_var")
+        self.assertEqual(variables[4].key, "extra_var")
+        self.assertEqual(variables[4].source, FormVariableSources.user_defined)
+        self.assertIsNone(variables[4].form_definition)
+        self.assertEqual(variables[4].data_type, FormVariableDataTypes.string)
+
+    def test_component_variables_ignored(self):
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+
+        with self.subTest("Create form"):
+            data = {
+                "name": "Create form",
+                "slug": "create-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "component1",
+                                        "hidden": False,
+                                        "clearOnHide": True,
+                                    },
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                "variables": [
+                    {
+                        "name": "extra_var",
+                        "key": "extra_var",
+                        "source": FormVariableSources.user_defined,
+                        "formDefinition": None,
+                        "dataType": FormVariableDataTypes.string,
+                    },
+                    {
+                        "name": "ignored",
+                        "key": "textfield",
+                        "source": FormVariableSources.component,
+                        "formDefinition": form_definition_uuid,
+                        "dataType": FormVariableDataTypes.string,
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(Form.objects.count(), 1)
+            form = Form.objects.get()
+            variables = form.formvariable_set.order_by("name")
+            self.assertEqual(variables.count(), 2)
+
+            # component variable, generated for the form step (based on the form defintion)
+            self.assertEqual(variables[0].name, "component1")
+            self.assertEqual(variables[0].key, "component1")
+
+            # user defined variable, from the request body
+            self.assertEqual(variables[1].key, "extra_var")
+            self.assertEqual(variables[1].source, FormVariableSources.user_defined)
+
+        with self.subTest("Update form"):
+            data = {
+                "name": "Create form",
+                "slug": "create-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "textfield",
+                                        "key": "component1",
+                                        "hidden": False,
+                                        "clearOnHide": True,
+                                    },
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                "variables": [
+                    {
+                        "name": "extra_var",
+                        "key": "extra_var",
+                        "source": FormVariableSources.user_defined,
+                        "formDefinition": None,
+                        "dataType": FormVariableDataTypes.string,
+                    },
+                    {
+                        "name": "ignored",
+                        "key": "textfield",
+                        "source": FormVariableSources.component,
+                        "formDefinition": form_definition_uuid,
+                        "dataType": FormVariableDataTypes.string,
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(Form.objects.count(), 1)
+            form = Form.objects.get()
+            variables = form.formvariable_set.order_by("name")
+            self.assertEqual(variables.count(), 2)
+
+            # component variable, generated for the form step (based on the form defintion)
+            self.assertEqual(variables[0].name, "component1")
+            self.assertEqual(variables[0].key, "component1")
+
+            # user defined variable, from the request body
+            self.assertEqual(variables[1].key, "extra_var")
+            self.assertEqual(variables[1].source, FormVariableSources.user_defined)
+
+    def test_static_variable_collision(self):
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "extra_var",
+                    "key": "extra_var",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": None,
+                    "dataType": FormVariableDataTypes.string,
+                },
+                {
+                    "name": "Static variable collision",
+                    "key": "form_name",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": form_definition_uuid,
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        error_message = response_data["invalidParams"][0]
+        self.assertEqual(error_message["code"], "unique")
+        self.assertEqual(error_message["name"], "variables.1")
+        self.assertTrue("static variable keys" in error_message["reason"])
+
+    def test_component_variable_collision(self):
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "extra_var",
+                    "key": "extra_var",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": None,
+                    "dataType": FormVariableDataTypes.string,
+                },
+                {
+                    "name": "Component variable collision",
+                    "key": "component1",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": form_definition_uuid,
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        error_message = response_data["invalidParams"][0]
+        self.assertEqual(error_message["code"], "unique")
+        self.assertEqual(error_message["name"], "variables.1")
+        self.assertTrue("component variable keys" in error_message["reason"])
+
+    def test_user_defined_all_prefill_fields(self):
+        customer_interactions_api = CustomerInteractionsAPIGroupConfigFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "customerProfile",
+                                    "key": "profile",
+                                    "name": "Profile",
+                                    "digitalAddressTypes": ["email"],
+                                    "shouldUpdateCustomerData": True,
+                                }
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "profile-prefill",
+                    "key": "profilePrefill",
+                    "formDefinition": None,
+                    "source": FormVariableSources.user_defined,
+                    "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                    "prefillAttribute": "demo",
+                    "prefillIdentifierRole": "main",
+                    "dataType": FormVariableDataTypes.string,
+                    "prefillOptions": {
+                        "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                        "profileFormVariable": "profile",
+                    },
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        error_message = response_data["invalidParams"][0]
+        self.assertEqual(error_message["code"], "invalid")
+        self.assertEqual(error_message["name"], "variables.0")
+        self.assertEqual(
+            error_message["reason"],
+            _(
+                "Prefill plugin, attribute and options can not be specified at the same time."
+            ),
+        )
+
+    def test_user_defined_missing_prefill_fields(self):
+        customer_interactions_api = CustomerInteractionsAPIGroupConfigFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+
+        with self.subTest("Missing required prefillOptions or prefillAttribute fields"):
+            data = {
+                "name": "Create form",
+                "slug": "create-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "customerProfile",
+                                        "key": "profile",
+                                        "name": "Profile",
+                                        "digitalAddressTypes": ["email"],
+                                        "shouldUpdateCustomerData": True,
+                                    }
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                # Note the missing prefillAttribute or prefillOptions fields.
+                "variables": [
+                    {
+                        "name": "profile-prefill",
+                        "key": "profilePrefill",
+                        "formDefinition": None,
+                        "source": FormVariableSources.user_defined,
+                        "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                        "prefillIdentifierRole": "main",
+                        "dataType": FormVariableDataTypes.string,
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+            response_data = response.json()
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(Form.objects.count(), 0)
+            self.assertEqual(len(response_data["invalidParams"]), 1)
+            error_message = response_data["invalidParams"][0]
+            self.assertEqual(error_message["code"], "invalid")
+            self.assertEqual(error_message["name"], "variables.0")
+            self.assertEqual(
+                error_message["reason"],
+                _(
+                    "Prefill plugin must be specified with either prefill attribute or prefill options."
+                ),
+            )
+
+        with self.subTest("Missing required prefillPlugin field"):
+            data = {
+                "name": "Create form",
+                "slug": "create-form",
+                "steps": [
+                    {
+                        "slug": "step-1",
+                        "formDefinition": {
+                            "uuid": form_definition_uuid,
+                            "configuration": {
+                                "components": [
+                                    {
+                                        "type": "customerProfile",
+                                        "key": "profile",
+                                        "name": "Profile",
+                                        "digitalAddressTypes": ["email"],
+                                        "shouldUpdateCustomerData": True,
+                                    }
+                                ],
+                            },
+                            "translations": {
+                                "en": {
+                                    "name": "Form configuration 1",
+                                    "internalName": "Form configuration 1",
+                                },
+                                "nl": {
+                                    "name": "Form configuratie 1",
+                                    "internalName": "Form configuratie 1",
+                                },
+                            },
+                        },
+                    },
+                ],
+                # Note the missing prefillPlugin field.
+                "variables": [
+                    {
+                        "name": "profile-prefill",
+                        "key": "profilePrefill",
+                        "formDefinition": None,
+                        "source": FormVariableSources.user_defined,
+                        "prefillAttribute": "",
+                        "prefillIdentifierRole": "main",
+                        "prefillOptions": {
+                            "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                            "profileFormVariable": "profile",
+                        },
+                        "dataType": FormVariableDataTypes.string,
+                    },
+                ],
+            }
+            response = self.client.put(url, data=data)
+            response_data = response.json()
+
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(Form.objects.count(), 0)
+            self.assertEqual(len(response_data["invalidParams"]), 1)
+            error_message = response_data["invalidParams"][0]
+            self.assertEqual(error_message["code"], "invalid")
+            self.assertEqual(error_message["name"], "variables.0")
+            self.assertEqual(
+                error_message["reason"],
+                _(
+                    "Prefill plugin must be specified with either prefill attribute or prefill options."
+                ),
+            )
+
+    def test_user_defined_profile_form_variable_incorrect_component_type(self):
+        customer_interactions_api = CustomerInteractionsAPIGroupConfigFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "customerProfile",
+                                    "key": "profile",
+                                    "name": "Profile",
+                                    "digitalAddressTypes": ["email"],
+                                    "shouldUpdateCustomerData": True,
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "textfield",
+                                    "name": "Text field",
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "profile-prefill",
+                    "key": "profilePrefill",
+                    "formDefinition": None,
+                    "source": FormVariableSources.user_defined,
+                    "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                    "prefillAttribute": "",
+                    "prefillIdentifierRole": "main",
+                    "prefillOptions": {
+                        "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                        "profileFormVariable": "textfield",
+                    },
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        error_message = response_data["invalidParams"][0]
+        self.assertEqual(error_message["code"], "invalid")
+        self.assertEqual(error_message["name"], "variables.0")
+        self.assertEqual(
+            error_message["reason"],
+            _(
+                "Only variables of 'profile' components are allowed as "
+                "profile form variable."
+            ),
+        )
+
+    def test_multiple_profile_variables_same_component(self):
+        customer_interactions_api = CustomerInteractionsAPIGroupConfigFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": False,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "customerProfile",
+                                    "key": "profile",
+                                    "name": "Profile",
+                                    "digitalAddressTypes": ["email"],
+                                    "shouldUpdateCustomerData": True,
+                                }
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "profile-prefill",
+                    "key": "profilePrefill",
+                    "formDefinition": None,
+                    "source": FormVariableSources.user_defined,
+                    "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                    "prefillAttribute": "",
+                    "prefillIdentifierRole": "main",
+                    "prefillOptions": {
+                        "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                        "profileFormVariable": "profile",
+                    },
+                    "dataType": FormVariableDataTypes.string,
+                },
+                {
+                    "name": "profile-prefill",
+                    "key": "profilePrefill2",
+                    "formDefinition": None,
+                    "source": FormVariableSources.user_defined,
+                    "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                    "prefillAttribute": "",
+                    "prefillIdentifierRole": "main",
+                    "prefillOptions": {
+                        "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                        "profileFormVariable": "profile",
+                    },
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        error_message = response_data["invalidParams"][0]
+        self.assertEqual(error_message["code"], "unique")
+        self.assertEqual(error_message["name"], "variables.1")
+        self.assertEqual(
+            error_message["reason"],
+            _(
+                "This profile form variable is already used in another "
+                "communication preferences prefill plugin."
+            ),
+        )
+
+    def test_profile_form_variable_unknown_key(self):
+        customer_interactions_api = CustomerInteractionsAPIGroupConfigFactory.create()
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "customerProfile",
+                                    "key": "profile",
+                                    "name": "Profile",
+                                    "digitalAddressTypes": ["email"],
+                                    "shouldUpdateCustomerData": True,
+                                }
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration 1",
+                                "internalName": "Form configuration 1",
+                            },
+                            "nl": {
+                                "name": "Form configuratie 1",
+                                "internalName": "Form configuratie 1",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "profile-prefill",
+                    "key": "profilePrefill",
+                    "formDefinition": None,
+                    "source": FormVariableSources.user_defined,
+                    "prefillPlugin": COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
+                    "prefillAttribute": "",
+                    "prefillIdentifierRole": "main",
+                    "prefillOptions": {
+                        "customerInteractionsApiGroup": customer_interactions_api.identifier,
+                        "profileFormVariable": "foobar",
+                    },
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Form.objects.count(), 0)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        error_message = response_data["invalidParams"][0]
+        self.assertEqual(error_message["code"], "invalid")
+        self.assertEqual(error_message["name"], "variables.0")
+        self.assertEqual(
+            error_message["reason"],
+            "Unknown component key 'foobar' specified for profile form variable",
+        )
 
 
 class FormEndpointAccessTests(APITestCase):


### PR DESCRIPTION
Closes #5959

[skip: e2e]

**Changes**

Adds the `variables` field to the `v3` form endpoint.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
