### PR TITLE
Support serializing extraElement values as CSV list

### DIFF
--- a/docs/configuration/registration/stufzds.rst
+++ b/docs/configuration/registration/stufzds.rst
@@ -193,18 +193,13 @@ information that's not readily available in the StUF-ZDS standard, through
 ``extraElementen``:
 
 * ``zaak.pv_orderid``: the registration variable "Payment public order IDs"
-  (``payment_public_order_ids``) exists, however emitting it will result in a ``.0``,
-  ``.1``, ... suffix being added to the name of the extra element, as multiple order
-  IDs may exist. This will effectively produce XML looking like:
-
-  .. code-block:: xml
-
-    <StUF:extraElement naam="zaak.pv_orderid.0">12334</StUF:extraElement>
-
-  .. warning:: It's currently unknown if Onegov can handle this or not.
+  (``payment_public_order_ids``) exists. You must check the "Comma-separate list values"
+  option for Onegov to understand this, otherwise multiple elements will be added each
+  with their own ``.$index`` suffix.
 
   .. note:: Administrators can control the template of these order IDs. Take into
-     account that Onegov has a 100-character limit on the value of this element.
+     account that Onegov has a 100-character limit on the value of this element,
+     especially if multiple order IDs exist for a submission.
 
 * ``zaak.pv_bedrag``: the registration variable "Payment amount" (``payment_amount``)
   can be mapped to this name. It uses a period (``.``) character as decimal separator,
@@ -214,9 +209,8 @@ information that's not readily available in the StUF-ZDS standard, through
   that manage this and for us the payment method is unknown anyway.
 
 * ``zaak.pv_transactieid``: the information is available in the registration variable
-  "Provider payment IDs" (``provider_payment_ids``), but it has the same limitation like
-  ``zaak.pv_orderid`` with regard to the suffixes. An element value may not exceed 100
-  characters here either.
+  "Provider payment IDs" (``provider_payment_ids``), but it has the same limitations
+  like ``zaak.pv_orderid``.
 
 * ``zaak.pv_betaalstatus``: this cannot be mapped, but the StUF-ZDS element
   ``<ZKN:betalingsIndicatie>`` is the right place and we manage that automatically

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -1796,15 +1796,22 @@ class ImportExportTests(TempdirMixin, TestCase):
                     {
                         "stuf_name": "payment_completed",
                         "form_variable": "payment_completed",
+                        "serialize_list_to_csv": False,
                     },
-                    {"stuf_name": "payment_amount", "form_variable": "payment_amount"},
+                    {
+                        "stuf_name": "payment_amount",
+                        "form_variable": "payment_amount",
+                        "serialize_list_to_csv": False,
+                    },
                     {
                         "stuf_name": "payment_public_order_ids",
                         "form_variable": "payment_public_order_ids",
+                        "serialize_list_to_csv": False,
                     },
                     {
                         "stuf_name": "provider_payment_ids",
                         "form_variable": "provider_payment_ids",
+                        "serialize_list_to_csv": False,
                     },
                 ],
                 "zds_zaaktype_code": "test",

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -605,6 +605,12 @@
       "value": "Variant"
     }
   ],
+  "4binPe": [
+    {
+      "type": 0,
+      "value": "Comma-separate list values"
+    }
+  ],
   "4sFGgA": [
     {
       "type": 0,
@@ -4787,6 +4793,26 @@
       "value": "Reference lists table code"
     }
   ],
+  "cQXRmG": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "heeftAlsInitiator/extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": ". When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list."
+    }
+  ],
   "cQvPLh": [
     {
       "type": 0,
@@ -5603,26 +5629,6 @@
       "value": "You must select a table."
     }
   ],
-  "i3qXzA": [
-    {
-      "type": 0,
-      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "heeftAlsInitiator/extraElementen"
-        }
-      ],
-      "type": 8,
-      "value": "code"
-    },
-    {
-      "type": 0,
-      "value": "."
-    }
-  ],
   "i7HknI": [
     {
       "type": 0,
@@ -6111,26 +6117,6 @@
     {
       "type": 0,
       "value": "Add item"
-    }
-  ],
-  "ljTD4F": [
-    {
-      "type": 0,
-      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "extraElementen"
-        }
-      ],
-      "type": 8,
-      "value": "code"
-    },
-    {
-      "type": 0,
-      "value": " for the case itself."
     }
   ],
   "ln72CJ": [
@@ -7719,6 +7705,26 @@
     {
       "type": 0,
       "value": "Select a property from the object type"
+    }
+  ],
+  "zzOZbd": [
+    {
+      "type": 0,
+      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " for the case itself. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list."
     }
   ]
 }

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -605,6 +605,12 @@
       "value": "Variant"
     }
   ],
+  "4binPe": [
+    {
+      "type": 0,
+      "value": "Comma-separate list values"
+    }
+  ],
   "4sFGgA": [
     {
       "type": 0,
@@ -2295,7 +2301,7 @@
   "H2IXy5": [
     {
       "type": 0,
-      "value": "Variables mapping (case)"
+      "value": "Variabelekoppelingen (zaak)"
     }
   ],
   "H4sILo": [
@@ -4775,6 +4781,26 @@
       "value": "Tabelcode"
     }
   ],
+  "cQXRmG": [
+    {
+      "type": 0,
+      "value": "Deze koppelingen laten je toe om variabelen mee te sturen in de XML voor StUF-ZDS. De opgegeven sleutels en waarden uit de inzendingsgegevens komen terecht in de "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "heeftAlsInitiator/extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": ". Bij variabelen die een lijst als waarde hebben, kan je ervoor kiezen om deze als komma-gescheiden element op te nemen in plaats van een element voor elk item in de lijst."
+    }
+  ],
   "cQvPLh": [
     {
       "type": 0,
@@ -5368,7 +5394,7 @@
   "gO2sGp": [
     {
       "type": 0,
-      "value": "Variables mapping (Initiator)"
+      "value": "Variabelekoppelingen (initiator)"
     }
   ],
   "gSSyoc": [
@@ -5589,26 +5615,6 @@
     {
       "type": 0,
       "value": "Je moet een tabel selecteren."
-    }
-  ],
-  "i3qXzA": [
-    {
-      "type": 0,
-      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "heeftAlsInitiator/extraElementen"
-        }
-      ],
-      "type": 8,
-      "value": "code"
-    },
-    {
-      "type": 0,
-      "value": "."
     }
   ],
   "i7HknI": [
@@ -6099,26 +6105,6 @@
     {
       "type": 0,
       "value": "Item toevoegen"
-    }
-  ],
-  "ljTD4F": [
-    {
-      "type": 0,
-      "value": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "extraElementen"
-        }
-      ],
-      "type": 8,
-      "value": "code"
-    },
-    {
-      "type": 0,
-      "value": " for the case itself."
     }
   ],
   "ln72CJ": [
@@ -7703,6 +7689,26 @@
     {
       "type": 0,
       "value": "Selecteer een attribuut uit het objecttype"
+    }
+  ],
+  "zzOZbd": [
+    {
+      "type": 0,
+      "value": "Deze koppelingen laten je toe om variabelen mee te sturen in de XML voor StUF-ZDS. De opgegeven sleutels en waarden uit de inzendingsgegevens komen terecht in de "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "extraElementen"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " op het hoogste niveau (van de zaak zelf). Bij variabelen die een lijst als waarde hebben, kan je ervoor kiezen om deze als komma-gescheiden element op te nemen in plaats van een element voor elk item in de lijst."
     }
   ]
 }

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsForm.js
@@ -1,3 +1,4 @@
+import {produce} from 'immer';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
@@ -6,6 +7,18 @@ import ModalOptionsConfiguration from 'components/admin/forms/ModalOptionsConfig
 import {ValidationErrorContext, filterErrors} from 'components/admin/forms/ValidationErrors';
 
 import StufZDSOptionsFormFields from './StufZDSOptionsFormFields';
+
+const normalizeFormData = formData => {
+  return produce(formData, draft => {
+    // ensure that the key serializeListToCsv is set for each mapping item
+    const allVariableMappings = [...draft.variablesMapping, ...draft.variablesMappingInitiator];
+    for (const mapping of allVariableMappings) {
+      if (!('serializeListToCsv' in mapping)) {
+        mapping.serializeListToCsv = false;
+      }
+    }
+  });
+};
 
 const StufZDSOptionsForm = ({name, label, schema, formData, onChange}) => {
   const validationErrors = useContext(ValidationErrorContext);
@@ -44,7 +57,7 @@ const StufZDSOptionsForm = ({name, label, schema, formData, onChange}) => {
           defaultMessage="Plugin configuration: StUF-ZDS"
         />
       }
-      initialFormData={initialFormData}
+      initialFormData={normalizeFormData(initialFormData)}
       onSubmit={values => onChange({formData: values})}
     >
       <StufZDSOptionsFormFields name={name} schema={schema} />
@@ -65,12 +78,14 @@ StufZDSOptionsForm.propTypes = {
       PropTypes.shape({
         formVariable: PropTypes.string,
         stufName: PropTypes.string,
+        serializeListToCsv: PropTypes.bool,
       })
     ),
     variablesMappingInitiator: PropTypes.arrayOf(
       PropTypes.shape({
         formVariable: PropTypes.string,
         stufName: PropTypes.string,
+        serializeListToCsv: PropTypes.bool,
       })
     ),
     zdsDocumenttypeOmschrijvingInzending: PropTypes.string,

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.js
@@ -85,8 +85,11 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
                 description="StUF-ZDS registration variablesMapping message"
                 defaultMessage={`This mapping is used to map the variable keys to keys
                 used in the XML that is sent to StUF-ZDS. Those keys and the values
-                belonging to them in the submission data are included in the
-                top level <code>extraElementen</code> for the case itself.
+                belonging to them in the submission data are included in the top level
+                <code>extraElementen</code> for the case itself. When a form variable
+                contains a list of values, you can opt to include the value as a
+                comma-separated list of values instead of including a separate extra
+                element for each item in the list.
               `}
                 values={{
                   code: chunks => <code>{chunks}</code>,
@@ -109,7 +112,11 @@ const StufZDSOptionsFormFields = ({name, schema}) => {
                 description="StUF-ZDS registration variablesMappingInitiator message"
                 defaultMessage={`This mapping is used to map the variable keys to keys
                 used in the XML that is sent to StUF-ZDS. Those keys and the values
-                belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>.
+                belonging to them in the submission data are included in
+                <code>heeftAlsInitiator/extraElementen</code>. When a form variable
+                contains a list of values, you can opt to include the value as a
+                comma-separated list of values instead of including a separate extra
+                element for each item in the list.
               `}
                 values={{
                   code: chunks => <code>{chunks}</code>,

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/StufZDSOptionsFormFields.stories.js
@@ -1,0 +1,246 @@
+import {Form, Formik} from 'formik';
+import {expect, fn, userEvent, within} from 'storybook/test';
+
+import {
+  FeatureFlagsDecorator,
+  FormDecorator,
+  FormModalContentDecorator,
+  ValidationErrorsDecorator,
+} from 'components/admin/form_design/story-decorators';
+import {rsSelect} from 'utils/storybookTestHelpers';
+
+import StufZDSOptionsFormFields from './StufZDSOptionsFormFields';
+
+const FormikDecorator = Story => {
+  return (
+    <Formik
+      initialValues={{
+        // defaults
+        zdsZaaktypeCode: '',
+        zdsZaaktypeOmschrijving: '',
+        zdsZaaktypeStatusCode: '',
+        zdsZaaktypeStatusOmschrijving: '',
+        zdsDocumenttypeOmschrijvingInzending: '',
+        zdsZaakdocVertrouwelijkheid: '',
+        variablesMapping: [],
+      }}
+      onSubmit={fn()}
+    >
+      <Form data-testid="test-form">
+        <Story />
+      </Form>
+    </Formik>
+  );
+};
+
+export default {
+  title: 'Form design/Registration/StUF-ZDS',
+  component: StufZDSOptionsFormFields,
+  decorators: [
+    FormikDecorator,
+    ValidationErrorsDecorator,
+    FormDecorator,
+    FeatureFlagsDecorator,
+    FormModalContentDecorator,
+  ],
+  args: {
+    name: 'form.registrationBackends.0.options',
+    schema: {
+      type: 'object',
+      properties: {
+        zdsZaakdocVertrouwelijkheid: {
+          type: 'string',
+          enum: [
+            'ZEER GEHEIM',
+            'GEHEIM',
+            'CONFIDENTIEEL',
+            'VERTROUWELIJK',
+            'ZAAKVERTROUWELIJK',
+            'INTERN',
+            'BEPERKT OPENBAAR',
+            'OPENBAAR',
+          ],
+          enumNames: [
+            'Zeer geheim',
+            'Geheim',
+            'Confidentieel',
+            'Vertrouwelijk',
+            'Zaakvertrouwelijk',
+            'Intern',
+            'Beperkt openbaar',
+            'Openbaar',
+          ],
+          title: 'Document confidentiality level',
+          description:
+            'Indication of the level to which extend the dossier of the ZAAK is meant to be public. This is set on the documents created for the ZAAK.',
+        },
+      },
+    },
+    availableComponents: {
+      textField1: {
+        label: 'textfield1',
+      },
+      textField2: {
+        label: 'textfield2',
+      },
+    },
+    availableFormVariables: [
+      {
+        dataFormat: '',
+        dataType: 'string',
+        form: 'http://localhost:8000/api/v2/forms/ae26e20c-f059-4fdf-bb82-afc377869bb5',
+        formDefinition: null,
+        initialValue: '',
+        isSensitiveData: false,
+        key: 'textField1',
+        name: 'textfield1',
+        prefillAttribute: '',
+        prefillPlugin: '',
+        source: 'component',
+      },
+      {
+        dataFormat: '',
+        dataType: 'string',
+        form: 'http://localhost:8000/api/v2/forms/ae26e20c-f059-4fdf-bb82-afc377869bb5',
+        formDefinition: null,
+        initialValue: '',
+        isSensitiveData: false,
+        key: 'textField2',
+        name: 'textfield2',
+        prefillAttribute: '',
+        prefillPlugin: '',
+        source: 'component',
+      },
+      {
+        dataFormat: '',
+        dataType: 'string',
+        form: 'http://localhost:8000/api/v2/forms/ae26e20c-f059-4fdf-bb82-afc377869bb5',
+        formDefinition: null,
+        initialValue: '',
+        isSensitiveData: false,
+        key: 'userDefinedVar1',
+        name: 'User defined string',
+        prefillAttribute: '',
+        prefillPlugin: '',
+        source: 'user_defined',
+      },
+      {
+        dataFormat: '',
+        dataType: 'array',
+        form: 'http://localhost:8000/api/v2/forms/ae26e20c-f059-4fdf-bb82-afc377869bb5',
+        formDefinition: null,
+        initialValue: [],
+        isSensitiveData: false,
+        key: 'userDefinedVar2',
+        name: 'User defined array',
+        prefillAttribute: '',
+        prefillPlugin: '',
+        source: 'user_defined',
+      },
+      {
+        dataFormat: '',
+        dataType: 'float',
+        form: 'http://localhost:8000/api/v2/forms/ae26e20c-f059-4fdf-bb82-afc377869bb5',
+        formDefinition: null,
+        initialValue: null,
+        isSensitiveData: false,
+        key: 'userDefinedVar3',
+        name: 'User defined float',
+        prefillAttribute: '',
+        prefillPlugin: '',
+        source: 'user_defined',
+      },
+    ],
+    registrationPluginsVariables: [
+      {
+        pluginIdentifier: 'stuf-zds-create-zaak',
+        pluginVerboseName: 'StUF-ZDS',
+        pluginVariables: [
+          {
+            form: null,
+            formDefinition: null,
+            name: 'Payment completed',
+            key: 'payment_completed',
+            source: '',
+            serviceFetchConfiguration: null,
+            prefillPlugin: '',
+            prefillAttribute: '',
+            prefillIdentifierRole: 'main',
+            prefillOptions: {},
+            dataType: 'boolean',
+            dataFormat: '',
+            isSensitiveData: false,
+            initialValue: null,
+          },
+          {
+            form: null,
+            formDefinition: null,
+            name: 'Payment amount',
+            key: 'payment_amount',
+            source: '',
+            serviceFetchConfiguration: null,
+            prefillPlugin: '',
+            prefillAttribute: '',
+            prefillIdentifierRole: 'main',
+            prefillOptions: {},
+            dataType: 'float',
+            dataFormat: '',
+            isSensitiveData: false,
+            initialValue: null,
+          },
+          {
+            form: null,
+            formDefinition: null,
+            name: 'Payment public order IDs',
+            key: 'payment_public_order_ids',
+            source: '',
+            serviceFetchConfiguration: null,
+            prefillPlugin: '',
+            prefillAttribute: '',
+            prefillIdentifierRole: 'main',
+            prefillOptions: {},
+            dataType: 'array',
+            dataFormat: '',
+            isSensitiveData: false,
+            initialValue: null,
+          },
+          {
+            form: null,
+            formDefinition: null,
+            name: 'Provider payment IDs',
+            key: 'provider_payment_ids',
+            source: '',
+            serviceFetchConfiguration: null,
+            prefillPlugin: '',
+            prefillAttribute: '',
+            prefillIdentifierRole: 'main',
+            prefillOptions: {},
+            dataType: 'array',
+            dataFormat: '',
+            isSensitiveData: false,
+            initialValue: null,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const VariablesMappingWithCSVSerialize = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('tab', {name: /Extra elementen/}));
+    const addVariableButton = canvas.getAllByRole('button', {name: /Variabele toevoegen/})[0];
+    await userEvent.click(addVariableButton);
+
+    const formVarSelect1 = canvas.getByLabelText('Formuliervariabele');
+    await rsSelect(formVarSelect1, 'Payment public order IDs');
+
+    await userEvent.click(addVariableButton);
+    const formVarSelect2 = canvas.getAllByLabelText('Formuliervariabele')[1];
+    await rsSelect(formVarSelect2, 'Payment completed');
+
+    expect(await canvas.findAllByRole('checkbox')).toHaveLength(1);
+  },
+};

--- a/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/VariablesMapping.js
+++ b/src/openforms/js/components/admin/form_design/registrations/stufzds/fields/VariablesMapping.js
@@ -1,22 +1,37 @@
 import {FieldArray, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import {useContext} from 'react';
+import {useContext, useEffect} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {FormContext} from 'components/admin/form_design/Context';
 import ButtonContainer from 'components/admin/forms/ButtonContainer';
 import Field from 'components/admin/forms/Field';
-import {TextInput} from 'components/admin/forms/Inputs';
+import {Checkbox, TextInput} from 'components/admin/forms/Inputs';
 import VariableSelection from 'components/admin/forms/VariableSelection';
 import {DeleteIcon, FAIcon} from 'components/admin/icons';
 
 import {PLUGIN_ID} from '../constants';
 
 const VariableMappingRow = ({prefix, onRemove}) => {
+  const {formVariables = []} = useContext(FormContext);
   const intl = useIntl();
-  const {getFieldProps} = useFormikContext();
+  const {getFieldProps, setFieldValue} = useFormikContext();
 
   const stufNameProps = getFieldProps(`${prefix}.stufName`);
+  const serializeListToCsvProps = getFieldProps({
+    name: `${prefix}.serializeListToCsv`,
+    type: 'checkbox',
+  });
+
+  const selectedFormVariable = getFieldProps(`${prefix}.formVariable`).value;
+  const formVariable = formVariables.find(fv => fv.key === selectedFormVariable);
+  const isArrayFormVariable = formVariable && formVariable.dataType === 'array';
+
+  useEffect(() => {
+    if (!isArrayFormVariable && serializeListToCsvProps.checked) {
+      setFieldValue(`${prefix}.serializeListToCsv`, false);
+    }
+  }, [setFieldValue, prefix, isArrayFormVariable, serializeListToCsvProps.checked]);
 
   return (
     <tr>
@@ -47,6 +62,21 @@ const VariableMappingRow = ({prefix, onRemove}) => {
             })}
           />
         </Field>
+      </td>
+
+      <td>
+        {isArrayFormVariable ? (
+          <Checkbox
+            {...serializeListToCsvProps}
+            aria-label={intl.formatMessage({
+              description: 'StUF-ZDS extraElement serializeListToCsv label',
+              defaultMessage: 'Comma-separate list values',
+            })}
+            disabled={false}
+          />
+        ) : (
+          '-'
+        )}
       </td>
 
       <td>
@@ -110,6 +140,12 @@ const VariablesMapping = ({name}) => {
                       description="StUF-ZDS extraElement name label"
                     />
                   </th>
+                  <th>
+                    <FormattedMessage
+                      description="StUF-ZDS extraElement serializeListToCsv label"
+                      defaultMessage="Comma-separate list values"
+                    />
+                  </th>
                   <th />
                 </tr>
               </thead>
@@ -127,7 +163,11 @@ const VariablesMapping = ({name}) => {
 
             <ButtonContainer
               onClick={() => {
-                arrayHelpers.insert(mappings.length, {formVariable: '', stufName: ''});
+                arrayHelpers.insert(mappings.length, {
+                  formVariable: '',
+                  stufName: '',
+                  serializeListToCsv: false,
+                });
               }}
             >
               <FormattedMessage description="Add variable button" defaultMessage="Add variable" />

--- a/src/openforms/js/components/admin/forms/Inputs.js
+++ b/src/openforms/js/components/admin/forms/Inputs.js
@@ -116,9 +116,11 @@ const Checkbox = ({
     <div className={classNames({'field--disabled': disabled, 'w-100': fullWidth})}>
       <div className="flex-container checkbox-row">
         <input type="checkbox" name={name} id={idFor} {...extraProps} />{' '}
-        <label className={classNames('inline', {vCheckboxLabel: !noVCheckbox})} htmlFor={idFor}>
-          {label}
-        </label>
+        {label && (
+          <label className={classNames('inline', {vCheckboxLabel: !noVCheckbox})} htmlFor={idFor}>
+            {label}
+          </label>
+        )}
       </div>
       {helpText && (
         <div className="help">
@@ -131,7 +133,7 @@ const Checkbox = ({
 
 Checkbox.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.node.isRequired,
+  label: PropTypes.node, // pass label or aria-label
   helpText: PropTypes.node,
   noVCheckbox: PropTypes.bool,
   fullWidth: PropTypes.bool,

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -254,6 +254,11 @@
     "description": "Worldline payment options 'variant' label",
     "originalDefault": "Variant"
   },
+  "4binPe": {
+    "defaultMessage": "Comma-separate list values",
+    "description": "StUF-ZDS extraElement serializeListToCsv label",
+    "originalDefault": "Comma-separate list values"
+  },
   "4sFGgA": {
     "defaultMessage": "The expressions here are extracted from the selected decision definition. It's possible certain inputs are displayed here that are already provided by a dependency of the selected decision, due to the complexity of the input expression.",
     "description": "DMN input expressions warning about extraction accuracy",
@@ -2259,6 +2264,11 @@
     "description": "Objects API variable registration configuration API error",
     "originalDefault": "Something went wrong when fetching the available target paths"
   },
+  "cQXRmG": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list.",
+    "description": "StUF-ZDS registration variablesMappingInitiator message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list."
+  },
   "cUVVbl": {
     "defaultMessage": "is greater than or equal to",
     "description": "\">=\" operator description",
@@ -2614,11 +2624,6 @@
     "description": "Form name field label",
     "originalDefault": "Internal name"
   },
-  "i3qXzA": {
-    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>.",
-    "description": "StUF-ZDS registration variablesMappingInitiator message",
-    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>."
-  },
   "i7HknI": {
     "defaultMessage": "Tab name",
     "description": "Name of the tab in the Form admin",
@@ -2833,11 +2838,6 @@
     "defaultMessage": "Add item",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
-  },
-  "ljTD4F": {
-    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself.",
-    "description": "StUF-ZDS registration variablesMapping message",
-    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself."
   },
   "ln72CJ": {
     "defaultMessage": "URL to the object type in the objecttypes API. If provided, an object will be created and a case object relation will be added to the case.",
@@ -3608,5 +3608,10 @@
     "defaultMessage": "Select a property from the object type",
     "description": "Prefill / Objects API: accessible label for object type property selection",
     "originalDefault": "Select a property from the object type"
+  },
+  "zzOZbd": {
+    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list.",
+    "description": "StUF-ZDS registration variablesMapping message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list."
   }
 }

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -256,6 +256,11 @@
     "isTranslated": true,
     "originalDefault": "Variant"
   },
+  "4binPe": {
+    "defaultMessage": "Comma-separate list values",
+    "description": "StUF-ZDS extraElement serializeListToCsv label",
+    "originalDefault": "Comma-separate list values"
+  },
   "4sFGgA": {
     "defaultMessage": "De expressies hieronder komen uit de geselecteerde beslisdefinitie. Het is mogelijk dat sommige inputs zichtbaar zijn die al ingevuld worden door een eerdere definitie. Dit komt door de complexiteit van de expressie.",
     "description": "DMN input expressions warning about extraction accuracy",
@@ -1037,7 +1042,7 @@
     "originalDefault": "Plugin configuration: ZGW APIs"
   },
   "H2IXy5": {
-    "defaultMessage": "Variables mapping (case)",
+    "defaultMessage": "Variabelekoppelingen (zaak)",
     "description": "StUF-ZDS registration variablesMapping label",
     "originalDefault": "Variables mapping (case)"
   },
@@ -2280,6 +2285,11 @@
     "description": "Objects API variable registration configuration API error",
     "originalDefault": "Something went wrong when fetching the available target paths"
   },
+  "cQXRmG": {
+    "defaultMessage": "Deze koppelingen laten je toe om variabelen mee te sturen in de XML voor StUF-ZDS. De opgegeven sleutels en waarden uit de inzendingsgegevens komen terecht in de <code>heeftAlsInitiator/extraElementen</code>. Bij variabelen die een lijst als waarde hebben, kan je ervoor kiezen om deze als komma-gescheiden element op te nemen in plaats van een element voor elk item in de lijst.",
+    "description": "StUF-ZDS registration variablesMappingInitiator message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list."
+  },
   "cUVVbl": {
     "defaultMessage": "is groter dan of gelijk aan",
     "description": "\">=\" operator description",
@@ -2512,7 +2522,7 @@
     "originalDefault": "Regular"
   },
   "gO2sGp": {
-    "defaultMessage": "Variables mapping (Initiator)",
+    "defaultMessage": "Variabelekoppelingen (initiator)",
     "description": "StUF-ZDS registration variablesMappingInitiator label",
     "originalDefault": "Variables mapping (Initiator)"
   },
@@ -2635,11 +2645,6 @@
     "defaultMessage": "Interne naam",
     "description": "Form name field label",
     "originalDefault": "Internal name"
-  },
-  "i3qXzA": {
-    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>.",
-    "description": "StUF-ZDS registration variablesMappingInitiator message",
-    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in <code>heeftAlsInitiator/extraElementen</code>."
   },
   "i7HknI": {
     "defaultMessage": "Tabnaam",
@@ -2856,11 +2861,6 @@
     "defaultMessage": "Item toevoegen",
     "description": "Add item to multi-input field",
     "originalDefault": "Add item"
-  },
-  "ljTD4F": {
-    "defaultMessage": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself.",
-    "description": "StUF-ZDS registration variablesMapping message",
-    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself."
   },
   "ln72CJ": {
     "defaultMessage": "Objecttyperesource-URL in de Objecttypen-API. Wanneer dit ingesteld is, dan wordt een object van dit type aangemaakt en aan de zaak gerelateerd.",
@@ -3636,5 +3636,10 @@
     "defaultMessage": "Selecteer een attribuut uit het objecttype",
     "description": "Prefill / Objects API: accessible label for object type property selection",
     "originalDefault": "Select a property from the object type"
+  },
+  "zzOZbd": {
+    "defaultMessage": "Deze koppelingen laten je toe om variabelen mee te sturen in de XML voor StUF-ZDS. De opgegeven sleutels en waarden uit de inzendingsgegevens komen terecht in de <code>extraElementen</code> op het hoogste niveau (van de zaak zelf). Bij variabelen die een lijst als waarde hebben, kan je ervoor kiezen om deze als komma-gescheiden element op te nemen in plaats van een element voor elk item in de lijst.",
+    "description": "StUF-ZDS registration variablesMapping message",
+    "originalDefault": "This mapping is used to map the variable keys to keys used in the XML that is sent to StUF-ZDS. Those keys and the values belonging to them in the submission data are included in the top level <code>extraElementen</code> for the case itself. When a form variable contains a list of values, you can opt to include the value as a comma-separated list of values instead of including a separate extra element for each item in the list."
   }
 }

--- a/src/openforms/registrations/contrib/stuf_zds/options.py
+++ b/src/openforms/registrations/contrib/stuf_zds/options.py
@@ -37,6 +37,15 @@ class MappingSerializer(serializers.Serializer):
         help_text=_("The name in StUF-ZDS to which the form variable should be mapped"),
         label=_("StUF-ZDS name"),
     )
+    serialize_list_to_csv = serializers.BooleanField(
+        label=_("Comma-separate list values"),
+        required=False,
+        default=False,
+        help_text=_(
+            "If enabled, list values will be serialized to a single element value, "
+            "with multiple values joined together by comma's."
+        ),
+    )
 
 
 class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):

--- a/src/openforms/registrations/contrib/stuf_zds/plugin.py
+++ b/src/openforms/registrations/contrib/stuf_zds/plugin.py
@@ -511,9 +511,24 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
             self.process_children(submission, zaak_data, extra_data)
 
             # The extraElement tag of StUF-ZDS expects primitive types
-            extra_data = flatten_data_and_convert_to_primitives(extra_data)
+            keys_to_csv_serialize = {
+                mapping["stuf_name"]
+                for mapping in options.get("variables_mapping", [])
+                if mapping.get("serialize_list_to_csv")
+            }
+            extra_data = flatten_data_and_convert_to_primitives(
+                extra_data,
+                keys_to_csv_serialize=keys_to_csv_serialize,
+            )
+
+            initiator_keys_to_csv_serialize = {
+                mapping["stuf_name"]
+                for mapping in options.get("variables_mapping_initiator", [])
+                if mapping.get("serialize_list_to_csv")
+            }
             extra_data_initiator = flatten_data_and_convert_to_primitives(
-                extra_data_initiator
+                extra_data_initiator,
+                keys_to_csv_serialize=initiator_keys_to_csv_serialize,
             )
 
             assert submission.registration_result is not None
@@ -607,8 +622,14 @@ class StufZDSRegistration(BasePlugin[RegistrationOptions]):
         self, submission: Submission, options: RegistrationOptions
     ):
         # The extraElement tag of StUF-ZDS expects primitive types
+        keys_to_csv_serialize = {
+            mapping["stuf_name"]
+            for mapping in options.get("variables_mapping", [])
+            if mapping.get("serialize_list_to_csv")
+        }
         extra_data = flatten_data_and_convert_to_primitives(
-            self.get_extra_data(submission, options)
+            self.get_extra_data(submission, options),
+            keys_to_csv_serialize=keys_to_csv_serialize,
         )
 
         zaak_options: ZaakOptions = {

--- a/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_emit_order_ids_as_csv_list_instead_of_using_suffixes.yaml
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/files/vcr_cassettes/StufZDSPluginPaymentVCRTests/test_emit_order_ids_as_csv_list_instead_of_using_suffixes.yaml
@@ -1,0 +1,280 @@
+interactions:
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01\n    xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"\n
+      \   xmlns:BG=\"http://www.egem.nl/StUF/sector/bg/0310\"\n    xmlns:GML=\"http://www.opengis.net/gml\"\n>\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>cc7f07f4-62fd-4b9b-8a11-45bc373fcc2b</StUF:referentienummer>\n<StUF:tijdstipBericht>20260504152207</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>abc123</ZKN:identificatie>\n        \n            <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \       \n        \n        \n        <ZKN:startdatum>20260504</ZKN:startdatum>\n
+      \       <ZKN:registratiedatum>20260504</ZKN:registratiedatum>\n        <ZKN:betalingsIndicatie>N.v.t.</ZKN:betalingsIndicatie>\n
+      \       \n\n        <ZKN:zaakniveau>1</ZKN:zaakniveau>\n        <ZKN:deelzakenIndicatie>N</ZKN:deelzakenIndicatie>\n
+      \       <StUF:tijdstipRegistratie>20260504152207</StUF:tijdstipRegistratie>\n
+      \       <StUF:extraElementen>\n\n<StUF:extraElement naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"payment_public_order_ids\">foo,bar</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"provider_payment_ids\">123456,654321</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \       <ZKN:isVan StUF:entiteittype=\"ZAKZKT\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:verwerkingssoort=\"I\" StUF:entiteittype=\"ZKT\">\n
+      \               \n                <ZKN:code>foo</ZKN:code>\n                <ZKN:ingangsdatumObject>20260504</ZKN:ingangsdatumObject>\n
+      \           </ZKN:gerelateerde>\n        </ZKN:isVan>\n        \n            <ZKN:heeftAlsInitiator
+      StUF:verwerkingssoort=\"T\" StUF:entiteittype=\"ZAKBTRINI\">\n                <ZKN:gerelateerde>\n
+      \                   \n                    \n                        <ZKN:natuurlijkPersoon
+      StUF:entiteittype=\"NPS\" StUF:verwerkingssoort=\"T\">\n                            \n
+      \                               <BG:inp.bsn>111222333</BG:inp.bsn>\n                                <BG:authentiek
+      StUF:metagegeven=\"true\">J</BG:authentiek>\n                            \n
+      \                           \n                            \n                            \n
+      \                           <BG:voornamen>Foo</BG:voornamen>\n                            \n
+      \                           \n\n                            \n                        </ZKN:natuurlijkPersoon>\n
+      \                   \n                </ZKN:gerelateerde>\n                <StUF:tijdstipRegistratie>20260504152207</StUF:tijdstipRegistratie>\n
+      \               \n\n\n                \n            </ZKN:heeftAlsInitiator>\n
+      \       \n        \n        \n        \n\n        \n\n        \n    </ZKN:object>\n</ZKN:zakLk01>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3792'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/creeerZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Mon, 04 May 2026 15:22:07 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:genereerDocumentIdentificatie_Di02 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Di02</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>f589b215-14d5-4bfb-9fb4-83d15bcaff58</StUF:referentienummer>\n<StUF:tijdstipBericht>20260504152207</StUF:tijdstipBericht>\n\n
+      \       <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n    </ZKN:stuurgegevens>\n</ZKN:genereerDocumentIdentificatie_Di02>\n
+      \   </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1347'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/genereerDocumentIdentificatie_Di02
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <ZKN:genereerDocumentIdentificatie_Du02\n
+        \               xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n                xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+        \           <ZKN:stuurgegevens>\n                <StUF:berichtcode>Du02</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:functie>genereerDocumentidentificatie</StUF:functie>\n
+        \           </ZKN:stuurgegevens>\n            <ZKN:melding>melding</ZKN:melding>\n
+        \           <ZKN:document StUF:entiteittype=\"EDC\" StUF:functie=\"entiteit\">\n
+        \               <ZKN:identificatie>1f603ab57f2788a7</ZKN:identificatie>\n
+        \           </ZKN:document>\n        </ZKN:genereerDocumentIdentificatie_Du02>\n
+        \   </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1364'
+      Content-Type:
+      - text/xml
+      Date:
+      - Mon, 04 May 2026 15:22:07 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:edcLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\"
+      xmlns:xmime=\"http://www.w3.org/2005/05/xmlmime\">\n    <ZKN:stuurgegevens>\n
+      \       <StUF:berichtcode>Lk01</StUF:berichtcode>\n        <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>962ee123-08d7-4c06-a0bd-a69e0d2f1b0c</StUF:referentienummer>\n<StUF:tijdstipBericht>20260504152207</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>EDC</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>T</StUF:mutatiesoort>\n        <StUF:indicatorOvername>I</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:entiteittype=\"EDC\" StUF:verwerkingssoort=\"T\">\n
+      \       <ZKN:identificatie>1f603ab57f2788a7</ZKN:identificatie>\n        <ZKN:dct.omschrijving>foo</ZKN:dct.omschrijving>\n
+      \       <ZKN:creatiedatum>20260504</ZKN:creatiedatum>\n        <ZKN:ontvangstdatum>20260504</ZKN:ontvangstdatum>\n
+      \       <ZKN:titel>inzending</ZKN:titel>\n        <ZKN:beschrijving>Ingezonden
+      formulier</ZKN:beschrijving>\n        <ZKN:formaat>application/pdf</ZKN:formaat>\n
+      \       <ZKN:taal>nld</ZKN:taal>\n        <ZKN:status>definitief</ZKN:status>\n
+      \       <ZKN:verzenddatum>20260504</ZKN:verzenddatum>\n        <ZKN:vertrouwelijkAanduiding>GEHEIM</ZKN:vertrouwelijkAanduiding>\n
+      \       <ZKN:auteur>open-forms</ZKN:auteur>\n        <ZKN:inhoud xmime:contentType=\"application/pdf\"
+      StUF:bestandsnaam=\"open-forms-inzending.pdf\"></ZKN:inhoud>\n        <StUF:tijdvakGeldigheid>\n
+      \           <StUF:beginGeldigheid>20260504</StUF:beginGeldigheid>\n            <StUF:eindGeldigheid
+      StUF:noValue=\"geenWaarde\" xsi:nil=\"true\"/>\n        </StUF:tijdvakGeldigheid>\n
+      \       <StUF:tijdstipRegistratie>20260504152207</StUF:tijdstipRegistratie>\n
+      \       <ZKN:isRelevantVoor StUF:entiteittype=\"EDCZAK\" StUF:verwerkingssoort=\"T\">\n
+      \           <ZKN:gerelateerde StUF:entiteittype=\"ZAK\" StUF:verwerkingssoort=\"I\">\n
+      \               <ZKN:identificatie>abc123</ZKN:identificatie>\n                <ZKN:omschrijving>my-form</ZKN:omschrijving>\n
+      \           </ZKN:gerelateerde>\n            <StUF:tijdstipRegistratie>20260504152207</StUF:tijdstipRegistratie>\n
+      \       </ZKN:isRelevantVoor>\n    </ZKN:object>\n</ZKN:edcLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3029'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/voegZaakdocumentToe_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>2301189518</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125731</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>ea84f068-55e1-43fd-b4a0-94fc18f9b7af</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Mon, 04 May 2026 15:22:07 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope\n    xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"\n
+      \   xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n>\n
+      \   <soapenv:Header>\n        \n\n    </soapenv:Header>\n    <soapenv:Body>\n
+      \       \n\n<ZKN:zakLk01 xmlns:ZKN=\"http://www.egem.nl/StUF/sector/zkn/0310\">\n
+      \   <ZKN:stuurgegevens>\n        <StUF:berichtcode>Lk01</StUF:berichtcode>\n
+      \       <StUF:zender>\n    <StUF:organisatie>zender_organisatie-0</StUF:organisatie>\n<StUF:applicatie>zender_applicatie-0</StUF:applicatie>\n<StUF:administratie>zender_administratie-0</StUF:administratie>\n<StUF:gebruiker>zender_gebruiker-0</StUF:gebruiker>\n\n</StUF:zender>\n<StUF:ontvanger>\n
+      \   <StUF:organisatie>ontvanger_organisatie-0</StUF:organisatie>\n<StUF:applicatie>ontvanger_applicatie-0</StUF:applicatie>\n<StUF:administratie>ontvanger_administratie-0</StUF:administratie>\n<StUF:gebruiker>ontvanger_gebruiker-0</StUF:gebruiker>\n\n</StUF:ontvanger>\n<StUF:referentienummer>439b8325-5da1-4ea7-9fc8-a4342bfbaa9e</StUF:referentienummer>\n<StUF:tijdstipBericht>20260504152207</StUF:tijdstipBericht>\n\n
+      \       <StUF:entiteittype>ZAK</StUF:entiteittype>\n    </ZKN:stuurgegevens>\n
+      \   <ZKN:parameters>\n        <StUF:mutatiesoort>W</StUF:mutatiesoort>\n        <StUF:indicatorOvername>V</StUF:indicatorOvername>\n
+      \   </ZKN:parameters>\n    <ZKN:object StUF:verwerkingssoort=\"W\" StUF:entiteittype=\"ZAK\">\n
+      \       <ZKN:identificatie>1234</ZKN:identificatie>\n        <ZKN:betalingsIndicatie>Geheel</ZKN:betalingsIndicatie>\n
+      \       <ZKN:laatsteBetaaldatum>20260504</ZKN:laatsteBetaaldatum>\n        <StUF:extraElementen>\n\n<StUF:extraElement
+      naam=\"language_code\">en</StUF:extraElement>\n\n<StUF:extraElement naam=\"payment_public_order_ids\">foo,bar</StUF:extraElement>\n\n<StUF:extraElement
+      naam=\"provider_payment_ids\">123456,654321</StUF:extraElement>\n\n</StUF:extraElementen>\n\n\n
+      \   </ZKN:object>\n</ZKN:zakLk01>\n    </soapenv:Body>\n</soapenv:Envelope>\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1977'
+      Content-Type:
+      - application/soap+xml
+      SOAPAction:
+      - http://www.egem.nl/StUF/sector/zkn/0310/updateZaak_Lk01
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:82/stuf-zds
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n
+        \   <soapenv:Header/>\n    <soapenv:Body>\n        <StUF:Bv03Bericht xmlns:StUF=\"http://www.egem.nl/StUF/StUF0301\"\n
+        \                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n
+        \                         xsi:schemaLocation=\"http://www.egem.nl/StUF/StUF0301
+        stuf0301.xsd\">\n            <StUF:stuurgegevens>\n                <StUF:berichtcode>Bv03</StUF:berichtcode>\n
+        \               <StUF:zender>\n                    <StUF:organisatie>KING</StUF:organisatie>\n
+        \                   <StUF:applicatie>STP</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:zender>\n                <StUF:ontvanger>\n                    <StUF:organisatie>ORG</StUF:organisatie>\n
+        \                   <StUF:applicatie>TTA</StUF:applicatie>\n                    <StUF:gebruiker/>\n
+        \               </StUF:ontvanger>\n                <!-- NOTE: these mock values
+        are meaningless -->\n                <StUF:referentienummer>7771605337</StUF:referentienummer>\n
+        \               <StUF:tijdstipBericht>20210520125824</StUF:tijdstipBericht>\n
+        \               <StUF:crossRefnummer>abeab17b-03cb-477b-95af-410f07947f40</StUF:crossRefnummer>\n
+        \           </StUF:stuurgegevens>\n        </StUF:Bv03Bericht>\n    </soapenv:Body>\n</soapenv:Envelope>"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1349'
+      Content-Type:
+      - text/xml
+      Date:
+      - Mon, 04 May 2026 15:22:07 GMT
+      Server:
+      - Werkzeug/3.1.4 Python/3.12.12
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/stuf_zds/tests/test_backend.py
@@ -3919,6 +3919,66 @@ class StufZDSPluginPaymentVCRTests(OFVCRMixin, StUFZDSTestBase):
                     value,
                 )
 
+    def test_emit_order_ids_as_csv_list_instead_of_using_suffixes(self):
+        """
+        Assert that lists of values can be emitted as comma-separated element value.
+
+        Some StUF-ZDS vendors don't support the suffixes in the extraElement names.
+        """
+        plugin = StufZDSRegistration(PLUGIN_IDENTIFIER)
+
+        options: RegistrationOptions = {
+            **self.options,
+            "variables_mapping": [
+                {
+                    "form_variable": "payment_public_order_ids",
+                    "stuf_name": "payment_public_order_ids",
+                    "serialize_list_to_csv": True,
+                },
+                {
+                    "form_variable": "provider_payment_ids",
+                    "stuf_name": "provider_payment_ids",
+                    "serialize_list_to_csv": True,
+                },
+            ],
+        }
+
+        with self.subTest("main registration"):
+            plugin.register_submission(self.submission, options)
+
+            stuf_request = self.cassette.requests[0]
+            xml_doc = etree.fromstring(stuf_request.body)
+            self.assertSoapXMLCommon(xml_doc)
+            expected_items = {
+                "payment_public_order_ids": "foo,bar",
+                "provider_payment_ids": "123456,654321",
+            }
+            for name, value in expected_items.items():
+                with self.subTest(extra_element=name, value=value):
+                    self.assertXPathEqual(
+                        xml_doc,
+                        f"//stuf:extraElementen/stuf:extraElement[@naam='{name}']",
+                        value,
+                    )
+
+        with self.subTest("update payment status registration"):
+            plugin.update_payment_status(self.submission, options)
+
+            stuf_request = self.cassette.requests[-1]
+            xml_doc = etree.fromstring(stuf_request.body)
+            self.assertSoapXMLCommon(xml_doc)
+            expected_items = {
+                "payment_public_order_ids": "foo,bar",
+                "provider_payment_ids": "123456,654321",
+            }
+            for name, value in expected_items.items():
+                with self.subTest(extra_element=name, value=value):
+                    self.assertXPathEqual(
+                        xml_doc,
+                        f"//stuf:extraElementen/stuf:extraElement[@naam='{name}']",
+                        value,
+                    )
+
 
 class StufZDSPluginPartnersComponentVCRTests(OFVCRMixin, StUFZDSTestBase):
     VCR_TEST_FILES = TESTS_DIR / "files"

--- a/src/openforms/registrations/contrib/stuf_zds/typing.py
+++ b/src/openforms/registrations/contrib/stuf_zds/typing.py
@@ -4,6 +4,10 @@ from typing import Literal, NotRequired, TypedDict
 class MappingItem(TypedDict):
     form_variable: str
     stuf_name: str
+    serialize_list_to_csv: NotRequired[bool]
+    """
+    If enabled, list values will be serialized as a comma separated string value.
+    """
 
 
 class RegistrationOptions(TypedDict):

--- a/src/openforms/registrations/contrib/stuf_zds/utils.py
+++ b/src/openforms/registrations/contrib/stuf_zds/utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection, Sequence
 from datetime import date, datetime, time
 from typing import Any
 
@@ -5,20 +6,33 @@ from openforms.typing import JSONPrimitive
 
 
 def _flatten_data_and_convert_to_primitives(
-    flattened_data: dict[str, JSONPrimitive], data: Any, path: str
+    flattened_data: dict[str, JSONPrimitive],
+    data: Any,
+    *,
+    path: str = "",
+    keys_to_csv_serialize: Collection[str] = (),
 ) -> None:
     match data:
         case dict():
             for key, value in data.items():
-                updated_path = f"{path}.{key}" if path else key
-                _flatten_data_and_convert_to_primitives(
-                    flattened_data, value, updated_path
-                )
+                # For the root mapping, test if the keys need to be CSV serialized instead of
+                # flattened recursively
+                if (
+                    path == ""
+                    and key in keys_to_csv_serialize
+                    and isinstance(value, Sequence)
+                ):
+                    flattened_data[key] = _csv_serialize_data(value)
+                else:
+                    updated_path = f"{path}.{key}" if path else key
+                    _flatten_data_and_convert_to_primitives(
+                        flattened_data, value, path=updated_path
+                    )
         case list():
             for index, value in enumerate(data):
-                updated_path = f"{path}.{index}" if path else index
+                updated_path = f"{path}.{index}" if path else str(index)
                 _flatten_data_and_convert_to_primitives(
-                    flattened_data, value, updated_path
+                    flattened_data, value, path=updated_path
                 )
         case date() | time() | datetime():
             flattened_data[path] = data.isoformat()
@@ -26,7 +40,20 @@ def _flatten_data_and_convert_to_primitives(
             flattened_data[path] = data
 
 
-def flatten_data_and_convert_to_primitives(data) -> dict[str, JSONPrimitive]:
+def _csv_serialize_data(value: Sequence[object]) -> str:
+    flattened_data = {}
+    for index, item in enumerate(value):
+        _flatten_data_and_convert_to_primitives(flattened_data, item, path=str(index))
+    # Note that this assumes no nested dicts that contain comma's, so with weird input
+    # data you'll get weird output...
+    return ",".join(str(item) for item in flattened_data.values())
+
+
+def flatten_data_and_convert_to_primitives(
+    data: Any,
+    *,
+    keys_to_csv_serialize: Collection[str] = (),
+) -> dict[str, JSONPrimitive]:
     """
     Flatten any nested data, and convert to JSON primitives.
 
@@ -37,5 +64,9 @@ def flatten_data_and_convert_to_primitives(data) -> dict[str, JSONPrimitive]:
     {"variableKey.0": "value1", "variableKey.1.key1": "2025-11-18"}
     """
     flattened_data = {}
-    _flatten_data_and_convert_to_primitives(flattened_data, data, "")
+    _flatten_data_and_convert_to_primitives(
+        flattened_data,
+        data,
+        keys_to_csv_serialize=keys_to_csv_serialize,
+    )
     return flattened_data


### PR DESCRIPTION
Closes #6242  - depends on #6218 being merged first

Special request for Onegov support :)

Instead of spreading the items into different elements, we use one element with the specified name and join all list values with a comma.

**Changes**

* Support CSV serialization of list value in types and runtime code
* Expose configuration option and update admin UI, added storybook stories for this aspect
* Updated vendor-specific notes in the documentation

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
