### PR TITLE
Fix crash in logic rule when it contains a property action that refers to a non-existing component

### DIFF
--- a/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Action.stories.js
@@ -464,3 +464,37 @@ export const DisabledProperty = {
     expect(propertyOptions[2]).toHaveValue('hidden');
   },
 };
+
+export const DisabledPropertyWithNonExistingComponent = {
+  render,
+  name: 'Disabled property with non-existing component',
+
+  args: {
+    prefixText: 'Action',
+
+    action: {
+      component: 'non-existing',
+      variable: '',
+      formStepUuid: '8f046d57-ef41-41e0-bb7a-a8dc618b9d43',
+      action: {
+        type: 'property',
+        property: {
+          type: 'bool',
+          value: 'disabled',
+        },
+      },
+    },
+    availableComponents: {
+      textfield: {
+        key: 'textfield',
+        type: 'textfield',
+        label: 'Textfield',
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const componentDropdown = canvas.getByRole('combobox', {name: 'Selecteer component'});
+    expect(componentDropdown).toBeVisible();
+  },
+};

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -32,7 +32,7 @@ const ActionProperty = ({action, errors, onChange}) => {
   const {components} = useContext(FormContext);
   const intl = useIntl();
   const isLayout = action.component
-    ? holdsSubmissionDataTypes.includes(components[action.component].type)
+    ? holdsSubmissionDataTypes.includes(components[action.component]?.type)
     : false;
   const modifiablePropertyChoices = Object.entries(MODIFIABLE_PROPERTIES)
     .filter(([, info]) => !isLayout || info.useInLayout)


### PR DESCRIPTION
Discovered while working on #6261 

[skip: e2e]

**Changes**

Added a question mark

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
