### PR TITLE
Mark 3.3.x as end of life

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Changelog
         `latest <https://open-forms.readthedocs.io/en/latest/changelog.html>`_ docs
         version.
 
+3.3.16 (2026-04-21)
+===================
+
+Final bugfix release in the ``3.3.x`` series.
+
+* [:backend:`5924`] Fixed validation messages being linked to the wrong (non-applicable)
+  steps, causing confusing error mesages in the public frontend.
+* [:backend:`6171`] Fixed missing required XML-attributes in StUF-ZDS messages.
+* Applied latest available security patches of the libraries that we use.
+
 3.5.0 "Kjeld" (2026-04-15)
 ==========================
 

--- a/docker/ci/config.json
+++ b/docker/ci/config.json
@@ -6,12 +6,12 @@
       "hasExtensionsVariant": true
     },
     {
-      "gitRef": "stable/3.4.x",
+      "gitRef": "stable/3.5.x",
       "tag": null,
       "hasExtensionsVariant": true
     },
     {
-      "gitRef": "stable/3.3.x",
+      "gitRef": "stable/3.4.x",
       "tag": null,
       "hasExtensionsVariant": true
     }


### PR DESCRIPTION
* Add the release notes of the final patch release to the main changelog
* Update the config file and remove the 3.3.x entry.

Once everything is published, the `stable/3.3.x` branch can be deleted as well.

[skip: e2e]