### PR TITLE
:memo: add typechecking install instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -77,6 +77,14 @@ development machine.
        $ source env/bin/activate
        $ pip install -r requirements/dev.txt
 
+
+Optionally, if you would like to have complete LSP support in your IDE, you can install the type checking dependencies:
+
+   .. code-block:: bash
+
+       $ pip install -r requirements/type-checking.txt
+
+
 4. Install and build the frontend libraries:
 
    .. code-block:: bash


### PR DESCRIPTION
**Changes**

Added instructions for optionally installing type checking.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes

[skip: e2e]