### PR TITLE
Fix crash when saving form without steps and with new logic evaluation

### DIFF
--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -36,7 +36,11 @@ class FormLogicListSerializer(ListWithChildSerializer):
             raise serializers.ValidationError(
                 _("Appointment forms cannot have logic rules.")
             )
-        if not form.new_logic_evaluation_enabled or is_appointment:
+        if (
+            not form.new_logic_evaluation_enabled
+            or is_appointment
+            or not form.form_step_map
+        ):
             return super().validate(attrs)
 
         # This will only run when the logic rules have passed individual serializer
@@ -95,6 +99,7 @@ class FormLogicListSerializer(ListWithChildSerializer):
         if (
             not form.new_logic_evaluation_enabled
             or form.type == FormTypeChoices.appointment
+            or not form.form_step_map
         ):
             return rules
 

--- a/src/openforms/forms/tests/test_api_form_logic_bulk.py
+++ b/src/openforms/forms/tests/test_api_form_logic_bulk.py
@@ -1989,3 +1989,14 @@ class FormLogicAPIGraphValidationTests(APITestCase):
             },
         ]
         self.assertEqual(response.json()["invalidParams"], expected_error)
+
+    @tag("gh-6213")
+    def test_create_without_steps(self):
+        """Ensure there is no crash when a form is saved without any steps."""
+        form = FormFactory.create(
+            new_logic_evaluation_enabled=True, generate_minimal_setup=False
+        )
+
+        url = reverse("api:form-logic-rules", kwargs={"uuid_or_slug": form.uuid})
+        response = self.client.put(url, data=[])
+        self.assertEqual(status.HTTP_200_OK, response.status_code)


### PR DESCRIPTION
Closes #6213

[skip: e2e]

**Changes**

Exit early in logic rule validation if the form has no steps

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
