### PR TITLE
Fix the `is_visible_in_frontend` context in the renderer and logic evaluation for file component

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -68,6 +68,7 @@ from ..typing import (
     EditGridComponent,
     FieldsetComponent,
     FileComponent,
+    FileValue,
     RadioComponent,
     SelectBoxesComponent,
     SelectComponent,
@@ -535,6 +536,14 @@ class File(BasePlugin[FileComponent]):
         }
         # fmt: on
         return base
+
+    @staticmethod
+    def test_conditional(
+        component: FileComponent, value: FileValue, compare_value: str
+    ) -> bool:
+        # See 6181 where we opted for a bandaid fix to handle the wrong compare value
+        # type.
+        return compare_value == "" and value == []
 
 
 @register("textarea")

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -11,7 +11,7 @@ from openforms.submissions.models import SubmissionStep
 from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
 
-from ..datastructures import FormioConfigurationWrapper, FormioData
+from ..datastructures import FormioData
 from ..service import format_value, holds_submission_data
 from ..typing import Component
 from ..utils import (
@@ -122,6 +122,8 @@ class ComponentNode(Node):
         if self.mode in visible_modes:
             return True
 
+        formio_config_wrapper = self.renderer.submission.total_configuration_wrapper
+
         # explicitly hidden components never show up. Note that this property can be set
         # by logic rules or by frontend logic!
         # We only pass the step data, since frontend logic only has access to the
@@ -138,15 +140,15 @@ class ComponentNode(Node):
             if not is_visible_in_frontend(
                 self.component,
                 artificial_repeating_group_data,
-                configuration_wrapper=FormioConfigurationWrapper(
-                    configuration=self.parent_node.component
-                ),
+                # we can pass the root config wrapper because all editgrid item component
+                # keys are already exposed in the config wrapper with their prefixed paths
+                configuration_wrapper=formio_config_wrapper,
             ):
                 return False
         elif not is_visible_in_frontend(
             self.component,
             self.step_data,
-            configuration_wrapper=self.renderer.submission.total_configuration_wrapper,
+            configuration_wrapper=formio_config_wrapper,
         ):
             return False
 

--- a/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
@@ -673,6 +673,71 @@ class ConditionalLogicTests(TestCase):
         )
         self.assertEqual(step.unsaved_data, {})
 
+    def test_file(self):
+        """
+        Ensure that we check whether the compare value for a file compares against
+        empty string.
+        """
+        submission = SubmissionFactory.from_components(
+            components_list=[
+                {
+                    "type": "file",
+                    "key": "file",
+                    "label": "file visible",
+                },
+                {
+                    "type": "textfield",
+                    "key": "textfield1",
+                    "label": "Textfield 1",
+                    "hidden": False,
+                    "conditional": {
+                        "show": True,
+                        "when": "file",
+                        "eq": "",
+                    },
+                    "clearOnHide": True,
+                },
+                {
+                    "type": "textfield",
+                    "key": "textfield2",
+                    "label": "Textfield 2",
+                    "hidden": False,
+                    "conditional": {
+                        "show": False,
+                        "when": "file",
+                        "eq": "",
+                    },
+                    "clearOnHide": True,
+                },
+            ],
+            form__new_renderer_enabled=True,
+        )
+        step = submission.submissionstep_set.first()
+
+        evaluate_form_logic(
+            submission,
+            step,
+            FormioData(
+                {
+                    "file": [],
+                    "textfield1": "keep me",
+                    "textfield2": "clear me",
+                }
+            ),
+        )
+
+        state = submission.variables_state
+        data = state.get_data(include_static_variables=False, include_unsaved=True)
+        self.assertEqual(
+            data,
+            {
+                "file": [],
+                "textfield1": "keep me",
+                "textfield2": "",
+            },
+        )
+        self.assertEqual(step.unsaved_data, {})
+
     @tag("gh-2056")
     def test_file_component_hidden_by_frontend_has_correct_empty_value(self):
         submission = SubmissionFactory.from_components(

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -358,6 +358,105 @@ class SubmissionSummaryRendererTests(TestCase):
         conditional_textfield3 = step_data[8]
         self.assertEqual(conditional_textfield3["value"], "Even more data")
 
+    @tag("gh-6181")
+    def test_namespaced_editgrid_summary_with_conditions_in_iteration_with_selectboxes(
+        self,
+    ):
+        form_step = FormStepFactory.create(
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "rootSelectboxesCondition",
+                        "type": "selectboxes",
+                        "label": "Root Selectboxes Condition",
+                        "values": [
+                            {"label": "C", "value": "c"},
+                            {"label": "D", "value": "d"},
+                        ],
+                    },
+                    {
+                        "key": "container.repeatingGroup",
+                        "type": "editgrid",
+                        "label": "Repeating Group",
+                        "components": [
+                            {
+                                "key": "selectboxesCondition",
+                                "type": "selectboxes",
+                                "label": "Selectboxes Condition",
+                                "values": [
+                                    {"label": "A", "value": "a"},
+                                    {"label": "B", "value": "b"},
+                                ],
+                            },
+                            {
+                                "key": "conditionallyVisible",
+                                "type": "textfield",
+                                "label": "Conditionally visible field",
+                                "conditional": {
+                                    "eq": "a",
+                                    "show": True,
+                                    "when": "container.repeatingGroup.selectboxesCondition",
+                                },
+                            },
+                            {
+                                "key": "conditionallyVisible2",
+                                "type": "textfield",
+                                "label": "Conditionally visible field 2",
+                                "conditional": {
+                                    "eq": "c",
+                                    "show": True,
+                                    "when": "rootSelectboxesCondition",
+                                },
+                            },
+                        ],
+                    },
+                ]
+            },
+            form_definition__slug="fd-0",
+            form_definition__name="Form Definition 0",
+        )
+
+        submission = SubmissionFactory.create(form=form_step.form)
+
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step,
+            data={
+                "rootSelectboxesCondition": {"c": True, "d": False},
+                "container": {
+                    "repeatingGroup": [
+                        {
+                            "selectboxesCondition": {"a": True, "b": False},
+                            "conditionallyVisible": "Some data",
+                            "conditionallyVisible2": "Some more data",
+                        },
+                        {
+                            "selectboxesCondition": {"a": False, "b": True},
+                            "conditionallyVisible2": "Even more data",
+                        },
+                    ]
+                },
+            },
+        )
+
+        data = submission.render_summary_page()
+        step_data = data[0]["data"]
+
+        # 1 Header for the whole repeating group +
+        # 1 Header for the root selectboxes +
+        # (1 Header for the single group + 3 nodes for the selectboxes/textfields) +
+        # (1 Header for the single group + 2 nodes for the selectboxes/textfield)
+        self.assertEqual(9, len(step_data))
+
+        conditional_textfield1 = step_data[4]
+        self.assertEqual(conditional_textfield1["value"], "Some data")
+
+        conditional_textfield2 = step_data[5]
+        self.assertEqual(conditional_textfield2["value"], "Some more data")
+
+        conditional_textfield3 = step_data[8]
+        self.assertEqual(conditional_textfield3["value"], "Even more data")
+
     @tag("gh-3778")
     def test_content_component_summary_has_empty_label(self):
         form_step = FormStepFactory.create(


### PR DESCRIPTION
Closes #6181 partly, cleans up my mess from #6220 and amends the file-specific bugfix part to #5134

[skip: e2e]

**Changes**

* Un-frick my wrong `FormioConfigurationWrapper` context passed to visibility check in the renderer/node visitor of the backend, which would work most of the time by direct comparison and broke for selectboxes and file components in an editgrid context.
* Added the proper selectboxes-based test after misreading/confusing radio/selectboxes data structures the entire day
* Applied a similar patch to the registry `test_conditional` after stumbling on it for the selectboxes component, and added a test after wondering why no test broken in the first place. Verified that the test indeed confirms the bug if there's no patch.  

e941bf0b7671df562469f6015316f6356484855e and 44d176b1ad32350bf64cce51f11a66d0758881dd need backporting to 3.4.x and 3.5.x, while 21b70b5b1db01aabed74783a950d8048f387a412 only needs to be backported to 3.5.x I believe.

I promise I won't merge this one without PR approval :grimacing: 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes