### PR TITLE
Remove UMD bundle fallback

### DIFF
--- a/docs/installation/upgrade-400.rst
+++ b/docs/installation/upgrade-400.rst
@@ -7,6 +7,7 @@ Open Forms 4.0 is a major version release that contains breaking changes.
 .. contents:: Jump to
    :depth: 1
    :local:
+   :backlinks: none
 
 Removal of legacy OpenID Connect callback endpoints
 ====================================================
@@ -33,3 +34,79 @@ deployment configuration:
 * ``USE_LEGACY_ORG_OIDC_ENDPOINTS``
 * ``USE_LEGACY_OIDC_ENDPOINTS``
 
+Removal of the UMD bundle (SDK)
+===============================
+
+.. note:: Relevant for: external integration developers.
+
+Since Open Forms 3.1, we prefer ESM bundles over UMD bundles because they're smaller
+and better suited for users with slow (mobile) network connections. The UMD bundle
+support has now been removed.
+
+**Impact**
+
+If you are loading the Javascript assets from any of the following endpoints:
+
+* ``/static/sdk/bundles/open-forms-sdk.js``
+* ``/static/sdk/open-forms-sdk.js``
+
+these URLs will no longer work. Instead, replace the ``.js`` extension with ``.mjs``:
+
+* ``/static/sdk/bundles/open-forms-sdk.mjs``
+* ``/static/sdk/open-forms-sdk.mjs``
+
+Additionally, the global ``window.OpenForms`` no longer exists, and you must use
+``import`` syntax to initialize the SDK, for example:
+
+.. code-block:: html
+
+    <link href="https://open-forms.example.com/static/sdk/bundles/open-forms-sdk.mjs" rel="modulepreload" />
+    <div
+        class="open-forms-sdk-root"
+        id="openforms-container"
+        data-sdk-module="https://open-forms.example.com/static/sdk/bundles/open-forms-sdk.mjs"
+        data-form-id="123"
+        data-base-url="https://open-forms.example.com/api/v2/"
+        data-base-path="/my-form/"
+        data-csp-nonce="POBdlO9C3gRmVC8l6/Facw=="
+    ></div>
+    <script type="module" src="/open-forms-sdk-wrapper.mjs"></script>
+
+with the ``open-forms-sdk-wrapper.mjs`` example code:
+
+.. code-block:: js
+
+    /**
+     * Given a form node on the page, extract the options from the data-* attributes and
+     * initialize it.
+     * @param  {HTMLDivElement} node The root node for the SDK where the form must be
+     * rendered. It must have the expected data attributes.
+     * @return {Void}
+     */
+    const initializeSDK = async node => {
+      const {
+        sdkModule,
+        formId,
+        baseUrl,
+        basePath,
+        cspNonce,
+        sentryDsn = '',
+        sentryEnv = '',
+      } = node.dataset;
+      const {OpenForm} = await import(sdkModule);
+
+      // initialize the SDK
+      const options = {
+        baseUrl,
+        formId,
+        basePath,
+        CSPNonce: cspNonce,
+      };
+      if (sentryDsn) options.sentryDSN = sentryDsn;
+      if (sentryEnv) options.sentryEnv = sentryEnv;
+      const form = new OpenForm(node, options);
+      form.init();
+    };
+
+    const sdkNodes = document.querySelectorAll('.open-forms-sdk-root');
+    sdkNodes.forEach(node => initializeSDK(node));

--- a/src/openforms/forms/templates/forms/sdk_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_snippet.html
@@ -1,10 +1,10 @@
-{% load openforms static %}{% if form %}{% with 'openforms-container' as div_id %}
+{% load openforms static %}{% if form %}
 {% sdk_urls as urls %}
 {# Preload the module #}
 <link href="{{ urls.sdk_esm_url }}" rel="modulepreload" />
 <div
     class="open-forms-sdk-root"
-    id="{{ div_id }}"
+    id="openforms-container"
     data-sdk-module="{{ urls.sdk_esm_url }}"
     data-form-id="{{ form.slug }}"
     data-base-url="{% api_base_url %}"
@@ -13,44 +13,6 @@
     {% if sdk_sentry_dsn %}data-sentry-dsn{% endif %}
     {% if sdk_sentry_env %}data-sentry-env{% endif %}
 ></div>
-{# Modern browsers support modules, legacy browsers ignore this and use the fallback #}
+{# Browsers since 2018 support module, the UMD fallback should not be necessary any longer #}
 <script type="module" src="{% static 'sdk-wrapper.mjs' %}"></script>
-
-{# Fallback #}
-<script src="{{ urls.sdk_umd_url }}" nomodule></script>
-<script nonce="{{ request.csp_nonce }}" nomodule>
-    const formId = '{{ form.slug|escapejs }}';
-    const baseUrl = '{% filter escapejs %}{% api_base_url %}{% endfilter %}';
-    const targetNode = document.getElementById('{{ div_id|escapejs }}');
-    {% if base_path %}
-    const basePath = '{{ base_path|escapejs }}';
-    {% else %}
-    const basePath = '{% filter escapejs %}{% url "forms:form-detail" slug=form.slug %}{% endfilter %}';
-    {% endif %}
-    const CSPNonce = '{{ request.csp_nonce|escapejs }}';
-    {% if sdk_sentry_dsn %}const sentryDSN = '{% filter escapejs %}{{ sdk_sentry_dsn }}{% endfilter %}';{% endif %}
-    {% if sdk_sentry_env %}const sentryEnv = '{% filter escapejs %}{{ sdk_sentry_env }}{% endfilter %}';{% endif %}
-    const form = new OpenForms.OpenForm(
-        targetNode,
-        {
-            baseUrl,
-            formId,
-            basePath,
-            CSPNonce,
-            {% if sdk_sentry_dsn %}sentryDSN,{% endif %}
-            {% if sdk_sentry_env %}sentryEnv,{% endif %}
-            languageSelectorTarget: '#react-portal--language-selection',
-            onLanguageChange: (newLanguageCode, initialDataReference) => {
-                // URL handling in JS requires a proper base since you can't just feed `foo` or `/foo`
-                // to the constructor. We only extract the pathname + query string again at the end.
-                const base = window.location.origin;
-                const url = new URL(basePath, base);
-                if (initialDataReference) {
-                    url.searchParams.set('initial_data_reference', initialDataReference);
-                }
-                window.location.replace(`${url.pathname}${url.search}`);
-            },
-        }
-    );
-    form.init();
-</script>{% endwith %}{% endif %}
+{% endif %}

--- a/src/openforms/utils/sdk_static.py
+++ b/src/openforms/utils/sdk_static.py
@@ -26,12 +26,10 @@ def get_sdk_urls():
     sdk_path /= "bundles"
 
     css_path = str(sdk_path / "open-forms-sdk.css")
-    umd_bundle_path = str(sdk_path / "open-forms-sdk.js")
     esm_bundle_path = str(sdk_path / "open-forms-sdk.mjs")
 
     return {
         "sdk_esm_url": static(esm_bundle_path),
-        "sdk_umd_url": static(umd_bundle_path),
         "sdk_css_url": static(css_path),
         "sdk_sentry_dsn": settings.SDK_SENTRY_DSN,
         "sdk_sentry_env": settings.SDK_SENTRY_ENVIRONMENT,

--- a/src/openforms/utils/tests/test_sdk_urls.py
+++ b/src/openforms/utils/tests/test_sdk_urls.py
@@ -25,11 +25,6 @@ class StableSDKUrlTests(ParametrizedTestCase, TestCase):
         ("stable_url", "resolved_url"),
         [
             param(
-                "/static/sdk/open-forms-sdk.js",
-                "/static/sdk/1.2.3/bundles/open-forms-sdk.js",
-                id="umd",
-            ),
-            param(
                 "/static/sdk/open-forms-sdk.mjs",
                 "/static/sdk/1.2.3/bundles/open-forms-sdk.mjs",
                 id="esm",

--- a/src/openforms/utils/views.py
+++ b/src/openforms/utils/views.py
@@ -51,8 +51,6 @@ class SDKRedirectView(RedirectView):
     def get_redirect_url(self, ext: str):
         urls = get_sdk_urls()
         match ext:
-            case "js":
-                return urls["sdk_umd_url"]
             case "mjs":
                 return urls["sdk_esm_url"]
             case "css":


### PR DESCRIPTION
Closes #6164 (partly)

Obsoleted since browsers since 2018 support modules natively. The UMD bundle is being removed from the SDK.

**Changes**

* Removed the inline javascript that initializes the SDK based on the UMD bundle
* Removed the script tag inclusion of the UMD bundle
* Removed the UMD bundle references in the URL translation/redirect machinery

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
