### PR TITLE
Small cleanups that are technically breaking changes

### DIFF
--- a/src/openforms/authentication/signals.py
+++ b/src/openforms/authentication/signals.py
@@ -33,7 +33,6 @@ logger = structlog.stdlib.get_logger(__name__)
 #
 # Custom signals
 #
-authentication_success = Signal()
 co_sign_authentication_success = Signal()
 """
 Signal a successful co-sign authentication.

--- a/src/openforms/authentication/tests/test_signals.py
+++ b/src/openforms/authentication/tests/test_signals.py
@@ -1,16 +1,12 @@
-from unittest.mock import patch
-
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.backends.base import SessionBase
 from django.core.exceptions import PermissionDenied
 from django.test import override_settings, tag
 
 from freezegun import freeze_time
-from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, APITestCase
 
 from openforms.accounts.tests.factories import StaffUserFactory, UserFactory
-from openforms.forms.tests.factories import FormStepFactory
 from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.tests.factories import SubmissionFactory
 
@@ -21,7 +17,6 @@ from ..constants import (
 )
 from ..registry import Registry
 from ..signals import set_auth_attribute_on_session, set_cosign_data_on_submission
-from ..views import AuthenticationReturnView
 from .mocks import Plugin, RequiresAdminPlugin, mock_register
 
 factory = APIRequestFactory()
@@ -233,89 +228,6 @@ class SetSubmissionIdentifyingAttributesTests(APITestCase):
         self.assertEqual(instance.auth_info.plugin, "organization_plugin")
         self.assertEqual(instance.auth_info.attribute, AuthAttribute.employee_id)
         self.assertEqual(instance.auth_info.value, "my-employee-id")
-
-    @override_settings(
-        CORS_ALLOW_ALL_ORIGINS=False, CORS_ALLOWED_ORIGINS=["http://foo.bar"]
-    )
-    def test_successful_auth_sends_signal(self):
-        register = Registry()
-        register("plugin1")(Plugin)
-        plugin = register["plugin1"]
-
-        step = FormStepFactory(
-            form__slug="myform",
-            form__authentication_backend="plugin1",
-            form_definition__login_required=True,
-        )
-        form = step.form
-
-        # we need an arbitrary request
-        factory = APIRequestFactory()
-        init_request = factory.get("/foo")
-        url = plugin.get_return_url(init_request, form)
-        next_url = "http://foo.bar"
-        request = factory.get(url, {"next": next_url})
-
-        # Add session information to the request:
-        request.session = SessionBase()
-        request.session.update(
-            {
-                FORM_AUTH_SESSION_KEY: {
-                    "plugin": "plugin1",
-                    "attribute": Plugin.provides_auth[0],
-                    "value": "123",
-                }
-            }
-        )
-
-        return_view = AuthenticationReturnView.as_view(register=register)
-
-        with patch(
-            "openforms.authentication.views.authentication_success.send"
-        ) as m_send:
-            response = return_view(request, slug=form.slug, plugin_id=plugin.identifier)
-
-            self.assertEqual(response.status_code, 302)
-            m_send.assert_called_once()
-            call_args = m_send.call_args.kwargs
-            self.assertIn("sender", call_args)
-            self.assertIn("request", call_args)
-            self.assertEqual(AuthenticationReturnView, call_args["sender"])
-            self.assertTrue(isinstance(call_args["request"], Request))
-
-    @override_settings(
-        CORS_ALLOW_ALL_ORIGINS=False, CORS_ALLOWED_ORIGINS=["http://foo.bar"]
-    )
-    def test_unsuccessful_auth_does_not_sends_signal(self):
-        register = Registry()
-        register("plugin1")(Plugin)
-        plugin = register["plugin1"]
-
-        step = FormStepFactory(
-            form__slug="myform",
-            form__authentication_backend="plugin1",
-            form_definition__login_required=True,
-        )
-        form = step.form
-
-        # we need an arbitrary request
-        init_request = factory.get("/foo")
-        url = plugin.get_return_url(init_request, form)
-        next_url = "http://foo.bar"
-        request = factory.get(url, {"next": next_url})
-
-        return_view = AuthenticationReturnView.as_view(register=register)
-
-        # No FORM_AUTH_SESSION_KEY in the session, since auth was unsuccessful
-        request.session = SessionBase()
-
-        with patch(
-            "openforms.authentication.views.authentication_success.send"
-        ) as m_send:
-            response = return_view(request, slug=form.slug, plugin_id=plugin.identifier)
-
-            self.assertEqual(response.status_code, 302)
-            m_send.assert_not_called()
 
     @tag("gh-1959")
     def test_setting_auth_attributes_flips_hashed_flag(self):

--- a/src/openforms/authentication/views.py
+++ b/src/openforms/authentication/views.py
@@ -48,11 +48,7 @@ from .constants import (
 from .exceptions import InvalidCoSignData
 from .forms import RegistratorSubjectInfoForm
 from .registry import register
-from .signals import (
-    authentication_logout,
-    authentication_success,
-    co_sign_authentication_success,
-)
+from .signals import authentication_logout, co_sign_authentication_success
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -417,10 +413,6 @@ class AuthenticationReturnView(AuthenticationFlowBaseView):
             audit_logger.info(
                 "user_authenticated", identifier=identifier, next=location
             )
-
-            if hasattr(request, "session") and FORM_AUTH_SESSION_KEY in request.session:
-                # XXX: this signal is unused, it's scheduled for removal
-                authentication_success.send(sender=self.__class__, request=request)
 
         return response
 

--- a/src/openforms/registrations/contrib/objects_api/handlers/v1.py
+++ b/src/openforms/registrations/contrib/objects_api/handlers/v1.py
@@ -5,7 +5,7 @@ Helpers for the template based Objects API registration handler.
 from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
-from typing import Literal, TypedDict
+from typing import TypedDict
 
 from django.conf import settings
 
@@ -43,19 +43,19 @@ class CosignContextData(TypedDict):
     bsn: str
     kvk: str
     pseudo: str
-    date: datetime | Literal[""]
+    date: datetime
 
 
 def get_cosign_context_data(submission: Submission) -> CosignContextData | None:
     if not (cosign := submission.cosign_state).is_signed:
         return None
 
-    cosign_date = cosign.signing_details.get("cosign_date")
+    cosign_date = cosign.signing_details["cosign_date"]
     return {
         "bsn": get_cosign_value(submission, AuthAttribute.bsn),
         "kvk": get_cosign_value(submission, AuthAttribute.kvk),
         "pseudo": get_cosign_value(submission, AuthAttribute.pseudo),
-        "date": datetime.fromisoformat(cosign_date) if cosign_date else "",
+        "date": datetime.fromisoformat(cosign_date),
     }
 
 

--- a/src/openforms/registrations/contrib/objects_api/registration_variables.py
+++ b/src/openforms/registrations/contrib/objects_api/registration_variables.py
@@ -159,8 +159,8 @@ class CosignDate(BaseStaticVariable):
     ) -> datetime | None:
         if not submission or not (cosign := submission.cosign_state).is_signed:
             return None
-        cosign_date = cosign.signing_details.get("cosign_date")
-        return datetime.fromisoformat(cosign_date) if cosign_date else None
+        cosign_date = cosign.signing_details["cosign_date"]
+        return datetime.fromisoformat(cosign_date)
 
 
 @register("cosign_bsn")

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -1245,54 +1245,6 @@ class V1HandlerTests(TestCase):
 
         self.assertEqual(record_data["data"], {})
 
-    def test_cosign_info_no_cosign_date(self):
-        """The cosign date might not be available on existing submissions."""
-
-        submission = SubmissionFactory.from_components(
-            [
-                {
-                    "key": "cosign",
-                    "type": "cosign",
-                    "validate": {"required": False},
-                },
-            ],
-            completed=True,
-            submitted_data={
-                "cosign": "example@localhost",
-            },
-            cosign_complete=True,
-            co_sign_data={
-                "version": "v2",
-                "plugin": "demo",
-                "attribute": AuthAttribute.bsn,
-                "value": "123456789",
-            },
-        )
-
-        ObjectsAPIRegistrationData.objects.create(submission=submission)
-        v1_options: RegistrationOptionsV1 = {
-            "objects_api_group": self.group,
-            "version": 1,
-            "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
-            "objecttype_version": 1,
-            "productaanvraag_type": "-dummy-",
-            "update_existing_object": False,
-            "auth_attribute_path": [],
-            "content_json": textwrap.dedent(
-                """
-                {
-                    "cosign_date": "{{ cosign_data.date }}"
-                }
-                """
-            ),
-        }
-        handler = ObjectsAPIV1Handler()
-
-        record_data = handler.get_record_data(submission=submission, options=v1_options)
-        data = record_data["data"]
-
-        self.assertEqual(data["cosign_date"], "")
-
     @tag("utrecht-243", "gh-4425")
     def test_payment_context_without_any_payment_attempts(self):
         submission = SubmissionFactory.create(

--- a/src/openforms/registrations/contrib/objects_api/tests/test_handler_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_handler_v2.py
@@ -335,56 +335,6 @@ class V2HandlerTests(TestCase):
         self.assertEqual(data["cosign_date"], None)
         self.assertEqual(data["cosign_pseudo"], "")
 
-    def test_cosign_info_no_cosign_date(self):
-        """The cosign date might not be available on existing submissions."""
-
-        submission = SubmissionFactory.from_components(
-            [
-                {
-                    "key": "cosign",
-                    "type": "cosign",
-                    "validate": {"required": False},
-                },
-            ],
-            completed=True,
-            submitted_data={
-                "cosign": "example@localhost",
-            },
-            cosign_complete=True,
-            co_sign_data={
-                "version": "v2",
-                "plugin": "demo",
-                "attribute": AuthAttribute.bsn,
-                "value": "123456789",
-            },
-        )
-
-        ObjectsAPIRegistrationData.objects.create(submission=submission)
-        v2_options: RegistrationOptionsV2 = {
-            "objects_api_group": self.group,
-            "version": 2,
-            "objecttype": UUID("f3f1b370-97ed-4730-bc7e-ebb20c230377"),
-            "objecttype_version": 1,
-            "update_existing_object": False,
-            "auth_attribute_path": [],
-            "variables_mapping": [
-                {
-                    "variable_key": "cosign_date",
-                    "target_path": ["cosign_date"],
-                },
-            ],
-            "transform_to_list": [],
-            "iot_attachment": "",
-            "iot_submission_csv": "",
-            "iot_submission_report": "",
-        }
-        handler = ObjectsAPIV2Handler()
-
-        record_data = handler.get_record_data(submission=submission, options=v2_options)
-        data = record_data["data"]
-
-        self.assertEqual(data["cosign_date"], None)
-
     @tag("utrecht-243", "gh-4425")
     def test_payment_variable_without_any_payment_attempts(self):
         submission = SubmissionFactory.create(

--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -75,14 +75,9 @@ class CosignV2Data(FormAuth):
     """
 
     version: Literal["v2"]
-    cosign_date: NotRequired[str]
+    cosign_date: str
     """
     ISO-8601 formatted datetime indicating when the cosigner confirmed the submission.
-
-    The key may be absent in legacy submissions, which is why it's marked as
-    ``NotRequired``. It was added in Open Forms 2.7.0
-
-    .. todo:: DeprecationWarning -> remove NotRequired in Open Forms 4.0.
     """
 
 

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -755,12 +755,10 @@ class Submission(models.Model):
         match co_sign_data:
             # v2 cosign
             case {"version": "v2"}:
-                timestamp = co_sign_data.get("cosign_date")
+                timestamp = co_sign_data["cosign_date"]
                 _co_sign_data: SubmissionCosignData = {
                     **co_sign_data,
-                    "cosign_date": (
-                        datetime.fromisoformat(timestamp) if timestamp else None
-                    ),
+                    "cosign_date": datetime.fromisoformat(timestamp),
                 }
                 return _co_sign_data
 

--- a/src/openforms/submissions/models/typing.py
+++ b/src/openforms/submissions/models/typing.py
@@ -13,4 +13,4 @@ class SubmissionCosignData(TypedDict):
     plugin: str
     attribute: AuthAttribute
     value: str
-    cosign_date: datetime | None
+    cosign_date: datetime


### PR DESCRIPTION
Part of #6164

**Changes**

* Deleted unused authentication signal
* Made possible-missing-key in cosign v2 data required at the type level, as it is in practice always present and historical data has been wiped by now

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
