### PR TITLE
[#6057] allow logging requests & responses for hal+json

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1277,6 +1277,7 @@ LOG_OUTGOING_REQUESTS_DB_SAVE_BODY = config(
 )
 LOG_OUTGOING_REQUESTS_CONTENT_TYPES = [
     ContentType(pattern="application/json", default_encoding="utf-8"),
+    ContentType(pattern="application/hal+json", default_encoding="utf-8"),
     ContentType(pattern="application/soap+xml", default_encoding="utf-8"),
     ContentType(pattern="application/xml", default_encoding="utf-8"),
     ContentType(pattern="text/xml", default_encoding="iso-8859-1"),


### PR DESCRIPTION
Closes #6057 

[skip: e2e]

**Changes**

Properly logs the requests & responses for requests that use the `application/hal+json` content type header.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
