### PR TITLE
cleanup after removing camunda registration backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ on:
 env:
   IMAGE_NAME: openformulieren/open-forms
   DJANGO_SETTINGS_MODULE: openforms.conf.ci
-  CAMUNDA_API_BASE_URL: http://localhost:8080/engine-rest/
-  CAMUNDA_USER: demo
-  CAMUNDA_PASSWORD: demo
   TEST_REPORT_RANDOM_STATE: 'true'
   OTEL_SERVICE_NAME: openforms-ci
 
@@ -78,21 +75,7 @@ jobs:
       - name: Start CI docker services
         run: |
           docker compose -f docker-compose.ci.yml up -d
-          docker compose -f docker-compose.camunda.yml up -d
         working-directory: docker
-
-      - name: Wait for Camunda to be up
-        run: |
-          endpoint="${CAMUNDA_API_BASE_URL}version"
-          version=""
-
-          until [ $version ]; do
-            echo "Checking if Camunda at ${CAMUNDA_API_BASE_URL} is up..."
-            version=$(curl -u ${CAMUNDA_USER}:${CAMUNDA_PASSWORD} "$endpoint" -s | jq -r ".version")
-            sleep 2
-          done
-
-          echo "Running Camunda $version"
 
       - name: Run tests
         run: |
@@ -159,21 +142,7 @@ jobs:
       - name: Start CI docker services
         run: |
           docker compose -f docker-compose.ci.yml up -d
-          docker compose -f docker-compose.camunda.yml up -d
         working-directory: docker
-
-      - name: Wait for Camunda to be up
-        run: |
-          endpoint="${CAMUNDA_API_BASE_URL}version"
-          version=""
-
-          until [ $version ]; do
-            echo "Checking if Camunda at ${CAMUNDA_API_BASE_URL} is up..."
-            version=$(curl -u ${CAMUNDA_USER}:${CAMUNDA_PASSWORD} "$endpoint" -s | jq -r ".version")
-            sleep 2
-          done
-
-          echo "Running Camunda $version"
 
       - name: Run tests
         run: |

--- a/docs/configuration/dmn/camunda.rst
+++ b/docs/configuration/dmn/camunda.rst
@@ -4,7 +4,7 @@
 Camunda 7
 =========
 
-Camunda_ is a process engine using BPM models. Open Forms supports Camunda 7.x
+Camunda_ is a process orchestrator with a DMN engine. Open Forms supports Camunda 7.x
 
 .. note::
 

--- a/src/openforms/contrib/camunda/tests/utils.py
+++ b/src/openforms/contrib/camunda/tests/utils.py
@@ -1,44 +1,23 @@
 import base64
-import os
-from unittest import skipIf
-from urllib.parse import urlparse
 
-from django_camunda.client import Camunda, get_client
 from django_camunda.models import CamundaConfig
 
-from openforms.tests.utils import can_connect
 
-# support configuration through envvars for tests/CI
-CAMUNDA_USER = os.getenv("CAMUNDA_USER", "demo")
-CAMUNDA_PASSWORD = os.getenv("CAMUNDA_PASSWORD", "demo")
-CAMUNDA_API_BASE_URL = os.getenv(
-    "CAMUNDA_API_BASE_URL", "http://localhost:8080/engine-rest/"
-)
-
-
-def require_camunda(func):
+class CamundaMixin:
     """
-    Decorator to skip test(s) if Camunda is not available.
+    Mixin to use Camunda in unit tests
     """
-    parsed = urlparse(CAMUNDA_API_BASE_URL)
-    conn_available = can_connect(parsed.netloc)
-    reason = (
-        f"Cannot connect to Camunda host '{CAMUNDA_API_BASE_URL}'. You can bring "
-        "the services up with docker-compose, see the 'docker/camunda' folder."
-    )
-    return skipIf(not conn_available, reason)(func)
 
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
-def get_camunda_client() -> Camunda:
-    """
-    Get a camunda client object that can connect to the configured instance.
-    """
-    parsed = urlparse(CAMUNDA_API_BASE_URL)
-    basic_auth = f"{CAMUNDA_USER}:{CAMUNDA_PASSWORD}"
-    b64 = base64.b64encode(basic_auth.encode()).decode()
-    config = CamundaConfig(
-        root_url=f"{parsed.scheme}://{parsed.netloc}",
-        rest_api_path=parsed.path[1:],  # cut off leading slash
-        auth_header=f"Basic {b64}",
-    )
-    return get_client(config=config)
+        # use docker compose fixtures
+        cls.config = CamundaConfig.get_solo()
+        cls.config.root_url = "http://localhost:8080/"
+        cls.config.rest_api_path = "engine-rest/"
+        b64 = base64.b64encode(b"demo:demo").decode()
+        cls.config.auth_header = f"Basic {b64}"
+        cls.config.save()
+
+        cls.addClassCleanup(CamundaConfig.clear_cache)

--- a/src/openforms/dmn/contrib/camunda/plugin.py
+++ b/src/openforms/dmn/contrib/camunda/plugin.py
@@ -47,7 +47,7 @@ def handle_camunda_error(error: requests.HTTPError):
 
     try:
         response_body = error.response.json()
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, requests.exceptions.JSONDecodeError) as exc:
         log.exception("json_body_decode_failure", exc_info=exc)
     else:
         log.error("camunda_request_failure", body=response_body)

--- a/src/openforms/dmn/contrib/camunda/tests/test_plugin.py
+++ b/src/openforms/dmn/contrib/camunda/tests/test_plugin.py
@@ -15,14 +15,14 @@ variables, see :mod:`openforms.contrib.camunda.tests.utils`.
 """
 
 from functools import partial
-from unittest.mock import patch
 
 from django.test import TestCase
 
 import requests_mock
 from lxml import etree
 
-from openforms.contrib.camunda.tests.utils import get_camunda_client, require_camunda
+from openforms.contrib.camunda.tests.utils import CamundaMixin
+from openforms.utils.tests.vcr import OFVCRMixin
 
 from ....registry import register
 from ....service import evaluate_dmn
@@ -31,20 +31,7 @@ _evaluate_dmn = partial(evaluate_dmn, "camunda7")
 plugin = register["camunda7"]
 
 
-@require_camunda
-class CamundaDMNTests(TestCase):
-    def setUp(self):
-        super().setUp()
-
-        # patch the get_client call to return our configured client
-        self.camunda_client = get_camunda_client()
-        patcher = patch(
-            "openforms.dmn.contrib.camunda.plugin.get_client",
-            return_value=self.camunda_client,
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
+class CamundaDMNTests(CamundaMixin, OFVCRMixin, TestCase):
     def test_list_process_definitions(self):
         definitions = plugin.get_available_decision_definitions()
 
@@ -111,11 +98,11 @@ class CamundaDMNTests(TestCase):
             requests_mock.Mocker() as m,
         ):
             m.get(
-                f"{self.camunda_client.root_url}decision-definition",
+                f"{self.config.api_root}decision-definition",
                 json=[{"id": "mocked-id"}],
             )
             m.post(
-                f"{self.camunda_client.root_url}decision-definition/mocked-id/evaluate",
+                f"{self.config.api_root}decision-definition/mocked-id/evaluate",
                 status_code=500,
                 text="errored",
             )

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_evaluate_with_pinned_version.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_evaluate_with_pinned_version.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&version=1
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":1,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b28d040f-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:1:b2a34b36-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"variables": {"invoiceCategory": {"type": "String", "value": "Misc"},
+      "amount": {"type": "Double", "value": 752.2}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '117'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa/evaluate
+  response:
+    body:
+      string: '[{"invoiceClassification":{"type":"String","value":"budget","valueInfo":{}}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_evaluate_without_pinned_version.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_evaluate_without_pinned_version.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&latestVersion=true
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b2a60a59-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:b2aa501e-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"variables": {"invoiceCategory": {"type": "String", "value": "Travel Expenses"},
+      "amount": {"type": "Double", "value": 30.0}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa/evaluate
+  response:
+    body:
+      string: '[{"invoiceClassification":{"type":"String","value":"day-to-day expense","valueInfo":{}}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_evaluation_bad_input.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_evaluation_bad_input.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&latestVersion=true
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b2a60a59-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:b2aa501e-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:46:38 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"variables": {"amount": {"type": "Double", "value": 30.0}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '60'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa/evaluate
+  response:
+    body:
+      string: '{"type":"RestException","message":"Cannot evaluate decision invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa:
+        Exception while evaluating decision with key ''null''"}'
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:46:38 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_get_decision_definition_versions.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_get_decision_definition_versions.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&sortBy=version&sortOrder=desc
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b2a60a59-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:b2aa501e-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null},{"id":"invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":1,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b28d040f-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:1:b2a34b36-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:42 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_get_inputs_outputs.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_get_inputs_outputs.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&version=1
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":1,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b28d040f-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:1:b2a34b36-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa/xml
+  response:
+    body:
+      string: '{"id":"invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa","dmnXml":"<?xml
+        version=\"1.0\" encoding=\"UTF-8\"?>\n<definitions xmlns=\"https://www.omg.org/spec/DMN/20191111/MODEL/\"
+        xmlns:dmndi=\"https://www.omg.org/spec/DMN/20191111/DMNDI/\" xmlns:dc=\"http://www.omg.org/spec/DMN/20180521/DC/\"
+        xmlns:di=\"http://www.omg.org/spec/DMN/20180521/DI/\" xmlns:camunda=\"http://camunda.org/schema/1.0/dmn\"
+        id=\"invoiceBusinessDecisions\" name=\"Invoice Business Decisions\" namespace=\"http://camunda.org/schema/1.0/dmn\">\n  <decision
+        id=\"invoiceClassification\" name=\"Invoice Classification\">\n    <decisionTable
+        id=\"decisionTable\">\n      <input id=\"clause1\" label=\"Invoice Amount\"
+        camunda:inputVariable=\"\">\n        <inputExpression id=\"inputExpression1\"
+        typeRef=\"double\">\n          <text>amount</text>\n        </inputExpression>\n      </input>\n      <input
+        id=\"InputClause_15qmk0v\" label=\"Invoice Category\" camunda:inputVariable=\"\">\n        <inputExpression
+        id=\"LiteralExpression_1oi86cw\" typeRef=\"string\">\n          <text>invoiceCategory</text>\n        </inputExpression>\n        <inputValues
+        id=\"UnaryTests_0kisa67\">\n          <text>\"Travel Expenses\",\"Misc\",\"Software
+        License Costs\"</text>\n        </inputValues>\n      </input>\n      <output
+        id=\"clause3\" label=\"Classification\" name=\"invoiceClassification\" typeRef=\"string\">\n        <outputValues
+        id=\"UnaryTests_08dl8wf\">\n          <text>\"day-to-day expense\",\"budget\",\"exceptional\"</text>\n        </outputValues>\n      </output>\n      <rule
+        id=\"DecisionRule_1of5a87\">\n        <inputEntry id=\"LiteralExpression_0yrqmtg\">\n          <text>&lt;
+        250</text>\n        </inputEntry>\n        <inputEntry id=\"UnaryTests_06edsin\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_046antl\">\n          <text>\"day-to-day expense\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"DecisionRule_1ak4z14\">\n        <inputEntry id=\"LiteralExpression_0qmsef6\">\n          <text>[250..1000]</text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_09b743h\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_05xxvip\">\n          <text>\"budget\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-4\">\n        <inputEntry id=\"UnaryTests_0le0gl8\">\n          <text>&gt;
+        1000</text>\n        </inputEntry>\n        <inputEntry id=\"UnaryTests_0pukamj\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_1e76ugx\">\n          <text>\"exceptional\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"DecisionRule_0cuxolz\">\n        <inputEntry id=\"LiteralExpression_05lyjk7\">\n          <text></text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_0ve4z34\">\n          <text>\"Travel Expenses\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_1bq8m03\">\n          <text>\"day-to-day expense\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-2\">\n        <inputEntry id=\"UnaryTests_1nssdlk\">\n          <text></text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_01ppb4l\">\n          <text>\"Software License Costs\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_0y00iih\">\n          <text>\"budget\"</text>\n        </outputEntry>\n      </rule>\n    </decisionTable>\n  </decision>\n  <decision
+        id=\"invoice-assign-approver\" name=\"Assign Approver Group\">\n    <informationRequirement
+        id=\"InformationRequirement_1kkeocv\">\n      <requiredDecision href=\"#invoiceClassification\"
+        />\n    </informationRequirement>\n    <decisionTable id=\"DecisionTable_16o85h8\"
+        hitPolicy=\"COLLECT\">\n      <input id=\"InputClause_0og2hn3\" label=\"Invoice
+        Classification\" camunda:inputVariable=\"\">\n        <inputExpression id=\"LiteralExpression_1vywt5q\"
+        typeRef=\"string\">\n          <text>invoiceClassification</text>\n        </inputExpression>\n        <inputValues
+        id=\"UnaryTests_0by7qiy\">\n          <text>\"day-to-day expense\",\"budget\",\"exceptional\"</text>\n        </inputValues>\n      </input>\n      <output
+        id=\"OutputClause_1cthd0w\" label=\"Approver Group\" name=\"result\" typeRef=\"string\">\n        <outputValues
+        id=\"UnaryTests_1ulmk9p\">\n          <text>\"management\",\"accounting\",\"sales\"</text>\n        </outputValues>\n      </output>\n      <rule
+        id=\"row-49839158-1\">\n        <inputEntry id=\"UnaryTests_18ifczd\">\n          <text>\"day-to-day
+        expense\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_0sgxulk\">\n          <text>\"accounting\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-6\">\n        <inputEntry id=\"UnaryTests_0kfae8g\">\n          <text>\"day-to-day
+        expense\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_1iksrro\">\n          <text>\"sales\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-5\">\n        <inputEntry id=\"UnaryTests_08cevwi\">\n          <text>\"budget\",
+        \"exceptional\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_0c7hz8g\">\n          <text>\"management\"</text>\n        </outputEntry>\n      </rule>\n    </decisionTable>\n  </decision>\n  <dmndi:DMNDI>\n    <dmndi:DMNDiagram
+        id=\"DMNDiagram_1cuuevk\">\n      <dmndi:DMNShape id=\"DMNShape_1abvt5s\"
+        dmnElementRef=\"invoiceClassification\">\n        <dc:Bounds height=\"55\"
+        width=\"100\" x=\"393\" y=\"325\" />\n      </dmndi:DMNShape>\n      <dmndi:DMNShape
+        id=\"DMNShape_1ay7af5\" dmnElementRef=\"invoice-assign-approver\">\n        <dc:Bounds
+        height=\"55\" width=\"100\" x=\"464\" y=\"194\" />\n      </dmndi:DMNShape>\n      <dmndi:DMNEdge
+        id=\"DMNEdge_1wn1950\" dmnElementRef=\"InformationRequirement_1kkeocv\">\n        <di:waypoint
+        x=\"458\" y=\"325\" />\n        <di:waypoint x=\"498\" y=\"249\" />\n      </dmndi:DMNEdge>\n    </dmndi:DMNDiagram>\n  </dmndi:DMNDI>\n</definitions>\n"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_get_inputs_outputs_table_with_dependency.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_get_inputs_outputs_table_with_dependency.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoice-assign-approver&version=1
+  response:
+    body:
+      string: '[{"id":"invoice-assign-approver:1:b2a39958-3c8c-11f1-b652-520740ce9cfa","key":"invoice-assign-approver","category":"http://camunda.org/schema/1.0/dmn","name":"Assign
+        Approver Group","version":1,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b28d040f-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:1:b2a34b36-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition/invoice-assign-approver:1:b2a39958-3c8c-11f1-b652-520740ce9cfa/xml
+  response:
+    body:
+      string: '{"id":"invoice-assign-approver:1:b2a39958-3c8c-11f1-b652-520740ce9cfa","dmnXml":"<?xml
+        version=\"1.0\" encoding=\"UTF-8\"?>\n<definitions xmlns=\"https://www.omg.org/spec/DMN/20191111/MODEL/\"
+        xmlns:dmndi=\"https://www.omg.org/spec/DMN/20191111/DMNDI/\" xmlns:dc=\"http://www.omg.org/spec/DMN/20180521/DC/\"
+        xmlns:di=\"http://www.omg.org/spec/DMN/20180521/DI/\" xmlns:camunda=\"http://camunda.org/schema/1.0/dmn\"
+        id=\"invoiceBusinessDecisions\" name=\"Invoice Business Decisions\" namespace=\"http://camunda.org/schema/1.0/dmn\">\n  <decision
+        id=\"invoiceClassification\" name=\"Invoice Classification\">\n    <decisionTable
+        id=\"decisionTable\">\n      <input id=\"clause1\" label=\"Invoice Amount\"
+        camunda:inputVariable=\"\">\n        <inputExpression id=\"inputExpression1\"
+        typeRef=\"double\">\n          <text>amount</text>\n        </inputExpression>\n      </input>\n      <input
+        id=\"InputClause_15qmk0v\" label=\"Invoice Category\" camunda:inputVariable=\"\">\n        <inputExpression
+        id=\"LiteralExpression_1oi86cw\" typeRef=\"string\">\n          <text>invoiceCategory</text>\n        </inputExpression>\n        <inputValues
+        id=\"UnaryTests_0kisa67\">\n          <text>\"Travel Expenses\",\"Misc\",\"Software
+        License Costs\"</text>\n        </inputValues>\n      </input>\n      <output
+        id=\"clause3\" label=\"Classification\" name=\"invoiceClassification\" typeRef=\"string\">\n        <outputValues
+        id=\"UnaryTests_08dl8wf\">\n          <text>\"day-to-day expense\",\"budget\",\"exceptional\"</text>\n        </outputValues>\n      </output>\n      <rule
+        id=\"DecisionRule_1of5a87\">\n        <inputEntry id=\"LiteralExpression_0yrqmtg\">\n          <text>&lt;
+        250</text>\n        </inputEntry>\n        <inputEntry id=\"UnaryTests_06edsin\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_046antl\">\n          <text>\"day-to-day expense\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"DecisionRule_1ak4z14\">\n        <inputEntry id=\"LiteralExpression_0qmsef6\">\n          <text>[250..1000]</text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_09b743h\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_05xxvip\">\n          <text>\"budget\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-4\">\n        <inputEntry id=\"UnaryTests_0le0gl8\">\n          <text>&gt;
+        1000</text>\n        </inputEntry>\n        <inputEntry id=\"UnaryTests_0pukamj\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_1e76ugx\">\n          <text>\"exceptional\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"DecisionRule_0cuxolz\">\n        <inputEntry id=\"LiteralExpression_05lyjk7\">\n          <text></text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_0ve4z34\">\n          <text>\"Travel Expenses\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_1bq8m03\">\n          <text>\"day-to-day expense\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-2\">\n        <inputEntry id=\"UnaryTests_1nssdlk\">\n          <text></text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_01ppb4l\">\n          <text>\"Software License Costs\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_0y00iih\">\n          <text>\"budget\"</text>\n        </outputEntry>\n      </rule>\n    </decisionTable>\n  </decision>\n  <decision
+        id=\"invoice-assign-approver\" name=\"Assign Approver Group\">\n    <informationRequirement
+        id=\"InformationRequirement_1kkeocv\">\n      <requiredDecision href=\"#invoiceClassification\"
+        />\n    </informationRequirement>\n    <decisionTable id=\"DecisionTable_16o85h8\"
+        hitPolicy=\"COLLECT\">\n      <input id=\"InputClause_0og2hn3\" label=\"Invoice
+        Classification\" camunda:inputVariable=\"\">\n        <inputExpression id=\"LiteralExpression_1vywt5q\"
+        typeRef=\"string\">\n          <text>invoiceClassification</text>\n        </inputExpression>\n        <inputValues
+        id=\"UnaryTests_0by7qiy\">\n          <text>\"day-to-day expense\",\"budget\",\"exceptional\"</text>\n        </inputValues>\n      </input>\n      <output
+        id=\"OutputClause_1cthd0w\" label=\"Approver Group\" name=\"result\" typeRef=\"string\">\n        <outputValues
+        id=\"UnaryTests_1ulmk9p\">\n          <text>\"management\",\"accounting\",\"sales\"</text>\n        </outputValues>\n      </output>\n      <rule
+        id=\"row-49839158-1\">\n        <inputEntry id=\"UnaryTests_18ifczd\">\n          <text>\"day-to-day
+        expense\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_0sgxulk\">\n          <text>\"accounting\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-6\">\n        <inputEntry id=\"UnaryTests_0kfae8g\">\n          <text>\"day-to-day
+        expense\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_1iksrro\">\n          <text>\"sales\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-5\">\n        <inputEntry id=\"UnaryTests_08cevwi\">\n          <text>\"budget\",
+        \"exceptional\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_0c7hz8g\">\n          <text>\"management\"</text>\n        </outputEntry>\n      </rule>\n    </decisionTable>\n  </decision>\n  <dmndi:DMNDI>\n    <dmndi:DMNDiagram
+        id=\"DMNDiagram_1cuuevk\">\n      <dmndi:DMNShape id=\"DMNShape_1abvt5s\"
+        dmnElementRef=\"invoiceClassification\">\n        <dc:Bounds height=\"55\"
+        width=\"100\" x=\"393\" y=\"325\" />\n      </dmndi:DMNShape>\n      <dmndi:DMNShape
+        id=\"DMNShape_1ay7af5\" dmnElementRef=\"invoice-assign-approver\">\n        <dc:Bounds
+        height=\"55\" width=\"100\" x=\"464\" y=\"194\" />\n      </dmndi:DMNShape>\n      <dmndi:DMNEdge
+        id=\"DMNEdge_1wn1950\" dmnElementRef=\"InformationRequirement_1kkeocv\">\n        <di:waypoint
+        x=\"458\" y=\"325\" />\n        <di:waypoint x=\"498\" y=\"249\" />\n      </dmndi:DMNEdge>\n    </dmndi:DMNDiagram>\n  </dmndi:DMNDI>\n</definitions>\n"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_list_process_definitions.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_list_process_definitions.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?latestVersion=true
+  response:
+    body:
+      string: '[{"id":"invoice-assign-approver:2:b2aa7730-3c8c-11f1-b652-520740ce9cfa","key":"invoice-assign-approver","category":"http://camunda.org/schema/1.0/dmn","name":"Assign
+        Approver Group","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b2a60a59-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:b2aa501e-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null},{"id":"invoiceClassification:2:b2aa772f-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b2a60a59-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:b2aa501e-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:04 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_retrieve_xml_looks_like_xml.yaml
+++ b/src/openforms/dmn/contrib/camunda/tests/vcr_cassettes/test_plugin/CamundaDMNTests/test_retrieve_xml_looks_like_xml.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&version=1
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":1,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"b28d040f-3c8c-11f1-b652-520740ce9cfa","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:1:b2a34b36-3c8c-11f1-b652-520740ce9cfa","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa/xml
+  response:
+    body:
+      string: '{"id":"invoiceClassification:1:b2a37247-3c8c-11f1-b652-520740ce9cfa","dmnXml":"<?xml
+        version=\"1.0\" encoding=\"UTF-8\"?>\n<definitions xmlns=\"https://www.omg.org/spec/DMN/20191111/MODEL/\"
+        xmlns:dmndi=\"https://www.omg.org/spec/DMN/20191111/DMNDI/\" xmlns:dc=\"http://www.omg.org/spec/DMN/20180521/DC/\"
+        xmlns:di=\"http://www.omg.org/spec/DMN/20180521/DI/\" xmlns:camunda=\"http://camunda.org/schema/1.0/dmn\"
+        id=\"invoiceBusinessDecisions\" name=\"Invoice Business Decisions\" namespace=\"http://camunda.org/schema/1.0/dmn\">\n  <decision
+        id=\"invoiceClassification\" name=\"Invoice Classification\">\n    <decisionTable
+        id=\"decisionTable\">\n      <input id=\"clause1\" label=\"Invoice Amount\"
+        camunda:inputVariable=\"\">\n        <inputExpression id=\"inputExpression1\"
+        typeRef=\"double\">\n          <text>amount</text>\n        </inputExpression>\n      </input>\n      <input
+        id=\"InputClause_15qmk0v\" label=\"Invoice Category\" camunda:inputVariable=\"\">\n        <inputExpression
+        id=\"LiteralExpression_1oi86cw\" typeRef=\"string\">\n          <text>invoiceCategory</text>\n        </inputExpression>\n        <inputValues
+        id=\"UnaryTests_0kisa67\">\n          <text>\"Travel Expenses\",\"Misc\",\"Software
+        License Costs\"</text>\n        </inputValues>\n      </input>\n      <output
+        id=\"clause3\" label=\"Classification\" name=\"invoiceClassification\" typeRef=\"string\">\n        <outputValues
+        id=\"UnaryTests_08dl8wf\">\n          <text>\"day-to-day expense\",\"budget\",\"exceptional\"</text>\n        </outputValues>\n      </output>\n      <rule
+        id=\"DecisionRule_1of5a87\">\n        <inputEntry id=\"LiteralExpression_0yrqmtg\">\n          <text>&lt;
+        250</text>\n        </inputEntry>\n        <inputEntry id=\"UnaryTests_06edsin\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_046antl\">\n          <text>\"day-to-day expense\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"DecisionRule_1ak4z14\">\n        <inputEntry id=\"LiteralExpression_0qmsef6\">\n          <text>[250..1000]</text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_09b743h\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_05xxvip\">\n          <text>\"budget\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-4\">\n        <inputEntry id=\"UnaryTests_0le0gl8\">\n          <text>&gt;
+        1000</text>\n        </inputEntry>\n        <inputEntry id=\"UnaryTests_0pukamj\">\n          <text>\"Misc\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_1e76ugx\">\n          <text>\"exceptional\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"DecisionRule_0cuxolz\">\n        <inputEntry id=\"LiteralExpression_05lyjk7\">\n          <text></text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_0ve4z34\">\n          <text>\"Travel Expenses\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_1bq8m03\">\n          <text>\"day-to-day expense\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-2\">\n        <inputEntry id=\"UnaryTests_1nssdlk\">\n          <text></text>\n        </inputEntry>\n        <inputEntry
+        id=\"UnaryTests_01ppb4l\">\n          <text>\"Software License Costs\"</text>\n        </inputEntry>\n        <outputEntry
+        id=\"LiteralExpression_0y00iih\">\n          <text>\"budget\"</text>\n        </outputEntry>\n      </rule>\n    </decisionTable>\n  </decision>\n  <decision
+        id=\"invoice-assign-approver\" name=\"Assign Approver Group\">\n    <informationRequirement
+        id=\"InformationRequirement_1kkeocv\">\n      <requiredDecision href=\"#invoiceClassification\"
+        />\n    </informationRequirement>\n    <decisionTable id=\"DecisionTable_16o85h8\"
+        hitPolicy=\"COLLECT\">\n      <input id=\"InputClause_0og2hn3\" label=\"Invoice
+        Classification\" camunda:inputVariable=\"\">\n        <inputExpression id=\"LiteralExpression_1vywt5q\"
+        typeRef=\"string\">\n          <text>invoiceClassification</text>\n        </inputExpression>\n        <inputValues
+        id=\"UnaryTests_0by7qiy\">\n          <text>\"day-to-day expense\",\"budget\",\"exceptional\"</text>\n        </inputValues>\n      </input>\n      <output
+        id=\"OutputClause_1cthd0w\" label=\"Approver Group\" name=\"result\" typeRef=\"string\">\n        <outputValues
+        id=\"UnaryTests_1ulmk9p\">\n          <text>\"management\",\"accounting\",\"sales\"</text>\n        </outputValues>\n      </output>\n      <rule
+        id=\"row-49839158-1\">\n        <inputEntry id=\"UnaryTests_18ifczd\">\n          <text>\"day-to-day
+        expense\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_0sgxulk\">\n          <text>\"accounting\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-6\">\n        <inputEntry id=\"UnaryTests_0kfae8g\">\n          <text>\"day-to-day
+        expense\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_1iksrro\">\n          <text>\"sales\"</text>\n        </outputEntry>\n      </rule>\n      <rule
+        id=\"row-49839158-5\">\n        <inputEntry id=\"UnaryTests_08cevwi\">\n          <text>\"budget\",
+        \"exceptional\"</text>\n        </inputEntry>\n        <outputEntry id=\"LiteralExpression_0c7hz8g\">\n          <text>\"management\"</text>\n        </outputEntry>\n      </rule>\n    </decisionTable>\n  </decision>\n  <dmndi:DMNDI>\n    <dmndi:DMNDiagram
+        id=\"DMNDiagram_1cuuevk\">\n      <dmndi:DMNShape id=\"DMNShape_1abvt5s\"
+        dmnElementRef=\"invoiceClassification\">\n        <dc:Bounds height=\"55\"
+        width=\"100\" x=\"393\" y=\"325\" />\n      </dmndi:DMNShape>\n      <dmndi:DMNShape
+        id=\"DMNShape_1ay7af5\" dmnElementRef=\"invoice-assign-approver\">\n        <dc:Bounds
+        height=\"55\" width=\"100\" x=\"464\" y=\"194\" />\n      </dmndi:DMNShape>\n      <dmndi:DMNEdge
+        id=\"DMNEdge_1wn1950\" dmnElementRef=\"InformationRequirement_1kkeocv\">\n        <di:waypoint
+        x=\"458\" y=\"325\" />\n        <di:waypoint x=\"498\" y=\"249\" />\n      </dmndi:DMNEdge>\n    </dmndi:DMNDiagram>\n  </dmndi:DMNDI>\n</definitions>\n"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:42:56 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1


### PR DESCRIPTION
Closes #5223

**Changes**
* this comment - https://github.com/open-formulieren/open-forms/pull/6189#discussion_r3110778022
* convert camunda tests to vcr and remove camunda docker from CI

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
