### PR TITLE
Remove private fields from public in FormStep serializer

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1507,6 +1507,8 @@ paths:
         Non-staff users receive a subset of the documented fields which are used
         for internal form configuration. These fields are:
 
+        - `internalName`
+        - `isReusable`
         - `translations`
       summary: List form steps
       parameters:
@@ -1547,6 +1549,8 @@ paths:
         Non-staff users receive a subset of the documented fields which are used
         for internal form configuration. These fields are:
 
+        - `internalName`
+        - `isReusable`
         - `translations`
       summary: Create a form step
       parameters:
@@ -1598,6 +1602,8 @@ paths:
         Non-staff users receive a subset of the documented fields which are used
         for internal form configuration. These fields are:
 
+        - `internalName`
+        - `isReusable`
         - `translations`
       summary: Retrieve form step details
       parameters:
@@ -1642,6 +1648,8 @@ paths:
         Non-staff users receive a subset of the documented fields which are used
         for internal form configuration. These fields are:
 
+        - `internalName`
+        - `isReusable`
         - `translations`
       summary: Update all details of a form step
       parameters:
@@ -1698,6 +1706,8 @@ paths:
         Non-staff users receive a subset of the documented fields which are used
         for internal form configuration. These fields are:
 
+        - `internalName`
+        - `isReusable`
         - `translations`
       summary: Update some details of a form step
       parameters:
@@ -1753,6 +1763,8 @@ paths:
         Non-staff users receive a subset of the documented fields which are used
         for internal form configuration. These fields are:
 
+        - `internalName`
+        - `isReusable`
         - `translations`
       summary: Delete a form step
       parameters:

--- a/src/openforms/forms/api/serializers/form_step.py
+++ b/src/openforms/forms/api/serializers/form_step.py
@@ -119,11 +119,9 @@ class FormStepSerializer(
             "configuration",
             "form_definition",
             "name",
-            "internal_name",
             "url",
             "is_applicable",
             "login_required",
-            "is_reusable",
             "literals",
         )
 


### PR DESCRIPTION
**Changes**

- Some internal fields were in public so they have been removed.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
