### PR TITLE
Upgrade form builder to v0.50.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/cli": "^6.6.1",
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.66.0",
-        "@open-formulieren/formio-builder": "^0.50.1",
+        "@open-formulieren/formio-builder": "^0.50.2",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -5141,9 +5141,9 @@
       "license": "EUPL-1.2"
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.1.tgz",
-      "integrity": "sha512-ic8MHnkGzBhkscZ9f5gjW1GH0VB6QKMRHx4Zg393fIjbFq9ApozRuDS+IsqTN1zSv5H5RYhlNVCPrrQaX098ow==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.2.tgz",
+      "integrity": "sha512-zEwoIVzIwR8aKdK5GfVEaBN3G5r6TezF2nA8/g1UyJowWVYKRMl6dEJuB5Cf0kQRxp+eBJn9I5WOPOjuxjn5cQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
@@ -23792,9 +23792,9 @@
       "integrity": "sha512-zMs6937ostu1b6q7WHYq4yjtKifnExOGAjWNYLMWuc+7ZttnhFnsf5QFXBR6P+YFDkzQNhJSKnGZnmmY1zZPOQ=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.1.tgz",
-      "integrity": "sha512-ic8MHnkGzBhkscZ9f5gjW1GH0VB6QKMRHx4Zg393fIjbFq9ApozRuDS+IsqTN1zSv5H5RYhlNVCPrrQaX098ow==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.2.tgz",
+      "integrity": "sha512-zEwoIVzIwR8aKdK5GfVEaBN3G5r6TezF2nA8/g1UyJowWVYKRMl6dEJuB5Cf0kQRxp+eBJn9I5WOPOjuxjn5cQ==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "@floating-ui/react": "^0.26.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@formatjs/cli": "^6.6.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.66.0",
-    "@open-formulieren/formio-builder": "^0.50.1",
+    "@open-formulieren/formio-builder": "^0.50.2",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",


### PR DESCRIPTION
Closes #6106 partly

**Changes**

- A new patch version was released in order to be consistent with the form type names that were changed in the backend.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
