### PR TITLE
Add management command for bulk converting forms to new logic evaluation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,31 @@ Changelog
         `latest <https://open-forms.readthedocs.io/en/latest/changelog.html>`_ docs
         version.
 
+3.5.2 (2026-05-xx)
+==================
+
+Regular bugfix release.
+
+.. note::
+
+    Because the legacy logic evaluation will be removed in Open Forms 4.0, we have added some
+    additional tooling to convert all forms to the new logic evaluation.
+
+    For each form, the logic rules will be reordered and any 'trigger from step' setting will be
+    removed. Note that this action cannot be easily reverted, so for large forms it is recommended to
+    create a copy of the form first, and enable the new logic evaluation feature flag manually
+    before running this command.
+
+    Any forms which contain rules with cycles will not be converted, and need to be resolved manually.
+    If such forms exist, the output of this command will contain a list of relevant form details.
+
+    In an app container, execute:
+
+    .. code-block:: bash
+
+        python /app/src/manage.py enable_new_logic_evaluation_for_all_forms
+
+
 3.5.1 (2026-05-06)
 ==================
 
@@ -130,7 +155,7 @@ removing the old renderer and Textfield address autofill support.
 
 **Legacy logic evaluation**
 
-The old logic evaluation will be removed in Open Forms 4.0. We will prioritize bugfixes in the new 
+The old logic evaluation will be removed in Open Forms 4.0. We will prioritize bugfixes in the new
 logic evaluation to make sure this migration will be as smooth as possible.
 
 **File Registration tab**
@@ -151,7 +176,7 @@ We plan to change the default for "Use generated zaaknummer" to unchecked in an 
 
 **StUF-ZDS registration**
 
-The usage of the branch number retrieved from the form's submission data will be replaced in 
+The usage of the branch number retrieved from the form's submission data will be replaced in
 Open Forms 4.0 by favouring the branch number obtained through the eHerkenning login.
 
 **DigiD/eHerkenning OIDC Strict mode**

--- a/src/openforms/forms/management/commands/enable_new_logic_evaluation_for_all_forms.py
+++ b/src/openforms/forms/management/commands/enable_new_logic_evaluation_for_all_forms.py
@@ -1,0 +1,93 @@
+from traceback import format_exc
+
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from tabulate import tabulate
+
+from ...logic_analysis import CyclesDetected
+from ...models import Form
+
+
+class Command(BaseCommand):
+    help = """
+    Enable new logic evaluation for all forms.
+
+    Note that this will re-order the logic rules and remove any 'trigger from step'
+    setting, which cannot be easily reverted. So, for large forms, it is recommended
+    to create a copy of the form first, and enable the new logic evaluation feature flag
+    manually before running this command.
+
+    Any forms which contain rules with cycles will not be converted, and need to be
+    resolved manually as well. If such forms exist, the output will contain a list of
+    relevant form details.
+    """
+
+    def handle(self, **options):
+        forms_to_convert = Form.objects.filter(
+            _is_deleted=False, new_logic_evaluation_enabled=False
+        )
+
+        if not forms_to_convert.exists():
+            self.stdout.write("All forms are already converted.")
+            return
+
+        forms_with_cycles_information = []
+        forms_to_update = []
+        n_updated_forms = 0
+        for form in forms_to_convert.iterator():
+            form.new_logic_evaluation_enabled = True
+
+            if form.is_appointment or not form.form_step_map:
+                n_updated_forms += 1
+                forms_to_update.append(form)
+                continue
+
+            try:
+                with transaction.atomic():
+                    form.apply_logic_analysis()
+                    form.formlogic_set.filter(trigger_from_step__isnull=False).update(
+                        trigger_from_step=None
+                    )
+                    form.save(update_fields=["new_logic_evaluation_enabled"])
+            except CyclesDetected as exc:
+                variables = {var for cycle in exc.cycles for var in cycle.variables}
+                form.new_logic_evaluation_enabled = False
+                forms_with_cycles_information.append(
+                    (
+                        form.pk,
+                        form.admin_name,
+                        form.active,
+                        ", ".join(sorted(variables)),
+                    )
+                )
+            except Exception:
+                form.new_logic_evaluation_enabled = False
+                self.stdout.write(
+                    f"Unexpected error while converting form '{form.admin_name} "
+                    f"({form.pk})': \n{format_exc()}"
+                )
+            else:
+                n_updated_forms += 1
+
+        Form.objects.bulk_update(forms_to_update, ["new_logic_evaluation_enabled"])
+        self.stdout.write(
+            f"New logic evaluation has been enabled for {n_updated_forms} form(s)."
+        )
+
+        if forms_with_cycles_information:
+            self.stdout.write(
+                "\nThe following forms still contain cycles, and were therefore "
+                "not updated. Please review them manually."
+            )
+            self.stdout.write(
+                tabulate(
+                    forms_with_cycles_information,
+                    headers=(
+                        "Form ID",
+                        "Form name",
+                        "Active",
+                        "Variables in cycles",
+                    ),
+                )
+            )

--- a/src/openforms/forms/tests/commands/test_enable_new_logic_evaluation.py
+++ b/src/openforms/forms/tests/commands/test_enable_new_logic_evaluation.py
@@ -1,0 +1,112 @@
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from ...models import Form, FormLogic
+from ..factories import FormFactory, FormLogicFactory, FormStepFactory
+
+
+class CommandTests(TestCase):
+    def test_happy(self):
+        FormFactory.create(
+            generate_minimal_setup=True, new_logic_evaluation_enabled=False
+        )
+        FormFactory.create(new_logic_evaluation_enabled=False)  # no steps
+        FormFactory.create(
+            new_logic_evaluation_enabled=False, is_appointment=True
+        )  # appointment
+
+        stdout = StringIO()
+        call_command("enable_new_logic_evaluation_for_all_forms", stdout=stdout)
+
+        output = stdout.getvalue().strip()
+        self.assertEqual("New logic evaluation has been enabled for 3 form(s).", output)
+        for form in Form.objects.iterator():
+            self.assertTrue(form.new_logic_evaluation_enabled)
+
+    def test_new_logic_evaluation_already_enabled(self):
+        FormFactory.create(
+            generate_minimal_setup=True, new_logic_evaluation_enabled=True
+        )
+
+        stdout = StringIO()
+        call_command("enable_new_logic_evaluation_for_all_forms", stdout=stdout)
+
+        output = stdout.getvalue().strip()
+        self.assertEqual("All forms are already converted.", output)
+        self.assertTrue(Form.objects.get().new_logic_evaluation_enabled)
+
+    def test_with_cycle(self):
+        form = FormFactory.create(name="Cool form", new_logic_evaluation_enabled=False)
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "foo"},
+                    {"type": "textfield", "key": "bar"},
+                ]
+            },
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "foo"}, "a"]},
+            actions=[
+                {
+                    "action": {"type": "variable", "value": "b"},
+                    "variable": "bar",
+                },
+            ],
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "bar"}, "b"]},
+            actions=[
+                {
+                    "action": {"type": "variable", "value": "a"},
+                    "variable": "foo",
+                },
+            ],
+        )
+
+        stdout = StringIO()
+        call_command("enable_new_logic_evaluation_for_all_forms", stdout=stdout)
+
+        output = stdout.getvalue().strip()
+        self.assertIn("New logic evaluation has been enabled for 0 form(s).", output)
+        self.assertIn("The following forms still contain cycles", output)
+        self.assertIn("Cool form", output)
+        self.assertIn("bar, foo", output)
+        self.assertFalse(Form.objects.get().new_logic_evaluation_enabled)
+
+    def test_with_trigger_from_step(self):
+        form = FormFactory.create(new_logic_evaluation_enabled=False)
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "key": "foo"},
+                    {"type": "textfield", "key": "bar"},
+                ]
+            },
+        )
+
+        FormLogicFactory.create(
+            form=form,
+            trigger_from_step=step,
+            json_logic_trigger={"==": [{"var": "bar"}, "b"]},
+            actions=[
+                {
+                    "action": {"type": "variable", "value": "a"},
+                    "variable": "foo",
+                },
+            ],
+        )
+
+        stdout = StringIO()
+        call_command("enable_new_logic_evaluation_for_all_forms", stdout=stdout)
+
+        output = stdout.getvalue().strip()
+        self.assertEqual("New logic evaluation has been enabled for 1 form(s).", output)
+        self.assertTrue(Form.objects.get().new_logic_evaluation_enabled)
+        self.assertIsNone(FormLogic.objects.get().trigger_from_step)


### PR DESCRIPTION
Partly closes #6164

Note that this merges into `stable/3.5.x`

[skip: e2e]

**Changes**

* Added management command
* Added placeholder in the changelog 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
