### PR TITLE
[#6128] hide empty label and value pairs for radio fields

### DIFF
--- a/src/openforms/formio/dynamic_config/dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/dynamic_options.py
@@ -127,6 +127,7 @@ def add_options_to_config(
         [
             {"label": escaped_label, "value": escaped_key}
             for escaped_key, escaped_label in items_array
+            if escaped_label
         ],
         missing=dict,
     )

--- a/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
@@ -764,6 +764,70 @@ class TestDynamicConfigAddingOptions(TestCase):
             ],
         )
 
+    def test_empty_label_value_pairs(self):
+        submission = SubmissionFactory.create()
+
+        with self.subTest("With empty label & value"):
+            configuration = {
+                "display": "form",
+                "components": [
+                    {
+                        "key": "radio",
+                        "type": "radio",
+                        "values": [{"label": "", "value": ""}],
+                        "openForms": {
+                            "dataSrc": "variable",
+                            "translations": {},
+                            "itemsExpression": {"var": "radioOptions"},
+                        },
+                    }
+                ],
+            }
+
+            rewrite_formio_components(
+                FormioConfigurationWrapper(configuration),
+                submission,
+                FormioData({"radioOptions": [["bar", "Foo"], ["", ""]]}),
+            )
+
+            self.assertEqual(
+                configuration["components"][0]["values"],
+                [
+                    {"label": "Foo", "value": "bar"},
+                ],
+            )
+
+        with self.subTest("With non-empty label & empty value"):
+            configuration = {
+                "display": "form",
+                "components": [
+                    {
+                        "key": "radio",
+                        "type": "radio",
+                        "values": [{"label": "", "value": ""}],
+                        "openForms": {
+                            "dataSrc": "variable",
+                            "translations": {},
+                            "itemsExpression": {"var": "radioOptions"},
+                        },
+                    }
+                ],
+            }
+
+            rewrite_formio_components(
+                FormioConfigurationWrapper(configuration),
+                submission,
+                FormioData({"radioOptions": [["bar", "Foo"], ["", "Bar"]]}),
+            )
+
+            self.assertEqual(
+                configuration["components"][0]["values"],
+                [
+                    {"label": "Foo", "value": "bar"},
+                    {"label": "Bar", "value": ""},
+                ],
+            )
+
 
 class TestDynamicConfigAddingOptionsForRequest(SubmissionsMixin, APITestCase):
     @tag("gh-2895")


### PR DESCRIPTION
Closes #6128 

**Changes**

Removes radio selection options where both the label and value are an empty string.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes

Tested locally using the form from this export:
[forms-export_0b55bcd5-a299-42ab-8282-cd8ad85a5627.zip](https://github.com/user-attachments/files/26928757/forms-export_0b55bcd5-a299-42ab-8282-cd8ad85a5627.zip)
