### PR TITLE
:boom: Drop support for elastic-apm

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -181,15 +181,6 @@ Logging, monitoring and Open Telemetry settings
 * ``SDK_SENTRY_ENVIRONMENT``: the environment label for the SDK to group events. Defaults
   to ``ENVIRONMENT``.
 
-* ``ELASTIC_APM_SERVER_URL``: Server URL of Elastic APM. Defaults to
-  ``None``. If not set, Elastic APM will be disabled by setting internal
-  setting ``ELASTIC_APM["ENABLED"]`` to ``False`` and
-  ``ELASTIC_APM["SERVER_URL"]`` to ``http://localhost:8200``. See
-  `Elastic settings`_.
-
-* ``ELASTIC_APM_SECRET_TOKEN``: Token for Elastic APM. Defaults to ``default``.
-  See `Elastic settings`_.
-
 * ``LOG_STD_OUT``: Write all log entries to ``stdout`` instead of log files.
   Defaults to ``True`` when using Docker and otherwise ``False``.
 
@@ -210,7 +201,6 @@ See :ref:`installation_observability_otel_config` for recommended environment va
 configuration.
 
 .. _`Sentry settings`: https://docs.sentry.io/
-.. _`Elastic settings`: https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html
 .. _`kubernetes attributes processor`: https://opentelemetry.io/docs/platforms/kubernetes/collector/components/#kubernetes-attributes-processor
 
 Processing of submissions

--- a/docs/installation/observability/tracing.rst
+++ b/docs/installation/observability/tracing.rst
@@ -4,12 +4,19 @@
 Tracing
 =======
 
-.. note:: A vendor-agnostic implementation is under development. Currently you can
-   already use Elastic APM.
-
 Tracing makes it possible to follow the flow of requests across system boundaries,
 e.g. from one application to another. This makes it possible to pinpoint where errors
 or performance degrations are situated exactly. Trace IDs also make it possible to
 correlate the relevant log entries.
 
-.. note:: Better support for (distributed) traces is underway.
+Since Open Forms 3.5, we have distributed tracing support. Open Forms will propagate
+traces that it receives from upstream services, and down to calls into other services
+like:
+
+* PostgreSQL database
+* Redis (cache + message queue)
+* External HTTP requests
+
+.. versionadded:: 3.5.0
+
+   Added support for distributed tracing and trace propagation.

--- a/docs/installation/upgrade-400.rst
+++ b/docs/installation/upgrade-400.rst
@@ -191,3 +191,17 @@ The following fallbacks were deprecated and have been removed.
   ``--of-backtotop-link-padding-block-end`` explicitly
 * removed fallback to ``--utrecht-button-padding-block-start``, specify
   ``--of-backtotop-link-padding-block-start`` explicitly
+
+Removal of the Elastic APM agent
+================================
+
+Elastic APM has historically been the mechanism to get some performance-related
+telemetry from Open Forms into an observability platform. Since Open Forms 3.3 (released
+9 months ago), we've been adding support for Open Telemetry as replacement, which is a
+vendor-agnostic observability protocol and ecosystem.
+
+You can remove any ``ELASTIC_APM_*`` related environment variables from your deployment
+code, and if you haven't done so yet, recommend you to set up the necessary
+:ref:`observability <installation_observability_index>` tooling. See
+:ref:`installation_observability_otel_config` on how to configure Open Forms to produce
+telemetry.

--- a/dotenv.example
+++ b/dotenv.example
@@ -22,10 +22,6 @@ DB_HOST=""
 # PROFILE=yes
 # DEBUG=no
 # ENVIRONMENT=<name>-dev
-# ELASTIC_APM_SERVICE_NAME=open-forms-<name>-dev
-# ELASTIC_APM_SECRET_TOKEN=
-# ELASTIC_APM_SERVER_URL=
-# DISABLE_APM_IN_DEV=no
 #
 # Recording Suwinet VCR cassettes
 # SUWINET_CLIENT_KEY=/path/to/privatekey.pem

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -94,7 +94,6 @@ drf-spectacular
 # WSGI servers & monitoring - production oriented
 uwsgi
 sentry-sdk[django]  # error monitoring
-elastic-apm  # Elastic APM integration
 flower # task monitoring
 
 # Common Ground integration

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,6 @@ celery-once==3.0.1
     # via -r requirements/base.in
 certifi==2026.1.4
     # via
-    #   elastic-apm
     #   pyproj
     #   requests
     #   self-certifi
@@ -269,10 +268,6 @@ drf-nested-routers==0.95.0
 drf-polymorphic==2.1.1
     # via -r requirements/base.in
 drf-spectacular==0.29.0
-    # via -r requirements/base.in
-ecs-logging==2.3.0
-    # via elastic-apm
-elastic-apm==6.25.0
     # via -r requirements/base.in
 et-xmlfile==2.0.0
     # via openpyxl
@@ -681,7 +676,6 @@ uritemplate==4.2.0
     # via drf-spectacular
 urllib3==2.6.3
     # via
-    #   elastic-apm
     #   requests
     #   sentry-sdk
 uwsgi==2.0.31
@@ -706,7 +700,6 @@ webencodings==0.5.1
     #   tinyhtml5
 wrapt==1.17.3
     # via
-    #   elastic-apm
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -83,7 +83,6 @@ certifi==2026.1.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elastic-apm
     #   pyproj
     #   requests
     #   self-certifi
@@ -441,15 +440,6 @@ drf-polymorphic==2.1.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
 drf-spectacular==0.29.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-ecs-logging==2.3.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   elastic-apm
-elastic-apm==6.25.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1216,7 +1206,6 @@ urllib3==2.6.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elastic-apm
     #   requests
     #   sentry-sdk
     #   types-requests
@@ -1267,7 +1256,6 @@ wrapt==1.17.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elastic-apm
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -95,7 +95,6 @@ certifi==2026.1.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elastic-apm
     #   httpcore
     #   httpx
     #   pyproj
@@ -475,15 +474,6 @@ drf-polymorphic==2.1.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
 drf-spectacular==0.29.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-ecs-logging==2.3.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   elastic-apm
-elastic-apm==6.25.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1348,7 +1338,6 @@ urllib3==2.6.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elastic-apm
     #   requests
     #   sentry-sdk
     #   types-requests
@@ -1413,7 +1402,6 @@ wrapt==1.17.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elastic-apm
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -78,7 +78,6 @@ certifi==2026.1.4
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elastic-apm
     #   pyproj
     #   requests
     #   self-certifi
@@ -424,15 +423,6 @@ drf-polymorphic==2.1.1
     #   -c requirements/base.txt
     #   -r requirements/base.txt
 drf-spectacular==0.29.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-ecs-logging==2.3.0
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
-    #   elastic-apm
-elastic-apm==6.25.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -1112,7 +1102,6 @@ urllib3==2.6.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elastic-apm
     #   requests
     #   sentry-sdk
 uwsgi==2.0.31
@@ -1151,7 +1140,6 @@ wrapt==1.17.3
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-    #   elastic-apm
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -92,7 +92,6 @@ certifi==2026.1.4
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elastic-apm
     #   pyproj
     #   requests
     #   self-certifi
@@ -471,15 +470,6 @@ drf-polymorphic==2.1.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
 drf-spectacular==0.29.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-ecs-logging==2.3.0
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
-    #   elastic-apm
-elastic-apm==6.25.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -1336,7 +1326,6 @@ urllib3==2.6.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elastic-apm
     #   requests
     #   sentry-sdk
     #   types-requests
@@ -1399,7 +1388,6 @@ wrapt==1.17.3
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-    #   elastic-apm
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis

--- a/src/openforms/appointments/api/views.py
+++ b/src/openforms/appointments/api/views.py
@@ -3,7 +3,6 @@ from copy import copy
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
-import elasticapm
 import structlog
 from drf_spectacular.plumbing import build_array_type, build_basic_type
 from drf_spectacular.types import OpenApiTypes
@@ -115,10 +114,6 @@ class ProductsListView(ListMixin, APIView):
                     "span.action": "get_products",
                 },
             ),
-            elasticapm.capture_span(
-                name="get-available-products",
-                span_type="app.appointments.get_products",
-            ),
         ):
             return plugin.get_available_products(**kwargs)
 
@@ -159,10 +154,6 @@ class LocationsListView(ListMixin, APIView):
                     "span.subtype": "appointments",
                     "span.action": "get_locations",
                 },
-            ),
-            elasticapm.capture_span(
-                name="get-available-locations",
-                span_type="app.appointments.get_locations",
             ),
         ):
             return plugin.get_locations(products)
@@ -210,9 +201,6 @@ class DatesListView(ListMixin, APIView):
                     "span.subtype": "appointments",
                     "span.action": "get_dates",
                 },
-            ),
-            elasticapm.capture_span(
-                name="get-available-dates", span_type="app.appointments.get_dates"
             ),
         ):
             dates = plugin.get_dates(products, location)
@@ -270,9 +258,6 @@ class TimesListView(ListMixin, APIView):
                     "span.subtype": "appointments",
                     "span.action": "get_times",
                 },
-            ),
-            elasticapm.capture_span(
-                name="get-available-times", span_type="app.appointments.get_times"
             ),
         ):
             times = plugin.get_times(products, location, date)
@@ -332,10 +317,6 @@ class RequiredCustomerFieldsListView(APIView):
                     "span.subtype": "appointments",
                     "span.action": "get_required_customer_fields",
                 },
-            ),
-            elasticapm.capture_span(
-                name="get-required-customer-fields",
-                span_type="app.appointments.get_required_customer_fields",
             ),
         ):
             fields, required_group_fields = plugin.get_required_customer_fields(

--- a/src/openforms/appointments/core.py
+++ b/src/openforms/appointments/core.py
@@ -7,7 +7,6 @@ way too much but can't be easily refactored without breaking existing functional
 
 from django.utils.translation import gettext_lazy as _
 
-import elasticapm
 import structlog
 from opentelemetry import trace
 
@@ -82,7 +81,6 @@ def book(appointment: Appointment, remarks: str = "") -> str:
         "span.action": "book_for_submission",
     },
 )
-@elasticapm.capture_span(span_type="app.appointments.book_for_submission")
 def book_for_submission(submission: Submission) -> str:
     """
     Given a submission instance, check if an appointment needs to be booked.

--- a/src/openforms/appointments/utils.py
+++ b/src/openforms/appointments/utils.py
@@ -2,7 +2,6 @@ import base64
 import io
 import re
 
-import elasticapm
 import qrcode
 import structlog
 from opentelemetry import trace
@@ -50,7 +49,6 @@ def get_formatted_phone_number(phone_number: str | None) -> str | None:
         "span.action": "delete",
     },
 )
-@elasticapm.capture_span(span_type="app.appointments.delete")
 def delete_appointment_for_submission(submission: Submission, plugin=None) -> None:
     """
     Delete/cancels the appointment for a given submission.

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -1,6 +1,5 @@
 import json
 import os
-import warnings
 from pathlib import Path
 
 # Django-hijack (and Django-hijack-admin)
@@ -979,29 +978,6 @@ if SENTRY_DSN:
 # Sentry for the Open-Forms SDK
 SDK_SENTRY_DSN = config("SDK_SENTRY_DSN", default="")
 SDK_SENTRY_ENVIRONMENT = config("SDK_SENTRY_ENVIRONMENT", default=ENVIRONMENT)
-
-#
-# Elastic APM
-#
-ELASTIC_APM_SERVER_URL = config("ELASTIC_APM_SERVER_URL", default="") or None
-ELASTIC_APM = {
-    "SERVICE_NAME": f"Open Forms - {ENVIRONMENT}",
-    "SECRET_TOKEN": config("ELASTIC_APM_SECRET_TOKEN", default="default"),
-    "SERVER_URL": ELASTIC_APM_SERVER_URL,
-}
-if not ELASTIC_APM_SERVER_URL:
-    ELASTIC_APM["ENABLED"] = False
-    ELASTIC_APM["SERVER_URL"] = "http://localhost:8200"
-else:  # pragma: no cover - can't test this in CI :/
-    warnings.warn(
-        "Elastic APM agent integration will be deprecated in favour of Open Telemetry",
-        category=PendingDeprecationWarning,
-        stacklevel=1,
-    )
-    MIDDLEWARE = ["elasticapm.contrib.django.middleware.TracingMiddleware"] + MIDDLEWARE
-    INSTALLED_APPS = INSTALLED_APPS + [
-        "elasticapm.contrib.django",
-    ]
 
 #
 # DJANGO REST FRAMEWORK

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -94,8 +94,6 @@ CACHES.update(
 # Library settings
 #
 
-ELASTIC_APM["DEBUG"] = config("DISABLE_APM_IN_DEV", default=True)
-
 # Django debug toolbar
 INSTALLED_APPS += ["debug_toolbar"]
 MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE

--- a/src/openforms/contrib/kadaster/clients/bag.py
+++ b/src/openforms/contrib/kadaster/clients/bag.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import elasticapm
 import requests
 import structlog
 from opentelemetry import trace
@@ -35,7 +34,6 @@ class BAGClient(HALClient):
         name="get-address",
         attributes={"span.type": "app", "span.subtype": "bag", "span.action": "query"},
     )
-    @elasticapm.capture_span(span_type="app.bag.query")
     def get_address(
         self, postcode: str, house_number: str, reraise_errors: bool = False
     ) -> AddressResult | None:

--- a/src/openforms/contrib/kvk/client.py
+++ b/src/openforms/contrib/kvk/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-import elasticapm
 import requests
 import structlog
 from opentelemetry import trace
@@ -67,7 +66,6 @@ class KVKProfileClient(HALClient):
     @tracer.start_as_current_span(
         name="get-profile", attributes={"span.type": "app", "span.subtype": "kvk"}
     )
-    @elasticapm.capture_span("app.kvk")
     def get_profile(self, kvk_nummer: str) -> BasisProfiel:
         """
         Retrieve the profile of a single entity by chamber of commerce number.
@@ -116,7 +114,6 @@ class KVKSearchClient(HALClient):
         name="get-search-results",
         attributes={"span.type": "app", "span.subtype": "kvk"},
     )
-    @elasticapm.capture_span("app.kvk")
     def get_search_results(self, query_params: SearchParams):
         """
         Perform a search against the KVK zoeken API.

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-import elasticapm
 from opentelemetry import trace
 
 from openforms.typing import JSONObject
@@ -89,7 +88,6 @@ def holds_submission_data(component: Component) -> bool:
     name="get-dynamic-configuration",
     attributes={"span.type": "app", "span.subtype": "formio"},
 )
-@elasticapm.capture_span(span_type="app.formio")
 def get_dynamic_configuration(
     config_wrapper: FormioConfigurationWrapper,
     submission: Submission,

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import elasticapm
 import structlog
 from glom import Coalesce, Path, glom
 from opentelemetry import trace
@@ -41,7 +40,6 @@ def _is_column_component(component: ComponentLike) -> TypeIs[ColumnsComponent]:
         "span.action": "configuration",
     },
 )
-@elasticapm.capture_span(span_type="app.formio.configuration")
 def iter_components(
     configuration: ComponentLike,
     *,
@@ -112,7 +110,6 @@ def iterate_components_with_configuration_path(
         "span.action": "configuration",
     },
 )
-@elasticapm.capture_span(span_type="app.formio.configuration")
 def flatten_by_path(configuration: FormioConfiguration) -> dict[str, Component]:
     """
     Flatten the formio configuration.

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -10,7 +10,6 @@ from django.db.models.constraints import UniqueConstraint
 from django.db.models.fields.json import KeyTransform
 from django.utils.translation import gettext_lazy as _
 
-import elasticapm
 import structlog
 from opentelemetry import trace
 
@@ -85,7 +84,6 @@ class FormVariableManager(models.Manager["FormVariable"]):
             "span.action": "models",
         },
     )
-    @elasticapm.capture_span(span_type="app.core.models")
     @transaction.atomic(savepoint=False)
     def synchronize_for(self, form_definition: FormDefinition):
         """

--- a/src/openforms/prefill/service.py
+++ b/src/openforms/prefill/service.py
@@ -34,7 +34,6 @@ So, to recap:
    form field default values.
 """
 
-import elasticapm
 import structlog
 from opentelemetry import trace
 
@@ -112,7 +111,6 @@ def inject_prefill(
 @tracer.start_as_current_span(
     name="prefill-variables", attributes={"span.type": "app", "span.subtype": "prefill"}
 )
-@elasticapm.capture_span(span_type="app.prefill")
 def prefill_variables(submission: Submission, register: Registry | None = None) -> None:
     """
     Update the submission variables state with the fetched attribute values.

--- a/src/openforms/prefill/sources.py
+++ b/src/openforms/prefill/sources.py
@@ -3,7 +3,6 @@ from functools import partial
 
 from django.core.exceptions import PermissionDenied
 
-import elasticapm
 import structlog
 from opentelemetry import trace
 from rest_framework.exceptions import ValidationError
@@ -57,7 +56,6 @@ def fetch_prefill_values_from_attribute(
     @tracer.start_as_current_span(
         name="invoke-plugin", attributes={"span.type": "app", "span.subtype": "prefill"}
     )
-    @elasticapm.capture_span(span_type="app.prefill")
     def invoke_plugin(
         structlog_ctx: Context,
         item: tuple[BasePlugin, IdentifierRoles, list[dict[str, str]]],

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -10,7 +10,6 @@ from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-import elasticapm
 import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -381,7 +380,6 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             "span.action": "serialization",
         },
     )
-    @elasticapm.capture_span(span_type="app.api.serialization")
     def to_representation(self, instance):
         in_form_logic_evaluation = self.context.get("in_form_logic_evaluation", False)
 
@@ -449,7 +447,6 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             "span.action": "serialization",
         },
     )
-    @elasticapm.capture_span(span_type="app.api.serialization")
     def get_configuration(self, instance) -> dict:
         serializer = FormDefinitionSerializer(
             instance=instance.form_step.form_definition, context=self.context

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-import elasticapm
 from opentelemetry import trace
 
 from openforms.formio.service import (
@@ -32,7 +31,6 @@ tracer = trace.get_tracer("openforms.submissions.form_logic")
         "span.action": "logic",
     },
 )
-@elasticapm.capture_span(span_type="app.submissions.logic")
 def evaluate_form_logic(
     submission: Submission,
     step: SubmissionStep,
@@ -143,9 +141,6 @@ def evaluate_form_logic(
                 "span.subtype": "submissions",
                 "span.action": "logic",
             },
-        ),
-        elasticapm.capture_span(
-            name="collect_logic_operations", span_type="app.submissions.logic"
         ),
     ):
         for operation in iter_evaluate_rules(

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -2,7 +2,6 @@ from collections.abc import Iterable, Iterator
 from copy import deepcopy
 from itertools import chain
 
-import elasticapm
 from json_logic import jsonLogic
 from opentelemetry import trace
 
@@ -231,11 +230,6 @@ def iter_evaluate_rules(
                     "span.action": "logic",
                     "ruleId": rule.pk,
                 },
-            ),
-            elasticapm.capture_span(
-                "evaluate_rule",
-                span_type="app.submissions.logic",
-                labels={"ruleId": rule.pk},
             ),
         ):
             triggered = False

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -16,7 +16,6 @@ from django.utils.safestring import SafeString
 from django.utils.timezone import localtime
 from django.utils.translation import get_language, gettext, gettext_lazy as _
 
-import elasticapm
 import structlog
 from django_jsonform.models.fields import ArrayField
 from furl import furl
@@ -580,7 +579,6 @@ class Submission(models.Model):
             "span.action": "loading",
         },
     )
-    @elasticapm.capture_span(span_type="app.data.loading")
     def load_submission_value_variables_state(
         self, refresh: bool = False
     ) -> SubmissionValueVariablesState:
@@ -601,7 +599,6 @@ class Submission(models.Model):
             "span.action": "loading",
         },
     )
-    @elasticapm.capture_span(span_type="app.data.loading")
     def load_execution_state(self, refresh: bool = False) -> SubmissionState:
         """
         Retrieve the current execution state of steps from the database.

--- a/src/openforms/validations/registry.py
+++ b/src/openforms/validations/registry.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from django.core.exceptions import ValidationError as DJ_ValidationError
 from django.utils.translation import gettext_lazy as _
 
-import elasticapm
 import structlog
 from opentelemetry import trace
 from rest_framework import serializers
@@ -65,7 +64,6 @@ class Registry(BaseRegistry[BasePlugin[JSONValue]]):
             "span.action": "validate",
         },
     )
-    @elasticapm.capture_span("app.validations.validate")
     def validate(
         self, plugin_id: str, value: JSONValue, submission: Submission
     ) -> ValidationResult:


### PR DESCRIPTION
Part of #6164

**Changes**

* Removed elasticapm instrumentation from the code. Anna had already added the equivalent OTel tracing instrumentation in the past
* Removed the elastic-apm dependency

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
