### PR TITLE
Fix fieldset in editgrid breaking json schema generation

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1086,12 +1086,24 @@ class CustomerProfile(BasePlugin):
         result["data"] = data
         return result
 
+    @staticmethod
+    def as_json_schema(component: CustomerProfileComponent) -> None:
+        raise NotImplementedError()
+
 
 @register("softRequiredErrors")
 class SoftRequiredErrors(BasePlugin):
     holds_submission_data = False
 
+    @staticmethod
+    def as_json_schema(component: Component) -> None:
+        return None
+
 
 @register("coSign")
 class CoSign(BasePlugin):
     holds_submission_data = False
+
+    @staticmethod
+    def as_json_schema(component: Component) -> None:
+        return None

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -61,6 +61,7 @@ from ..registry import BasePlugin, register
 from ..serializers import build_serializer
 from ..service import as_json_schema
 from ..typing import (
+    Column,
     ColumnsComponent,
     Component,
     ContentComponent,
@@ -975,9 +976,9 @@ class Content(BasePlugin):
         component["html"] = post_process_html(component["html"], request)
 
     @staticmethod
-    def as_json_schema(component: ContentComponent) -> JSONObject:
+    def as_json_schema(component: ContentComponent) -> None:
         # Not relevant as content components don't have values
-        raise NotImplementedError()
+        return None
 
 
 class EditGridField(serializers.Field):
@@ -1099,20 +1100,10 @@ class EditGrid(BasePlugin[EditGridComponent]):
         label = component.get("label", "Edit grid")
         validate = component.get("validate", {})
 
-        # Build the edit grid object properties by iterating over the child components
+        # Build the edit grid object properties by iterating over the child schemas
         properties = {}
-        for child in component["components"]:
-            schema = as_json_schema(child)
-
-            match child["type"]:
-                case "content" | "softRequiredErrors":
-                    continue
-                case "fieldset" | "columns":
-                    assert isinstance(schema, list)
-                    for child_schema in schema:
-                        properties.update(child_schema)
-                case _:
-                    properties[child["key"]] = schema
+        for child_schema in _build_child_schema_list(component):
+            properties.update(child_schema)
 
         base = {
             "title": label,
@@ -1236,6 +1227,13 @@ class Columns(BasePlugin[ColumnsComponent]):
                 data_for_visible_state=data_for_visible_state,
             )
 
+    @staticmethod
+    def as_json_schema(component: ColumnsComponent) -> list[JSONObject]:
+        schemas = []
+        for column in component["columns"]:
+            schemas.extend(_build_child_schema_list(column))
+        return schemas
+
 
 @register("fieldset")
 class Fieldset(BasePlugin[FieldsetComponent]):
@@ -1274,3 +1272,24 @@ class Fieldset(BasePlugin[FieldsetComponent]):
             components_to_ignore_hidden=_components_to_ignore_hidden,
             data_for_visible_state=data_for_visible_state,
         )
+
+    @staticmethod
+    def as_json_schema(component: FieldsetComponent) -> list[JSONObject]:
+        return _build_child_schema_list(component)
+
+
+def _build_child_schema_list(
+    component_like: EditGridComponent | FieldsetComponent | Column,
+) -> list[JSONObject]:
+    """Generate and add the children's schemas to a list."""
+    schema_list = []
+    for child in component_like["components"]:
+        child_schema = as_json_schema(child)
+        match child_schema:
+            case None:
+                continue
+            case list():
+                schema_list.extend(child_schema)
+            case _:
+                schema_list.append({child["key"]: child_schema})
+    return schema_list

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -141,8 +141,9 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin):  # noqa: UP046
         return serializers.JSONField(required=required, allow_null=True)
 
     @staticmethod
-    def as_json_schema(component: ComponentT) -> JSONObject:
-        """Return JSON schema for this formio component plugin. This routine should be
+    def as_json_schema(component: ComponentT) -> JSONObject | list[JSONObject] | None:
+        """
+        Return JSON schema for this formio component plugin. This routine should be
         implemented in the child class
         """
         raise NotImplementedError()

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -28,12 +28,7 @@ from .dynamic_config import (
 )
 from .registry import ComponentRegistry, register
 from .serializers import build_serializer as _build_serializer
-from .typing import (
-    Column,
-    ColumnsComponent,
-    Component,
-    FieldsetComponent,
-)
+from .typing import Component
 from .utils import (
     get_component_empty_value,
     get_readable_path_from_configuration_path,
@@ -145,7 +140,8 @@ def build_serializer(
 def as_json_schema(
     component: Component, _register: ComponentRegistry | None = None
 ) -> JSONObject | list[JSONObject] | None:
-    """Return a JSON schema of a component.
+    """
+    Return a JSON schema of a component.
 
     A description will be added if it is available.
 
@@ -162,45 +158,10 @@ def as_json_schema(
     :returns: None for content and softRequiredErrors components, list of JSON objects
       for columns and fieldsets, and a JSON object otherwise.
     """
-    from typing import cast  # noqa: TID251
-
     registry = _register or register
 
-    match component["type"]:
-        case "content" | "softRequiredErrors":
-            return None
-        case "columns":
-            component = cast(ColumnsComponent, component)
-            schemas = []
-            for column in component["columns"]:
-                _add_child_schemas_to_schema_list(column, schemas)
-            return schemas
-        case "fieldset":
-            component = cast(FieldsetComponent, component)
-            schemas = []
-            _add_child_schemas_to_schema_list(component, schemas)
-            return schemas
-        case _:
-            component_plugin = registry[component["type"]]
-            schema = component_plugin.as_json_schema(component)
-            if description := component.get("description"):
-                schema["description"] = description
-            return schema
-
-
-def _add_child_schemas_to_schema_list(
-    nested_component_with_children: FieldsetComponent | Column,
-    schema_list: list[JSONObject],
-):
-    """Generate and add the children's schemas to the passed schema list."""
-    for child in nested_component_with_children.get("components", []):
-        child_schema = as_json_schema(child)
-        if child_schema is None:
-            # None for content and softRequiredErrors components
-            continue
-        if isinstance(child_schema, list):
-            # Columns and fieldset components return a list of children
-            schema_list.extend(child_schema)
-        else:
-            # Other components get added to the list as a dict with their key
-            schema_list.append({child["key"]: child_schema})
+    component_plugin = registry[component["type"]]
+    schema = component_plugin.as_json_schema(component)
+    if isinstance(schema, dict) and (description := component.get("description")):
+        schema["description"] = description
+    return schema

--- a/src/openforms/forms/json_schema.py
+++ b/src/openforms/forms/json_schema.py
@@ -148,7 +148,9 @@ def generate_variable_schema(
 
     if backend_id:
         assert backend_options is not None
-        process_variable_schema(component, schema, backend_id, backend_options)
+        process_variable_schema(
+            component, schema, backend_id, backend_options, configuration_wrapper
+        )
 
     return schema
 

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -441,7 +441,8 @@ class FormVariable(models.Model):
         self._json_schema = value
 
     def as_json_schema(self) -> JSONObject:
-        """Return JSON schema of form variable.
+        """
+        Return JSON schema of form variable.
 
         If the schema generation for a formio component fails, fall back to a basic
         schema based on the data type.

--- a/src/openforms/forms/tests/test_json_schema.py
+++ b/src/openforms/forms/tests/test_json_schema.py
@@ -68,6 +68,25 @@ class GenerateJsonSchemaTests(TestCase):
                         ],
                         "dataSrc": DataSrcOptions.manual,
                     },
+                    # Components to make codecov happy. Note that putting coSign and
+                    # softRequiredErrors inside an editgrid doesn't make much sense
+                    {
+                        "type": "editgrid",
+                        "key": "editgrid",
+                        "label": "Editgrid",
+                        "components": [
+                            {
+                                "type": "coSign",
+                                "key": "coSign",
+                                "label": "Cosign",
+                            },
+                            {
+                                "type": "softRequiredErrors",
+                                "key": "softRequiredErrors",
+                                "label": "Errors",
+                            },
+                        ],
+                    },
                 ]
             }
         )
@@ -114,6 +133,7 @@ class GenerateJsonSchemaTests(TestCase):
             "auth_bsn",
             "today",
             "foo",
+            "editgrid",
         )
         schema = generate_json_schema(form, vars_to_include)
 
@@ -195,6 +215,16 @@ class GenerateJsonSchemaTests(TestCase):
                 },
             },
             "foo": {"type": "array", "title": "Foo"},
+            "editgrid": {
+                "title": "Editgrid",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+            },
         }
         expected_required = {
             "today",
@@ -206,6 +236,7 @@ class GenerateJsonSchemaTests(TestCase):
             "radio",
             "file",
             "foo",
+            "editgrid",
         }
 
         with self.subTest("properties"):

--- a/src/openforms/registrations/base.py
+++ b/src/openforms/registrations/base.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from rest_framework import serializers
 
+from openforms.formio.service import FormioConfigurationWrapper
 from openforms.formio.typing import Component
 from openforms.plugins.plugin import AbstractBasePlugin
 from openforms.typing import JSONObject
@@ -113,7 +114,11 @@ class BasePlugin[OptionsT: Options](ABC, AbstractBasePlugin):
         return None
 
     def process_variable_schema(
-        self, component: Component, schema: JSONObject, options: OptionsT
+        self,
+        component: Component,
+        schema: JSONObject,
+        options: OptionsT,
+        configuration_wrapper: FormioConfigurationWrapper,
     ):
         """Process a variable schema for this registration plugin."""
         raise NotImplementedError()

--- a/src/openforms/registrations/contrib/generic_json/plugin.py
+++ b/src/openforms/registrations/contrib/generic_json/plugin.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 
 from zgw_consumers.client import build_client
 
-from openforms.formio.service import FormioData
+from openforms.formio.service import FormioConfigurationWrapper, FormioData
 from openforms.formio.typing import (
     Component,
     EditGridComponent,
@@ -119,6 +119,7 @@ class GenericJSONRegistration(BasePlugin):
         component: Component,
         schema: JSONObject,
         options: GenericJSONOptions,
+        configuration_wrapper: FormioConfigurationWrapper,
     ):
         """Process a variable schema for the Generic JSON format.
 
@@ -131,8 +132,9 @@ class GenericJSONRegistration(BasePlugin):
 
         :param component: Component
         :param schema: JSON schema.
-        :param backend_options: Backend options, needed for the transform-to-list option of
+        :param options: Backend options, needed for the transform-to-list option of
           selectboxes components.
+        :param configuration_wrapper: Formio configuration wrapper.
         """
         transform_to_list = options["transform_to_list"]
 
@@ -183,15 +185,14 @@ class GenericJSONRegistration(BasePlugin):
                 _properties = schema["items"]["properties"]
                 assert isinstance(_properties, dict)
 
-                component = cast(EditGridComponent, component)
-                for child_component in component["components"]:
-                    child_key = child_component["key"]
-                    child_schema = _properties[child_key]
+                for child_key, child_schema in _properties.items():
+                    child_component = configuration_wrapper[child_key]
                     assert isinstance(child_schema, dict)
                     self.process_variable_schema(
                         child_component,
                         child_schema,
                         options,
+                        configuration_wrapper,
                     )
             case {"type": "partners"}:
                 assert isinstance(schema["items"], dict)

--- a/src/openforms/registrations/contrib/generic_json/plugin.py
+++ b/src/openforms/registrations/contrib/generic_json/plugin.py
@@ -121,7 +121,8 @@ class GenericJSONRegistration(BasePlugin):
         options: GenericJSONOptions,
         configuration_wrapper: FormioConfigurationWrapper,
     ):
-        """Process a variable schema for the Generic JSON format.
+        """
+        Process a variable schema for the Generic JSON format.
 
         The following components need extra attention:
         - File components: we send the content of the file encoded with base64, instead of

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -15,7 +15,8 @@ from openforms.contrib.objects_api.clients import (
     get_objecttypes_client,
 )
 from openforms.contrib.objects_api.ownership_validation import validate_object_ownership
-from openforms.formio.typing import Component, EditGridComponent
+from openforms.formio.service import FormioConfigurationWrapper
+from openforms.formio.typing import Component
 from openforms.registrations.utils import execute_unless_result_exists
 from openforms.typing import JSONObject
 from openforms.variables.service import get_static_variables
@@ -211,7 +212,11 @@ class ObjectsAPIRegistration(BasePlugin[RegistrationOptions]):
         return options["version"] == 2
 
     def process_variable_schema(
-        self, component: Component, schema: JSONObject, options: RegistrationOptions
+        self,
+        component: Component,
+        schema: JSONObject,
+        options: RegistrationOptions,
+        configuration_wrapper: FormioConfigurationWrapper,
     ):
         """Process a variable schema for the Objects API format.
 
@@ -226,6 +231,7 @@ class ObjectsAPIRegistration(BasePlugin[RegistrationOptions]):
         :param schema: JSON schema.
         :param options: Backend options, needed for the transform-to-list option of
           selectboxes components.
+        :param configuration_wrapper: Formio configuration wrapper.
         """
         assert options["version"] == 2
         transform_to_list = options["transform_to_list"]
@@ -267,21 +273,18 @@ class ObjectsAPIRegistration(BasePlugin[RegistrationOptions]):
                     schema.pop(prop)
 
             case {"type": "editgrid"}:
-                from typing import cast  # noqa: TID251
-
                 assert isinstance(schema["items"], dict)
                 _properties = schema["items"]["properties"]
                 assert isinstance(_properties, dict)
 
-                component = cast(EditGridComponent, component)
-                for child_component in component["components"]:
-                    child_key = child_component["key"]
-                    child_schema = _properties[child_key]
+                for child_key, child_schema in _properties.items():
+                    child_component = configuration_wrapper[child_key]
                     assert isinstance(child_schema, dict)
                     self.process_variable_schema(
                         child_component,
                         child_schema,
                         options,
+                        configuration_wrapper,
                     )
             case _:
                 pass

--- a/src/openforms/registrations/contrib/objects_api/plugin.py
+++ b/src/openforms/registrations/contrib/objects_api/plugin.py
@@ -218,7 +218,8 @@ class ObjectsAPIRegistration(BasePlugin[RegistrationOptions]):
         options: RegistrationOptions,
         configuration_wrapper: FormioConfigurationWrapper,
     ):
-        """Process a variable schema for the Objects API format.
+        """
+        Process a variable schema for the Objects API format.
 
         The following components need extra attention:
         - File components: we send a url or list of urls, instead of the output from the

--- a/src/openforms/registrations/service.py
+++ b/src/openforms/registrations/service.py
@@ -49,7 +49,8 @@ def process_variable_schema(
     backend_options: dict,
     configuration_wrapper: FormioConfigurationWrapper,
 ):
-    """Process a variable schema according to the given registration backend.
+    """
+    Process a variable schema according to the given registration backend.
 
     :param component: Formio component configuration of the variable.
     :param schema: JSON schema of the variable.

--- a/src/openforms/registrations/service.py
+++ b/src/openforms/registrations/service.py
@@ -1,3 +1,4 @@
+from openforms.formio.service import FormioConfigurationWrapper
 from openforms.formio.typing import Component
 from openforms.submissions.models import Submission
 from openforms.typing import JSONObject
@@ -42,7 +43,11 @@ def plugin_allows_json_schema_generation(backend: str, options: dict) -> bool:
 
 
 def process_variable_schema(
-    component: Component, schema: JSONObject, backend_id: str, backend_options: dict
+    component: Component,
+    schema: JSONObject,
+    backend_id: str,
+    backend_options: dict,
+    configuration_wrapper: FormioConfigurationWrapper,
 ):
     """Process a variable schema according to the given registration backend.
 
@@ -52,6 +57,7 @@ def process_variable_schema(
     :param backend_options: Backend options. Note: there is no check to ensure the
       options are valid and correspond to the provided ``backend_id``, so please ensure
       that they do.
+    :param configuration_wrapper: Formio configuration wrapper.
     """
     try:
         plugin = registry[backend_id]
@@ -64,4 +70,6 @@ def process_variable_schema(
             f"not implemented."
         )
 
-    plugin.process_variable_schema(component, schema, backend_options)
+    plugin.process_variable_schema(
+        component, schema, backend_options, configuration_wrapper
+    )

--- a/src/openforms/registrations/tests/test_process_variable_schema.py
+++ b/src/openforms/registrations/tests/test_process_variable_schema.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
+from openforms.formio.service import FormioConfigurationWrapper
 from openforms.forms.tests.factories import (
     FormDefinitionFactory,
     FormFactory,
@@ -24,7 +25,13 @@ class ProcessVariableSchemaTests(TestCase):
             "label": "textfield",
         }
         with self.assertRaises(InvalidBackendIdError):
-            process_variable_schema(component, {}, "non_existing_backend", {})
+            process_variable_schema(
+                component,
+                {},
+                "non_existing_backend",
+                {},
+                FormioConfigurationWrapper({"components": []}),
+            )
 
     def test_backend_that_should_not_allow_schema_generation(self):
         component = {
@@ -34,7 +41,11 @@ class ProcessVariableSchemaTests(TestCase):
         }
         with self.assertRaises(InvalidBackendIdError):
             process_variable_schema(
-                component, {}, "email", {"to_emails": ["foo@example.com"]}
+                component,
+                {},
+                "email",
+                {"to_emails": ["foo@example.com"]},
+                FormioConfigurationWrapper({"components": []}),
             )
 
 
@@ -85,7 +96,13 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
         var = form.formvariable_set.get(key="file")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "objects_api", self.options)
+        process_variable_schema(
+            component,
+            schema,
+            "objects_api",
+            self.options,
+            form_def.configuration_wrapper,
+        )
 
         expected_schema = {
             "title": "file",
@@ -120,7 +137,13 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
         var = form.formvariable_set.get(key="file_multiple")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "objects_api", self.options)
+        process_variable_schema(
+            component,
+            schema,
+            "objects_api",
+            self.options,
+            form_def.configuration_wrapper,
+        )
 
         expected_schema = {
             "title": "file multiple",
@@ -154,7 +177,13 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
         var = form.formvariable_set.get(key="selectboxes")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "objects_api", self.options)
+        process_variable_schema(
+            component,
+            schema,
+            "objects_api",
+            self.options,
+            form_def.configuration_wrapper,
+        )
 
         expected_schema = {
             "title": "Selectboxes",
@@ -207,7 +236,9 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
         var = form.formvariable_set.get(key="selectboxes_as_list")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "objects_api", options)
+        process_variable_schema(
+            component, schema, "objects_api", options, form_def.configuration_wrapper
+        )
 
         expected_schema = {
             "title": "Selectboxes as list",
@@ -289,7 +320,13 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
         var = form.formvariable_set.get(key="editgrid")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "objects_api", self.options)
+        process_variable_schema(
+            component,
+            schema,
+            "objects_api",
+            self.options,
+            form_def.configuration_wrapper,
+        )
 
         expected_schema = {
             "title": "Editgrid",
@@ -373,7 +410,9 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
         var = form.formvariable_set.get(key="file")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "json_dump", self.options)
+        process_variable_schema(
+            component, schema, "json_dump", self.options, form_def.configuration_wrapper
+        )
 
         expected_schema = {
             "title": "file",
@@ -413,7 +452,9 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
         var = form.formvariable_set.get(key="file_multiple")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "json_dump", self.options)
+        process_variable_schema(
+            component, schema, "json_dump", self.options, form_def.configuration_wrapper
+        )
 
         expected_schema = {
             "title": "file multiple",
@@ -455,7 +496,9 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
         var = form.formvariable_set.get(key="selectboxes")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "json_dump", self.options)
+        process_variable_schema(
+            component, schema, "json_dump", self.options, form_def.configuration_wrapper
+        )
 
         expected_schema = {
             "title": "Selectboxes",
@@ -503,7 +546,9 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
         var = form.formvariable_set.get(key="selectboxes_as_list")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "json_dump", options)
+        process_variable_schema(
+            component, schema, "json_dump", options, form_def.configuration_wrapper
+        )
 
         expected_schema = {
             "title": "Selectboxes as list",
@@ -585,7 +630,9 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
         var = form.formvariable_set.get(key="editgrid")
         schema = var.as_json_schema()
 
-        process_variable_schema(component, schema, "json_dump", self.options)
+        process_variable_schema(
+            component, schema, "json_dump", self.options, form_def.configuration_wrapper
+        )
 
         expected_schema = {
             "title": "Editgrid",

--- a/src/openforms/registrations/tests/test_process_variable_schema.py
+++ b/src/openforms/registrations/tests/test_process_variable_schema.py
@@ -260,6 +260,24 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
                                 ],
                                 "validate": {"required": False},
                             },
+                            {
+                                "key": "fieldset",
+                                "type": "fieldset",
+                                "label": "Fieldset",
+                                "components": [
+                                    {
+                                        "type": "file",
+                                        "key": "fileInFieldset",
+                                        "label": "File in fieldset",
+                                        "storage": "url",
+                                        "url": "",
+                                        "useConfigFiletypes": False,
+                                        "filePattern": "",
+                                        "file": {"type": [], "allowedTypesLabels": []},
+                                        "multiple": False,
+                                    }
+                                ],
+                            },
                         ],
                     },
                 ]
@@ -299,8 +317,13 @@ class ProcessVariableSchemaObjectsApiTests(TestCase):
                         "required": ["a", "b"],
                         "additionalProperties": False,
                     },
+                    "fileInFieldset": {
+                        "type": "string",
+                        "title": "File in fieldset",
+                        "oneOf": [{"format": "uri"}, {"pattern": "^$"}],
+                    },
                 },
-                "required": ["file", "file_multiple", "selectboxes"],
+                "required": ["file", "file_multiple", "selectboxes", "fileInFieldset"],
                 "additionalProperties": False,
             },
         }
@@ -533,6 +556,24 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
                                 ],
                                 "validate": {"required": False},
                             },
+                            {
+                                "key": "fieldset",
+                                "type": "fieldset",
+                                "label": "Fieldset",
+                                "components": [
+                                    {
+                                        "type": "file",
+                                        "key": "fileInFieldset",
+                                        "label": "File in fieldset",
+                                        "storage": "url",
+                                        "url": "",
+                                        "useConfigFiletypes": False,
+                                        "filePattern": "",
+                                        "file": {"type": [], "allowedTypesLabels": []},
+                                        "multiple": False,
+                                    }
+                                ],
+                            },
                         ],
                     },
                 ]
@@ -585,8 +626,18 @@ class ProcessVariableSchemaGenericJsonTests(TestCase):
                         "required": ["a", "b"],
                         "additionalProperties": False,
                     },
+                    "fileInFieldset": {
+                        "title": "File in fieldset",
+                        "type": ["null", "object"],
+                        "properties": {
+                            "file_name": {"type": "string"},
+                            "content": {"type": "string", "format": "base64"},
+                        },
+                        "required": ["file_name", "content"],
+                        "additionalProperties": False,
+                    },
                 },
-                "required": ["file", "file_multiple", "selectboxes"],
+                "required": ["file", "file_multiple", "selectboxes", "fileInFieldset"],
                 "additionalProperties": False,
             },
         }


### PR DESCRIPTION
Closes #6148

[skip: e2e]

**Changes**

* Ensured children of editgrids are processed properly (NOTE: only need to backport this!)
* Moved all JSON schema generation to the component registry (cleanup)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
