### PR TITLE
Onegov/Ilionx-specific StUF-ZDS tweaks

### DIFF
--- a/docs/configuration/registration/stufzds.rst
+++ b/docs/configuration/registration/stufzds.rst
@@ -136,8 +136,11 @@ These SOAP-operations are used by this plugin:
 * ``creeerZaak_Lk01``
 
    * ``heeftAlsInitiator`` (the initiator can be excluded if needed)
-   * ``heeftAlsOverigBetrokkene`` (will only be set if an employee logs in on behalf of a client)
+   * ``heeftAlsOverigBetrokkene`` (set if: an employee logs in on behalf of
+     a client, the submission has been cosigned or there are family member relations)
    * ``heeft`` (the status can be excluded if needed)
+   * ``extraElementen``, all remaining unmapped submission data elements + explicitly
+     mapped (registration) variables through the configuration
 
 * ``updateZaak_Lk01`` (only used when delayed payments are enabled)
 * ``genereerDocumentIdentificatie_Di02``

--- a/docs/configuration/registration/stufzds.rst
+++ b/docs/configuration/registration/stufzds.rst
@@ -15,6 +15,10 @@ register form submissions.
    This service contains sensitive data and requires a connection to an
    external system, offered or maintained by a service provider.
 
+.. contents:: Jump to
+   :depth: 2
+   :local:
+   :backlinks: none
 
 What does the Open Forms administator need?
 ===========================================
@@ -145,3 +149,63 @@ These SOAP-operations are used by this plugin:
 * ``updateZaak_Lk01`` (only used when delayed payments are enabled)
 * ``genereerDocumentIdentificatie_Di02``
 * ``voegZaakdocumentToe_Lk01`` (for both the submission document and each attachment)
+
+Vendor-specific notes
+=====================
+
+Some vendors of StUF-ZDS-compatible systems require some extra attention.
+
+.. tip:: Missing some vendors here? Let us know in a
+   `Github issue <https://github.com/open-formulieren/open-forms/issues>`_.
+
+Onegov 365 zaaksysteem
+----------------------
+
+``<ZKN:startdatum>`` support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Onegov expects a datetime here rather than a date. However, the StUF-ZDS standard
+prescribes a date without any time information.
+
+As a workaround, you should update the form registration configuration with an
+``extraElement`` mapping. In the registration plugin configuration options, ensure that
+there's a mapping entry from the form variable "Submission completion timestamp"
+(``completed_on``) to the name ``zaak.pv_startdatum``.
+
+Payment details information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open Forms uses the StUF-ZDS elements ``<ZKN:betalingsIndicatie>`` and
+``<ZKN:laatsteBetaaldatum>`` to report the payment status. Onegov expects additional
+information that's not readily available in the StUF-ZDS standard, through
+``extraElementen``:
+
+* ``zaak.pv_orderid``: the registration variable "Payment public order IDs"
+  (``payment_public_order_ids``) exists, however emitting it will result in a ``.0``,
+  ``.1``, ... suffix being added to the name of the extra element, as multiple order
+  IDs may exist. This will effectively produce XML looking like:
+
+  .. code-block:: xml
+
+    <StUF:extraElement naam="zaak.pv_orderid.0">12334</StUF:extraElement>
+
+  .. warning:: It's currently unknown if Onegov can handle this or not.
+
+  .. note:: Administrators can control the template of these order IDs. Take into
+     account that Onegov has a 100-character limit on the value of this element.
+
+* ``zaak.pv_bedrag``: the registration variable "Payment amount" (``payment_amount``)
+  can be mapped to this name. It uses a period (``.``) character as decimal separator,
+  as expected by Onegov.
+
+* ``zaak.pv_betaalmethode``: this should be omitted - Open Forms uses payment providers
+  that manage this and for us the payment method is unknown anyway.
+
+* ``zaak.pv_transactieid``: the information is available in the registration variable
+  "Provider payment IDs" (``provider_payment_ids``), but it has the same limitation like
+  ``zaak.pv_orderid`` with regard to the suffixes. An element value may not exceed 100
+  characters here either.
+
+* ``zaak.pv_betaalstatus``: this cannot be mapped, but the StUF-ZDS element
+  ``<ZKN:betalingsIndicatie>`` is the right place and we manage that automatically
+  already.

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -152,38 +152,29 @@ def _prepare_value(value: Any):
 
 
 def _get_extra_variables_mapping(submission: Submission, options: RegistrationOptions):
-    plugin_payment_static_variables = [
-        "payment_completed",
-        "payment_amount",
-        "payment_public_order_ids",
-        "provider_payment_ids",
-    ]
-
-    key_mapping = {
-        mapping["form_variable"]: mapping["stuf_name"]
-        for mapping in options.get("variables_mapping", [])
-    }
-
-    plugin_payment_static_variables_data = {
-        key_mapping[variable.key]: _prepare_value(variable.initial_value)
-        for variable in get_static_variables(
-            submission=submission,
-            variables_registry=variables_registry,
-        )
-        if variable.key in key_mapping
-    }
-
+    # Grab the variables data from the submission state & inject the static registration
+    # variable values
     state_variables_data = submission.variables_state.get_data(
         include_static_variables=True
     )
+    state_variables_data.update(
+        {
+            variable.key: variable.initial_value
+            for variable in get_static_variables(
+                submission=submission,
+                variables_registry=variables_registry,
+            )
+        }
+    )
 
-    submission_variables_data = {
-        stuf_name: _prepare_value(state_variables_data.get(variable_name))
-        for variable_name, stuf_name in key_mapping.items()
-        if variable_name not in plugin_payment_static_variables
+    # emit only what was explicitly mapped in the options
+    variables_mapping = options.get("variables_mapping", [])
+    return {
+        mapping["stuf_name"]: _prepare_value(
+            state_variables_data.get(mapping["form_variable"])
+        )
+        for mapping in variables_mapping
     }
-
-    return {**plugin_payment_static_variables_data, **submission_variables_data}
 
 
 @register(PLUGIN_IDENTIFIER)

--- a/src/openforms/registrations/contrib/stuf_zds/registration_variables.py
+++ b/src/openforms/registrations/contrib/stuf_zds/registration_variables.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext_lazy as _
@@ -69,3 +70,16 @@ class ProviderPaymentIds(BaseStaticVariable):
             return None
 
         return submission.payments.get_completed_provider_payment_ids()
+
+
+@register("completed_on")
+class CompletedOn(BaseStaticVariable):
+    name = _("Submission completion timestamp")
+    data_type = FormVariableDataTypes.datetime
+
+    def get_initial_value(
+        self, submission: Submission | None = None
+    ) -> datetime | None:
+        if submission is None:
+            return None
+        return submission.completed_on

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSConfirmationEmailVCRTests/test_confirmation_email_is_only_attached_once.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSConfirmationEmailVCRTests/test_confirmation_email_is_only_attached_once.yaml
@@ -6,7 +6,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7d76961c-c546-4cc9-b225-eb0d9f0f6dbd</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>41467e32-7738-4a5d-ab91-4cca88cb5318</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -23,7 +23,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -40,7 +40,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>5e0ae40fe4dde195</ZKN:identificatie>\n
+        \               <ZKN:identificatie>a00936501a98979d</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -51,9 +51,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -64,25 +64,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7213b8ff-7c09-4669-a046-cd60ad22420d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5c97e14b-6f13-4e87-9a32-0773a14e74fa</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>5e0ae40fe4dde195</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>a00936501a98979d</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>Bevestigingsmail</ZKN:titel>\n        <ZKN:beschrijving>De
       bevestigingsmail die naar de initiator is verstuurd.</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"bevestigingsmail.pdf\">JVBERi0xLjcKJfCflqQKNSAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAxNjA+PgpzdHJlYW0KeNpdzc0KwjAMB/B7niIvYJus3VZh7LAPUGHosLKDeJjCdpr48f7gTJkH+UN+SUooI81Z8VycZeXcOk0s3iZ4Aqk0ltdfI+sQfXz0d8gy3ZTbCinPoahK0D0rwvENcoavEQoPvHzhDDKRYjIxJ+gn0JtTe9h3+J0GOGdE0TWnGZMGSIgGgYxgEyGOAhwIB9b9Ly/od1B7qJsS2iUfuVAzuAplbmRzdHJlYW0KZW5kb2JqCjcgMCBvYmoKPDwvTGVuZ3RoMSAyNTcyL0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDEzNzE+PgpzdHJlYW0KeNrNVmtsk1UYfs/5ehmVAe16YWyw9it8G127Xr62GwJykdLhBgMxOCCO1VG2QbcOVmQETVTwB8swRBP+aOIlJhJ/iJc/JPJTjBKNEhJNFIkRZ5CQaDTwb63POV+H25iYmJj4vTnnvZz3vM/7nnN6TokR0Vx6lhRam96Q2siusstEc76C9cGO7eHY/h/2fEbEWqF39wxkhvgZ/gaRUgE915sZHgJfAP9PwSt6c0f31b3y/jUiUwN8Rvqymb1L36pcjLHP0ZJ9MFg/4b8jngn60r6Bwkh1LTsP/Sxady7fk3Gdcp7B3ALGPxjIjAzRbkpgDPHIO5gZyNaPrvmRyPo6Ea8Yyg8XSq9RDPhnxTiJWjizXBm/YN8zf9Vtsio3YKGrlvE+wcd/uT6Xqkp3lBP8ElQLcTI+zDOFit8B9x2qIqdyQkaa+nVKSyfFy3NmjiMA385OkxkJjPJO6G0GZ10UY+th5WZuMZs5N82cne7oSLO1yL5g5GAKsWWTPnyhzNSL6J3UNTlDrt7/+FOqSZuq8zxpWFnt7/x5lpz/FovdomYZw2Pw+338Barl6+71Y93YdZI7q6A50TPJTSR20oETrmDUS620mR6jHspSngqlktyZVmov2waFrXR9Os1yUv677+EyHaC3p9Hl+xFTQPF7KMdeuksX5HnE/vE/cB51Ij2hx5IJe1zz+xM+l1+1uFy+xBTN7nTrOkzCCyapaZVqJOqrZH5wloqohgRL8Xvw4kewBKrD7GZwYQD80qVwteBFV9Aj+M2b0CezSCGLRbNlYYch2dysWwWYAeGLXlyyzKHY4lYR/WcRdWFw4uuagKvtm3I8eR8EpsfTq6r0maU02xW/Yi8X44si9Z++/OKagVS8o3g1Pp68oalKwBNkv6KMiY/5KlHCIgHqXs7dE8/xZyZui0KYOPF8G3Br7uICzWr1N/s8/noNKRhAZzy+aHdQNZnjZq6jM6mhTET1AII3Rn2N5841+qIT35bXprl0h13kKvmIzKqmJeLJpB5zu11Oix9FqRaL2AnUISwWVrO+d+XK7JrA1ngo6I9pK+rSW8Mpu11rs7UcffLAMd0d8quLwxsa9u7a319fN6/aE1yMX4HAGAeGh5ZIFIAAA/vvNkLL2FUSzsrqBo4V9mfyxQ95W2t8k8M6V9uyLLqqebXZdvr5sRdHjjQN9DTWKI5KZ5OPpbZmdu8QVdRiZfqBsHzGjnj0pAElF8ZvL5dkqLUVaiTsM79Zaa7bHOnYuVw1vxtdHUp4YBP73oLt2Nbif6L3FpaK7VzXGnqk8QpOFhkVcRvwHkBNUypyWuqBLUEAwepyTx8poB1qW/1QG5pt9NTYyZNjp0bjw0PyGxa543Vhm/jLYlc9iGT3J7AmOJK6S2RsrL7LYvmtPdXuCC6wu61Nx48HVMeSBZVxW2oH29Iw3+6Ia8dWFM/pEZMStNjwy7PSLnEjmeZA7pJ3lJDFCeoqy5zm0aGyrFCLfM2FbKKldL4sm+k9ulqWLaSyMdwTeRqio5jZT73URwXcZjGKUBQvrpfSGM3DnsPN5sUd1w7/JkjrYMmBP3p31rDUsuBZxHoK/V54bhF3JJqXtkt7P+2TXr10GPMzsMTgFQHFaSXQOkBpSJPz/poVmjFvtsjeGT475MgwxvK4l73TsPDSgvbB77CM0wevQVl9A7KPwrMFTcf58wJb1NoipUPoE4gh5HR5rQxtBH0UsYW8Ab3IoSBxQzK3QZlFVuoZ9AeR2UGpdaJXQf9ctWJc8aVXxf+d2R5CYniR5pPxf6784OHsNIIYhZEp7gcQo40ghnerFf02oDB6HIR5fwJBCICYCmVuZHN0cmVhbQplbmRvYmoKOCAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAyNzM+PgpzdHJlYW0KeNpdkc9qxCAQxu8+hcftYdGY7G4PIVC2lxz6h6Z9gETHVGhUjDnk7avjsoUKCj+++ZzhG3btn3trImXvwckBItXGqgCr24IEOsFsLKkEVUbGG+Erl9ETlszDvkZYeqsdaVvKPpK4xrDTw5NyEzwQ9hYUBGNnevi6DomHzfsfWMBGyknXUQU6ffQy+tdxAcrQduxV0k3cj8nzV/G5e6ACuSrDSKdg9aOEMNoZSMvT6Wir0+kIWPVPr3ixTVp+jyGXiymVc948dpnqC9KpKcSLppCELiSReI0kOFJzRjrXSCdRSBeqCkGh0uFSOqS2qJ1w2NtUeeyc7j0TuYWQ4sAVYA45AWPhviXvfHbl+wtlSokZCmVuZHN0cmVhbQplbmRvYmoKMTggMCBvYmoKPDwvVHlwZSAvTWV0YWRhdGEvU3VidHlwZSAvWE1ML0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDI1ND4+CnN0cmVhbQp42oWQwW7DIBBE7/0KRM9mY0etahQnh0RRL6mitlLPGEiCUgMCLBN/fbFrub3lxrBvVrOz2kTL+FUGVMuz0hXGSIkKfz0dFge7lRf12jv50b998v7KS4E364dVpLGxjQwMxeZbexorzISpJU3v4Rtwgpw40ffdfkKsOFX4EoKlANqTESfcNJAGkJMl4D+wZUOCCe66jjClGmLcGcZh8oMSs8H92zzA3XJE87IsYVFAUWSJyPxNBxYz7R/xeoy2k547ZYMyGg2a1aYNw/VTAGqZSzrHCO4b6NEZ0XLpUnGS+dvRKR3Q8wv5tcPURWoF5u6SmKuXOh3sUrc/LwCEggplbmRzdHJlYW0KZW5kb2JqCjIwIDAgb2JqCjw8L1R5cGUgL09ialN0bS9OIDE1L0ZpcnN0IDEwNC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCA4MjM+PgpzdHJlYW0KeNqFVFlv2zgQft9fMY8xCpukJOoACgNJnDRGN4nXcpsCgh5oiXG4K4sGRWPrf78zktIkxTYFfHCOb+4ZARwCCFMIQaQSIgijFGKIpIAM4kiC4JBGMQiBH56ACPATpCBQP4iQjvA/4SBQMwzwB1XDJANBogiV8BllyR8fP7LN6aCBrdROd+yzqTsoYnS+LtmlPbYexHz+onWpvGrsbtAGQXos9+5Y+Y3Tem2tJ8/E/Wr0v9qtnH7UTrcVaqORhekOjTotbLUxvtGASD2fs1vl/lm2j5ZU6K3rZ8mfqt3B2YTdaq9q9I3FIOtDSI3aTmvJoUC1LWEfnozXK2sw6oLPsjgKspiCnKWBFFyWbI3mNBRTQRXB7/OjnM/LwVwsf2lO8kiSOTHjacZl+r65IcSr7/5T7pXXZE8hkv4rRUXF7L7db//WlUceEivlvXbtQORPqjaYek9c2sa6/KAqjdNAtb221JfgpRIvLcQfLLcfW3Ora6Mu7HeMH2mZyVmQSJkJHB0xS9MsiSNqc+sR0oHsMWvd2aOjhg2N3KhtBywf2zyY74CzjTP735m+aLSuf6P0OgNKbKG7ypmDt64n79QeBTdf/lrdP3y4s95Oc+3MYy+7VnvTnOCM2NCzJ+y6UbsO4l5+MbqeBlkIGS6T4HFWsiXOsKnO2x1OIGfnXdUXDEWMfBNBAJz1w402u6dRlnu9/wop7x839OhDMI0OIPm5FSRi+XHrh61ZLohBooBdqE73DfyfpFAxP3Vo/3kb1npnOu8wx/PabvWE3bsaNWkpljVGavxpgn4Oh0bvKXBO47JcbOyn5eJWHYA9a7EHKEIogpiXgOtfJFmIjwR3PehLU4LEyY8FcvFqFFEW4COAQoayhFSgCG+OTBIkEBTKoCx/6hbepXeLQDz+bvYb+6U1la019EvOrlokKNcfWUxvxhbVCktvaRALwftrNTgejNJV/BHL3XHf0RAUou9S+Wbg3t6ucXmIpENKMXxGnHzl4DXsCovOcmB4zo5U/V55vJ2r8Q7+GnVn24HRw5IRtoPeAOHl+3g8CC1B+VtU/IJaOVsfK+3g7EGr7rRydMnidCYm8/l/MHrSqQplbmRzdHJlYW0KZW5kb2JqCjIxIDAgb2JqCjw8L1R5cGUgL1hSZWYvSW5kZXggWzAgMjJdL1cgWzEgMiAyXS9TaXplIDIyL1Jvb3QgMiAwIFIvSW5mbyAxOSAwIFIvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggNzI+PgpzdHJlYW0KeNolzDEOgCAAQ9FfVBBFWTyc5/OGJg5uaMPykjZpgdYCBxiZYAZRezeKBxSvHicTTTKzyWYxqylmU3r7Ylc+/4Nywwe+pAfACmVuZHN0cmVhbQplbmRvYmoKc3RhcnR4cmVmCjMzMTMKJSVFT0YK</ZKN:inhoud>\n
-      \       <StUF:tijdvakGeldigheid>\n            <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n
+      StUF:bestandsnaam=\"bevestigingsmail.pdf\">JVBERi0xLjcKJfCflqQKNSAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAxNjA+PgpzdHJlYW0KeNpdzckKwkAMBuB7niIv4Ewyna1QCnY5qPQgDogUD1VoTxWX9wfLDPUgP+QLCSGMtGTDS/Gahfe5sxrvM7yAhDNx+2viOEWensMDikJ29a5BKkuomhrkwIJw+kA8w/cEVQBeX/gMcye8YWMVhhlktT0fLg2yxTBCXxCpW0kLmUtQRI0RyiLaRoxKcCIdaP8/vGLYQxug7Wo4rvkChxwzgAplbmRzdHJlYW0KZW5kb2JqCjcgMCBvYmoKPDwvTGVuZ3RoMSAyNTI4L0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDEzMzQ+PgpzdHJlYW0KeNrNVXtsU1Uc/s7t7QOsY8VuwGSuc8ggEB7rHkRQAWEMAoowpi4KK6Vb1wfr2EDm5BE0Q4OA08mmJoJolsg/DjAEdJQYo4IJJibqZgiCbjxKfKCRROh663dv260bvmJi4vnl3vN7fr/HPaeFAJCCrdChori4dMnB9a6T1PzGZ+yCefOLxVnRDYgOyrOXzCktmX7atALQuSn/8uDyqXm+5o7VtF+lXOb0OwLSHukNQCqh7Kty1AVgJAHf8zFX+RoqP9r07TXAOI4+nW6XY03BufZ7GL+R9kI3FSNtZh3lUsrj3P76jUW7dQ2A/Bh1Fb4ap2NEVso6xr5L+yG/Y2MALVI7bVbKtrUOv2v0kXwfoO+krjJQU1cfPYNy8vmqnY8EE6RolN1SyQcXnqx+VNsjm4v6d9XyiDQMk9BGf82vf5kga9Fc0W4V+w8WI4x+JROwZF7v7gukdg/BILqmkVYePT8x071qxKxryDJhaB3XuyN3p3abzmtZpQFsmOO82o2OJFjpJL6nYhrfRVA7KCYJlJAEHsIyvh8mCQg5Q7wAPWdk179CuDtiu64LldJIQhoMOr1BL0lyYkKJtbRy/hrM5hTrDVbFKl41+kVPBbD3XFd/NdAmY9UqUneZfQIjkUqNxMgSLEEpnHChBvX8CtB0i+O6taou2jOYbprcf7kmxmkOvIOo6S/pMKlnKIkUMaOfVsZnOZYzGY4JN+VdillmGM9qQ9zG057Lr/NlzKTyySshC3ecX/H3bYkU4m74B/2Xx3y1U53gkzAG6cuTZOcAL80AwrvJz2J9p1GZiJd24H+9DDdQmyzrl6LWNH2g/qFLXwbrv80lN8Zw5c4/x+/Pk4tF8uc3++mKMJObkTPnbZOHkQ/igTgvMBqFcV79jZgS53VJejmJ15NPj/MGcsA83kcPHCjDeiwnvw7VrKFM4+rI1/C22pBHZDt/beZSruE9SY6yJcXdT2sADZpUBTfqaZ3AOz9Rw5hGspNbTQ8bsappr+OzjvEO+DGZ2oXM52Q2G++mj2TjL1oCq06TXNzVfBv4XkPP4UOqcdLXQZQqzdNGXsW3EUXtJECf1cStpp+N8TXM69Bsw7W7y7NheI538nbAXmC35BRkp+VYsuO7PS2bumzutcGgtCCoM6jvYORYsO9G0KOH1xvpk2SvNwyPR9oW2eyJI+qziHjrIERyMQzpQKMWGbbcUHao/jwBxlP0H93vP0wMJBc5Qkt/ShyWzJJZtH1yInI0qGCnAq2C8NdyrpZf3hb+SbaEYzXwBOvnEnMEoHWQ6IlQYvsJZWGjfkqjsvCER/41JCqUfaGw2aNWEu2RM+V5yFB/CUTOnShIhT0vfZQlZwolQ5o13Z5XWCRn5n7TcVm5KDIuu066vGk7n365rXXPE7syxH0HDgm7gqiYPnWacvX5rZcuXrz81Cb1/0NFLiOyVZ0zu4sh2WNJ8pkERi2FUS7ru7T/9YbXslom//BBSLkg0r/7WUhfGJqf3fJiKk9815ktm97pYJY+ka90HXzvePCY2u8i3rkfiZ85MPN7BUtPi08xf7xaP4XS9g7htr/p62h/S5H3VjRsbdrn0S3zHvet/fSryMf8iviw+f3DSoYnUbWHqLdgFHBXXmFBDMaaPipRdZoVkrultbWlpbXtJXUmY0IhMUa5VHyltzcU6u294mSpishTPlMU5bRa6cxojy5XX6si3pbDytSPk21Jmsf4grP79x8T5Up7fnHJXGmHaVfz3md0nV6xSDnijTy+ffGKVc1NO9/G7x8qvm0KZW5kc3RyZWFtCmVuZG9iago4IDAgb2JqCjw8L0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDI3Mz4+CnN0cmVhbQp42l2Rz2rEIBDG7z6Fx+1h0Zjsbg8hULaXHPqHpn2ARMdUaFSMOeTtq+OyhQoKP775nOEbdu2fe2siZe/ByQEi1caqAKvbggQ6wWwsqQRVRsYb4SuX0ROWzMO+Rlh6qx1pW8o+krjGsNPDk3ITPBD2FhQEY2d6+LoOiYfN+x9YwEbKSddRBTp99DL613EBytB27FXSTdyPyfNX8bl7oAK5KsNIp2D1o4Qw2hlIy9PpaKvT6QhY9U+veLFNWn6PIZeLKZVz3jx2meoL0qkpxIumkIQuJJF4jSQ4UnNGOtdIJ1FIF6oKQaHS4VI6pLaonXDY21R57JzuPRO5hZDiwBVgDjkBY+G+Je98duX7C2VKiRkKZW5kc3RyZWFtCmVuZG9iagoxOCAwIG9iago8PC9UeXBlIC9NZXRhZGF0YS9TdWJ0eXBlIC9YTUwvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMjU0Pj4Kc3RyZWFtCnjahZDBbsMgEETv/QpEz2ZjR61qFCeHRFEvqaK2Us8YSIJSAwIsE399sWu5veXGsG9Ws7PaRMv4VQZUy7PSFcZIiQp/PR0WB7uVF/XaO/nRv33y/spLgTfrh1WksbGNDAzF5lt7GivMhKklTe/hG3CCnDjR991+Qqw4VfgSgqUA2pMRJ9w0kAaQkyXgP7BlQ4IJ7rqOMKUaYtwZxmHygxKzwf3bPMDdckTzsixhUUBRZInI/E0HFjPtH/F6jLaTnjtlgzIaDZrVpg3D9VMAaplLOscI7hvo0RnRculScZL529EpHdDzC/m1w9RFagXm7pKYq5c6HexStz8vAISCCmVuZHN0cmVhbQplbmRvYmoKMjAgMCBvYmoKPDwvVHlwZSAvT2JqU3RtL04gMTUvRmlyc3QgMTA0L0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDgxOD4+CnN0cmVhbQp42oVUbW/aSBD+fr9iPgadYHeN1y9ShRRC0qBcUoS5pBXyh8WeEPeMF60XXfn3N2OTJqmuiWTBvD3zvqNAQgDjBMagEg0hjMMEIgi1ghSiUIOSkJBIKfpUAN03JjHZBzoERV8Qx6BYNCZlRP8J/ZAo1BJUSioZ/vHpk1gd9whiYbbYipuqbGEdUfBlLi7sofGgJpMXqwvjTW23vTUothOZd4fCrxzi0lrPkVl6X+G/6BYOH9FhU5A1OZlV7b42x5ktVpWvEQiJk4m4Ne6fefNo2YRpLJ81f5lmC2cDcYvelBSbmsHe+5RqsxmWVMuazDaMfXiqPC5sRVmv5SiNwiCNOMlREmgldS6W5A5hPaQWcZvgmcgnk7x3F+nfuqN2aXanRjJJpU7ed9enePnDf8688cj+DCH5vzDcVKru65fNdyw8yYhZGO/RNT2TPZmyotI75sLW1mV7UyBtA/f2yvJcgpdOvIyQfqjd/jSaWywrM7U/KH/idapHQax1qmh11ChJ0jgKecyNJ0gLusMssbUHxwPrB7kymxZEdhpz774FKVau2n3kelojlh8Yva6AC5thW7hq763r2DuzI8X0/OHm2+zPGX4394dhhq567LRXZlfVRzjrFdApBuKqNtsWos5iego/DMY0PBmEkAY0ujntcVWcN1vaQinO24KbRhrB4Zlme1r3/TVW26delXnc3UMiO+KaiS6FqsYA4l+HwSqRHTa+fzfzGQtYFYipabEb4f+WRabZsaUIzy9iiduq9Y6qPC/tBgfiiyvJkh/GvKRUK38cUKT9vsYdZy55Zeazlf08n92aPYhnK/EA6zF9KskhJCKJAyJieu9R2LUmB62Zi3OI6VnpSBIREJGSYaJIFYYQSWYIFRKR/zIyOk7v9oFl8oMGrOzfTVXYEqF76+KyIYbL/VnI8Po0ptJQ/y3v41rJ7mj1oXu3fBx/ZnN32LW8B2vVjSp/s3dvT9jpDTHL95RzuCGcfhXgNeyS+i4yEHTVDjyAzvh0Qhenc/h71J1tekEHi0+wLXQOGK/fx9NdaBgq36KiF9TC2fJQoIOzBzTtceH4oEXJSA0mk/8A/kLURQplbmRzdHJlYW0KZW5kb2JqCjIxIDAgb2JqCjw8L1R5cGUgL1hSZWYvSW5kZXggWzAgMjJdL1cgWzEgMiAyXS9TaXplIDIyL1Jvb3QgMiAwIFIvSW5mbyAxOSAwIFIvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggNzM+PgpzdHJlYW0KeNolzMENgCAAQ9FfVBBFubiJ8zmfA7iKd7Th8pI2aYHWAgcYmWAGUXs3ihcUrx4nE00ys8lmMaspZlN6+mJXPv+DcsMHsJAHJwplbmRzdHJlYW0KZW5kb2JqCnN0YXJ0eHJlZgozMjcxCiUlRU9GCg==</ZKN:inhoud>\n
+      \       <StUF:tijdvakGeldigheid>\n            <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n
       \           <StUF:eindGeldigheid StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n
-      \       </StUF:tijdvakGeldigheid>\n        <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      \       </StUF:tijdvakGeldigheid>\n        <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -92,13 +92,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7788'
+      - '7736'
       Content-Type:
       - application/soap+xml
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -125,9 +125,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSConfirmationEmailVCRTests/test_confirmation_emails_are_attached_when_updating_registration.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSConfirmationEmailVCRTests/test_confirmation_emails_are_attached_when_updating_registration.yaml
@@ -6,7 +6,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fb7985e9-141b-46ae-9fe0-7f3f572f82ce</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c5c34e29-9c63-4330-bba4-f2a024986112</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -23,7 +23,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -40,7 +40,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>def25e1d89abeb4f</ZKN:identificatie>\n
+        \               <ZKN:identificatie>7b2cca444a12e6dc</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -51,9 +51,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -64,25 +64,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ae40507e-d487-4e41-a812-9ff00912ba71</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>126a33a8-5eb9-4f10-b2b1-e47c272dc325</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>def25e1d89abeb4f</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>7b2cca444a12e6dc</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>Bevestigingsmail</ZKN:titel>\n        <ZKN:beschrijving>De
       bevestigingsmail die naar de initiator is verstuurd.</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"bevestigingsmail.pdf\">JVBERi0xLjcKJfCflqQKNSAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAxNjU+PgpzdHJlYW0KeNptzU0KwjAQBeD9nGIuYDLTpG2EkkXTggpFixEX4qIK7ariz/3BmlhX8iDfZMIjjDRlwdNhNAtjlnmm8TrCA0jkaXj9DWEdI/f37gZFIRu3rpCshbJyIDsWhMMLQg2fA5QeeP7CKGQiwaRSztCPIFeHdrc94ufWw6kgSi6WJlQeoUDSB0gFdBZIkwhHYkGbP8tvj7WlM/oN1B7qxkE75w2hlTaUCmVuZHN0cmVhbQplbmRvYmoKNyAwIG9iago8PC9MZW5ndGgxIDI2NTYvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMTQzNT4+CnN0cmVhbQp42rVWXWxURRQ+M3f3blmpdNv9aWlpd++2t2W72/25u9vyU/ktLbbQIgYLxNK1LG2x7Ra6SAmYoOADTTEYE59MTAgPxgcx+qCJL8aIiY1ijIkmCkbFGiQkGpU+GNv6zdyllIIYNN6TO+dnZs53zszcM5cYES2m46TQ2uaNTZvYJfYZkb0S1pXt28Ox/d/u+YiItUDv7hlMDfMRxUmk5EHP9qZGhsELML4MPK934Mi+97rPdhBZIhjzfl86tbfyXL4PfR/jTfbBYPuQ/wp/FuiVfYPZ0dJW9gf0V/F2D2R6UksPlxzH3GPof3MwNTpMuymBvhro3qHUYLp6bM33RLbfiXjecGYkO/sKxYgW/Sn6SeTCmXoyczGxZ8nqG2RTrsJCl9TJPsEnf7qymIpmp5ST/CJUlTiZD+ZZQjNfA/c1KiKnclJ6mv90SksnxXNzFvbDAd/OzpAVAYzxTuitJmddFGPrYeVWrlqtnFsWzm5ub29maxF91ozBEmJVN8fwYj4hM7PAV9fNGXL1/uPDw7Se/qdHKSH9NqwM6VhZ/W9jSZPz32Kx61QvfXhMfs+cn6Myvu7Ocawbu05yZxW8TrRMcgt1S14AiwW7EKUW2kKPUg+lKUPZ2Vm5N8LalrMOCevslYV0l/Nyf0/VfVFfjs7gu5tPU/ciVgPaeQe9wN6eo+/kucS5YZfxBXmIjIQRSyYcqurX9EQyWV9vOJxuw3B1b9AiemO5u6x8Q3TT2ogWDZSEeX7dyvLiPG9VfPpcuCQgPOFE8N9wwo05T3Hd70/4XH5Ndbl8iXma6dcnR8EkNT1fi0R9+cwPzpoiminBMnMZfOZdWIDLrgWLA+ATE0AFn3EFPYJfuzYviiZEsfRuUThgEHnZBJgJ4YteKK8qVOxxm/D+o/BaHJz+ojTgav0y5w8VZoICt/szioqMhanUOxS/4sgl44si9B8+/eQbE2lmSvHqfDJ5VdeUgCfIfkYa0x/w1SKFpQLUvZy7p5/hT0/fEIkw8Q3xbcAtncMFms3mr/d5/NU6QjCBXvL4ot1BzWKNW7mBxqKFUhHNAwheG/XVnj9f64tOf5Vbm/rZKXaBa4QabtV0PRFPJo2Y2+1yqn4kpamq2AnkISwqK13fu2pVek2gIx4K+mP6iormjnCTw6G32huOPPHkUcMd8mvLwhtr9u7a319d8WCJJ7gMX53AmASGh8olCkCAgf13m66l7yIJZ2MVg0ez+1OZmbd4a0t8c6Ftsb61Krq6vtFqP/Ps+POjh+sGe2pLlcJ8Z52PNXWkdu8QWeB24v1AWL5gRzxG0oSSC+N35FIy1bI8LRL2Wc/mWyu2RNp3Ltesr0cbQwkPbGLfG7Ad2xr8j/dex1KxnetaQg/Xfo6TRWZG3A68B8Q3cisjp1oNbAkCCFYxcOxwFu/B1saHWvHax06Pnzo1fnosPjIsnxERO+4rtpm/KHbVA08OfwJrgiNpuETE5uq7VPWXtqa2wmCBw22rO3EioBWWF+TH7U072NaaJY7CuH50xcx5I2JRgqpd1hMb7RJVzrIIcpese0IWZ6grJ3N6kA7mZIUa5B+CkC1USe/kZCu9QZdyskoaG6cNqIvDdAQz+6kXFSiL+hijCGpkAlIzejOwD6BSelEz2zC+DtI6WAbAH5mbNSK1NHgavp5Cuxcjt4qqi9dL26W9n/bJUb10CPNTsMQwKgKK0yqgtYOaId2cd2tWaMG8u3n2LhizQ/aMoC+DOu+9DQu3N2gfxh2SfvowakhmX4PooxjZgNfACfQCW+TaIKWDaBPwIeTm3FqZ2qi8WeJS3ohWxJCVuCEZ25CMIi31FNoDiOyA1DrRaqB/zloxL5fZl8U/1N0uV2K445aQ+Y+Yu0RxdmpBjMKIFBUCxGgTiOEebEG7DSiMHgNh3l8saJh9CmVuZHN0cmVhbQplbmRvYmoKOCAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAyNzc+PgpzdHJlYW0KeNpdkc1qxCAUhfc+hcvpYtD8zXQRAmW6yaI/NO0DJHpNhUbFmEXevnoNU6ig8HHu8V6P7NY/90YHyt69FQMEqrSRHla7eQF0glkbUpRUahEOwlMsoyMsmod9DbD0RlnStpR9RHENfqenJ2kneCDszUvw2sz09HUbIg+bcz+wgAmUk66jElS86GV0r+MClKHt3Muo67Cfo+ev4nN3QEvkIg8jrITVjQL8aGYgLY+ro62KqyNg5D+9OGyTEt+jT+XlFMs5rx+7RNUVqakz8axJpFJlEki8Qio5Un1BulRITZlJZSoyQabc4Zo7xLaoNUhFjVQVOPoxY3pEyvqekNi8j+Hgh2AqKQ9t4P5nzrrkSvsXTl+LwQplbmRzdHJlYW0KZW5kb2JqCjE4IDAgb2JqCjw8L1R5cGUgL01ldGFkYXRhL1N1YnR5cGUgL1hNTC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAyNTQ+PgpzdHJlYW0KeNqFkMFuwyAQRO/9CkTPZmNHrWoUJ4dEUS+porZSzxhIglIDAiwTf32xa7m95cawb1azs9pEy/hVBlTLs9IVxkiJCn89HRYHu5UX9do7+dG/ffL+ykuBN+uHVaSxsY0MDMXmW3saK8yEqSVN7+EbcIKcONH33X5CrDhV+BKCpQDakxEn3DSQBpCTJeA/sGVDggnuuo4wpRpi3BnGYfKDErPB/ds8wN1yRPOyLGFRQFFkicj8TQcWM+0f8XqMtpOeO2WDMhoNmtWmDcP1UwBqmUs6xwjuG+jRGdFy6VJxkvnb0Skd0PML+bXD1EVqBebukpirlzod7FK3Py8AhIIKZW5kc3RyZWFtCmVuZG9iagoyMCAwIG9iago8PC9UeXBlIC9PYmpTdG0vTiAxNS9GaXJzdCAxMDQvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggODI1Pj4Kc3RyZWFtCnjahVRtb9MwEP7Or7iPq1BrO4nzIqFK27qxCraVpjCkKh/cxOsMaVw5rqD/nrskYxuCIVWN7+W59zsBHAIIUwhBpBIiCKMUYoikgAziSILgkEYxCIE/gd8Af2ECAvUDiXSE3yQDgZphiASywjQFgSqRRGUS8fjNu3dsddxrYAu11S37YKoW1jE6Xxbs3B4aD2I6fdI6V17VdttrgyA9lnt3KP3Kab201pNn4n4x+od2C6fvtdNNidpoZGbafa2OM1uujK81IFJPp+xaue/z5t6SCr119Sj5qJotnIzYtfaqQt9YDLLeh1SrzbiSHNaotiHs3YPxemENRr3mkyyOgiymICdpIAWXBVuiOQ3rMZaIygSPj2I6LXpzsfynOckjKiyICU8zLtPXzfUhXvz073OvvCZ7CpH0LRUVFbP7erv5pkuPPCQWynvtmp7IH1RlMPWOOLe1dflelRqngWp7aakvwVMlnlqIf1huP7TmWldGndmfGD/SMpOTIJEyEzg6YpKmWRJH1ObGI6QF2WGWurUHRw3rG7lSmxZYPrS5N98CZytndv8zfVZrXf1H6XkGlNhMt6Uze29dR96oHQquPn9a3N69vbHejnPtzH0nu1Q7Ux/hhNjQsUfsslbbFuJOfja4HgdZCBkuk+BxVrA5zrApT5stTiBnp23ZFQxFjHwTQQCc9f2VNtuHQZZ7vfsCKe8eV/ToQjC1DiD5sxUkYvlh4/utmc+IQaKAnalWdw38S1KomB9btP+4DUu9Na13mONpZTd6xG5dhZq0FPMKIzX+OEI/+32tdxQ4p3GZz1b2/Xx2rfbAHrXYHaxDWAcxLyDAlcEuFBAhJ8lCfCS49EFXowIkrkAskJugXpQF+AgQEMoCUoEiPD4ySZBAUCiDovijbXigXq0G8firZVjZz40pbaWh23Z20SBBSf9OZ3w19KpS2ANLE7kWvDtbvePeKJ3H37HcHHYtTcNadO0qXkzeyyM2bBGRdFEphg+Ik88cPIddYPVZDgzv2oHa0CkPR3QxHMR/o25s0zM6WDLAttAZILx8HY+XoSEof4mKn1ALZ6tDqR2c3GnVHheOTlqcTsRoOv0Fcc/UpgplbmRzdHJlYW0KZW5kb2JqCjIxIDAgb2JqCjw8L1R5cGUgL1hSZWYvSW5kZXggWzAgMjJdL1cgWzEgMiAyXS9TaXplIDIyL1Jvb3QgMiAwIFIvSW5mbyAxOSAwIFIvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggNzM+PgpzdHJlYW0KeNolzMENgCAAQ9FfVAQVuTiOF0d1OmfwhDZcXtImLdBa4AAjE8wgau9G8YLi0+NkoplNMtksZjWbKUpXX+zK939QTvgAxccG6QplbmRzdHJlYW0KZW5kb2JqCnN0YXJ0eHJlZgozMzg4CiUlRU9GCg==</ZKN:inhoud>\n
-      \       <StUF:tijdvakGeldigheid>\n            <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n
+      StUF:bestandsnaam=\"bevestigingsmail.pdf\">JVBERi0xLjcKJfCflqQKNSAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAxNjU+PgpzdHJlYW0KeNptzcsKwjAQBdD9fMX8gMlMmiYplIB9LFS6EAMi4qIK7ari4//BklhXciEnzHAZRpqz4vlxmoVzhTUabxM8gYTN4/b3ieMUeXj0dyhL2dWbBsl7qJoaZM+CcHxDrOFrhCoALydchoUVLufcKAwTyGp93J0aZINhgHNJpK6eZjKboIgaIpRFtInkKsGJVNDuz/DbY+3pgmELbYC2q2G/5ANsUTZcCmVuZHN0cmVhbQplbmRvYmoKNyAwIG9iago8PC9MZW5ndGgxIDI1OTIvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMTM4OD4+CnN0cmVhbQp42rVVfWxTVRQ/9/W9tsMKK7YbTCatE4YBga3tZmQqIJSPgEwYE5coK6Vb1w/W0YGM8bEMAyqCTqebGoWgWSL/OCAhoFBiMApESIwfmxLEuPFRREWDiazrq7/72m7d5hca78m795xzz/2d3z3v3veIEdFwaiAVldvtJQv3rXGdgOc3PGPmzJptZ9fZ90SsHbZ94YySuXmntUuJVOtg/7JoyZR8X1P7Cszz+FKn3xEQgioDkVAMu7bSEQyQBkJ0FY+u0ldXoTt3ZgSRxoqYK26XY6XtfNv9WM/xCtxwjDTpVLBLYN/l9teuK2oTg0SiD75yX7XTMfIefQPWfoj5/X7HugA1C22YQ04yrXL4XaMOWhErfQJfRaA6WBs7S2XQrXwej0BaEmIx7BZOPHRhfdVjyhjdVNg38pllQhpNpFbEK3F9TUuishot1smx/6BhhcYvZxPps2909gbSOwdhAF3xCE8cmlE4bcPyEUW/0lgtDeZxozN6X3qn9lslq9CPTbqELlAauKjgM0AY+E5EP4Wmoi8kvg87hNFcCKNHaDH6RyEcg4lZ7AWSUCuL9CrMO+KjqoMqhJGAVqtVkloSBDFZqWQrrpi9kqajmrVqg2xgr2n8rKucaNf5jj5WpFTIoDDjo0jlypgOj4iVeeCzkErISS6qplq8D0p4FyS8q7g31jVYhtTxZlvmTcn0hCyjxgHyxl/KKUjPYGHj2KI+WZOo6RjUZBhNGMKymIp0pDmnFLMRpz8Xb+mL+BTXU1vSZu6EvvTvi8CGA3ftP6hWWTxWOeVJPQVjgL8sxXb268K9RJHnoReB32mqSK4XttN/blImKvs/NXUP1QzIVUw12rx+/kO4lJLh3+YS6+O44pE/x+/Lk0vzxU+HxqkKaRoGDWqOWyemQQ/Rwwmd0SgqSOj8Czg5oatS/GKKLkHPSOhqaESzcCc95KBSWkNLoK+mKnAoVbQg9GrcWBPlA9mC785M2NXkHbDKlLLuIcwGqE6xKslNtZidgHt/t4IxFWKBtgIRJmBVYT6IZzXWO8hPk+Cdh3xOZDPRDPJBTPi2JbGCiuXCyPOtRb8SkcMGsXEi1gGUSiXSBJ3jm4DCdxJAzArgViHOhPXVyOtQ5oYpdxfnTnVdusYts82sl2zjLHqzkeUwUf6M+Z5lokf8+viWqz3rPTwaJ0n9DG7w7UQWm0WfYzMbc/TmxGgxmuEzY6wJhYQ5IZWa96Ho4VBvT8gjkdcb7RVErzdCHo/QGN2URJTGAvHWAYjQ4hjC3nplZUTfI2/n8TgvmpOIH9UXn8b6k4O3kv4kOyDoBB1r/fhY9FBIph0yKQwiX4m5Sn6xMfKTqI/EOeC8SzOBOYLXgG8/sSdAsW3H5Hn10uR6ed4xj3g9zMrl3eGIzsOZxLrEbHEWZfHvBsu5k2zpZMnPyNTnTIalNhoyLPkFhWJ27jftl+WLLOuy64TLa9yx5eXWllee3JnFHty7n1lkirG8KVPla881XLp48fKGjfyvw5FLgWzgdcbu4kiWeBIrkpBGSaERS3sv7Xmz7vWxzZN++CAsX2AZ3/3MhM/VTU9vfjEd96Pj7OaN77YjSy+zyh373jsaOsz3Ox839EfgZ/fX/AEG6sZEFa3jOX8YJW3tzG15y9fe9rYs7iqva9i626Na7D3qW3Xqy+hHeIt0vOn9A3KWJ8naA9Rb8L+hcfkFtjiMISMzydpoIMHd3NLS3NzS+hKvyehwmI2WL9mvdHeHw93dV5ygKrN8+Ywsy6c502mxLlWuVMMRb8sBM/5yzPqUeoy3nduz5zArk9us9rkzhe3anU27nlId8bL58kFv9PFtC5Yub9q64x0c9d8BVYLTWAplbmRzdHJlYW0KZW5kb2JqCjggMCBvYmoKPDwvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMjc3Pj4Kc3RyZWFtCnjaXZHNasQgFIX3PoXL6WLQ/M10EQJlusmiPzTtAyR6TYVGxZhF3r56DVOooPBx7vFej+zWP/dGB8revRUDBKq0kR5Wu3kBdIJZG1KUVGoRDsJTLKMjLJqHfQ2w9EZZ0raUfURxDX6npydpJ3gg7M1L8NrM9PR1GyIPm3M/sIAJlJOuoxJUvOhldK/jApSh7dzLqOuwn6Pnr+Jzd0BL5CIPI6yE1Y0C/GhmIC2Pq6OtiqsjYOQ/vThskxLfo0/l5RTLOa8fu0TVFampM/GsSaRSZRJIvEIqOVJ9QbpUSE2ZSWUqMkGm3OGaO8S2qDVIRY1UFTj6MWN6RMr6npDYvI/h4IdgKikPbeD+Z8665Er7F05fi8EKZW5kc3RyZWFtCmVuZG9iagoxOCAwIG9iago8PC9UeXBlIC9NZXRhZGF0YS9TdWJ0eXBlIC9YTUwvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMjU0Pj4Kc3RyZWFtCnjahZDBbsMgEETv/QpEz2ZjR61qFCeHRFEvqaK2Us8YSIJSAwIsE399sWu5veXGsG9Ws7PaRMv4VQZUy7PSFcZIiQp/PR0WB7uVF/XaO/nRv33y/spLgTfrh1WksbGNDAzF5lt7GivMhKklTe/hG3CCnDjR991+Qqw4VfgSgqUA2pMRJ9w0kAaQkyXgP7BlQ4IJ7rqOMKUaYtwZxmHygxKzwf3bPMDdckTzsixhUUBRZInI/E0HFjPtH/F6jLaTnjtlgzIaDZrVpg3D9VMAaplLOscI7hvo0RnRculScZL529EpHdDzC/m1w9RFagXm7pKYq5c6HexStz8vAISCCmVuZHN0cmVhbQplbmRvYmoKMjAgMCBvYmoKPDwvVHlwZSAvT2JqU3RtL04gMTUvRmlyc3QgMTA0L0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDgyNj4+CnN0cmVhbQp42oVUbW/iOBD+fr9iPhadwC/EeZFWSKW0W9RrFxGu3RXKB5O41HshRo7RLf/+ZhK6bVe3rWTCjOeZ9/EI4CBhnMIYRKoggnGUQgyREpBBHCkQHFK8EgKPxI/EE0UgEC9j/CAp0xgEIscRypEcZ8gkKFIZCDxKjP/49ImtjnsDbKG3pmU3tmphHaPzZcEu3KEJICaTF9SFDrp22x4NgnAsD/5QhpU3ZulcIM90e2/Nv8YvvHk03jQlotHIzLb7Wh9nrlzZUBtATTOZsFvt/5k3j44gRJvqWfKXbrZwNmC3JugKfWMxyHofUq03w0pxWCNsQ7oPTzaYhbMY9ZqPsjiSWUxBjlKpBFcFW6I5A+uhkFgJ/D0TxWRS9OZi9VtzikeKzIkRTzOu0vfN9SFe/gif86CDIXsaNem/1FRUzO7rl813Uwa8Q2ahQzC+6Zn8SVcWU++YC1c7n+91aXAaqLZXjvoiXyrx0kL8YLnDqTW3prJ66n5g/MirTI1kolQmcHTEKE2zJI6ozU1AlRZUp7M0rTt4aljfyJXetMDyU5t78y1wtvJ295HpaW1M9QHodQaU2My0pbf74HzH3ukdCqbnDzffZn/OzHd9fxjmxtvHTnqld7Y+wlkvgE4wYFe13rYQd4jpyf1QjrF5XEaQSWzdHOfYlufNFqeQs/O2pKKhhJF7ogmP476/Nnb71IvyYHb3kPKOuCaiC8HWRkLyazNIxPLDJvTvZj6jCxJJNtWt6Vr4v2khND+26OH5RSzN1rbBY5bnlduYAfviK0TSw5hXGKoNxwF62u9rs6PIOY3MfLZyn+ezW70H9oxiD7Ae4xFpARKfTTyOC4jwJk0kEgnexFFXowKUIi4pIEGgijkSEokMgalAEa6amBODWhESxS+9wy31bkHojn9QiZX7u7Glqwx0j55dNshQ3j8zGl6f+lVpbISjwVwL3m2v3nVvlrbkz2juDruWBmItup4Vbwbw7S47PSZiabFSDDeop145eK12iQ1gOTBcbwfqRAc+7dLFaS/+XuvONf1Fp5ac1LbQGSB99b4+LoiGVPlbrfhFa+FddSiNh7MHo9vjwtNmi9ORGEwm/wF9OtZHCmVuZHN0cmVhbQplbmRvYmoKMjEgMCBvYmoKPDwvVHlwZSAvWFJlZi9JbmRleCBbMCAyMl0vVyBbMSAyIDJdL1NpemUgMjIvUm9vdCAyIDAgUi9JbmZvIDE5IDAgUi9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCA3MD4+CnN0cmVhbQp42iXMUQqAIACD4X9WppUK0Uk7XVfryRq+fLDBBvQeuMDIBDOJNrpZvKD4jLiYaFaTTDab2c1hitI5FlX5/g9KhQ+z+wYuCmVuZHN0cmVhbQplbmRvYmoKc3RhcnR4cmVmCjMzNDIKJSVFT0YK</ZKN:inhoud>\n
+      \       <StUF:tijdvakGeldigheid>\n            <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n
       \           <StUF:eindGeldigheid StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n
-      \       </StUF:tijdvakGeldigheid>\n        <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      \       </StUF:tijdvakGeldigheid>\n        <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -92,13 +92,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7892'
+      - '7824'
       Content-Type:
       - application/soap+xml
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -125,9 +125,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -138,7 +138,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>82d19e1f-e3df-429d-9887-ebabcef01560</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>81891492-2d45-4a9d-b22b-d484344acaf8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -155,7 +155,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -172,7 +172,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>c973a39c62e0e198</ZKN:identificatie>\n
+        \               <ZKN:identificatie>f78ea58982ec2c45</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -183,9 +183,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -196,25 +196,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e73dc992-6a59-4c25-9094-4b1d5360ba36</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d009397c-e606-49c0-9fc9-8631d0817c1e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>c973a39c62e0e198</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>f78ea58982ec2c45</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>Bevestigingsmail</ZKN:titel>\n        <ZKN:beschrijving>De
       bevestigingsmail die naar de initiator is verstuurd.</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"bevestigingsmail.pdf\">JVBERi0xLjcKJfCflqQKNSAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAxNjU+PgpzdHJlYW0KeNptzcsKwjAQBdD9fMX8gMlMk7QRShZ9gApFixEX4qIK7ari4//BmlhXciFnMuESRpqy4OmwmoW1yyzVeB3hASQyE15/Q1jHyP29u0Gey6ZcV0jOQVGVIDsWhMMLQg2fAxQeeP7CKmQiwaQMp+hHkKtDu9se8XPr4ZQTJRdHEyqLUCDpA6QCOg2YJMKRWND2z/LbY+PojH4DtYe6KaGd8wahrTaVCmVuZHN0cmVhbQplbmRvYmoKNyAwIG9iago8PC9MZW5ndGgxIDI2ODAvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMTQ1Mj4+CnN0cmVhbQp42rVWa2xURRQ+M3cfdW1pt93tUlro7t32tmx3u+9ugbY8ty22UB4GCtXStSxtsS/oIiVgIgI/aIohMfEXxsSY+EgUo39M+GUUExuNMRo1iMaIFSQYiab8a+s3cy9YSsVg9J7MnMfMnO+cmbnnXmJElE3PkEJrmjYkG9ll9jmRrQ7WlW3bg5H9P+z5mIg1Q+/qHkgN84ziJFKyoGd6UiPD4HmYHwPP6uk/sm/NY1NeIlMIcy71plN7y17JqcDYJ2g1vTBYP+K/w58JelnvQGa0uIVNQX8Nrat/qDtVkrvkKtYew/g7A6nRYeqgOMYqobsHUwPpirHVPwIqm4hnDQ+NZGZfogjwHWKcRC6cWY4ny5N7cuumyKpcg4UuWyZ7BZ/85Uo2FczeUk7yL6FaiJP+YJ0pMPMtcN+gAnIoJ6WnuU+7tLRTzFgzfxwO+HZ2lswIYIy3Q2/ROeukCFsHKzdzi9nMuWn+6qa2tia2BtFn9BhMAVZ+ew5fzCdkZib46ry9Qu7ef/DwINXT//AoRaTdhTNEGnZW+9s40uT4t1jsBiWkD5fO75vvKSrha++dx7pw6iRPVkFzoGeSm6hL8jxYTDiFCDXTJnqUuilNQ5SZnZVnI6ythnVQWGevzKcF7suDPuEHoIxB5+ibucT4fSkGSt9DL7IP7tCv8l7izrCbeIM8RNF4ooHHY5pXtVicqhaP1UQjhU6HxWqNRmoSiai1/tV4Q3E4HgjZyyLdqT397W2vXw24rSafeeP7DR3bqlc0+tZXFmsrWztaG0/tvFC9NP9NIOCm8D9w86MCAZ7idkB44x4ncJxOT3yOZncURqMwiVkwSU3LUUNhTw7zgrNkSNUlWGa+A5+5AIuvKMiu+xf7wCcmgkWCzzj9LsGvX4dORhRJRLFkoSjsMMgMBZgO4QlfXFaer9hiVuH9Z+F1sX/6q2Kfs+Vrwx8qzwT57vYXLSiIzk8lYVe8it1IxhNG6D999un3OtLMLcWt8cmaa5qq+Fx+9hvSmP6Q14kUlgjQwuW8cPo4f3p6SiTCxLvFtwK3+A4u0KxWb8Lj8lZoCEEHesHlCXf5VZM5ZuZRdCY1kAqpLkDwqrCn6vz5Kk94+pKxN4nZW+wiV8UdMKuaOHhx8uLovcZtgE/kISwWVryuZ9Wq9GrflljA741oK0qbtgSTdrvWYqs98sSTR6OFAa+6NLihcu/u/X0VpYuKXP6leBsFxiQwXLRMohi3y+kp1F1L3wUSzspKB45m9qeGZt7lLc2xjfnWbG1zebguUW+2nX12/LnRw9UD3VXFSn6Oo9rDkltSHTtEFiXYmT4gLJ93Iq5ojQ4lN8ZrN1LS1ZIsNRT0mF/OMZduCrXtWq6a3wrXB+Iu2MS51+I4ttZ6H++5ga1iu9Y2Bx6p+gI3i/SMuA14DyOnORk5LBXAliCAYKX9xw5n0A621De0oNnGzoyfPj1+Ziw2MiyfERE7vmNsI39enKoLnuzeOPYEVzLqFBHru++0WG62Jlvz/Xn2Qmv1iRM+NX9ZXk7MltzBNlfm2vNj2tEVM+ejIZPit9hklbHSblH9TA9B7pT1UMjiDnUaMqdFdNCQFaqVfw5CNlEZvWfIZnqbLhuyhVQ2TutRL4fpCFb2UQ/1ojaJuhlCrYpDasLoEOz9qKBu1NJWzK+GtBaWfvBtd1aNSC0Nnoavp9DvxczNohqjuWm7tPfRPjmrhw5hfQqWCGaFQDFaBbQ2UBOk2+v+WhWYt24hz+55c3bIkRGMDaH+u+/Ccss6vA/zDkk/vZg1KLOvRPRhzKxFi+IGuoEtcq2V0kH0cfgQcpOxV7o2ij4M30LegF7EkJG4ARnboIwiLfUU+gOI7IDU2tGroH/OWtE/ObPnxL/VQh9dYvj25ZL+72h8XHF3qkCMgogUFQLEqBHE8H1sRr8VKIx2grDuT8NikoQKZW5kc3RyZWFtCmVuZG9iago4IDAgb2JqCjw8L0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDI3Nz4+CnN0cmVhbQp42l2RzW6EIBSF9zwFy+liIqLOdGFMmunGRX9S2wdQuFiSCgRx4dsXLmaalASSL+ce7uVQ3Prn3uhAi3dvxQCBKm2kh9VuXgCdYNaGlJxKLcJBeIpldKSI5mFfAyy9UZa0LS0+orgGv9PTk7QTPJDizUvw2sz09HUbIg+bcz+wgAmUka6jElS86GV0r+MCtEDbuZdR12E/R89fxefugHLkMg8jrITVjQL8aGYgLYuro62KqyNg5D+9PGyTEt+jT+V8iuWM1Y9douqK1NSZWNYkEleZBBKrkDhDqi9Ilwqp4ZlUpjITZModrrlDbItag1Q2SBXH0Y8Z0yNS1veExOZ9DAc/BFNJeWgD9z9z1iVX2r9O+ovDCmVuZHN0cmVhbQplbmRvYmoKMTggMCBvYmoKPDwvVHlwZSAvTWV0YWRhdGEvU3VidHlwZSAvWE1ML0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDI1ND4+CnN0cmVhbQp42oWQwW7DIBBE7/0KRM9mY0etahQnh0RRL6mitlLPGEiCUgMCLBN/fbFrub3lxrBvVrOz2kTL+FUGVMuz0hXGSIkKfz0dFge7lRf12jv50b998v7KS4E364dVpLGxjQwMxeZbexorzISpJU3v4Rtwgpw40ffdfkKsOFX4EoKlANqTESfcNJAGkJMl4D+wZUOCCe66jjClGmLcGcZh8oMSs8H92zzA3XJE87IsYVFAUWSJyPxNBxYz7R/xeoy2k547ZYMyGg2a1aYNw/VTAGqZSzrHCO4b6NEZ0XLpUnGS+dvRKR3Q8wv5tcPURWoF5u6SmKuXOh3sUrc/LwCEggplbmRzdHJlYW0KZW5kb2JqCjIwIDAgb2JqCjw8L1R5cGUgL09ialN0bS9OIDE1L0ZpcnN0IDEwNC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCA4Mjc+PgpzdHJlYW0KeNqFVNtu2zgQfd+vmMcYhU1SEnUBCgNJnDRGN4nXcpsCgh5oiXG4K4sGRWPrv98ZSWmSYpsChsW5nLnPCOAQQJhCCCKVEEEYpRBDJAVkEEcSBIc0ikEI/An8BvgLExCoH0ikI/wmGQjUDEMkkBWmKQhUiSQqk4jHf3z8yDangwa2Ujvdsc+m7qCI0fm6ZJf22HoQ8/mL1qXyqrG7QRsE6bHcu2PlN07rtbWePBP3q9H/ardy+lE73VaojUYWpjs06rSw1cb4RgMi9XzObpX7Z9k+WlKht66fJX+qdgdnE3arvarRNxaDrA8hNWo7rSWHAtW2hH14Ml6vrMGoCz7L4ijIYgpylgZScFmyNZrTUEyxRFQmeH6U83k5mIvlL81JHlFhQcx4mnGZvm9uCPHqu/+Ue+U12VOIpG+lqKiY3bf77d+68shDYqW8164diPxJ1QZT74lL21iXH1SlcRqotteW+hK8VOKlhfiH5fZja251bdSF/Y7xIy0zOQsSKTOBoyNmaZolcURtbj1COpA9Zq07e3TUsKGRG7XtgOVjmwfzHXC2cWb/O9MXjdb1b5ReZ0CJLXRXOXPw1vXkndqj4ObLX6v7hw931ttprp157GXXam+aE5wRG3r2hF03atdB3MsvRtfTIAshw2USPM5KtsQZNtV5u8MJ5Oy8q/qCoYiRbyIIgLN+uNFm9zTKcq/3XyHl/eOGHn0IptEBJD+3gkQsP279sDXLBTFIFLAL1em+gf+TFCrmpw7tP2/DWu9M5x3meF7brZ6we1ejJi3FssZIjT9N0M/h0Og9Bc5pXJaLjf20XNyqA7BnLfYARQhFEPMSAgEFdqGECDlJFuIjwaUP+hqVIHEFYoHcBFcrygJ8BAgIZQkpIun4yCRBAkGhDMryp7bhgXq3GsTj75ZhY7+0prK1hn7b2VWLBCX9I53pzdirWmEPLE1kIXh/tgbHg1E6jz9iuTvuO5qGQvTtKt9M3tsjNm4RkXRRKYbPiJOvHLyGXWH1WQ4M79qR2tArj0d0NR7EX6PubDswelgywnbQGyC8fB+Pl6ElKH+Lil9QK2frY6UdnD1o1Z1Wjk5anM7EZD7/D3Pb1KcKZW5kc3RyZWFtCmVuZG9iagoyMSAwIG9iago8PC9UeXBlIC9YUmVmL0luZGV4IFswIDIyXS9XIFsxIDIgMl0vU2l6ZSAyMi9Sb290IDIgMCBSL0luZm8gMTkgMCBSL0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDcxPj4Kc3RyZWFtCnjaJczBDYAgAEPRX1QEFbm4l4mjOp2e0IbLS9qkBVoLHGBkghlE7d0oXlB8epxMNLNJJpvFrGYzRenqi135/g/KCR/MPgcvCmVuZHN0cmVhbQplbmRvYmoKc3RhcnR4cmVmCjM0MDcKJSVFT0YK</ZKN:inhoud>\n
-      \       <StUF:tijdvakGeldigheid>\n            <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n
+      StUF:bestandsnaam=\"bevestigingsmail.pdf\">JVBERi0xLjcKJfCflqQKNSAwIG9iago8PC9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCAxNjU+PgpzdHJlYW0KeNptzcsKwjAQBdD9fMX8gMlMmqQplIB9LFS6EAMi4qIK7ari4//BklhXciEnzHAZRpqz4vlxmoVzRW413iZ4AoncxO3vE8cp8vDo71CWsqs3DZL3UDU1yJ4F4fiGWMPXCFUAXk64DItcOMPGKgwTyGp93J0aZIthgHNJpK6eZrI8QRE1RCiLaBsxKsGJVNDuz/DbY+PpgmELbYC2q2G/5ANsaTZdCmVuZHN0cmVhbQplbmRvYmoKNyAwIG9iago8PC9MZW5ndGgxIDI2NDQvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMTQzMz4+CnN0cmVhbQp42q1Ve2xTVRj/zu3tY7OOFdttTAYdVQaBDLZ2m8oAQSiPAE4YQ5coK6Nb1660YwWZE1imYQoCTiebioKIS+QfBxgEhRIFFYxgTNSNEMSw8SjxgUYSoeutv3Pb7ukLw/lyz/le5/d957vnu5cYESVQHSmoxGotnL93lf0ENH/gGT5rxkwru85+JGJtkK3zpxXOzjqlWUykWAP5t4cXTciubGxbBjv3Lyp127yCT2EgEgog+8pt1V5Sg4iAQdryypqyJWNt24nUFmCMcNhty3POt07Gfo6X64BiqFGrgFwI+R6H27cmv1UUicRK6EoqPaU2w1v6Y8A/Dvs+t22Nl5qEVtj0kI0rbG57ygELfJVfQlfm9VT7wmepGLyF2/EIpCEhHMZpocRDF5+qeExeQ+vyelZueVSIo3HUAn/Zr2doSJR3Y4Q7OPZfDOxQu6U0Il3ajY5ub2LHAAygyxrhiYPvvJ9Qv3RI/nUaqaGBedzoCD2Q2KH5QY4q9GKTNsoLFIdcFNAZQAz5jsM8gSZiziN+DiuI0WwQo0doIeYlII7BxFT2IilRK7PyVYgjIquincqEoYBWqRRKlVIQxFilYqOgbOZyehDV9Kn0kp69pnazzhKiHefbe7IiuUJ6OTO+ilQir4nQiNiZjXzmUyGVkp085MP7oKh2XlS7gmvDnQNpUB1vfWTdAhVHaSVt70cf/CN1URfTD6KprKKHtkZrOhw1iacxg3IsoHwtqc/JxazH7c/AW/o2YuJ83xGTmSPKL/73ErAE4K7+D7UqjvjKtzzG98Hopy/uI5f28sJ9REF+3nzkd4rKYvuFTXRbhjKZbhNS/6G6SVX94hRQlSarN/9BeRSR/v/GEmsjuOLhv8fviZNBc8WvB/sp8mgSFjVqjq4T48D7aUGUZ5RCuVGefwEzo7yij17swyvBJ0V5FTiiGehJJ9moiFbRIvArqQI5FMlcNXgPOpZ3cCaZ8d2ZDtlDrn67jH32PQSrl2pkqZwc5IN1DPp+rIwxEWQGtwweRmBVwF6NZyX228hN46Gdg3iliGakaVQJMuLbFsOqliU7Vh5vNebl8IwfkE0pfG1AKZc9jeA5vhEo/CRe+CwDbgX8jNjvQVybbIuXexd3TlygvIYOJmbSTWHmbNGgZyo1S88x69Jz2BSWYxltGqViKq/rjCPAEqTTKVqpQfCs6p7MPt1W98bGrdvFKhZ/f/6FT85KXyXDdlDa7WbHtwU3Nu/Zggi4farn0fV3E5mBacpJN5h06dHVbJDjYK3y+4VZfoWKz/7QIX/3Tb9TSS5XqFsQXa4gOZ1CfWidkyKIypFAvLMfIrgIhrCnVt4Z1N2UNnF/3DH1Sfin9PjHsd7gzMTk8CfZfkEraFnL50dDB/0SbZZIziB4RsyQ44v1wV9EXTCSA3pEOR2YQ4jkE8TOBCjWcFSaU6vMrJXmHHWKvwdYibQzENQ6eSbhTjFNnEGp/FvDTKMoJ5HM2UnJOlMmJJVBn2TOzs0T0zK+b7siXWKpV+wn7C7D5mdeaWne9uSWVDZ1zz5mlijMsiZMlK69UHf50qUrT6/lfyqOXARkPa8zThdBMkeCWBCE1HIItVjUfXnXmzWvj2wa/9PHAekiS7rwKxO+UTU+t/6lRPRU+9n1a99rQ5RuZpHa9354xH+In3cu7snPwE/rrTm/LEmGaBXlS8KFwtY25jC/XdnWulsSd5TU1G3Y6VQsdB2pXPHFd6HP8BbpWONH+6VUZyxrJ1DvoGSie7NzI3cNySfHsjboSXA0NTc3NTW3vMxrMiwQYMOky9arXV2BQFfX1VKkKrFs6bQkSad4ppPCnYoMZRVHvMuEzPjLSdf1qcfonHO7dh1ixVKrxTp7urBJs6Vxx7OKwy42VzrgCj3eMG/x0sYNm99Fe/wJaB/kTwplbmRzdHJlYW0KZW5kb2JqCjggMCBvYmoKPDwvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMjc3Pj4Kc3RyZWFtCnjaXZHNboQgFIX3PAXL6WIios50YUya6cZFf1LbB1C4WJIKBHHh2xcuZpqUBJIv5x7u5VDc+ufe6ECLd2/FAIEqbaSH1W5eAJ1g1oaUnEotwkF4imV0pIjmYV8DLL1RlrQtLT6iuAa/09OTtBM8kOLNS/DazPT0dRsiD5tzP7CACZSRrqMSVLzoZXSv4wK0QNu5l1HXYT9Hz1/F5+6AcuQyDyOshNWNAvxoZiAti6ujrYqrI2DkP708bJMS36NP5XyK5YzVj12i6orU1JlY1iQSV5kEEquQOEOqL0iXCqnhmVSmMhNkyh2uuUNsi1qDVDZIFcfRjxnTI1LW94TE5n0MBz8EU0l5aAP3P3PWJVfav076i8MKZW5kc3RyZWFtCmVuZG9iagoxOCAwIG9iago8PC9UeXBlIC9NZXRhZGF0YS9TdWJ0eXBlIC9YTUwvRmlsdGVyIC9GbGF0ZURlY29kZS9MZW5ndGggMjU0Pj4Kc3RyZWFtCnjahZDBbsMgEETv/QpEz2ZjR61qFCeHRFEvqaK2Us8YSIJSAwIsE399sWu5veXGsG9Ws7PaRMv4VQZUy7PSFcZIiQp/PR0WB7uVF/XaO/nRv33y/spLgTfrh1WksbGNDAzF5lt7GivMhKklTe/hG3CCnDjR991+Qqw4VfgSgqUA2pMRJ9w0kAaQkyXgP7BlQ4IJ7rqOMKUaYtwZxmHygxKzwf3bPMDdckTzsixhUUBRZInI/E0HFjPtH/F6jLaTnjtlgzIaDZrVpg3D9VMAaplLOscI7hvo0RnRculScZL529EpHdDzC/m1w9RFagXm7pKYq5c6HexStz8vAISCCmVuZHN0cmVhbQplbmRvYmoKMjAgMCBvYmoKPDwvVHlwZSAvT2JqU3RtL04gMTUvRmlyc3QgMTA0L0ZpbHRlciAvRmxhdGVEZWNvZGUvTGVuZ3RoIDgyNj4+CnN0cmVhbQp42oVUbW/iOBD+fr9iPhadwHaI8yKtkEppt6jXLiJcuyuUDyaZ0uyFGDlGt/z7m0notl3dtpIJM5555t2jQEIA4wTGoBINIYzDBCIItYIUolCDkpDQlVJ0AvoEdMIQFOkHEX2IDJIIFGmOQ5ITOU6JiUmkU1B0tBr/8emTWB33CGJhttiKm6psYR2R82UuLuyh8aAmkxetC+NNbbe9NijWE5l3h8KvHOLSWs+e+fa+wn/RLRw+osOmIG0yMqvafW2OM1usKl8jEBInE3Fr3D/z5tGyCtNYPkv+Ms0WzgbiFr0pyTcVg633IdVmMyy1hDWpbRj78FR5XNiKol7LURqFQRpxkKMk0ErqXCzJHMJ6qAKqBP2eiXwyyXtzkf6tOS1DzebUSCap1Mn75voQL3/4z5k3HtmeIST/F4aLStl9/bL5joWnO2IWxnt0Tc9kT6asKPWOubC1ddneFEjTwLW9styX4KUSLy2kD5Xbn1pzi2VlpvYHxU+8TvUoiLVOFY2OGiVJGkcht7nxBGlBd5gltvbguGF9I1dm04LITm3uzbcgxcpVu49MT2vE8gOl1xlwYjNsC1ftvXUde2d2JJieP9x8m/05w+/m/jDM0FWPnfTK7Kr6CGe9ADrBQFzVZttC1GlMT+6HwZiaJ4MQ0oBaN6c5rorzZktTKMV5W3DRSCLYPdOsT+O+v8Zq+9SLMo+7e0hkR1wz0YVQ1RhA/GszWCSyw8b372Y+4wsWBWJqWuxa+L9pkWp2bMnD84tY4rZqvaMsz0u7wYH44krS5IcxLynUyh8H5Gm/r3HHkUsemflsZT/PZ7dmD+JZSzzAekxHJTnQylhH4yiHkG6SOCAippso7GqUg9bMxTnE9L50JIkIiEhJMWEorZpIMkOokIj8l97Rlnq3IHwnP6jEyv7dVIUtEbpHLy4bYjjvnxkNr0/9Kg01wvJgrpXstlfvujfLW/JnNHeHXcsDsVZdz/I3A/h2l50eE7O8WDmGG8LpVw5ewy6pASIDQevtwJ3olE+7dHHai79H3dmmv+hg8Qm2hc4A4/X7eFoQDUPlW1T0glo4Wx4KdHD2gKY9LhxvtigZqcFk8h9/SdZICmVuZHN0cmVhbQplbmRvYmoKMjEgMCBvYmoKPDwvVHlwZSAvWFJlZi9JbmRleCBbMCAyMl0vVyBbMSAyIDJdL1NpemUgMjIvUm9vdCAyIDAgUi9JbmZvIDE5IDAgUi9GaWx0ZXIgL0ZsYXRlRGVjb2RlL0xlbmd0aCA3Mz4+CnN0cmVhbQp42iXMwQ2AIABD0V9UBBW5uI0HR3U6h/CENlxe0iYt0FrgACMTzCBq70bxguLT42SimU0y2SxmNZspSldf7Mr3f1BO+ADFCAbiCmVuZHN0cmVhbQplbmRvYmoKc3RhcnR4cmVmCjMzODcKJSVFT0YK</ZKN:inhoud>\n
+      \       <StUF:tijdvakGeldigheid>\n            <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n
       \           <StUF:eindGeldigheid StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n
-      \       </StUF:tijdvakGeldigheid>\n        <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      \       </StUF:tijdvakGeldigheid>\n        <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -224,13 +224,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7912'
+      - '7888'
       Content-Type:
       - application/soap+xml
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -257,9 +257,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSConfirmationEmailVCRTests/test_raises_when_confirmation_email_was_not_sent.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSConfirmationEmailVCRTests/test_raises_when_confirmation_email_was_not_sent.yaml
@@ -7,20 +7,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>36493366-d283-4ff4-b6b2-7b29b87ad76d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>556ee974-fce6-435f-bcca-2752cceebf00</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      000</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      000</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"textfield\">Foo</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
       StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
       StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -30,7 +30,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -48,7 +48,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -75,9 +75,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -88,7 +88,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>77c2cd58-ee8e-491f-a451-505f0e93cbb7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8dd6c22e-bd31-40a7-8bf8-eb1562766680</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -105,7 +105,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -122,7 +122,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>9abae26182f0b086</ZKN:identificatie>\n
+        \               <ZKN:identificatie>d45962301766e2f9</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -133,9 +133,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -146,25 +146,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>905661a7-73f4-46c5-b8fb-cf7c7b21add9</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190756</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6cb62bfb-6a33-4839-8a69-a03fe490605c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>9abae26182f0b086</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>d45962301766e2f9</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190756</StUF:tijdstipRegistratie>\n
+      000</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -180,7 +180,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:56 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_betrokkene.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_betrokkene.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -37,7 +37,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 17 Mar 2026 11:14:36 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
       - Kestrel
     status:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -78,7 +78,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 17 Mar 2026 11:14:36 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
       - Kestrel
     status:
@@ -91,20 +91,20 @@ interactions:
       \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f842331c-b760-43b3-9671-c4a40f354de8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111437</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fcb88aa4-1ada-41a1-af10-7318fb76ba26</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260317</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260317</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260317</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -114,7 +114,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -144,7 +144,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -171,9 +171,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:14:37 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -183,8 +183,8 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>745d071c-a96b-412c-96cb-1a9f82a7a51b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111437</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1682637a-aadd-4591-bf4b-46cea3a391be</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -201,7 +201,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -218,7 +218,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>3f98d2ee369dbcc0</ZKN:identificatie>\n
+        \               <ZKN:identificatie>4e38becae7ddf2c7</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -229,9 +229,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:14:37 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -241,26 +241,26 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ccd1129c-d942-4e64-9d39-ac13ec3e20c5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111437</StUF:tijdstipBericht>\n\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e38fbc4d-83b4-44c2-a566-f4176dab8210</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102837</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>3f98d2ee369dbcc0</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260317</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260317</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>4e38becae7ddf2c7</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260317</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260317</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260317111437</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102837</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -276,7 +276,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -303,9 +303,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:14:37 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_extraelementen.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_children_as_extraelementen.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -37,7 +37,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 17 Mar 2026 11:16:06 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
       - Kestrel
     status:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -78,7 +78,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 17 Mar 2026 11:16:07 GMT
+      - Thu, 30 Apr 2026 10:28:37 GMT
       Server:
       - Kestrel
     status:
@@ -91,16 +91,16 @@ interactions:
       \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>99b4bc7a-443a-4926-8539-2ae5fbd0f221</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111607</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9d3c0c40-25b0-4772-b6a1-d84feb852ecf</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260317</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260317</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260317111607</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"childrenKey.0.bsn\">999993677</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"childrenKey.0.firstNames\">Truus</StUF:extraElement>\n\n<StUF:extraElement
@@ -110,7 +110,7 @@ interactions:
       naam=\"childrenKey.0.dateOfBirth\">1960-09-12</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260317</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -120,7 +120,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260317111607</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -138,7 +138,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -165,9 +165,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:16:07 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -177,8 +177,8 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>53fda444-3825-4483-9c7d-9b5a2870734f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111608</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8e08f3ed-059f-400d-8d05-0200d2afce8e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -195,7 +195,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -212,7 +212,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>bfa7c0d5c1b740e8</ZKN:identificatie>\n
+        \               <ZKN:identificatie>1d66524d0c8c5199</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -223,9 +223,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:16:08 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -235,26 +235,26 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ceebb88d-becb-4a57-8264-b643a9f4eebc</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111608</StUF:tijdstipBericht>\n\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d63f9d2a-0f0b-4387-ab65-c63b6f4f5bbd</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>bfa7c0d5c1b740e8</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260317</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260317</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>1d66524d0c8c5199</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260317</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260317</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260317111608</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260317111608</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -270,7 +270,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -297,9 +297,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:16:08 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_enabled_children_selection.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_and_enabled_children_selection.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -37,7 +37,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 17 Mar 2026 11:15:32 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
       - Kestrel
     status:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -78,7 +78,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 17 Mar 2026 11:15:32 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
       - Kestrel
     status:
@@ -91,20 +91,20 @@ interactions:
       \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>90b9337f-a175-4d29-b653-f11347147576</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111533</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>88b5c9cb-c524-4f28-ad22-1559b1c677ca</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260317</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260317</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260317</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -114,7 +114,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -143,7 +143,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -170,9 +170,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:15:33 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -182,8 +182,8 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>612d805e-c899-4162-a49f-8a1d26dcd570</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111533</StUF:tijdstipBericht>\n\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>dc2549c8-1462-485a-a652-744e6485d034</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -200,7 +200,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -217,7 +217,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>be3bf76624258b57</ZKN:identificatie>\n
+        \               <ZKN:identificatie>07fd575077e8a09d</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -228,9 +228,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:15:33 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -240,26 +240,26 @@ interactions:
       \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>32351591-d890-4f67-bf57-ea96e5f9019f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260317111533</StUF:tijdstipBericht>\n\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1b110aac-2cce-44c4-9a7a-e1c8e259df1d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>be3bf76624258b57</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260317</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260317</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>07fd575077e8a09d</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260317</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260317</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260317111533</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -275,7 +275,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -302,9 +302,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Tue, 17 Mar 2026 11:15:33 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.6 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_disabled_selection_and_manually_added_children.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_disabled_selection_and_manually_added_children.yaml
@@ -7,19 +7,19 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b89a846f-37f5-4ad7-b065-9bfefa919e5c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>498e2626-c96a-4be0-9eba-da8d2c9bc333</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -29,7 +29,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -71,7 +71,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -98,9 +98,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -111,7 +111,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9f118708-657e-47bd-a66e-deafbe11532f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9445746d-c6ec-4ecd-bba3-517defadacad</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -128,7 +128,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -145,7 +145,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>23ea0eb1acc8019e</ZKN:identificatie>\n
+        \               <ZKN:identificatie>70db84579fe02ace</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -156,9 +156,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -169,25 +169,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fb794be4-df9c-43c0-a5e3-47891909337c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>acab42d8-38b2-4113-802e-a23467de9126</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>23ea0eb1acc8019e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>70db84579fe02ace</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -203,7 +203,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -230,9 +230,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_enabled_selection_and_manually_added_children.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_one_form_step_enabled_selection_and_manually_added_children.yaml
@@ -7,19 +7,19 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a3e787f5-b08b-425f-a971-7fc07e46d1ab</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>049179cd-18c3-4752-86e5-e57bcbb16b40</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -29,7 +29,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -59,7 +59,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -86,9 +86,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -99,7 +99,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9adf4f27-771e-438f-ae81-95118e366e1f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>70356cf5-8c26-4b4a-8d86-103542f23c86</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -116,7 +116,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -133,7 +133,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>9b3b4a670ff6522e</ZKN:identificatie>\n
+        \               <ZKN:identificatie>89efc6320fe40fc6</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -144,9 +144,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -157,25 +157,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a7cb44c3-6ff6-4c11-b661-83773d136ba5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>4a1f78f1-3a1a-4cad-91a3-dd1e4ddc7b34</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>9b3b4a670ff6522e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>89efc6320fe40fc6</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -191,7 +191,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -218,9 +218,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_and_children_as_betrokkene.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_and_children_as_betrokkene.yaml
@@ -7,21 +7,21 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>856ca30f-751d-4613-9649-6cced157ad66</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c56417b8-e0ea-467a-a2f6-c1fc1eaa75ee</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      007</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      007</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.bsn\">999993677</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.childName\">Truus</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -31,7 +31,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -61,7 +61,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -88,9 +88,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -101,7 +101,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1273fdf5-8859-443c-9e3f-25f73f195014</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>bdc9b97e-37aa-48bf-a43c-c15168b265a7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -118,7 +118,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -135,7 +135,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>df808c01c340af2e</ZKN:identificatie>\n
+        \               <ZKN:identificatie>ad4d3e5a48a8ab41</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -146,9 +146,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -159,25 +159,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8fdb25fc-2982-4871-9c52-625915784ba3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1ef60e0a-8aef-4749-96f1-c266ee90e76c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>df808c01c340af2e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>ad4d3e5a48a8ab41</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      007</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      007</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -193,7 +193,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -220,9 +220,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_and_children_as_extraElementen.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_and_children_as_extraElementen.yaml
@@ -7,15 +7,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f2a17363-4f21-4441-ad08-a4a3fdeaaf57</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ce97699d-2596-49af-a673-0e4d4cb380cf</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      008</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      008</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"childrenKey.0.bsn\">999993677</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"childrenKey.0.affixes\">van der</StUF:extraElement>\n\n<StUF:extraElement
@@ -27,7 +27,7 @@ interactions:
       naam=\"extraChildDetails.0.childName\">Truus</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -37,7 +37,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -55,7 +55,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -82,9 +82,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -95,7 +95,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3da21d59-1ffe-4d8d-88a5-f1fa230edd22</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>85f71f5e-84df-49dc-8081-5fd4290337c5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -112,7 +112,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -129,7 +129,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>5b31edfc7fa571a9</ZKN:identificatie>\n
+        \               <ZKN:identificatie>287c38a4a46ecebe</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -140,9 +140,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:38 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -153,25 +153,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c318f0f8-53eb-4bbe-adbb-a1d73db2b872</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b3b83b82-15e5-4a9d-970e-aaeb03ee7b7e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102838</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>5b31edfc7fa571a9</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>287c38a4a46ecebe</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      008</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      008</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102838</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -187,7 +187,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -214,9 +214,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_and_enabled_children_selection.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_and_enabled_children_selection.yaml
@@ -7,21 +7,21 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a3ffd38b-62b8-4621-949b-8e6253bbf08c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>40365897-4312-4d2b-a79d-b64a25e09e09</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      009</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      009</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.bsn\">999970100</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.childName\">Olle</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -31,7 +31,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -60,7 +60,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -87,9 +87,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -100,7 +100,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7abc3057-fcbe-4e1a-a4fa-1b4cd69708fb</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6d2d1b5c-43b1-4eaf-a126-e0b01cf40272</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -117,7 +117,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -134,7 +134,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>0a4e3fd1cf657c33</ZKN:identificatie>\n
+        \               <ZKN:identificatie>d91470e2eed41c56</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -145,9 +145,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -158,25 +158,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b1b007e3-f4df-4f73-87c5-c274affe6ca9</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3e73cffd-60f1-4266-a773-be7d08e0a9a7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>0a4e3fd1cf657c33</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>d91470e2eed41c56</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      009</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      009</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -192,7 +192,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -219,9 +219,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_disabled_selection_and_manually_added_children.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_disabled_selection_and_manually_added_children.yaml
@@ -7,15 +7,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e662d654-47ee-45f7-be32-6dcbf43b9d31</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>07f79739-07b1-41b0-b4a0-5ce8f77000df</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      010</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      010</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.bsn\">999970100</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.childName\">Olle</StUF:extraElement>\n\n<StUF:extraElement
@@ -23,7 +23,7 @@ interactions:
       naam=\"extraChildDetails.1.childName\">Onne</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -33,7 +33,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -73,7 +73,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -100,9 +100,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -113,7 +113,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>abc0ef9d-f7d2-40d4-8344-f3e987a825fe</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d12837c7-8e16-4df9-bc50-3b5bd03fd8f7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -130,7 +130,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -147,7 +147,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>4b32f099d5e26aa9</ZKN:identificatie>\n
+        \               <ZKN:identificatie>0a282ee7974f1959</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -158,9 +158,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -171,25 +171,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b999e9ea-fe70-42e5-8fc6-09a897e9e052</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8f838c46-d835-4480-9897-33d4b2d22f91</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>4b32f099d5e26aa9</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>0a282ee7974f1959</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      010</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      010</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -205,7 +205,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -232,9 +232,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_enabled_selection_and_manually_added_children.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_create_zaak_with_two_form_steps_enabled_selection_and_manually_added_children.yaml
@@ -7,21 +7,21 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a2745af7-7f35-4d4f-9e91-4683ec08769b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ade2fd6b-2215-41e0-b28d-145e8497921e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      011</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      011</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.bsn\">999970100</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extraChildDetails.0.childName\">Olle</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -31,7 +31,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n    \n        <ZKN:heeftAlsOverigBetrokkene
       StUF:entiteittype=\"ZAKBTROVR\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n
@@ -60,7 +60,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -87,9 +87,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -100,7 +100,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3705f138-668f-4f84-8004-d30c11d6cf0f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f385d41d-5aeb-4620-8bb6-d934138e8253</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -117,7 +117,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -134,7 +134,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>25b96cd8af6a78c7</ZKN:identificatie>\n
+        \               <ZKN:identificatie>67d5f0361067b1ca</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -145,9 +145,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -158,25 +158,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>15597f0e-ddec-42f2-ba58-539519724d0d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190757</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>291337dd-c244-4c5e-8a1a-60a0a2eb3c11</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>25b96cd8af6a78c7</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>67d5f0361067b1ca</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      011</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190757</StUF:tijdstipRegistratie>\n
+      011</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -192,7 +192,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -219,9 +219,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_registration_as_extra_elementen_when_children_component_is_hidden.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginChildrenComponentVCRTests/test_registration_as_extra_elementen_when_children_component_is_hidden.yaml
@@ -7,20 +7,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>43ded351-f21f-497b-8419-e80516e7df96</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2d1fc42a-9e15-4a04-ac84-1bf5e8d2bcb5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">nl</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"textfield\">foo</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
       StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
       StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -30,7 +30,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -48,7 +48,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -75,9 +75,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -88,7 +88,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c84ec80b-bb68-4cad-8c1e-6356f3a038a9</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d9319505-193f-4ff7-a7cc-3c3382de2435</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -105,7 +105,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -122,7 +122,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>e551893101acd3c0</ZKN:identificatie>\n
+        \               <ZKN:identificatie>3cc7ad8c774bc355</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -133,9 +133,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -146,25 +146,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-1</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-1</StUF:applicatie>\n<StUF:administratie>zender_administratie-1</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-1</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d35d0dee-83e8-4520-ad6e-1da1b8bae433</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-1</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-1</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-1</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-1</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>61662fea-1738-48eb-84ab-eb6ec75e316f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>e551893101acd3c0</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>3cc7ad8c774bc355</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -180,7 +180,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_hidden_partners.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_hidden_partners.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -35,7 +35,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
       - Kestrel
     status:
@@ -49,19 +49,19 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9018a64f-3a14-4f9c-b3d5-96434c1775bf</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>bef01e9d-84f6-4b8a-8aaa-39a309196a38</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc999</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -71,7 +71,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -89,7 +89,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -116,9 +116,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -129,7 +129,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c370576f-5cb6-4a46-874a-1d08bcf6e9be</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a42e6549-9eed-4884-884f-8438757ea0ef</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -146,7 +146,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -163,7 +163,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>d26f4a895784ee66</ZKN:identificatie>\n
+        \               <ZKN:identificatie>20a6587e9b41658d</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -174,9 +174,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -187,25 +187,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>43856cf3-599f-4a5c-8738-be9e13b90130</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>74b4c766-fd5b-43e3-80b5-211d54e69f1a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>d26f4a895784ee66</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>20a6587e9b41658d</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc999</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -221,7 +221,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -248,9 +248,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_no_partners_retrieved.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_no_partners_retrieved.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -35,7 +35,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
       - Kestrel
     status:
@@ -49,19 +49,19 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>af0a5551-907a-421e-9537-5c16c563eeb4</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b8750a10-1e03-4367-8b05-adb4f3af1982</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc999</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -71,7 +71,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -89,7 +89,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -116,9 +116,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -129,7 +129,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0eada991-14e6-4618-8f33-2792aa83d3e9</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5dcc30cb-9781-47e7-9696-bb1bb77c7f4f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -146,7 +146,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -163,7 +163,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>8096e5e12d763145</ZKN:identificatie>\n
+        \               <ZKN:identificatie>98b2c010f75504f3</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -174,9 +174,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -187,25 +187,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>725471fe-42b1-4a57-b5ca-d6f0fec09496</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3e7d3335-dae2-468b-804d-df2577332fa5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102839</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>8096e5e12d763145</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>98b2c010f75504f3</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc999</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102839</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -221,7 +221,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -248,9 +248,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_partners_as_betrokkene.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_partners_as_betrokkene.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +39,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 25 Mar 2026 19:07:57 GMT
+      - Thu, 30 Apr 2026 10:28:39 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999995182",
+      "123456782"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.33.0
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999995182"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
       - Kestrel
     status:
@@ -53,19 +94,19 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>08fc2f0b-3397-4748-8c2f-d6bce2ae2a07</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ce67dfda-b981-441e-8066-da1d561cceae</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -75,7 +116,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n    \n        <ZKN:heeftAlsOverigBetrokkene StUF:entiteittype=\"ZAKBTROVR\"
       StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde>\n                <ZKN:natuurlijkPersoon
@@ -114,7 +155,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -141,9 +182,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -154,7 +195,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>14196528-775f-4f5f-884f-a0da8f8afe2e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>95d96099-3a61-4d6b-b4fd-f48f15ad63fa</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -171,7 +212,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -188,7 +229,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>1faad6105cd5daf5</ZKN:identificatie>\n
+        \               <ZKN:identificatie>84cc4ac697330204</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -199,9 +240,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -212,25 +253,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0353fe4d-aa65-41c0-b171-f28d7e72c04a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>52b5a970-b6fa-4258-9d19-798ddc4127f0</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>1faad6105cd5daf5</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>84cc4ac697330204</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -246,7 +287,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -273,9 +314,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_partners_as_extraElementen.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_create_zaak_with_partners_as_extraElementen.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +39,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999995182",
+      "123456782"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.33.0
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999995182"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
       - Kestrel
     status:
@@ -53,15 +94,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>52d64b36-6c8a-4c9e-be41-3bc9540e946a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>22918428-1753-4080-8a8f-00bf624af037</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc890</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"partnersKey.0.bsn\">999995182</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"partnersKey.0.firstNames\">Anna Maria Petra</StUF:extraElement>\n\n<StUF:extraElement
@@ -75,7 +116,7 @@ interactions:
       naam=\"partnersKey.1.dateOfBirth\">1945-04-18</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -85,7 +126,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -103,7 +144,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -130,9 +171,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -143,7 +184,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>eef50206-3dd5-4600-916b-188cacd0e460</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>32719e8c-8237-4531-aaed-9d9195e77bb3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -160,7 +201,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -177,7 +218,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>09695d71fab11a91</ZKN:identificatie>\n
+        \               <ZKN:identificatie>6dc670fb5d12ad47</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -188,9 +229,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -201,25 +242,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>4bc7c1a0-7ca4-4893-a9c3-f024f7c0092e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>582a4180-5f77-4341-a44d-2a636acf42f5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>09695d71fab11a91</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>6dc670fb5d12ad47</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc890</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -235,7 +276,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -262,9 +303,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_only_relevant_variables_are_taken_into_account.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_only_relevant_variables_are_taken_into_account.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
       x-doelbinding:
       - ''
       x-gebruiker:
@@ -39,7 +39,48 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999995182",
+      "123456782"], "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '166'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.33.0
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999995182"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
       - Kestrel
     status:
@@ -53,15 +94,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2852a673-4857-4e82-9aaa-56ca0ff2802e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>59f62669-b216-4b61-9a3c-e8cb82e33bdc</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc890</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"partnersKey.0.bsn\">999995182</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"partnersKey.0.firstNames\">Anna Maria Petra</StUF:extraElement>\n\n<StUF:extraElement
@@ -75,7 +116,7 @@ interactions:
       naam=\"partnersKey.1.dateOfBirth\">1945-04-18</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -85,7 +126,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -103,7 +144,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -130,9 +171,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -143,7 +184,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>caada3ea-1a85-406a-955d-b9e9b6e3c80d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>709b5436-23ba-4866-bea1-317049259588</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -160,7 +201,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -177,7 +218,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>cf460de38bcec24c</ZKN:identificatie>\n
+        \               <ZKN:identificatie>1b0ca723bfe0784a</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -188,9 +229,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -201,25 +242,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>63d73ecc-9278-4541-81bb-2c86a16dff07</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c50f9552-1dfc-4641-bb1a-43684500a9a8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102840</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>cf460de38bcec24c</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>1b0ca723bfe0784a</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc890</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -235,7 +276,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -262,9 +303,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:40 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_partners_registration_with_date_of_birth_as_str.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_partners_registration_with_date_of_birth_as_str.yaml
@@ -7,15 +7,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7d6b75f9-f188-42a3-97b6-af26ba595bab</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b6e0033a-fa1b-43c5-ae11-846b984fe1ad</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102841</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      019</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      019</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">nl</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"stuf_bg_partners_mutable.0.bsn\">123123123</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"stuf_bg_partners_mutable.0.affixes\">van</StUF:extraElement>\n\n<StUF:extraElement
@@ -26,7 +26,7 @@ interactions:
       naam=\"stuf_bg_partners_mutable.0.dateOfBirth\">1985-06-15</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -36,7 +36,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102840</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -54,7 +54,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -81,9 +81,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:41 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -94,7 +94,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5df1cf7b-a85f-4603-942a-1b6c9f14f367</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5d748f36-133c-4644-9c63-5fac60e4d7f9</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102841</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -111,7 +111,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -128,7 +128,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>d80d727e91387c58</ZKN:identificatie>\n
+        \               <ZKN:identificatie>921a281cdd0cf12a</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -139,9 +139,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:41 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -152,25 +152,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>72176682-ae30-4802-8eef-b53d7a73be5c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2b46cdce-2375-458d-9e85-03d6ec57a65c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102841</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>d80d727e91387c58</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>921a281cdd0cf12a</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102841</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      019</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      019</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102841</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -186,7 +186,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -213,9 +213,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:41 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_registration_as_extra_elementen_when_partners_component_is_hidden.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPartnersComponentVCRTests/test_registration_as_extra_elementen_when_partners_component_is_hidden.yaml
@@ -7,20 +7,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2a7929c5-c848-45f0-b759-7a0066f476ac</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a02ced82-d5fd-4487-8d06-72be656daa35</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102841</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>Form
-      020</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      020</ZKN:omschrijving>\n        \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102841</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">nl</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"textfield\">foo</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
       StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
       StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -30,7 +30,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102841</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -48,7 +48,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -75,9 +75,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:41 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -88,7 +88,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d5d6f3e7-f00f-479e-bc01-f303b2a3f2b1</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b7236c5e-26f8-4562-bbb2-dfec078eec2a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102841</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -105,7 +105,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -122,7 +122,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>be7700c7dfbb1ae9</ZKN:identificatie>\n
+        \               <ZKN:identificatie>8066d240b8b7c9fb</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -133,9 +133,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:41 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -146,25 +146,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-2</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-2</StUF:applicatie>\n<StUF:administratie>zender_administratie-2</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-2</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c6f847f3-d3c4-49de-9724-661462a52526</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190758</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-2</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-2</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-2</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-2</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9df1bf3b-a74a-4524-af70-4c06bfadc675</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102841</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>be7700c7dfbb1ae9</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>8066d240b8b7c9fb</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102841</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>Form
-      020</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190758</StUF:tijdstipRegistratie>\n
+      020</ZKN:omschrijving>\n            </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102841</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -180,7 +180,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:58 GMT
+      - Thu, 30 Apr 2026 10:28:41 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_register_submission_with_payment.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_register_submission_with_payment.yaml
@@ -7,15 +7,15 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-6</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-6</StUF:applicatie>\n<StUF:administratie>zender_administratie-6</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-6</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7b2e2c69-b4d7-4d9a-8be8-e216ad0579eb</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190759</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8bf41af9-f1a1-45c4-ab38-00f3b16e5551</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102842</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190759</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102842</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"payment_completed\">true</StUF:extraElement>\n\n<StUF:extraElement naam=\"payment_amount\">40.0</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"payment_public_order_ids.0\">foo</StUF:extraElement>\n\n<StUF:extraElement
@@ -24,7 +24,7 @@ interactions:
       naam=\"provider_payment_ids.1\">654321</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -34,7 +34,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           <BG:voornamen>Foo</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190759</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102842</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -52,7 +52,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -79,9 +79,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:59 GMT
+      - Thu, 30 Apr 2026 10:28:42 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -92,7 +92,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-6</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-6</StUF:applicatie>\n<StUF:administratie>zender_administratie-6</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-6</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7b7e0436-9b5b-4cf6-b54b-582473cb847f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190759</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e65a7402-319f-4972-97d3-c1dfb0641003</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102842</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -109,7 +109,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -126,7 +126,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>a1bf2f1f7ded64c1</ZKN:identificatie>\n
+        \               <ZKN:identificatie>4388db40ec1f8e7a</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -137,9 +137,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:59 GMT
+      - Thu, 30 Apr 2026 10:28:42 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -150,25 +150,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-6</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-6</StUF:applicatie>\n<StUF:administratie>zender_administratie-6</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-6</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1a9b52fe-ac74-4078-835b-b3f61c98abe2</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190759</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1f026182-b632-462b-b716-0355bbc2567c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102842</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>a1bf2f1f7ded64c1</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>4388db40ec1f8e7a</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190759</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102842</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190759</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102842</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -211,9 +211,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:59 GMT
+      - Thu, 30 Apr 2026 10:28:42 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_set_zaak_payment.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_set_zaak_payment.yaml
@@ -6,12 +6,12 @@ interactions:
       \       \n\n<ZKN:zakLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-6</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-6</StUF:applicatie>\n<StUF:administratie>zender_administratie-6</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-6</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f68e5a2a-02c6-42f9-b104-129a2ff84057</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190759</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c9bf03c9-a854-46a5-8bfd-aa4f50b772ba</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102842</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>W</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"W\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>1234</ZKN:identificatie>\n        <ZKN:betalingsIndicatie>Geheel</ZKN:betalingsIndicatie>\n
-      \       <ZKN:laatsteBetaaldatum>20260325</ZKN:laatsteBetaaldatum>\n        <StUF:extraElementen>\n\n<StUF:extraElement
+      \       <ZKN:laatsteBetaaldatum>20260430</ZKN:laatsteBetaaldatum>\n        <StUF:extraElementen>\n\n<StUF:extraElement
       naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement naam=\"payment_completed\">true</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"payment_amount\">40.0</StUF:extraElement>\n\n<StUF:extraElement naam=\"payment_public_order_ids.0\">foo</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"payment_public_order_ids.1\">bar</StUF:extraElement>\n\n<StUF:extraElement
@@ -32,7 +32,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/updateZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -59,9 +59,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:59 GMT
+      - Thu, 30 Apr 2026 10:28:42 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_set_zaak_payment_incorrect_variables_mapping.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_set_zaak_payment_incorrect_variables_mapping.yaml
@@ -6,12 +6,12 @@ interactions:
       \       \n\n<ZKN:zakLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-6</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-6</StUF:applicatie>\n<StUF:administratie>zender_administratie-6</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-6</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f52510e7-3216-4308-b09c-ab99fe308844</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190759</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-6</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-6</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-6</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-6</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e1ee02b8-c392-4afa-91bd-c0249e3533ee</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102842</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>W</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"W\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>1234</ZKN:identificatie>\n        <ZKN:betalingsIndicatie>Geheel</ZKN:betalingsIndicatie>\n
-      \       <ZKN:laatsteBetaaldatum>20260325</ZKN:laatsteBetaaldatum>\n        <StUF:extraElementen>\n\n<StUF:extraElement
+      \       <ZKN:laatsteBetaaldatum>20260430</ZKN:laatsteBetaaldatum>\n        <StUF:extraElementen>\n\n<StUF:extraElement
       naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement naam=\"paymentAmount\">40.0</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"foo\">None</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -29,7 +29,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/updateZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -56,9 +56,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:07:59 GMT
+      - Thu, 30 Apr 2026 10:28:42 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_date_related_values_in_extra_elementen.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_date_related_values_in_extra_elementen.yaml
@@ -7,21 +7,21 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d14f5e65-1614-4e62-a3b6-ff41efb9678a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>afa95749-3588-45f6-9481-a8546cffbf45</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"date\">2025-11-18</StUF:extraElement>\n\n<StUF:extraElement naam=\"datetime\">2025-11-18T14:21:00+01:00</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"time\">14:21:00</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
       StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
       StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -31,7 +31,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -49,7 +49,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -76,9 +76,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -89,7 +89,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>94d643a8-df7d-42ee-ac1e-7ff45f4893e4</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>36407475-ff6c-4484-8872-b97d30d6e393</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -106,7 +106,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -123,7 +123,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>85ad31363043f104</ZKN:identificatie>\n
+        \               <ZKN:identificatie>63e4d888b9bc0d38</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -147,25 +147,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>72c2f24e-9ba7-482a-ac4c-f9c626736501</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6db495d3-057b-4831-bf2c-7271bdda929b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>85ad31363043f104</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>63e4d888b9bc0d38</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -181,7 +181,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -208,9 +208,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_extra_mapped_extra_elementen_are_picked_up.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_extra_mapped_extra_elementen_are_picked_up.yaml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2c1b52ee-2e09-4c73-ae52-7058957b5161</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430101413</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"name\">Willie</StUF:extraElement>\n\n<StUF:extraElement naam=\"zaak.pv_startdatum\">2026-04-30T12:00:00+00:00</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           \n                            \n                            \n\n
+      \                           \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3740'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:14:13 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>904351f1-851f-4bc4-8d73-f18f5f060520</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430101413</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>32bd480455171def</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:14:13 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7126bffd-0111-4e0b-a38f-43fcdd99d9a5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430101413</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>32bd480455171def</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:14:13 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_extra_mapped_extra_elementen_are_picked_up.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_extra_mapped_extra_elementen_are_picked_up.yaml
@@ -7,7 +7,7 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2c1b52ee-2e09-4c73-ae52-7058957b5161</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430101413</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d9540562-618d-4fad-8956-a6adc016aaa6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
@@ -15,7 +15,7 @@ interactions:
       \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
       \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"name\">Willie</StUF:extraElement>\n\n<StUF:extraElement naam=\"zaak.pv_startdatum\">2026-04-30T12:00:00+00:00</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
@@ -30,7 +30,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -75,7 +75,7 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Thu, 30 Apr 2026 10:14:13 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
       - Werkzeug/3.1.4 Python/3.12.12
     status:
@@ -88,7 +88,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>904351f1-851f-4bc4-8d73-f18f5f060520</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430101413</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e10b05b5-aa1c-4b51-a771-d60d5da7f5d6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -122,7 +122,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>32bd480455171def</ZKN:identificatie>\n
+        \               <ZKN:identificatie>dc8a4291005f0435</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -133,7 +133,7 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Thu, 30 Apr 2026 10:14:13 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
       - Werkzeug/3.1.4 Python/3.12.12
     status:
@@ -146,11 +146,11 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7126bffd-0111-4e0b-a38f-43fcdd99d9a5</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430101413</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b81e32f0-e434-4f92-916f-ff59e2971cb0</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>32bd480455171def</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:identificatie>dc8a4291005f0435</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
       \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
@@ -160,11 +160,11 @@ interactions:
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
       \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430101413</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -207,7 +207,7 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Thu, 30 Apr 2026 10:14:13 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
       - Werkzeug/3.1.4 Python/3.12.12
     status:

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_illegal_characters_in_xml_are_removed.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_illegal_characters_in_xml_are_removed.yaml
@@ -7,20 +7,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>48915698-6c79-47b5-a6f2-3342b1a823d3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5011b72d-bfbe-4084-a7de-9ce90c7be232</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"achternaam\">badvalue</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -30,7 +30,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           <BG:voornamen>badvalue</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102846</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -48,7 +48,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -75,9 +75,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:46 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -88,7 +88,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c24dafea-5052-4e41-864a-4496cd1f166a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7243e382-1a3a-40eb-bc37-cd5444a28b56</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102846</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -105,7 +105,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -122,7 +122,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>11ecb368de8d2a48</ZKN:identificatie>\n
+        \               <ZKN:identificatie>bd065fea3a3bfea0</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -133,9 +133,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -146,25 +146,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>de0d79f3-811a-4b0c-955d-5724ae640431</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>73888220-cc1f-4f3b-812f-831d42148094</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>11ecb368de8d2a48</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>bd065fea3a3bfea0</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -180,7 +180,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_key_with_period_used_as_registration_attribute.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginVCRTests/test_key_with_period_used_as_registration_attribute.yaml
@@ -7,20 +7,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>164bd9e2-e2ce-4359-baf0-e2c2e40710fc</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c1e44cd1-1125-448f-b67a-d1c7c62ecaad</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"extra\">Extra tekst</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -31,7 +31,7 @@ interactions:
       \                           \n                            <BG:voornamen>Hans</BG:voornamen>\n
       \                           \n                            \n\n                            \n
       \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \               <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -49,7 +49,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -76,9 +76,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -89,7 +89,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>23ff9209-5926-4cc7-97ac-29baf0480a33</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e09d0ceb-4fc5-4dc8-b6b8-b3fe6decd065</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -106,7 +106,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -123,7 +123,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>ff6c94dfd6c4e92c</ZKN:identificatie>\n
+        \               <ZKN:identificatie>87162b97bbc24ce1</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -147,25 +147,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-31</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-31</StUF:applicatie>\n<StUF:administratie>zender_administratie-31</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-31</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>bc2f4354-e0f2-4196-8b0b-13c382785030</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190801</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-31</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-31</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-31</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-31</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>33925c79-abf4-48b3-80b3-21a987e83ae8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>ff6c94dfd6c4e92c</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>87162b97bbc24ce1</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190801</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -181,7 +181,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -208,9 +208,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:01 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/XMLSanitizerVCRTests/test_xml_generation_with_various_texts.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/XMLSanitizerVCRTests/test_xml_generation_with_various_texts.yaml
@@ -7,20 +7,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8b985c10-d872-4522-9950-2d17ebf8de17</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>48a34a7e-b2f2-4e51-81b0-3f55381adb30</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"achternaam\">badvalue</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -30,7 +30,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           <BG:voornamen>badvalue</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -48,7 +48,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -75,9 +75,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -88,7 +88,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2d688583-cf5c-497c-9051-889d49c0526d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1ff8be36-94de-4fe4-b989-6ece5a122043</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -105,7 +105,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -122,7 +122,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>e3f9710ed263fc63</ZKN:identificatie>\n
+        \               <ZKN:identificatie>481cea6f50640479</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -133,9 +133,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -146,25 +146,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>173a2fff-5a6a-4ce5-b2db-67adc6b89af1</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>805ffcea-7ab5-4a9a-aafb-fba7199b949a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>e3f9710ed263fc63</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>481cea6f50640479</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -180,7 +180,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -221,20 +221,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>67696031-fa43-401c-bb65-32a5ea417c36</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>66f81804-c6c8-4479-a9bb-c62f5e8ff396</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"achternaam\">badvalue</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -244,7 +244,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           <BG:voornamen>badvalue</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -262,7 +262,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -289,9 +289,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -302,7 +302,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5ec70a0f-95b1-46eb-af67-f6209f47a386</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>63371a74-cb07-410c-9489-8f050fd3bedd</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -319,7 +319,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -336,7 +336,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>d0b358bd9d5c1db1</ZKN:identificatie>\n
+        \               <ZKN:identificatie>6bda510af9870ce1</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -347,9 +347,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -360,25 +360,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>8835e035-2048-4c4b-903a-6381bee226fe</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>01d09813-8c8f-4a98-9e9e-b6a24f0863f4</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>d0b358bd9d5c1db1</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>6bda510af9870ce1</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -394,7 +394,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -421,9 +421,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -435,20 +435,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>cf03fb07-c353-44a2-a3e6-22852ef57051</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ccc05026-c846-46dd-a1fa-ad141da05a42</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"achternaam\">badvalue</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -458,7 +458,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           <BG:voornamen>badvalue</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -476,7 +476,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -503,9 +503,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -516,7 +516,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e7b13357-d359-4072-84d7-121f8e000dd4</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c6636f22-9111-432e-b59b-7d59127666af</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -533,7 +533,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -550,7 +550,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>d57ef688c89af13b</ZKN:identificatie>\n
+        \               <ZKN:identificatie>59a8428aa8aaf4c4</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -561,9 +561,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -574,25 +574,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>05d4e933-05d2-4999-bfa6-dc33fde974da</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>57172e0b-3684-4c22-b18b-9c66f666cda0</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>d57ef688c89af13b</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>59a8428aa8aaf4c4</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -608,7 +608,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -635,9 +635,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -649,20 +649,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9a328f4d-3bef-42a2-a0ec-a4d622ddfffb</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e87fd085-37c5-4df0-af84-ec56eca52ed3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
       naam=\"achternaam\"></StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
       StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
       StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -672,7 +672,7 @@ interactions:
       \                           \n                            \n                            \n
       \                           \n                            \n                            \n\n
       \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -690,7 +690,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -717,9 +717,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -730,7 +730,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d95de580-7587-42da-a008-10f7397cc700</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>10b77529-98d4-42d1-b807-e9d306a24613</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -747,7 +747,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -764,7 +764,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>c0c7a35062271475</ZKN:identificatie>\n
+        \               <ZKN:identificatie>0a8ebee0c501bd87</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -775,9 +775,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -788,25 +788,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>841104aa-f566-4899-b3f0-26974c035bc6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>383a0598-69f5-49aa-8c27-a45dec1dc22d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>c0c7a35062271475</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>0a8ebee0c501bd87</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -822,7 +822,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -849,9 +849,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -863,20 +863,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0d08f738-4114-4286-837e-3d3e15e50487</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e1e913ad-3419-4d1b-9c3a-6b190693667f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\x90\xFE\u9728\x8B\xAFUN\xFBI\xEE</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      naam=\"achternaam\">?\xBA\xABD\xD3</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -884,10 +884,9 @@ interactions:
       \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
       StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
       \                           \n                            \n                            \n
-      \                           <BG:voornamen>\x90\xFE\u9728\x8B\xAFUN\xFBI\xEE</BG:voornamen>\n
-      \                           \n                            \n\n                            \n
-      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \                           <BG:voornamen>?\xBA\xABD\xD3</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -899,13 +898,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3713'
+      - '3693'
       Content-Type:
       - application/soap+xml
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -932,9 +931,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -945,7 +944,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>4a780f7b-b383-4011-8fa8-fda1fee8b361</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e2fd657d-57e7-4cec-b044-8c7d0abb2290</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -962,7 +961,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -979,7 +978,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>ac362f5787547bbe</ZKN:identificatie>\n
+        \               <ZKN:identificatie>d5b45772827301b0</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -990,9 +989,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1003,25 +1002,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>59a7629a-b94d-47f8-8c9e-0a95063e4f01</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190802</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5448ea10-fc5e-49e2-802f-062a84ce193b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102847</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>ac362f5787547bbe</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>d5b45772827301b0</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190802</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102847</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -1037,7 +1036,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1064,9 +1063,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:02 GMT
+      - Thu, 30 Apr 2026 10:28:47 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1078,20 +1077,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1e7790b1-3f9c-41cc-9451-78b71cd3ade3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190803</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b630950c-8c89-4145-8bbb-aaea0dba9620</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102848</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190803</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102848</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">&#x27;/</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      naam=\"achternaam\">\xC3\xB3\xCB</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -1099,9 +1098,1080 @@ interactions:
       \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
       StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
       \                           \n                            \n                            \n
-      \                           <BG:voornamen>&#x27;/</BG:voornamen>\n                            \n
+      \                           <BG:voornamen>\xC3\xB3\xCB</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190803</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102848</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3689'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:48 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>738b0bae-26eb-4525-9cf5-c1c185c9f230</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102848</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>b4dc02806b018e32</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:48 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>78f773d6-fc22-43e1-b12b-19a1f6adac11</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102848</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>b4dc02806b018e32</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102848</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102848</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:48 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>178f2b45-58a8-4c4c-adef-ce4f245b3484</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\u023A</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\u023A</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3681'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>aed8ce4b-0090-4970-a979-9e71d90d3bd2</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>b2209d4ffcf7b606</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>eabe8184-b383-4796-a7c6-d063593fec02</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>b2209d4ffcf7b606</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ad3368c2-1171-4027-8acc-896f01e64a46</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xE8\x90\x8D\xED</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xE8\x90\x8D\xED</BG:voornamen>\n
+      \                           \n                            \n\n                            \n
+      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
+      \               <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3693'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>40dd7979-af6d-4d1f-9c4a-2c201123b917</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>51fd6f6fc98d89cc</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f0deba12-69af-4ae9-8e73-1fe97b072cf8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>51fd6f6fc98d89cc</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9672ac0b-7bfc-4e46-b761-4a1a692b2512</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xE0</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xE0</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3681'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b8f6e313-c329-42e1-894e-65c8220dc39d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>10b200239cdf7bb9</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f978e1a4-1a5b-4cf5-9f3a-843e27c16dd7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>10b200239cdf7bb9</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>4c6369f1-fce1-4e8b-b3e6-28833d7b7cf0</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">Wr\u9B81r=g</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>Wr\u9B81r=g</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3693'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>628000ca-514d-49f7-9d10-006e30099e93</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>7e868af35beccc1c</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d732e795-089a-40be-a8fd-becbf01b0cb2</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>7e868af35beccc1c</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:49 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>dfa3229d-7d1a-4e9f-bcc5-962b644c7b89</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xB9B\xF6\x8E</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xB9B\xF6\x8E</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -1119,7 +2189,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1146,9 +2216,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:03 GMT
+      - Thu, 30 Apr 2026 10:28:49 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1159,7 +2229,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>729713bd-6da4-4ec2-ad2f-b207d813afb8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190803</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>400d9d9f-8f4a-430e-93d5-4aad6b4b9143</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -1176,7 +2246,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1193,7 +2263,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>85afa792c5add025</ZKN:identificatie>\n
+        \               <ZKN:identificatie>6000123847d53c69</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -1204,9 +2274,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:03 GMT
+      - Thu, 30 Apr 2026 10:28:49 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1217,25 +2287,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b668bbd0-47a3-40dd-a28b-bdab72af1298</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190803</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c08f6e09-11ff-4053-a451-8f24c75432a8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>85afa792c5add025</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>6000123847d53c69</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190803</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190803</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -1251,7 +2321,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1278,9 +2348,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:03 GMT
+      - Thu, 30 Apr 2026 10:28:49 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1292,21 +2362,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>33bd648a-845f-47dd-b1d7-de8176ccb7b7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>884928f3-ca80-423a-874a-c95766c973d3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102849</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\u0287\u01DD\u026F\u0250 \u0287\u1D09s \u0279olop \u026Fnsd\u1D09
-      \u026F\u01DD\u0279o\u02E5</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      naam=\"achternaam\">\xBB\x90g&lt;\xCA\xBECLy</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -1314,225 +2383,10 @@ interactions:
       \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
       StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
       \                           \n                            \n                            \n
-      \                           <BG:voornamen>\u0287\u01DD\u026F\u0250 \u0287\u1D09s
-      \u0279olop \u026Fnsd\u1D09 \u026F\u01DD\u0279o\u02E5</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3759'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c1f6c37b-48d3-4679-a1d1-22f3d4c5fa7e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>19ebd2b2b3e3a77c</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ad194266-2d90-4e69-b13b-00eefed98743</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>19ebd2b2b3e3a77c</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fbf59dbc-02b8-4746-b651-1b55322541ff</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\xFF\xC0\xD56\\\xC0\uF31B\xF5\xC6\xDE\u081D\xD4\xDB</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\xFF\xC0\xD56\\\xC0\uF31B\xF5\xC6\xDE\u081D\xD4\xDB</BG:voornamen>\n
+      \                           <BG:voornamen>\xBB\x90g&lt;\xCA\xBECLy</BG:voornamen>\n
       \                           \n                            \n\n                            \n
       \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \               <StUF:tijdstipRegistratie>20260430102849</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -1544,13 +2398,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3729'
+      - '3709'
       Content-Type:
       - application/soap+xml
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1577,9 +2431,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1590,7 +2444,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7841821c-6eca-47d9-978a-76640163406e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b3ba287a-856d-4687-a0aa-c4cafc7ba1f2</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -1607,7 +2461,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1624,7 +2478,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>aa3067c0a409e058</ZKN:identificatie>\n
+        \               <ZKN:identificatie>b4cd0abf916911e0</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -1635,9 +2489,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1648,25 +2502,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>7e1e86cc-94ff-4e7d-b212-956ed925ec71</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>86176413-28fc-496c-8e37-f7f13c7e6d6f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>aa3067c0a409e058</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>b4cd0abf916911e0</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -1682,7 +2536,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1709,9 +2563,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1723,20 +2577,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>78090853-05e9-4e17-a248-6e823e1e568f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2cac9105-7dd1-4001-b47c-9153b3a69302</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">X\x95</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      naam=\"achternaam\">j}E</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -1744,9 +2598,9 @@ interactions:
       \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
       StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
       \                           \n                            \n                            \n
-      \                           <BG:voornamen>X\x95</BG:voornamen>\n                            \n
+      \                           <BG:voornamen>j}E</BG:voornamen>\n                            \n
       \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -1764,7 +2618,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1791,9 +2645,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1804,7 +2658,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1dbce207-554e-44ef-a451-008b8cee9e05</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>12b900e8-3ee2-4fc4-8a81-e5c7ec211ea9</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -1821,7 +2675,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1838,7 +2692,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>1f02d4493307f2c4</ZKN:identificatie>\n
+        \               <ZKN:identificatie>08e851bccd9e5d16</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -1849,9 +2703,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1862,25 +2716,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d599f30a-339d-4e85-bf9d-d5151d0ba7cd</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>997e9ceb-9354-4b23-8ce6-a293c1227473</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>1f02d4493307f2c4</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>08e851bccd9e5d16</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -1896,7 +2750,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -1923,9 +2777,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -1937,20 +2791,20 @@ interactions:
       \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>417dd3fd-e845-482e-a350-95bcdf945170</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d8a0ef04-3c8f-46fb-ad85-8728bb587700</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
       \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
       \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">k\xB5\xDD$\xB7g\xCA\xB7=\xFD</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      naam=\"achternaam\">D\xDF\x8A\xB8i\x86</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
       \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
       \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
       StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
       \                   \n                    \n                        <ZKN:natuurlijkPersoon
@@ -1958,2797 +2812,10 @@ interactions:
       \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
       StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
       \                           \n                            \n                            \n
-      \                           <BG:voornamen>k\xB5\xDD$\xB7g\xCA\xB7=\xFD</BG:voornamen>\n
+      \                           <BG:voornamen>D\xDF\x8A\xB8i\x86</BG:voornamen>\n
       \                           \n                            \n\n                            \n
       \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3709'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d9006bcf-9211-4b69-b612-d9b456dda8e7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>014df5c63f49021e</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5261619d-eba9-47cf-a8ad-b97466e3a579</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>014df5c63f49021e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ac4ad84d-22e0-4185-94b1-267e8327a919</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\xAAF\x99\u516A\x99\xFA\xB6\xEC</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\xAAF\x99\u516A\x99\xFA\xB6\xEC</BG:voornamen>\n
-      \                           \n                            \n\n                            \n
-      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3709'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6fb942b2-344c-490b-a126-776597a8a945</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>da617a5adbe64aee</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3972f191-eb50-452e-8aac-6d19b5c87c84</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>da617a5adbe64aee</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0424113a-26a6-4bd9-95a1-dc08958b1a67</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\xE8]\x93?</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\xE8]\x93?</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3689'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e72900bf-32da-43ee-b5b7-33c403d8e611</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>3b0f7ea43139a919</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fecd159d-e904-441d-b3d1-8df027974156</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>3b0f7ea43139a919</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b5fa5605-db9b-4d55-8c75-2c746d39de56</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\x88\xA9\xDF</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\x88\xA9\xDF</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3689'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d35266db-fe34-44f3-bac1-04a9b8e0d28c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>1c042817537d4182</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1d551a32-cf6c-4488-b4f1-ad067c739a69</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>1c042817537d4182</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>96a68db6-f1cb-4d70-bc84-8648bbf92b2f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">n</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
-      StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
-      StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>n</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3679'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>c948f968-0152-45a2-ab82-0a88871c1b6e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>1cd138c87d47c81f</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b34477ca-1da5-4a94-af29-dd5f33ad0e01</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>1cd138c87d47c81f</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>abe2f3b8-a682-4fae-b575-13e6351b8a00</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\xFE\xDF</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\xFE\xDF</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3685'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6c43b4fe-6f7e-40e7-9087-899b56d4b25b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>1c81112be890fe3b</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1c7df567-0cae-4a1d-b070-be80e9f94af1</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>1c81112be890fe3b</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>11c0d9b8-aa0c-4254-b060-89ffd48b4f2a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\xA9\xDD</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\xA9\xDD</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3685'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>90120ad7-0ee7-4310-9b81-cbb35c6f6880</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>a8a384f35398d7dd</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9450a117-6b7d-4995-8aa1-27c99c917f20</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>a8a384f35398d7dd</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>27856183-ebc4-4b2f-b22b-cfe7329c6446</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">INTERN</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>INTERN</BG:voornamen>\n                            \n
-      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3689'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>dcc46dd8-cb39-4111-a4d4-405c7500970e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>b74a93e58a8a1c83</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>30a97fdf-4fdb-45d8-9b58-eb3b4280382c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>b74a93e58a8a1c83</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>dda48e38-0460-4efb-b238-6ca0fec5bfd7</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\xB9%\xC7\xA3\_\xFE#\x96[u</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\xB9%\xC7\xA3\_\xFE#\x96[u</BG:voornamen>\n
-      \                           \n                            \n\n                            \n
-      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3709'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>56d5ee3a-710c-4695-ac82-ffdf2a1ed527</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>c2109cb289f9d609</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1bc25fb0-3354-47f1-be8b-77c3122245ec</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>c2109cb289f9d609</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6a364c29-c3e3-4088-bc1b-6c6519c8da69</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\"></StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
-      StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
-      StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           \n                            \n                            \n\n
-      \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3648'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d60798d8-9e02-48f0-b2f8-92912c24991c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>a5ae3bf22e2be1d5</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fa4def5e-6523-4d1e-b9ca-c93a4f0f9055</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>a5ae3bf22e2be1d5</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>86350c72-0042-4e5a-8845-6927914fafd4</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">jp\xE9\xD4\xDD\xE91U</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>jp\xE9\xD4\xDD\xE91U</BG:voornamen>\n
-      \                           \n                            \n\n                            \n
-      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3701'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>778aa6d8-d01c-4420-84e0-8c34ba7e7b53</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>073f84755419ff9e</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>42dec613-265b-4b99-836a-7aa446a0a3e8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190804</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>073f84755419ff9e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190804</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:04 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>de0a3281-15f6-4e40-b47c-3fd8d02988b6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">pq\xC4\xA5\xE3\xDD\x83\x9A\xF8\xF1</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>pq\xC4\xA5\xE3\xDD\x83\x9A\xF8\xF1</BG:voornamen>\n
-      \                           \n                            \n\n                            \n
-      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3713'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>b87e1b73-4df1-435f-bf55-d2369eef8d1d</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>ae640d782c5f4e27</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ba9959f3-b99e-4c8c-b02a-8585626e8cf2</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>ae640d782c5f4e27</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>d7f26561-2e6f-4766-bca9-89d4751766f6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\"></StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n        <ZKN:isVan
-      StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n            <ZKN:gerelateerde
-      StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n                \n                <ZKN:code>foo</ZKN:code>\n
-      \               <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           \n                            \n                            \n\n
-      \                           \n                        </ZKN:natuurlijkPersoon>\n
-      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
-      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3648'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2c342ce9-302d-4cb7-ba9e-262e1969e79f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
-      \   </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1355'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
-        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
-        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
-        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
-        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>99da52065e7e8797</ZKN:identificatie>\n
-        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
-        \   </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1364'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
-      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
-      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3f9eb1f8-67a1-4f33-a5fe-92ca184c8190</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>99da52065e7e8797</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
-      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
-      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
-      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
-      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
-      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
-      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
-      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3039'
-      Content-Type:
-      - application/soap+xml
-      SOAPAction:
-      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
-      User-Agent:
-      - python-requests/2.32.5
-    method: POST
-    uri: http://localhost:82/stuf-zds
-  response:
-    body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
-        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
-        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
-        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
-        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
-        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
-        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
-        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
-        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
-        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
-        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
-        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
-        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1349'
-      Content-Type:
-      - text/xml
-      Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
-      Server:
-      - Werkzeug/3.1.7 Python/3.12.13
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
-      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
-      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
-      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
-      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
-      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
-      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>98b89f5a-6cb7-4f37-a580-7127211becf1</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
-      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
-      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
-      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
-      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \       \n        \n        \n        <ZKN:startdatum>20260325</ZKN:startdatum>\n
-      \       <ZKN:registratiedatum>20260325</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
-      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
-      \       <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
-      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
-      naam=\"achternaam\">\_\xE5}\xB2\x818</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
-      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
-      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
-      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260325</ZKN:ingangsdatumObject>\n
-      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
-      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
-      \                   \n                    \n                        <ZKN:natuurlijkPersoon
-      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
-      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
-      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
-      \                           \n                            \n                            \n
-      \                           <BG:voornamen>\_\xE5}\xB2\x818</BG:voornamen>\n
-      \                           \n                            \n\n                            \n
-      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
-      \               <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
+      \               <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
       \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
@@ -4766,7 +2833,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -4793,9 +2860,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -4806,7 +2873,7 @@ interactions:
       \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
       \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
       \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>2d9d3a9f-1721-4ba4-a349-a4a496ba0e5f</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>52179941-a415-4c15-a222-6a4c39718afd</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
       \   </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
@@ -4823,7 +2890,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -4840,7 +2907,7 @@ interactions:
         \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
         \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
         \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
-        \               <ZKN:identificatie>9a9b94699d2cad91</ZKN:identificatie>\n
+        \               <ZKN:identificatie>2cd740aae9b3c955</ZKN:identificatie>\n
         \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
         \   </soapenv:Body>\n</soapenv:Envelope>"
     headers:
@@ -4851,9 +2918,9 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK
@@ -4864,25 +2931,25 @@ interactions:
       \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
       xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
       \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
-      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>fd086621-5a27-4c41-8ac9-0ad3a3497632</StUF:referentienummer>\n<StUF:tijdstipBericht>20260325190805</StUF:tijdstipBericht>\n\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>37a4e7dc-2981-4984-b092-2b3c83a5ef9e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
       \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
       \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
       \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
-      \       <ZKN:identificatie>9a9b94699d2cad91</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
-      \       <ZKN:creatiedatum>20260325</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260325</ZKN:ontvangstdatum>\n
+      \       <ZKN:identificatie>2cd740aae9b3c955</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
       \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
       formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
       \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
-      \       <ZKN:verzenddatum>20260325</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
       \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
       StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
-      \           <StUF:beginGeldigheid>20260325</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
       StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
-      \       <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
       \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
       \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
-      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260325190805</StUF:tijdstipRegistratie>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
       \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
     headers:
       Accept:
@@ -4898,7 +2965,7 @@ interactions:
       SOAPAction:
       - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.33.0
     method: POST
     uri: http://localhost:82/stuf-zds
   response:
@@ -4925,9 +2992,1943 @@ interactions:
       Content-Type:
       - text/xml
       Date:
-      - Wed, 25 Mar 2026 19:08:05 GMT
+      - Thu, 30 Apr 2026 10:28:50 GMT
       Server:
-      - Werkzeug/3.1.7 Python/3.12.13
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>56baf22a-58d0-4462-a639-a68eb7561577</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">u\xE2\x8F&quot;\xA3</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>u\xE2\x8F&quot;\xA3</BG:voornamen>\n
+      \                           \n                            \n\n                            \n
+      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
+      \               <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3703'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ed88c02a-70b0-4e68-9243-7aecff9e9b30</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>c6bb2a63bf849e12</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ec840335-abe6-4846-ae86-8f73f0168cf6</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>c6bb2a63bf849e12</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6c4fee22-f44f-4c1e-b41d-51cb7aedf644</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\u092A\u0928\u094D\u0939 \u092A\u0928\u094D\u0939 \u0924\u094D\u0930
+      \u0930\u094D\u091A \u0915\u0943\u0915\u0943 \u0921\u094D\u0921 \u0928\u094D\u0939\u0943\u0947
+      \u0625\u0644\u0627 \u0628\u0633\u0645 \u0627\u0644\u0644\u0647</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\u092A\u0928\u094D\u0939 \u092A\u0928\u094D\u0939
+      \u0924\u094D\u0930 \u0930\u094D\u091A \u0915\u0943\u0915\u0943 \u0921\u094D\u0921
+      \u0928\u094D\u0939\u0943\u0947 \u0625\u0644\u0627 \u0628\u0633\u0645 \u0627\u0644\u0644\u0647</BG:voornamen>\n
+      \                           \n                            \n\n                            \n
+      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
+      \               <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3891'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>15e99a04-e2af-4780-adde-1b14d5b9bd84</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>d90f297fdfb8f321</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>334c1955-e607-43e8-a731-31e4c7921052</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>d90f297fdfb8f321</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>eee2d57a-4310-4e19-8a87-99c492680fe3</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">h\x9F\xB6?\xA3\x8E</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>h\x9F\xB6?\xA3\x8E</BG:voornamen>\n
+      \                           \n                            \n\n                            \n
+      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
+      \               <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3697'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3f1cc7d2-9b0f-45b3-814b-2a47afb2f3a8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>9e7707438b19a857</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5340e146-9b32-4615-a50d-1625c9fcb5bd</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>9e7707438b19a857</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>00c03bca-d944-48e2-bfbf-15c368dd9950</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xD8</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xD8</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3681'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>e19bc353-22cf-4934-a61d-24cebdc6aa20</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>d7b63bdad4a7d56a</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>5dc82e07-7fdf-4d0a-8a26-cfffdb388a47</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>d7b63bdad4a7d56a</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0f658b72-b04d-49f0-b66b-3b5e16ee7966</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xC9</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xC9</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3681'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>0ad8660c-4bdd-40a2-87c8-090bc76ad5a4</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>983ab0d1a873bf46</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9137485c-e4e2-4793-bbe4-49cdc2b871d8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102850</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>983ab0d1a873bf46</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102850</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:50 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>1f5cb1aa-3be4-4d38-b020-075ca417db86</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xBA</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xBA</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3681'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>6ff4256f-95eb-44bd-9abc-b4750c455dd8</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>b38ea83c07de0251</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>da14d734-2d36-44e6-8eda-1ebc7bb20552</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>b38ea83c07de0251</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>59182425-b630-485c-b9ab-0d0fa9939b8b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\x87j\xBF\uEB4C</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\x87j\xBF\uEB4C</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3693'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>9176e905-80d5-4245-adda-c4108e407710</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>4296a54797bba3ef</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>201d17df-c705-4c51-a021-538ecc40f550</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>4296a54797bba3ef</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>40cf0cd1-f2d5-46cf-946f-c94b95ef95c0</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\xE5C</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\xE5C</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3683'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>689b08e6-b2d9-4d2a-86fd-a6a759339a06</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>7fda0bd0a6c87dd4</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>3653e76e-dc3f-4f57-a237-63500e419a47</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>7fda0bd0a6c87dd4</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>ad66f65a-e0c4-4486-bc56-f25aa133b55b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260430</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260430</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"achternaam\">\x91\xB8\xAB\xEA</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260430</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>\x91\xB8\xAB\xEA</BG:voornamen>\n
+      \                           \n                            \n\n                            \n
+      \                       </ZKN:natuurlijkPersoon>\n                    \n                </ZKN:gerelateerde>\n
+      \               <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \               \n            </ZKN:heeftAlsInitiator>\n        \n        \n
+      \       \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3693'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>35b6375f-bb14-431a-888a-3107a0bb0f3a</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>8f5063002d83b18e</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-32</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-32</StUF:applicatie>\n<StUF:administratie>zender_administratie-32</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-32</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-32</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-32</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-32</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-32</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>a485ead1-65c4-4271-8cab-26e65a297607</StUF:referentienummer>\n<StUF:tijdstipBericht>20260430102851</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>8f5063002d83b18e</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260430</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260430</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260430</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260430</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>foo-zaak</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260430102851</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3039'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Thu, 30 Apr 2026 10:28:51 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
     status:
       code: 200
       message: OK

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -1,5 +1,5 @@
 import dataclasses
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import patch
@@ -3512,6 +3512,58 @@ class StufZDSPluginVCRTests(OFVCRMixin, StUFZDSTestBase):
             {
                 "//zkn:object/zkn:heeftAlsInitiator/zkn:gerelateerde/zkn:natuurlijkPersoon/bg:voornamen": "badvalue",
                 "//stuf:extraElementen/stuf:extraElement[@naam='achternaam']": "badvalue",
+            },
+        )
+
+    def test_extra_mapped_extra_elementen_are_picked_up(self):
+        """
+        Assert that any registration variables that are mapped in the options are emitted.
+
+        Regression test for the review in
+        https://github.com/open-formulieren/open-forms/pull/6233 where the variable was
+        added, but an internal allowlist was blocking it from being included in the XML.
+        Instead, the configuration options should be the only source of truth.
+        """
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "name",
+                    "type": "textfield",
+                    "label": "Name",
+                },
+            ],
+            form__name="my-form",
+            bsn="111222333",
+            public_registration_reference="foo-zaak",
+            registration_result={"intermediate": {"zaaknummer": "foo-zaak"}},
+            submitted_data={"name": "Willie"},
+            language_code="en",
+            completed=True,
+            completed_on=datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC),
+        )
+
+        plugin = StufZDSRegistration("stuf")
+        options: RegistrationOptions = {
+            **self.options,
+            "variables_mapping": [
+                {
+                    "form_variable": "completed_on",
+                    "stuf_name": "zaak.pv_startdatum",
+                }
+            ],
+        }
+        plugin.register_submission(submission, options)
+
+        stuf_request = self.cassette.requests[0]
+        xml_doc = etree.fromstring(stuf_request.body)
+        self.assertSoapXMLCommon(xml_doc)
+
+        # Ensure that date-related values are formatted correctly
+        self.assertXPathEqualDict(
+            xml_doc,
+            {
+                "//stuf:extraElementen/stuf:extraElement[@naam='name']": "Willie",
+                "//stuf:extraElementen/stuf:extraElement[@naam='zaak.pv_startdatum']": "2026-04-30T12:00:00+00:00",
             },
         )
 

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -1,3 +1,18 @@
+"""
+Test the correct behaviour of the StUF-ZDS registration plugin.
+
+.. warning:: when re-recording the VCR cassettes, make sure to spin up all necessary
+   compose services!
+
+   In the root of the repository:
+
+   .. code-block:: bash
+
+       cd docker
+       ./start_vcr_services.sh
+
+"""
+
 import dataclasses
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -3986,7 +4001,7 @@ class StufZDSPluginPartnersComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         prefill_variables(submission)
         self.plugin.register_submission(submission, self.options)
 
-        stuf_request = self.cassette.requests[1]
+        stuf_request = self.cassette.requests[2]
         xml_doc = etree.fromstring(stuf_request.body)
 
         self.assertSoapXMLCommon(xml_doc)
@@ -4071,7 +4086,7 @@ class StufZDSPluginPartnersComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         prefill_variables(submission)
         self.plugin.register_submission(submission, self.options)
 
-        stuf_request = self.cassette.requests[1]
+        stuf_request = self.cassette.requests[2]
         xml_doc = etree.fromstring(stuf_request.body)
 
         self.assertSoapXMLCommon(xml_doc)
@@ -4234,7 +4249,7 @@ class StufZDSPluginPartnersComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
         prefill_variables(submission)
         self.plugin.register_submission(submission, self.options)
 
-        stuf_request = self.cassette.requests[1]
+        stuf_request = self.cassette.requests[2]
         xml_doc = etree.fromstring(stuf_request.body)
 
         self.assertSoapXMLCommon(xml_doc)

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_variables.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_variables.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
 from django.test import SimpleTestCase
+
+from openforms.submissions.tests.factories import SubmissionFactory
 
 from ..registration_variables import register
 
@@ -10,6 +14,7 @@ class VariableEvaluationTests(SimpleTestCase):
             "payment_amount",
             "payment_public_order_ids",
             "provider_payment_ids",
+            "completed_on",
         ):
             with self.subTest(variable=name):
                 variable = register[name]
@@ -20,3 +25,12 @@ class VariableEvaluationTests(SimpleTestCase):
                     raise self.failureException(
                         "Variable must be able to handle None"
                     ) from exc
+
+    def test_submission_completed_on_returns_datetime(self):
+        submission = SubmissionFactory.build(completed=True)
+        variable = register["completed_on"]
+
+        variable = variable.get_static_variable(submission=submission)
+
+        assert isinstance(variable.initial_value, datetime)
+        self.assertIsNotNone(variable.initial_value.tzinfo)


### PR DESCRIPTION
Closes #6230

**Changes**

* Added a new registration variable for StUF-ZDS
* Documented Onegov-specific configuration instructions and pitfalls

While this is technically a new feature, we plan to backport it as the changes are simple and will greatly benefit the municipality that's currently blocked by these limitations.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
