### PR TITLE
Bandaid fix for odd conditional.eq comparison with file components

### DIFF
--- a/src/openforms/formio/datastructures.py
+++ b/src/openforms/formio/datastructures.py
@@ -162,7 +162,10 @@ class FormioConfigurationWrapper:
             path = ".".join(path_bits[: depth + 1])
             component = glom(self.configuration, path)
             nodes.append(component)
-        return all(is_visible_in_frontend(node, values) for node in nodes)
+        return all(
+            is_visible_in_frontend(node, values, configuration_wrapper=self)
+            for node in nodes
+        )
 
     def get_child_component_keys(self, key: str) -> set[str]:
         """

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal, NotRequired, TypedDict
@@ -13,6 +15,7 @@ from furl import furl
 from openforms.emails.utils import strip_tags_plus  # TODO: put somewhere else
 from openforms.formio.typing import Component
 from openforms.submissions.rendering.constants import RenderModes
+from openforms.submissions.rendering.renderer import Renderer
 from openforms.utils.urls import build_absolute_uri
 
 from ..datastructures import FormioData
@@ -25,6 +28,7 @@ from .registry import register
 class ContainerMixin:
     is_layout = True
 
+    renderer: Renderer
     step_data: FormioData
     component: Component
     mode: RenderModes
@@ -42,7 +46,11 @@ class ContainerMixin:
             return True
 
         # We only pass the step data, since frontend logic only has access to the current step data.
-        if not is_visible_in_frontend(self.component, self.step_data):
+        if not is_visible_in_frontend(
+            self.component,
+            self.step_data,
+            configuration_wrapper=self.renderer.submission.total_configuration_wrapper,
+        ):
             return False
 
         render_configuration = RENDER_CONFIGURATION[self.mode]

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -11,7 +11,7 @@ from openforms.submissions.models import SubmissionStep
 from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
 
-from ..datastructures import FormioData
+from ..datastructures import FormioConfigurationWrapper, FormioData
 from ..service import format_value, holds_submission_data
 from ..typing import Component
 from ..utils import (
@@ -136,10 +136,18 @@ class ComponentNode(Node):
                 current_iteration_data
             )
             if not is_visible_in_frontend(
-                self.component, artificial_repeating_group_data
+                self.component,
+                artificial_repeating_group_data,
+                configuration_wrapper=FormioConfigurationWrapper(
+                    configuration=self.parent_node.component
+                ),
             ):
                 return False
-        elif not is_visible_in_frontend(self.component, self.step_data):
+        elif not is_visible_in_frontend(
+            self.component,
+            self.step_data,
+            configuration_wrapper=self.renderer.submission.total_configuration_wrapper,
+        ):
             return False
 
         render_configuration = RENDER_CONFIGURATION[self.mode]

--- a/src/openforms/formio/tests/test_utils.py
+++ b/src/openforms/formio/tests/test_utils.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, tag
 
 from hypothesis import example, given, strategies as st
 
@@ -6,63 +6,118 @@ from openforms.formio.tests.search_strategies import formio_key
 from openforms.tests.search_strategies import json_primitives
 from openforms.typing import JSONPrimitive
 
-from ..datastructures import FormioData
+from ..datastructures import FormioConfigurationWrapper, FormioData
 from ..typing import Component, SelectBoxesComponent
 from ..utils import get_component_empty_value, is_visible_in_frontend
+
+FORMIO_COMPONENTS: list[Component] = [
+    {
+        "type": "selectboxes",
+        "key": "selectBoxes1",
+        "label": "Select boxes",
+        "values": [
+            {"value": "a", "label": "A"},
+            {"value": "b", "label": "B"},
+        ],
+    },
+    {
+        "type": "file",
+        "key": "file1",
+        "label": "File",
+    },
+]
 
 
 class FormioUtilsTest(SimpleTestCase):
     def test_is_visible_in_frontend_with_selectboxes(self):
         data = FormioData({"selectBoxes1": {"a": True, "b": False}})
 
-        component = {
+        component: Component = {
             "key": "textField1",
             "type": "textfield",
+            "label": "Text field",
             "conditional": {"show": True, "when": "selectBoxes1", "eq": "a"},
         }
+        configuration_wrapper = FormioConfigurationWrapper(
+            {"components": [*FORMIO_COMPONENTS, component]}
+        )
 
-        result = is_visible_in_frontend(component, data)
+        result = is_visible_in_frontend(component, data, configuration_wrapper)
 
         self.assertTrue(result)
 
     def test_is_hidden_in_frontend_with_selectboxes(self):
         data = FormioData({"selectBoxes1": {"a": True, "b": False}})
 
-        component = {
+        component: Component = {
             "key": "textField1",
             "type": "textfield",
+            "label": "Text field",
             "conditional": {"show": False, "when": "selectBoxes1", "eq": "a"},
         }
+        configuration_wrapper = FormioConfigurationWrapper(
+            {"components": [*FORMIO_COMPONENTS, component]}
+        )
 
-        result = is_visible_in_frontend(component, data)
+        result = is_visible_in_frontend(component, data, configuration_wrapper)
 
         self.assertFalse(result)
 
     def test_is_hidden_if_not_selected(self):
         data = FormioData({"selectBoxes1": {"a": False, "b": False}})
 
-        component = {
+        component: Component = {
             "key": "textField1",
             "type": "textfield",
+            "label": "Text field",
             "conditional": {"show": True, "when": "selectBoxes1", "eq": "a"},
         }
+        configuration_wrapper = FormioConfigurationWrapper(
+            {"components": [*FORMIO_COMPONENTS, component]}
+        )
 
-        result = is_visible_in_frontend(component, data)
+        result = is_visible_in_frontend(component, data, configuration_wrapper)
 
         self.assertFalse(result)
 
     def test_is_visible_if_not_selected(self):
         data = FormioData({"selectBoxes1": {"a": False, "b": False}})
 
-        component = {
+        component: Component = {
             "key": "textField1",
             "type": "textfield",
+            "label": "Text field",
             "conditional": {"show": False, "when": "selectBoxes1", "eq": "a"},
         }
+        configuration_wrapper = FormioConfigurationWrapper(
+            {"components": [*FORMIO_COMPONENTS, component]}
+        )
 
-        result = is_visible_in_frontend(component, data)
+        result = is_visible_in_frontend(component, data, configuration_wrapper)
 
         self.assertTrue(result)
+
+    @tag("gh-6181")
+    def test_is_hidden_in_frontend_with_file(self):
+        data = FormioData({"file1": []})
+
+        component: Component = {
+            "type": "textfield",
+            "key": "textField1",
+            "label": "textfield",
+            "conditional": {
+                "show": False,
+                "when": "file1",
+                "eq": "",  # should be [], but formio-builder/formio legacy use strings...
+            },
+        }
+        configuration_wrapper = FormioConfigurationWrapper(
+            {"components": [*FORMIO_COMPONENTS, component]}
+        )
+
+        result = is_visible_in_frontend(component, data, configuration_wrapper)
+
+        self.assertFalse(result)
 
     @given(
         hidden=st.booleans(),
@@ -94,9 +149,12 @@ class FormioUtilsTest(SimpleTestCase):
                 "eq": eq,
             },
         }
+        configuration_wrapper = FormioConfigurationWrapper(
+            {"components": [*FORMIO_COMPONENTS, component]}
+        )
 
         try:
-            is_visible_in_frontend(component, data)
+            is_visible_in_frontend(component, data, configuration_wrapper)
         except Exception:
             self.fail("Visibility check unexpectedly crashed")
 

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -400,7 +400,8 @@ def is_visible_in_frontend(
         return conditional_show
 
     if (
-        isinstance(trigger_component_value, dict)
+        trigger_component["type"] == "selectboxes"
+        and isinstance(trigger_component_value, dict)
         and compare_value in trigger_component_value
     ):
         return (

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -17,7 +17,7 @@ from .constants import COMPONENT_DATA_SUBTYPES, COMPONENT_DATATYPES
 from .typing import Column, ColumnsComponent, Component, FormioConfiguration
 
 if TYPE_CHECKING:
-    from .datastructures import FormioData
+    from .datastructures import FormioConfigurationWrapper, FormioData
 
 logger = structlog.stdlib.get_logger(__name__)
 tracer = trace.get_tracer("openforms.formio.utils")
@@ -344,7 +344,11 @@ def conform_to_mask(value: str, mask: str) -> str:
     return "".join(result)
 
 
-def is_visible_in_frontend(component: Component, data: FormioData) -> bool:
+def is_visible_in_frontend(
+    component: Component,
+    data: FormioData,
+    configuration_wrapper: FormioConfigurationWrapper,
+) -> bool:
     """Check if the component is visible because of frontend logic
 
     The rules in formio are expressed as:
@@ -369,8 +373,31 @@ def is_visible_in_frontend(component: Component, data: FormioData) -> bool:
     if not (trigger_component_key := conditional.get("when")):
         return not hidden
 
+    assert conditional_show is not None
+
+    # be resilient on the component key lookup - the old comparison seemed to mostly
+    # work and this whole code should be cleaned up anyway when we go the msgspec route
+    if trigger_component_key in configuration_wrapper:
+        trigger_component = configuration_wrapper[trigger_component_key]
+    else:
+        trigger_component: Component = {
+            "type": "unknown",
+            "key": trigger_component_key,
+            "label": "unknown",
+        }
     trigger_component_value = data.get(trigger_component_key, None)
     compare_value = conditional.get("eq")
+
+    # special treatment for emptyness check of file component - due to a bug in the
+    # formio-builder you can configure the `eq` as an empty string by leaving it blank.
+    # Our new renderer needed the same patch, and the legacy formio.js renderer already
+    # exhibited this behaviour.
+    if (
+        trigger_component["type"] == "file"
+        and compare_value == ""
+        and trigger_component_value == []
+    ):
+        return conditional_show
 
     if (
         isinstance(trigger_component_value, dict)

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -267,6 +267,15 @@ class SubmissionSummaryRendererTests(TestCase):
             form_definition__configuration={
                 "components": [
                     {
+                        "key": "rootRadioCondition",
+                        "type": "radio",
+                        "label": "Root Radio Condition",
+                        "values": [
+                            {"label": "C", "value": "c"},
+                            {"label": "D", "value": "d"},
+                        ],
+                    },
+                    {
                         "key": "container.repeatingGroup",
                         "type": "editgrid",
                         "label": "Repeating Group",
@@ -290,8 +299,18 @@ class SubmissionSummaryRendererTests(TestCase):
                                     "when": "container.repeatingGroup.radioCondition",
                                 },
                             },
+                            {
+                                "key": "conditionallyVisible2",
+                                "type": "textfield",
+                                "label": "Conditionally visible field 2",
+                                "conditional": {
+                                    "eq": "c",
+                                    "show": True,
+                                    "when": "rootRadioCondition",
+                                },
+                            },
                         ],
-                    }
+                    },
                 ]
             },
             form_definition__slug="fd-0",
@@ -304,15 +323,20 @@ class SubmissionSummaryRendererTests(TestCase):
             submission=submission,
             form_step=form_step,
             data={
+                "rootRadioCondition": "c",
                 "container": {
                     "repeatingGroup": [
                         {
                             "radioCondition": "a",
                             "conditionallyVisible": "Some data",
+                            "conditionallyVisible2": "Some more data",
                         },
-                        {"radioCondition": "b"},
+                        {
+                            "radioCondition": "b",
+                            "conditionallyVisible2": "Even more data",
+                        },
                     ]
-                }
+                },
             },
         )
 
@@ -320,13 +344,19 @@ class SubmissionSummaryRendererTests(TestCase):
         step_data = data[0]["data"]
 
         # 1 Header for the whole repeating group +
-        # (1 Header for the single group + 2 nodes for the radio/textfield) +
-        # (1 Header for the single group + 1 nodes for the radio)
-        self.assertEqual(6, len(step_data))
+        # 1 Header for the root radio +
+        # (1 Header for the single group + 3 nodes for the radio/textfields) +
+        # (1 Header for the single group + 2 nodes for the radio/textfield)
+        self.assertEqual(9, len(step_data))
 
-        conditional_textfield = step_data[3]
+        conditional_textfield1 = step_data[4]
+        self.assertEqual(conditional_textfield1["value"], "Some data")
 
-        self.assertEqual(conditional_textfield["value"], "Some data")
+        conditional_textfield2 = step_data[5]
+        self.assertEqual(conditional_textfield2["value"], "Some more data")
+
+        conditional_textfield3 = step_data[8]
+        self.assertEqual(conditional_textfield3["value"], "Even more data")
 
     @tag("gh-3778")
     def test_content_component_summary_has_empty_label(self):


### PR DESCRIPTION
Partly closes #6181

The builder is misconfigured and allows string values to be provided as comparison value, and the proper fix for it takes a lot more work so we apply a workaround to match the legacy renderer behaviour.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
