### PR TITLE
StUF-ZDS: Add extra elements on the initiator level

### DIFF
--- a/docs/configuration/registration/stufzds.rst
+++ b/docs/configuration/registration/stufzds.rst
@@ -140,6 +140,9 @@ These SOAP-operations are used by this plugin:
 * ``creeerZaak_Lk01``
 
    * ``heeftAlsInitiator`` (the initiator can be excluded if needed)
+
+       * ``extraElementen``, explicitely mapped variables through the configuration
+
    * ``heeftAlsOverigBetrokkene`` (set if: an employee logs in on behalf of
      a client, the submission has been cosigned or there are family member relations)
    * ``heeft`` (the status can be excluded if needed)
@@ -149,6 +152,15 @@ These SOAP-operations are used by this plugin:
 * ``updateZaak_Lk01`` (only used when delayed payments are enabled)
 * ``genereerDocumentIdentificatie_Di02``
 * ``voegZaakdocumentToe_Lk01`` (for both the submission document and each attachment)
+
+
+.. note:: We provide support of ``extraElementen`` for  ``creeerZaak_Lk01`` on two levels:
+
+    * ``ZKN:object/StUF:extraElementen``
+    * ``ZKN:object/ZKN:heeftAlsInitiator/StUF:extraElementen``
+
+   Both mappings can be added on the "Extra elements" tab of the plugin configuration options,
+   and any form variable that's not mapped explicitly will be included in the object level extra elements.
 
 Vendor-specific notes
 =====================
@@ -209,3 +221,15 @@ information that's not readily available in the StUF-ZDS standard, through
 * ``zaak.pv_betaalstatus``: this cannot be mapped, but the StUF-ZDS element
   ``<ZKN:betalingsIndicatie>`` is the right place and we manage that automatically
   already.
+
+Contact information
+^^^^^^^^^^^^^^^^^^^
+
+Open Forms uses the StUF-ZDS element ``heeftAlsAanspreekpunt`` to send contact details of the initiator.
+Onegov doesn't support it, therefore we added a workaround with ``extraElement`` mapping on the initiator level.
+
+In the registration plugin configuration options, go to the "Extra elements" tab and add mapping entries
+on the **initiator** level. The expected StUF names are:
+
+* ``pv_afwijkendtelefoon``: use the form variable that contains the phone number
+* ``pv_emailafwijkend``: use the form variable that contains the email address

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -2311,6 +2311,12 @@
       "value": "Plugin configuration: ZGW APIs"
     }
   ],
+  "H2IXy5": [
+    {
+      "type": 0,
+      "value": "Variables mapping (case)"
+    }
+  ],
   "H4sILo": [
     {
       "type": 0,
@@ -3327,26 +3333,6 @@
     {
       "type": 0,
       "value": "Specify a positive, non-zero file size without decimals, e.g. 10MB."
-    }
-  ],
-  "QWOU1l": [
-    {
-      "type": 0,
-      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "extraElementen"
-        }
-      ],
-      "type": 8,
-      "value": "code"
-    },
-    {
-      "type": 0,
-      "value": "."
     }
   ],
   "QaPqxz": [
@@ -4889,12 +4875,6 @@
       "value": "Product request type"
     }
   ],
-  "csTJIN": [
-    {
-      "type": 0,
-      "value": "Variables mapping"
-    }
-  ],
   "cuivC6": [
     {
       "type": 0,
@@ -5403,6 +5383,12 @@
       "value": "Regular"
     }
   ],
+  "gO2sGp": [
+    {
+      "type": 0,
+      "value": "Variables mapping (Initiator)"
+    }
+  ],
   "gSSyoc": [
     {
       "type": 0,
@@ -5621,6 +5607,26 @@
     {
       "type": 0,
       "value": "You must select a table."
+    }
+  ],
+  "i3qXzA": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "heeftAlsInitiator/extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": "."
     }
   ],
   "i7HknI": [
@@ -6117,6 +6123,26 @@
     {
       "type": 0,
       "value": "Add item"
+    }
+  ],
+  "ljTD4F": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " for the case itself."
     }
   ],
   "ln72CJ": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -2298,6 +2298,12 @@
       "value": "Plugin-instellingen: Zaakgericht Werken API's"
     }
   ],
+  "H2IXy5": [
+    {
+      "type": 0,
+      "value": "Variables mapping (case)"
+    }
+  ],
   "H4sILo": [
     {
       "type": 0,
@@ -3310,26 +3316,6 @@
     {
       "type": 0,
       "value": "Geef een bestandsgrootte groter dan nul zonder decimalen op, bijvoorbeeld '10MB'."
-    }
-  ],
-  "QWOU1l": [
-    {
-      "type": 0,
-      "value": "Deze koppelingen laten je toe om variabelen mee te sturen in de XML voor StUF-ZDS. De opgegeven sleutels en waarden uit de inzendingsgegevens komen terecht in "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "extraElementen"
-        }
-      ],
-      "type": 8,
-      "value": "code"
-    },
-    {
-      "type": 0,
-      "value": "."
     }
   ],
   "QaPqxz": [
@@ -4877,12 +4863,6 @@
       "value": "Productaanvraagtype"
     }
   ],
-  "csTJIN": [
-    {
-      "type": 0,
-      "value": "Variabelekoppelingen"
-    }
-  ],
   "cuivC6": [
     {
       "type": 0,
@@ -5391,6 +5371,12 @@
       "value": "Regular"
     }
   ],
+  "gO2sGp": [
+    {
+      "type": 0,
+      "value": "Variables mapping (Initiator)"
+    }
+  ],
   "gSSyoc": [
     {
       "type": 0,
@@ -5609,6 +5595,26 @@
     {
       "type": 0,
       "value": "Je moet een tabel selecteren."
+    }
+  ],
+  "i3qXzA": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "heeftAlsInitiator/extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": "."
     }
   ],
   "i7HknI": [
@@ -6105,6 +6111,26 @@
     {
       "type": 0,
       "value": "Item toevoegen"
+    }
+  ],
+  "ljTD4F": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " for the case itself."
     }
   ],
   "ln72CJ": [

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
@@ -20,6 +20,7 @@ const StufZDSOptionsForm = ({name, label, schema, formData, onChange}) => {
     zdsDocumenttypeOmschrijvingInzending: '',
     zdsZaakdocVertrouwelijkheid: '',
     variablesMapping: [],
+    variablesMappingInitiator: [],
     // existing configuration
     ...formData,
   };
@@ -61,6 +62,12 @@ StufZDSOptionsForm.propTypes = {
   }).isRequired,
   formData: PropTypes.shape({
     variablesMapping: PropTypes.arrayOf(
+      PropTypes.shape({
+        formVariable: PropTypes.string,
+        stufName: PropTypes.string,
+      })
+    ),
+    variablesMappingInitiator: PropTypes.arrayOf(
       PropTypes.shape({
         formVariable: PropTypes.string,
         stufName: PropTypes.string,

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
@@ -34,7 +34,12 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
     `${name}.variablesMapping`,
     validationErrors
   ).length;
-  const numBaseErrors = relevantErrors.length - numVariablesMappingErrors;
+  const numVariablesMappingInitiatorErrors = filterErrors(
+    `${name}.variablesMappingInitiator`,
+    validationErrors
+  ).length;
+  const numBaseErrors =
+    relevantErrors.length - numVariablesMappingErrors - numVariablesMappingInitiatorErrors;
 
   return (
     <ValidationErrorsProvider errors={relevantErrors}>
@@ -46,7 +51,7 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
               defaultMessage="Base"
             />
           </Tab>
-          <Tab hasErrors={numVariablesMappingErrors > 0}>
+          <Tab hasErrors={numVariablesMappingErrors + numVariablesMappingInitiatorErrors > 0}>
             <FormattedMessage
               description="StUF-ZDS registration backend options, 'extra elements' tab label"
               defaultMessage="Extra elements"
@@ -70,7 +75,7 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
             title={
               <FormattedMessage
                 description="StUF-ZDS registration variablesMapping label"
-                defaultMessage="Variables mapping"
+                defaultMessage="Variables mapping (case)"
               />
             }
             fieldNames={['variablesMapping']}
@@ -80,14 +85,38 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
                 description="StUF-ZDS registration variablesMapping message"
                 defaultMessage={`This mapping is used to map the variable keys to keys
                 used in the XML that is sent to StUF-ZDS. Those keys and the values
-                belonging to them in the submission data are included in <code>extraElementen</code>.
+                belonging to them in the submission data are included in the
+                top level <code>extraElementen</code> for the case itself.
               `}
                 values={{
                   code: chunks => <code>{chunks}</code>,
                 }}
               />
             </div>
-            <VariablesMapping />
+            <VariablesMapping name="variablesMapping" />
+          </Fieldset>
+          <Fieldset
+            title={
+              <FormattedMessage
+                description="StUF-ZDS registration variablesMappingInitiator label"
+                defaultMessage="Variables mapping (Initiator)"
+              />
+            }
+            fieldNames={['variablesMappingInitiator']}
+          >
+            <div className="description">
+              <FormattedMessage
+                description="StUF-ZDS registration variablesMappingInitiator message"
+                defaultMessage={`This mapping is used to map the variable keys to keys
+                used in the XML that is sent to StUF-ZDS. Those keys and the values
+                belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>.
+              `}
+                values={{
+                  code: chunks => <code>{chunks}</code>,
+                }}
+              />
+            </div>
+            <VariablesMapping name="variablesMappingInitiator" />
           </Fieldset>
         </TabPanel>
       </Tabs>

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/VariablesMapping.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/VariablesMapping.js
@@ -80,11 +80,8 @@ const VariablesMapping = ({name}) => {
   const pluginVariables =
     formContext.registrationPluginsVariables.find(entry => entry.pluginIdentifier === PLUGIN_ID)
       ?.pluginVariables ?? [];
-  const userDefinedVariables = formContext.formVariables.filter(
-    variable => variable.source === 'user_defined'
-  );
 
-  const formVariables = pluginVariables.concat(userDefinedVariables);
+  const formVariables = pluginVariables.concat(formContext.formVariables);
 
   const {getFieldProps} = useFormikContext();
   const {value: mappings = []} = getFieldProps(name);

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/VariablesMapping.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/VariablesMapping.js
@@ -72,12 +72,9 @@ VariableMappingRow.propTypes = {
  *
  * Inspired on the `VariableMapping` component - we can't re-use that one because we
  * don't (yet) receive dropdowns/form variable context from the backend to display
- * options in a dropdown for the StUF extraElementen targets. The component offers the
- * selection of static variables for the payments (with their default values) along with
- * the available user defined variables.
- *
+ * options in a dropdown for the StUF extraElementen targets.
  */
-const VariablesMapping = () => {
+const VariablesMapping = ({name}) => {
   const formContext = useContext(FormContext);
 
   const pluginVariables =
@@ -90,14 +87,14 @@ const VariablesMapping = () => {
   const formVariables = pluginVariables.concat(userDefinedVariables);
 
   const {getFieldProps} = useFormikContext();
-  const {value: mappings = []} = getFieldProps('variablesMapping');
+  const {value: mappings = []} = getFieldProps(name);
 
   return (
     // use a new Form Context and let the registration variables shadow the normal form
     // variables, so that the form variable dropdown can be re-used.
     <FormContext.Provider value={{...formContext, formVariables}}>
       <FieldArray
-        name="variablesMapping"
+        name={name}
         render={arrayHelpers => (
           <div className={'mapping-table'} style={{marginBlockStart: '10px'}}>
             <table>
@@ -124,7 +121,7 @@ const VariablesMapping = () => {
                 {mappings.map((_, index) => (
                   <VariableMappingRow
                     key={index}
-                    prefix={`variablesMapping.${index}`}
+                    prefix={`${name}.${index}`}
                     onRemove={() => arrayHelpers.remove(index)}
                   />
                 ))}
@@ -145,6 +142,8 @@ const VariablesMapping = () => {
   );
 };
 
-VariablesMapping.propTypes = {};
+VariablesMapping.propTypes = {
+  name: PropTypes.string.isRequired,
+};
 
 export default VariablesMapping;

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -1029,6 +1029,11 @@
     "description": "ZGW APIs registration options modal title",
     "originalDefault": "Plugin configuration: ZGW APIs"
   },
+  "H2IXy5": {
+    "defaultMessage": "Variables mapping (case)",
+    "description": "StUF-ZDS registration variablesMapping label",
+    "originalDefault": "Variables mapping (case)"
+  },
   "H6VxhG": {
     "defaultMessage": "Maintenance mode",
     "description": "Form maintenance mode field label",
@@ -1618,11 +1623,6 @@
     "defaultMessage": "Save text",
     "description": "Form step save text label",
     "originalDefault": "Save text"
-  },
-  "QWOU1l": {
-    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>extraElementen</code>.",
-    "description": "StUF-ZDS registration variablesMapping message",
-    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>extraElementen</code>."
   },
   "QaPqxz": {
     "defaultMessage": "No (with overview page)",
@@ -2294,11 +2294,6 @@
     "description": "Legacy objects API registration options: 'productaanvraagType' label",
     "originalDefault": "Product request type"
   },
-  "csTJIN": {
-    "defaultMessage": "Variables mapping",
-    "description": "StUF-ZDS registration variablesMapping label",
-    "originalDefault": "Variables mapping"
-  },
   "cuivC6": {
     "defaultMessage": "Version",
     "description": "ZGW APIs registration options 'objecttypeVersion' label",
@@ -2499,6 +2494,11 @@
     "description": "regular form type option label",
     "originalDefault": "Regular"
   },
+  "gO2sGp": {
+    "defaultMessage": "Variables mapping (Initiator)",
+    "description": "StUF-ZDS registration variablesMappingInitiator label",
+    "originalDefault": "Variables mapping (Initiator)"
+  },
   "gUl3mu": {
     "defaultMessage": "Are you sure that you want to remove this mapping?",
     "description": "Confirmation message to remove a mapping",
@@ -2618,6 +2618,11 @@
     "defaultMessage": "Internal name",
     "description": "Form name field label",
     "originalDefault": "Internal name"
+  },
+  "i3qXzA": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>.",
+    "description": "StUF-ZDS registration variablesMappingInitiator message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>."
   },
   "i7HknI": {
     "defaultMessage": "Tab name",
@@ -2838,6 +2843,11 @@
     "defaultMessage": "Add item",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
+  },
+  "ljTD4F": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself.",
+    "description": "StUF-ZDS registration variablesMapping message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself."
   },
   "ln72CJ": {
     "defaultMessage": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -1041,6 +1041,11 @@
     "description": "ZGW APIs registration options modal title",
     "originalDefault": "Plugin configuration: ZGW APIs"
   },
+  "H2IXy5": {
+    "defaultMessage": "Variables mapping (case)",
+    "description": "StUF-ZDS registration variablesMapping label",
+    "originalDefault": "Variables mapping (case)"
+  },
   "H6VxhG": {
     "defaultMessage": "Onderhoudsmodus",
     "description": "Form maintenance mode field label",
@@ -1635,11 +1640,6 @@
     "defaultMessage": "'Opslaan' tekst",
     "description": "Form step save text label",
     "originalDefault": "Save text"
-  },
-  "QWOU1l": {
-    "defaultMessage": "Deze koppelingen laten je toe om variabelen mee te sturen in de XML voor StUF-ZDS. De opgegeven sleutels en waarden uit de inzendingsgegevens komen terecht in <code>extraElementen</code>.",
-    "description": "StUF-ZDS registration variablesMapping message",
-    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>extraElementen</code>."
   },
   "QaPqxz": {
     "defaultMessage": "Nee (met overzichtspagina)",
@@ -2316,11 +2316,6 @@
     "description": "Legacy objects API registration options: 'productaanvraagType' label",
     "originalDefault": "Product request type"
   },
-  "csTJIN": {
-    "defaultMessage": "Variabelekoppelingen",
-    "description": "StUF-ZDS registration variablesMapping label",
-    "originalDefault": "Variables mapping"
-  },
   "cuivC6": {
     "defaultMessage": "Versie",
     "description": "ZGW APIs registration options 'objecttypeVersion' label",
@@ -2521,6 +2516,11 @@
     "description": "regular form type option label",
     "originalDefault": "Regular"
   },
+  "gO2sGp": {
+    "defaultMessage": "Variables mapping (Initiator)",
+    "description": "StUF-ZDS registration variablesMappingInitiator label",
+    "originalDefault": "Variables mapping (Initiator)"
+  },
   "gUl3mu": {
     "defaultMessage": "Ben je zeker dat je deze koppeling wil verwijderen?",
     "description": "Confirmation message to remove a mapping",
@@ -2640,6 +2640,11 @@
     "defaultMessage": "Interne naam",
     "description": "Form name field label",
     "originalDefault": "Internal name"
+  },
+  "i3qXzA": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>.",
+    "description": "StUF-ZDS registration variablesMappingInitiator message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>."
   },
   "i7HknI": {
     "defaultMessage": "Tabnaam",
@@ -2861,6 +2866,11 @@
     "defaultMessage": "Item toevoegen",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
+  },
+  "ljTD4F": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself.",
+    "description": "StUF-ZDS registration variablesMapping message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself."
   },
   "ln72CJ": {
     "defaultMessage": "Objecttyperesource-URL in de Objecttypen-API. Wanneer dit ingesteld is, dan wordt een object van dit type aangemaakt en aan de zaak gerelateerd.",

--- a/src/openforms/registrations/contrib/stuf_zds/options.py
+++ b/src/openforms/registrations/contrib/stuf_zds/options.py
@@ -81,11 +81,21 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
 
     variables_mapping = MappingSerializer(
         many=True,
-        label=_("Variables mapping"),
+        label=_("Variables mapping for Object level"),
         help_text=_(
             "This mapping is used to map the variable keys to keys used in the XML "
             "that is sent to StUF-ZDS. Those keys and the values belonging to them in "
-            "the submission data are included in extraElementen."
+            "the submission data are included in Object/extraElementen."
+        ),
+        required=False,
+    )
+    variables_mapping_initiator = MappingSerializer(
+        many=True,
+        label=_("Variables mapping for Initiator level"),
+        help_text=_(
+            "This mapping is used to map the variable keys to keys used in the XML "
+            "that is sent to StUF-ZDS. Those keys and the values belonging to them in "
+            "the submission data are included in heeftAlsInitiator/extraElementen."
         ),
         required=False,
     )
@@ -98,6 +108,8 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
         # To avoid duplicating the title and help text for each item
         del data["properties"]["variables_mapping"]["items"]["title"]
         del data["properties"]["variables_mapping"]["items"]["description"]
+        del data["properties"]["variables_mapping_initiator"]["items"]["title"]
+        del data["properties"]["variables_mapping_initiator"]["items"]["description"]
         return data
 
     def _handle_import(self, attrs) -> None:

--- a/src/openforms/registrations/contrib/stuf_zds/options.py
+++ b/src/openforms/registrations/contrib/stuf_zds/options.py
@@ -81,7 +81,7 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
 
     variables_mapping = MappingSerializer(
         many=True,
-        label=_("Variables mapping for Object level"),
+        label=_("Variables mapping (case)"),
         help_text=_(
             "This mapping is used to map the variable keys to keys used in the XML "
             "that is sent to StUF-ZDS. Those keys and the values belonging to them in "
@@ -91,7 +91,7 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
     )
     variables_mapping_initiator = MappingSerializer(
         many=True,
-        label=_("Variables mapping for Initiator level"),
+        label=_("Variables mapping (initiator)"),
         help_text=_(
             "This mapping is used to map the variable keys to keys used in the XML "
             "that is sent to StUF-ZDS. Those keys and the values belonging to them in "

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -151,7 +151,9 @@ def _prepare_value(value: Any):
             return value
 
 
-def _get_extra_variables_mapping(submission: Submission, options: RegistrationOptions):
+def _get_extra_variables_mapping(
+    option: str, submission: Submission, options: RegistrationOptions
+):
     # Grab the variables data from the submission state & inject the static registration
     # variable values
     state_variables_data = submission.variables_state.get_data(
@@ -168,32 +170,13 @@ def _get_extra_variables_mapping(submission: Submission, options: RegistrationOp
     )
 
     # emit only what was explicitly mapped in the options
-    variables_mapping = options.get("variables_mapping", [])
+    variables_mapping = options.get(option, [])
     return {
         mapping["stuf_name"]: _prepare_value(
             state_variables_data.get(mapping["form_variable"])
         )
         for mapping in variables_mapping
     }
-
-
-def _get_extra_variables_mapping_initiator(
-    submission: Submission, options: RegistrationOptions
-):
-    key_mapping = {
-        mapping["form_variable"]: mapping["stuf_name"]
-        for mapping in options.get("variables_mapping_initiator", [])
-    }
-
-    state_variables_data = submission.variables_state.get_data(
-        include_static_variables=True
-    )
-
-    submission_variables_data = {
-        stuf_name: _prepare_value(state_variables_data.get(variable_name))
-        for variable_name, stuf_name in key_mapping.items()
-    }
-    return submission_variables_data
 
 
 @register(PLUGIN_IDENTIFIER)
@@ -265,7 +248,9 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
         self, submission: Submission, options: RegistrationOptions
     ) -> dict[str, Any]:
         data = get_unmapped_data(submission, self.zaak_mapping, REGISTRATION_ATTRIBUTE)
-        extra_variables_mapping = _get_extra_variables_mapping(submission, options)
+        extra_variables_mapping = _get_extra_variables_mapping(
+            "variables_mapping", submission, options
+        )
 
         # Remove duplicates for variables that are present in the data and are also handled
         # by the `_get_extra_variables_mapping`.
@@ -274,22 +259,6 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                 data.pop(mapping["form_variable"], None)
 
         return {**data, **extra_variables_mapping}
-
-    def get_extra_data_initiator(
-        self, submission: Submission, options: RegistrationOptions
-    ) -> dict[str, Any]:
-        data = get_unmapped_data(submission, self.zaak_mapping, REGISTRATION_ATTRIBUTE)
-        extra_variables_mapping_initiator = _get_extra_variables_mapping_initiator(
-            submission, options
-        )
-
-        # Remove duplicates for variables that are present in the data and are also handled
-        # by the `_get_extra_variables_mapping_initiator`.
-        for mapping in options.get("variables_mapping_initiator", []):
-            if mapping["form_variable"] in data:
-                data.pop(mapping["form_variable"], None)
-
-        return {**data, **extra_variables_mapping_initiator}
 
     def process_partners(
         self,
@@ -522,7 +491,11 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
             self.process_vestiging(submission, zaak_data)
 
             extra_data = self.get_extra_data(submission, options)
-            extra_data_initiator = self.get_extra_data_initiator(submission, options)
+            # we don't include unmapped data to 'extra_data_initiator'
+            # therefore we don't reuse self.get_extra_data here
+            extra_data_initiator = _get_extra_variables_mapping(
+                "variables_mapping_initiator", submission, options
+            )
 
             # mutate the zaak_data and the extra data for the family members components
             # according to the type of the registration we want to send (zaakbetrokkene
@@ -572,7 +545,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                     zaak_id,
                     zaak_data,
                     LangInjection(submission, extra_data),
-                    LangInjection(submission, extra_data_initiator),
+                    extra_data_initiator,
                 ),
                 submission,
                 "intermediate.zaak_created",

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -177,6 +177,25 @@ def _get_extra_variables_mapping(submission: Submission, options: RegistrationOp
     }
 
 
+def _get_extra_variables_mapping_initiator(
+    submission: Submission, options: RegistrationOptions
+):
+    key_mapping = {
+        mapping["form_variable"]: mapping["stuf_name"]
+        for mapping in options.get("variables_mapping_initiator", [])
+    }
+
+    state_variables_data = submission.variables_state.get_data(
+        include_static_variables=True
+    )
+
+    submission_variables_data = {
+        stuf_name: _prepare_value(state_variables_data.get(variable_name))
+        for variable_name, stuf_name in key_mapping.items()
+    }
+    return submission_variables_data
+
+
 @register(PLUGIN_IDENTIFIER)
 class StufZDSRegistration(BasePlugin[RegistrationOptions]):
     verbose_name = _("StUF-ZDS")
@@ -255,6 +274,22 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                 data.pop(mapping["form_variable"], None)
 
         return {**data, **extra_variables_mapping}
+
+    def get_extra_data_initiator(
+        self, submission: Submission, options: RegistrationOptions
+    ) -> dict[str, Any]:
+        data = get_unmapped_data(submission, self.zaak_mapping, REGISTRATION_ATTRIBUTE)
+        extra_variables_mapping_initiator = _get_extra_variables_mapping_initiator(
+            submission, options
+        )
+
+        # Remove duplicates for variables that are present in the data and are also handled
+        # by the `_get_extra_variables_mapping_initiator`.
+        for mapping in options.get("variables_mapping_initiator", []):
+            if mapping["form_variable"] in data:
+                data.pop(mapping["form_variable"], None)
+
+        return {**data, **extra_variables_mapping_initiator}
 
     def process_partners(
         self,
@@ -487,6 +522,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
             self.process_vestiging(submission, zaak_data)
 
             extra_data = self.get_extra_data(submission, options)
+            extra_data_initiator = self.get_extra_data_initiator(submission, options)
 
             # mutate the zaak_data and the extra data for the family members components
             # according to the type of the registration we want to send (zaakbetrokkene
@@ -496,6 +532,9 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
 
             # The extraElement tag of StUF-ZDS expects primitive types
             extra_data = flatten_data_and_convert_to_primitives(extra_data)
+            extra_data_initiator = flatten_data_and_convert_to_primitives(
+                extra_data_initiator
+            )
 
             assert submission.registration_result is not None
             if internal_reference := submission.registration_result.get(
@@ -533,6 +572,7 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
                     zaak_id,
                     zaak_data,
                     LangInjection(submission, extra_data),
+                    LangInjection(submission, extra_data_initiator),
                 ),
                 submission,
                 "intermediate.zaak_created",

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from functools import partial
 from io import BytesIO
-from typing import Any, override
+from typing import Any, Literal, override
 
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -152,7 +152,10 @@ def _prepare_value(value: Any):
 
 
 def _get_extra_variables_mapping(
-    option: str, submission: Submission, options: RegistrationOptions
+    submission: Submission,
+    options: RegistrationOptions,
+    *,
+    option: Literal["variables_mapping", "variables_mapping_initiator"],
 ):
     # Grab the variables data from the submission state & inject the static registration
     # variable values
@@ -249,7 +252,9 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
     ) -> dict[str, Any]:
         data = get_unmapped_data(submission, self.zaak_mapping, REGISTRATION_ATTRIBUTE)
         extra_variables_mapping = _get_extra_variables_mapping(
-            "variables_mapping", submission, options
+            submission,
+            options,
+            option="variables_mapping",
         )
 
         # Remove duplicates for variables that are present in the data and are also handled
@@ -494,7 +499,9 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
             # we don't include unmapped data to 'extra_data_initiator'
             # therefore we don't reuse self.get_extra_data here
             extra_data_initiator = _get_extra_variables_mapping(
-                "variables_mapping_initiator", submission, options
+                submission,
+                options,
+                option="variables_mapping_initiator",
             )
 
             # mutate the zaak_data and the extra data for the family members components

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSExtraElementsTests/test_register_with_variables_mapping_initiator.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSExtraElementsTests/test_register_with_variables_mapping_initiator.yaml
@@ -1,0 +1,221 @@
+interactions:
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e9ef6092-c2bc-406c-92b3-231fcb9edde6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260424132140</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>OF-1234</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260424</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260424</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260424132140</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"phone\">0612345678</StUF:extraElement>\n\n<StUF:extraElement naam=\"email\">john@smith.com</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"payment_completed\">true</StUF:extraElement>\n\n<StUF:extraElement naam=\"payment_amount\">40.0</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"payment_public_order_ids.0\">foo</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"provider_payment_ids.0\">123456</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260424</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>John</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260424132140</StUF:tijdstipRegistratie>\n
+      \               \n                <StUF:extraElementen>\n\n<StUF:extraElement
+      naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement naam=\"pv_afwijkendtelefoon\">0612345678</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"pv_emailafwijkend\">john@smith.com</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \           </ZKN:heeftAlsInitiator>\n        \n        \n        \n        \n\n
+      \       \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4324'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Fri, 24 Apr 2026 13:21:41 GMT
+      Server:
+      - Werkzeug/3.1.7 Python/3.12.13
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0a7e2078-786a-46ac-8529-80a9061739eb</StUF:referentienummer>\n<StUF:tijdstipBericht>20260424132141</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1347'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>290ea5a8c45ef7a2</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Fri, 24 Apr 2026 13:21:41 GMT
+      Server:
+      - Werkzeug/3.1.7 Python/3.12.13
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f04e69b2-0d46-442f-bfab-bcd1ef09a71d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260424132141</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>290ea5a8c45ef7a2</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260424</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260424</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260424</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260424</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260424132141</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>OF-1234</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260424132141</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3030'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Fri, 24 Apr 2026 13:21:41 GMT
+      Server:
+      - Werkzeug/3.1.7 Python/3.12.13
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend_extra_elements.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend_extra_elements.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from pathlib import Path
 
 from lxml import etree
 from privates.test import temp_private_root
@@ -19,13 +18,9 @@ from ..options import default_variables_mapping
 from ..plugin import PLUGIN_IDENTIFIER, StufZDSRegistration
 from ..typing import RegistrationOptions
 
-TESTS_DIR = Path(__file__).parent.resolve()
-
 
 @temp_private_root()
 class StufZDSExtraElementsTests(OFVCRMixin, StUFZDSTestBase):
-    VCR_TEST_FILES = TESTS_DIR / "files"
-
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -104,21 +99,6 @@ class StufZDSExtraElementsTests(OFVCRMixin, StUFZDSTestBase):
         stuf_request = self.cassette.requests[0]
         xml_doc = etree.fromstring(stuf_request.body)
         self.assertSoapXMLCommon(xml_doc)
-
-        # check that we still have payment attributes on the Object level
-        expected_items = {
-            "payment_completed": "true",
-            "payment_amount": "40.0",
-            "payment_public_order_ids.0": "foo",
-            "provider_payment_ids.0": "123456",
-        }
-        for name, value in expected_items.items():
-            with self.subTest(extra_element=name, value=value):
-                self.assertXPathEqual(
-                    xml_doc,
-                    f"//zkn:object/stuf:extraElementen/stuf:extraElement[@naam='{name}']",
-                    value,
-                )
 
         # check extra attributes on the Initiator level
         expected_items = {

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend_extra_elements.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend_extra_elements.py
@@ -1,0 +1,134 @@
+from decimal import Decimal
+from pathlib import Path
+
+from lxml import etree
+from privates.test import temp_private_root
+
+from openforms.payments.constants import PaymentStatus
+from openforms.payments.tests.factories import SubmissionPaymentFactory
+from openforms.submissions.tests.factories import (
+    SubmissionFactory,
+)
+from openforms.utils.tests.vcr import OFVCRMixin
+from stuf.stuf_zds.models import StufZDSConfig
+from stuf.stuf_zds.tests import StUFZDSTestBase
+from stuf.tests.factories import StufServiceFactory
+
+from ....constants import RegistrationAttribute
+from ..options import default_variables_mapping
+from ..plugin import PLUGIN_IDENTIFIER, StufZDSRegistration
+from ..typing import RegistrationOptions
+
+TESTS_DIR = Path(__file__).parent.resolve()
+
+
+@temp_private_root()
+class StufZDSExtraElementsTests(OFVCRMixin, StUFZDSTestBase):
+    VCR_TEST_FILES = TESTS_DIR / "files"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.zds_service = StufServiceFactory.create(
+            soap_service__url="http://localhost:82/stuf-zds"
+        )
+        config = StufZDSConfig.get_solo()
+        config.service = cls.zds_service
+        config.save()
+        cls.addClassCleanup(StufZDSConfig.clear_cache)
+
+    def test_register_with_variables_mapping_initiator(self):
+        options: RegistrationOptions = {
+            "zds_zaaktype_code": "foo",
+            "zds_documenttype_omschrijving_inzending": "foo",
+            "zds_zaakdoc_vertrouwelijkheid": "GEHEIM",
+            "variables_mapping": default_variables_mapping(),
+            "variables_mapping_initiator": [
+                {
+                    "form_variable": "phone",
+                    "stuf_name": "pv_afwijkendtelefoon",
+                },
+                {
+                    "form_variable": "email",
+                    "stuf_name": "pv_emailafwijkend",
+                },
+            ],
+        }
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "name",
+                    "type": "textfield",
+                    "label": "Name",
+                    "registration": {
+                        "attribute": RegistrationAttribute.initiator_voornamen,
+                    },
+                },
+                {
+                    "key": "phone",
+                    "type": "phoneNumber",
+                    "label": "Phone",
+                },
+                {
+                    "key": "email",
+                    "type": "email",
+                    "label": "Email",
+                },
+            ],
+            form__name="my-form",
+            bsn="111222333",
+            submitted_data={
+                "name": "John",
+                "phone": "0612345678",
+                "email": "john@smith.com",
+            },
+            language_code="en",
+            public_registration_reference="OF-1234",
+            registration_result={"zaak": "1234"},
+        )
+        # can't pass this as part of `SubmissionFactory.from_components`
+        submission.price = Decimal("40.00")
+        submission.save()
+        SubmissionPaymentFactory.create(
+            submission=submission,
+            amount=Decimal("25.00"),
+            public_order_id="foo",
+            status=PaymentStatus.completed,
+            provider_payment_id="123456",
+        )
+        plugin = StufZDSRegistration(PLUGIN_IDENTIFIER)
+
+        plugin.register_submission(submission, options)
+
+        stuf_request = self.cassette.requests[0]
+        xml_doc = etree.fromstring(stuf_request.body)
+        self.assertSoapXMLCommon(xml_doc)
+
+        # check that we still have payment attributes on the Object level
+        expected_items = {
+            "payment_completed": "true",
+            "payment_amount": "40.0",
+            "payment_public_order_ids.0": "foo",
+            "provider_payment_ids.0": "123456",
+        }
+        for name, value in expected_items.items():
+            with self.subTest(extra_element=name, value=value):
+                self.assertXPathEqual(
+                    xml_doc,
+                    f"//zkn:object/stuf:extraElementen/stuf:extraElement[@naam='{name}']",
+                    value,
+                )
+
+        # check extra attributes on the Initiator level
+        expected_items = {
+            "pv_afwijkendtelefoon": "0612345678",
+            "pv_emailafwijkend": "john@smith.com",
+        }
+        for name, value in expected_items.items():
+            with self.subTest(extra_element=name, value=value):
+                self.assertXPathEqual(
+                    xml_doc,
+                    f"//zkn:object/zkn:heeftAlsInitiator/stuf:extraElementen/stuf:extraElement[@naam='{name}']",
+                    value,
+                )

--- a/src/openforms/registrations/contrib/stuf_zds/tests/vcr_cassettes/test_backend_extra_elements/StufZDSExtraElementsTests/test_register_with_variables_mapping_initiator.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/vcr_cassettes/test_backend_extra_elements/StufZDSExtraElementsTests/test_register_with_variables_mapping_initiator.yaml
@@ -7,15 +7,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e9ef6092-c2bc-406c-92b3-231fcb9edde6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260424132140</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>328cd9bb-8f6f-433f-910a-67a9ea2c0461</StUF:referentienummer>\n<StUF:tijdstipBericht>20260501095133</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>OF-1234</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260424</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260424</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260501</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260501</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260424132140</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260501095133</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"phone\">0612345678</StUF:extraElement>\n\n<StUF:extraElement naam=\"email\">john@smith.com</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"payment_completed\">true</StUF:extraElement>\n\n<StUF:extraElement naam=\"payment_amount\">40.0</StUF:extraElement>\n\n<StUF:extraElement
@@ -23,7 +23,7 @@ interactions:
       naam=\"provider_payment_ids.0\">123456</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260424</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260501</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -33,12 +33,12 @@ interactions:
       \                           \n                            \n                            \n
       \                           <BG:voornamen>John</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260424132140</StUF:tijdstipRegistratie>\n
-      \               \n                <StUF:extraElementen>\n\n<StUF:extraElement
-      naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement naam=\"pv_afwijkendtelefoon\">0612345678</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"pv_emailafwijkend\">john@smith.com</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \           </ZKN:heeftAlsInitiator>\n        \n        \n        \n        \n\n
-      \       \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260501095133</StUF:tijdstipRegistratie>\n
+      \               <StUF:extraElementen>\n\n<StUF:extraElement naam=\"pv_afwijkendtelefoon\">0612345678</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"pv_emailafwijkend\">john@smith.com</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
       - '*/*'
@@ -47,7 +47,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4324'
+      - '4261'
       Content-Type:
       - application/soap+xml
       SOAPAction:
@@ -80,7 +80,7 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 24 Apr 2026 13:21:41 GMT
+      - Fri, 01 May 2026 09:51:33 GMT
       Server:
       - Werkzeug/3.1.7 Python/3.12.13
     status:
@@ -93,7 +93,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0a7e2078-786a-46ac-8529-80a9061739eb</StUF:referentienummer>\n<StUF:tijdstipBericht>20260424132141</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b96946cd-aca3-4fde-86cc-f6a8aedcf582</StUF:referentienummer>\n<StUF:tijdstipBericht>20260501095133</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -127,7 +127,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>290ea5a8c45ef7a2</ZKN:identificatie>\n
+        \               <ZKN:identificatie>a27a079eb046842f</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -138,7 +138,7 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 24 Apr 2026 13:21:41 GMT
+      - Fri, 01 May 2026 09:51:33 GMT
       Server:
       - Werkzeug/3.1.7 Python/3.12.13
     status:
@@ -151,25 +151,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f04e69b2-0d46-442f-bfab-bcd1ef09a71d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260424132141</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b88ab923-c9ea-4986-9a8e-7c2f5b921e44</StUF:referentienummer>\n<StUF:tijdstipBericht>20260501095133</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>290ea5a8c45ef7a2</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260424</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260424</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>a27a079eb046842f</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260501</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260501</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260424</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260501</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260424</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260501</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260424132141</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260501095133</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>OF-1234</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260424132141</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260501095133</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Fri, 24 Apr 2026 13:21:41 GMT
+      - Fri, 01 May 2026 09:51:33 GMT
       Server:
       - Werkzeug/3.1.7 Python/3.12.13
     status:

--- a/src/openforms/registrations/contrib/stuf_zds/typing.py
+++ b/src/openforms/registrations/contrib/stuf_zds/typing.py
@@ -23,3 +23,4 @@ class RegistrationOptions(TypedDict):
         "OPENBAAR",
     ]
     variables_mapping: NotRequired[list[MappingItem]]
+    variables_mapping_initiator: NotRequired[list[MappingItem]]

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import uuid
 from collections import OrderedDict
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator, Mapping, MutableMapping
 from datetime import datetime
 from typing import (
     Any,
@@ -223,7 +223,7 @@ class Client(BaseClient):
         zaak_identificatie: str,
         zaak_data: MutableMapping[str, Any],
         extra_data: ExtraData,
-        extra_data_initiator: MutableMapping[str, Any] | None = None,
+        extra_data_initiator: Mapping[str, Any] | None = None,
     ) -> None:
         now = timezone.now()
         context = {

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -223,6 +223,7 @@ class Client(BaseClient):
         zaak_identificatie: str,
         zaak_data: MutableMapping[str, Any],
         extra_data: ExtraData,
+        extra_data_initiator: ExtraData,
     ) -> None:
         now = timezone.now()
         context = {
@@ -242,6 +243,7 @@ class Client(BaseClient):
             "co_signer": self.zds_options.get("cosigner"),
             "zaak_identificatie": zaak_identificatie,
             "extra": extra_data,
+            "extra_initiator": extra_data_initiator,
             "global_config": GlobalConfiguration.get_solo(),
             **zaak_data,
         }

--- a/src/stuf/stuf_zds/client.py
+++ b/src/stuf/stuf_zds/client.py
@@ -223,7 +223,7 @@ class Client(BaseClient):
         zaak_identificatie: str,
         zaak_data: MutableMapping[str, Any],
         extra_data: ExtraData,
-        extra_data_initiator: ExtraData,
+        extra_data_initiator: MutableMapping[str, Any] | None = None,
     ) -> None:
         now = timezone.now()
         context = {
@@ -243,7 +243,7 @@ class Client(BaseClient):
             "co_signer": self.zds_options.get("cosigner"),
             "zaak_identificatie": zaak_identificatie,
             "extra": extra_data,
-            "extra_initiator": extra_data_initiator,
+            "extra_initiator": extra_data_initiator or {},
             "global_config": GlobalConfiguration.get_solo(),
             **zaak_data,
         }

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -62,7 +62,7 @@
         <ZKN:zaakniveau>1</ZKN:zaakniveau>
         <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>
         <StUF:tijdstipRegistratie>{{ tijdstip_registratie }}</StUF:tijdstipRegistratie>
-        {% include "stuf_zds/soap/includes/extraElementen.xml" %}
+        {% include "stuf_zds/soap/includes/extraElementen.xml" with extra=extra %}
         <ZKN:isVan StUF:entiteittype="ZAKZKT" StUF:verwerkingssoort="T">
             <ZKN:gerelateerde StUF:verwerkingssoort="I" StUF:entiteittype="ZKT">
                 {% if zds_zaaktype_omschrijving %}
@@ -133,6 +133,7 @@
                 {% if initiator.contactpersoonNaam or initiator.telefoonnummer or initiator.emailadres %}
                     {% include "stuf_zds/soap/includes/heeftAlsAanspreekpunt.xml" %}
                 {% endif %}
+                {% include "stuf_zds/soap/includes/extraElementen.xml" with extra=extra_initiator %}
             </ZKN:heeftAlsInitiator>
         {% elif not global_config.allow_empty_initiator %}
             <ZKN:heeftAlsInitiator StUF:verwerkingssoort="T" StUF:entiteittype="ZAKBTRINI">

--- a/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
+++ b/src/stuf/stuf_zds/templates/stuf_zds/soap/creeerZaak.xml
@@ -130,10 +130,11 @@
                     {% endif %}
                 </ZKN:gerelateerde>
                 <StUF:tijdstipRegistratie>{{ tijdstip_registratie }}</StUF:tijdstipRegistratie>
+                {% include "stuf_zds/soap/includes/extraElementen.xml" with extra=extra_initiator %}
+
                 {% if initiator.contactpersoonNaam or initiator.telefoonnummer or initiator.emailadres %}
                     {% include "stuf_zds/soap/includes/heeftAlsAanspreekpunt.xml" %}
                 {% endif %}
-                {% include "stuf_zds/soap/includes/extraElementen.xml" with extra=extra_initiator %}
             </ZKN:heeftAlsInitiator>
         {% elif not global_config.allow_empty_initiator %}
             <ZKN:heeftAlsInitiator StUF:verwerkingssoort="T" StUF:entiteittype="ZAKBTRINI">


### PR DESCRIPTION
Closes #5951

**Changes**

* [x] add another fieldset in "Extra elementen" tab in the Admin UI for Initiator level. No default variables, add component variables support
* [x] adjust registration plugin to process it via `variables_mapping_initiator` config option
* [x] add extra elementen in the stuf-zds client and correspondent xml template
* [x] make plugin implementation DRYer if possible
* [x] test that elements are present in the request
* [x] document how to set up it  

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
