### PR TITLE
[#6139] Fixed wrong entity type when co-signer in StUF-ZDS

### DIFF
--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -146,7 +146,7 @@
             </ZKN:heeftAlsInitiator>
         {% endif %}
         {% if co_signer %}
-            <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype="ZAKOBJ" StUF:verwerkingssoort="T">
+            <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype="ZAKBTROVR" StUF:verwerkingssoort="T">
                 <ZKN:gerelateerde>
                     <ZKN:natuurlijkPersoon StUF:entiteittype="NPS" StUF:verwerkingssoort="T">
                         <BG:inp.bsn>{{ co_signer }}</BG:inp.bsn>


### PR DESCRIPTION
Closes #6139

**Changes**

- Fixed wrong entity type in StUF-ZDS (in the zaak creation). According to the xsds/wsdls this is fixed and should be `ZAKBTROVR`.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
