### PR TITLE
Use addressnl custom validation errors in backend validation

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -8,10 +8,10 @@ from django.core.validators import MaxValueValidator, MinValueValidator, RegexVa
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 from django.utils.html import format_html
-from django.utils.translation import gettext as _
+from django.utils.translation import get_language, gettext as _
 
 import structlog
-from glom import glom
+from glom import Path, glom
 from rest_framework import ISO_8601, serializers
 from rest_framework.request import Request
 
@@ -577,10 +577,20 @@ class AddressValueSerializer(serializers.Serializer):
             self.component, "openForms.components.city.validate.pattern", default=""
         ):
             if not re.fullmatch(city_regex, value):
-                raise serializers.ValidationError(
-                    _("City does not match the specified pattern."),
-                    code="invalid",
+                language_code = get_language().split("-")[0]
+                error_message = glom(
+                    self.component,
+                    Path(
+                        "openForms",
+                        "components",
+                        "city",
+                        "translatedErrors",
+                        language_code,
+                        "pattern",
+                    ),
+                    default=_("City does not match the specified pattern."),
                 )
+                raise serializers.ValidationError(error_message, code="invalid")
         return value
 
     def validate_postcode(self, value: str) -> str:
@@ -589,10 +599,20 @@ class AddressValueSerializer(serializers.Serializer):
             self.component, "openForms.components.postcode.validate.pattern", default=""
         ):
             if not re.fullmatch(postcode_regex, value):
-                raise serializers.ValidationError(
-                    _("Postcode does not match the specified pattern."),
-                    code="invalid",
+                language_code = get_language().split("-")[0]
+                error_message = glom(
+                    self.component,
+                    Path(
+                        "openForms",
+                        "components",
+                        "postcode",
+                        "translatedErrors",
+                        language_code,
+                        "pattern",
+                    ),
+                    default=_("Postcode does not match the specified pattern."),
                 )
+                raise serializers.ValidationError(error_message, code="invalid")
         return value.upper().replace(" ", "")
 
     def validate(self, attrs):

--- a/src/openforms/formio/tests/validation/test_addressnl.py
+++ b/src/openforms/formio/tests/validation/test_addressnl.py
@@ -287,7 +287,11 @@ class AddressNLValidationTests(SimpleTestCase):
                 "components": {
                     "postcode": {
                         "validate": {"pattern": "1017 [A-Za-z]{2}"},
-                        "translatedErrors": {},
+                        "translatedErrors": {
+                            "en": {
+                                "pattern": "Custom postcode error",
+                            }
+                        },
                     }
                 }
             },
@@ -307,7 +311,9 @@ class AddressNLValidationTests(SimpleTestCase):
         is_valid, errors = validate_formio_data(component, data)
 
         self.assertFalse(is_valid)
-        self.assertEqual(errors["addressNl"]["postcode"][0].code, "invalid")
+        error_detail = errors["addressNl"]["postcode"][0]
+        self.assertEqual(error_detail.code, "invalid")
+        self.assertEqual(str(error_detail), "Custom postcode error")
 
     def test_addressNL_custom_city_validation_fail(self):
         component: AddressNLComponent = {
@@ -319,7 +325,11 @@ class AddressNLValidationTests(SimpleTestCase):
                 "components": {
                     "city": {
                         "validate": {"pattern": "Amsterdam"},
-                        "translatedErrors": {},
+                        "translatedErrors": {
+                            "en": {
+                                "pattern": "Custom city error",
+                            }
+                        },
                     }
                 }
             },
@@ -339,7 +349,9 @@ class AddressNLValidationTests(SimpleTestCase):
         is_valid, errors = validate_formio_data(component, data)
 
         self.assertFalse(is_valid)
-        self.assertEqual(errors["addressNl"]["city"][0].code, "invalid")
+        error_detail = errors["addressNl"]["city"][0]
+        self.assertEqual(error_detail.code, "invalid")
+        self.assertEqual(str(error_detail), "Custom city error")
 
     def test_addressNL_custom_postcode_and_city_validation_success(self):
         component: AddressNLComponent = {


### PR DESCRIPTION
Closes #4699

**Changes**

Added regression test and fixed retrieving the custom validation errors. The logic is taken from the renderer implementation, as our types don't really help here.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
