### PR TITLE
Implement runtime file component registration config resolution

### DIFF
--- a/docs/manual/registration/objects-api.rst
+++ b/docs/manual/registration/objects-api.rst
@@ -172,3 +172,27 @@ Op basis van sjablonen
 
 Zie de rubriek in de :ref:`sjabloondocumentatie <objecten_api_registratie>`.
 
+Gedeelde functionaliteit
+========================
+
+Bijlagen uploaden
+-----------------
+
+Bestanden die toegevoegd zijn door de gebruiker in "Bestandsupload"-velden worden
+geüpload naar de Documenten API (mits :ref:`ingesteld <configuration_registration_objects>`).
+De resulterende resource-URLs zijn vervolgens beschikbaar om op te nemen in het Object
+wat aangemaakt wordt.
+
+In de plugin-instellingen kan je een catalogus selecteren en vervolgens kies je het
+standaard-documenttype wat voor dergelijke bijlagen gebruikt dient te worden. Per
+"Bestandsupload"-veld kan je hiervan afwijken, indien nodig, via de "Registratie"-tab,
+waar je de catalogus-identificatie en omschrijving van het documenttype kan opgeven.
+Omdat dit omslachtig kan zijn als je veel uploadvelden hebt, kan je ook de
+plugin-instellingen in bulk kopiëren naar (een deel van) de uploadvelden. Dit vind je
+in de plugin-instellingen onder het kopje "Documenttypen".
+
+.. versionadded:: 3.5.2
+
+    Sinds Open Formulieren 3.5.2 kan je de bijlage-uploads instellen met een
+    catalogusreferentie en documenttypeomschrijving in plaats van een URL naar een
+    informatieobjecttype.

--- a/docs/manual/registration/zgw-apis.rst
+++ b/docs/manual/registration/zgw-apis.rst
@@ -29,3 +29,32 @@ op.
 
 .. note:: Indien je onvoldoende rechten hebt, vraag dan een functioneel beheerder om
    deze instelling aan te passen.
+
+Documenten
+==========
+
+Aan de zaak worden standaard een aantal documenten toegevoegd als zaakdocumenten:
+
+* De bevestigings-PDF met de inzendingsgegevens.
+* De bevestigingsmail die verstuurd is naar de inzender.
+* Alle bestanden die door de gebruiker toegevoegd zijn in "Bestandsupload"-velden.
+
+Gebruikersbijlagen
+------------------
+
+Bestanden die toegevoegd zijn door de gebruiker in "Bestandsupload"-velden worden
+geüpload naar de Documenten API en aan de zaak gerelateerd.
+
+In de plugin-instellingen kan je een catalogus selecteren en vervolgens kies je het
+standaard-documenttype wat voor dergelijke bijlagen gebruikt dient te worden. Per
+"Bestandsupload"-veld kan je hiervan afwijken, indien nodig, via de "Registratie"-tab,
+waar je de catalogus-identificatie en omschrijving van het documenttype kan opgeven.
+Omdat dit omslachtig kan zijn als je veel uploadvelden hebt, kan je ook de
+plugin-instellingen in bulk kopiëren naar (een deel van) de uploadvelden. Dit vind je
+in de plugin-instellingen onder het kopje "Bijlage-documenttypen".
+
+.. versionadded:: 3.5.2
+
+    Sinds Open Formulieren 3.5.2 kan je de bijlage-uploads instellen met een
+    catalogusreferentie en documenttypeomschrijving in plaats van een URL naar een
+    informatieobjecttype.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/cli": "^6.6.1",
         "@fortawesome/fontawesome-free": "^6.1.1",
         "@open-formulieren/design-tokens": "^0.66.0",
-        "@open-formulieren/formio-builder": "^0.50.2",
+        "@open-formulieren/formio-builder": "^0.51.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -5228,9 +5228,9 @@
       "license": "EUPL-1.2"
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.2.tgz",
-      "integrity": "sha512-zEwoIVzIwR8aKdK5GfVEaBN3G5r6TezF2nA8/g1UyJowWVYKRMl6dEJuB5Cf0kQRxp+eBJn9I5WOPOjuxjn5cQ==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.51.0.tgz",
+      "integrity": "sha512-BwyCYTrAngf5j/buX+xNUIaZhR0Xr9Rx/U/CySwEGZWwwamc2dfc6JfSjqaI4eR4tG695VJ6RlorCfZNfcaVtA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
@@ -5238,7 +5238,7 @@
         "@formio/vanilla-text-mask": "^5.1.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
-        "@open-formulieren/types": "^1.1.0",
+        "@open-formulieren/types": "^1.2.0",
         "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
         "dompurify": "^3.3.3",
@@ -5298,9 +5298,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-ihgy4Lrdk5Wt+uHMT1BfdNvbOCzOvWWoCCmMUQ6ByXVF2Su5AxC6HoMsc8WhhP3jrLACIyCEFqkEQKAQsTmuEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-4G3XDPC1uncrRen7kxEJhISNtWFhB381/5wKheQurBIKzE9P8q8KQNUzsTCGTVjMjElnUvN4QskUeZyJV9ij0w==",
       "license": "EUPL-1.2"
     },
     "node_modules/@react-leaflet/core": {
@@ -23934,16 +23934,16 @@
       "integrity": "sha512-zMs6937ostu1b6q7WHYq4yjtKifnExOGAjWNYLMWuc+7ZttnhFnsf5QFXBR6P+YFDkzQNhJSKnGZnmmY1zZPOQ=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.50.2.tgz",
-      "integrity": "sha512-zEwoIVzIwR8aKdK5GfVEaBN3G5r6TezF2nA8/g1UyJowWVYKRMl6dEJuB5Cf0kQRxp+eBJn9I5WOPOjuxjn5cQ==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-0.51.0.tgz",
+      "integrity": "sha512-BwyCYTrAngf5j/buX+xNUIaZhR0Xr9Rx/U/CySwEGZWwwamc2dfc6JfSjqaI4eR4tG695VJ6RlorCfZNfcaVtA==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
         "@floating-ui/react": "^0.26.4",
         "@formio/vanilla-text-mask": "^5.1.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
-        "@open-formulieren/types": "^1.1.0",
+        "@open-formulieren/types": "^1.2.0",
         "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
         "dompurify": "^3.3.3",
@@ -23992,9 +23992,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-ihgy4Lrdk5Wt+uHMT1BfdNvbOCzOvWWoCCmMUQ6ByXVF2Su5AxC6HoMsc8WhhP3jrLACIyCEFqkEQKAQsTmuEA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-4G3XDPC1uncrRen7kxEJhISNtWFhB381/5wKheQurBIKzE9P8q8KQNUzsTCGTVjMjElnUvN4QskUeZyJV9ij0w=="
     },
     "@react-leaflet/core": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@formatjs/cli": "^6.6.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.66.0",
-    "@open-formulieren/formio-builder": "^0.50.2",
+    "@open-formulieren/formio-builder": "^0.51.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/contrib/zgw/resolvers.py
+++ b/src/openforms/contrib/zgw/resolvers.py
@@ -1,0 +1,81 @@
+from collections.abc import MutableMapping
+from datetime import date
+from typing import TypedDict
+
+from .clients import CatalogiClient
+from .clients.catalogi import Catalogus, InformatieObjectType
+
+
+class CatalogueParams(TypedDict):
+    domain: str
+    rsin: str
+
+
+# domain, RSIN
+type CatalogueIdentifiers = tuple[str, str]
+
+# catalogue url, description, valid on
+type DocumentTypeIdentifiers = tuple[str, str, date]
+
+
+class DocumentTypeResolver:
+    """
+    Resolver helper that caches lookups to prevent identical network requests.
+
+    Resolver instances are intended to be short-lived (e.g. the duration of an HTTP
+    request-response cycle or celery task), so that the garbage collector cleans up the
+    internal in-memory cache.
+    """
+
+    def __init__(self, client: CatalogiClient):
+        self.client = client
+        self._catalogue_cache: MutableMapping[
+            CatalogueIdentifiers, Catalogus | None
+        ] = {}
+        self._document_type_cache: MutableMapping[
+            DocumentTypeIdentifiers, InformatieObjectType | None
+        ] = {}
+
+    def resolve(
+        self,
+        *,
+        catalogue: CatalogueParams,
+        description: str,
+        on_date: date,
+        within_casetype: str = "",
+    ) -> InformatieObjectType:
+        """
+        Resolve a document type versio within a catalogue at a particular date.
+        """
+        catalogus = self._resolve_catalogue(catalogue)
+        if catalogus is None:
+            raise RuntimeError(f"Could not resolve catalogue {catalogue}")
+
+        cache_key: DocumentTypeIdentifiers = (catalogus["url"], description, on_date)
+        if cache_key not in self._document_type_cache:
+            versions = self.client.find_informatieobjecttypen(
+                catalogus=catalogus["url"],
+                description=description,
+                valid_on=on_date,
+                within_casetype=within_casetype,
+            )
+            self._document_type_cache[cache_key] = (
+                None if versions is None else versions[0]
+            )
+
+        version = self._document_type_cache[cache_key]
+        if version is None:
+            raise RuntimeError(
+                "Could not find a document type with description "
+                f"'{description}' in the case type that is valid on "
+                f"{on_date.isoformat()}."
+            )
+        return version
+
+    # TODO: when expanding this to the zaaktypen, this can be extracted into a separate
+    # resolver class
+    def _resolve_catalogue(self, catalogue: CatalogueParams) -> Catalogus | None:
+        cache_key: CatalogueIdentifiers = (catalogue["domain"], catalogue["rsin"])
+        if cache_key not in self._catalogue_cache:
+            self._catalogue_cache[cache_key] = self.client.find_catalogus(**catalogue)
+        return self._catalogue_cache[cache_key]

--- a/src/openforms/contrib/zgw/service.py
+++ b/src/openforms/contrib/zgw/service.py
@@ -4,6 +4,15 @@ from typing import Literal, NotRequired, TypedDict
 from openforms.submissions.models import SubmissionFileAttachment, SubmissionReport
 
 from .clients.documenten import DocumentenClient
+from .resolvers import DocumentTypeResolver
+
+__all__ = [
+    "DocumentOptions",
+    "DocumentTypeResolver",
+    "create_report_document",
+    "create_csv_document",
+    "create_attachment_document",
+]
 
 type SupportedLanguage = Literal["nl", "en"]
 

--- a/src/openforms/formio/typing/vanilla.py
+++ b/src/openforms/formio/typing/vanilla.py
@@ -1,5 +1,7 @@
 from typing import Literal, NotRequired, TypedDict
 
+from openforms.registrations.contrib.zgw_apis.typing import CatalogueOption
+
 from .base import Component, OptionDict
 from .dates import DatePickerConfig
 
@@ -13,6 +15,19 @@ class FileConfig(TypedDict):
     type: NotRequired[list[str]]
 
 
+class FileComponentRegistrationDocType(TypedDict):
+    catalogue: CatalogueOption
+    description: str
+
+
+class FileComponentRegistration(TypedDict):
+    bronorganisatie: NotRequired[str]
+    docVertrouwelijkheidaanduiding: NotRequired[str]
+    titel: NotRequired[str]
+    documentType: NotRequired[FileComponentRegistrationDocType]
+    informatieobjecttype: NotRequired[str]  # DeprecationWarning #4939
+
+
 class FileComponent(Component):
     storage: Literal["url"]
     url: str
@@ -20,6 +35,7 @@ class FileComponent(Component):
     filePattern: str
     file: FileConfig
     maxNumberOfFiles: NotRequired[int]
+    registration: NotRequired[FileComponentRegistration]
 
 
 class FileData(TypedDict):

--- a/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
+++ b/src/openforms/forms/tests/e2e_tests/test_registration_backend_conf.py
@@ -2,6 +2,7 @@ from django.urls import resolve, reverse
 
 from asgiref.sync import sync_to_async
 from furl import furl
+from typing_extensions import deprecated
 
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.registrations.contrib.zgw_apis.tests.factories import (
@@ -19,6 +20,9 @@ from ..factories import FormFactory
 from .helpers import close_modal, open_component_options_modal, phase
 
 
+@deprecated(
+    "Dropdown document type selection in file registration tab is being phased out."
+)
 class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
     async def test_configuring_zgw_api_group(self):
         """
@@ -118,6 +122,7 @@ class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
 
                 await open_component_options_modal(page, label="File upload test")
                 await modal.get_by_role("tab", name="Registration").click()
+                await modal.get_by_role("button", name="Legacy").click()
                 await close_modal(page, "Save")
 
             with phase("Update the ZGW API group configured"):
@@ -136,6 +141,7 @@ class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
 
                 await open_component_options_modal(page, label="File upload test")
                 await modal.get_by_role("tab", name="Registration").click()
+                await modal.get_by_role("button", name="Legacy").click()
                 await close_modal(page, "Save")
 
         self.assertEqual(len(requests_to_endpoint), 2)
@@ -248,6 +254,7 @@ class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
 
                 await open_component_options_modal(page, label="File upload test")
                 await modal.get_by_role("tab", name="Registration").click()
+                await modal.get_by_role("button", name="Legacy").click()
                 await close_modal(page, "Save")
 
             with phase("Update the Objects API group configured"):
@@ -269,6 +276,7 @@ class FormDesignerRegistrationBackendConfigTests(OFVCRMixin, E2ETestCase):
 
                 await open_component_options_modal(page, label="File upload test")
                 await modal.get_by_role("tab", name="Registration").click()
+                await modal.get_by_role("button", name="Legacy").click()
                 await close_modal(page, "Save")
 
         self.assertEqual(len(requests_to_endpoint), 2)

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -129,6 +129,12 @@
       "value": "Set the text of the 'Save row' button."
     }
   ],
+  "/xFb1n": [
+    {
+      "type": 0,
+      "value": "The 'domein' attribute for the Catalogus resource in the Catalogi API."
+    }
+  ],
   "/yDnA3": [
     {
       "type": 0,
@@ -273,6 +279,12 @@
       "value": "Regular Expression Pattern"
     }
   ],
+  "1andg+": [
+    {
+      "type": 0,
+      "value": "The 'rsin' attribute for the Catalogus resource in the Catalogi API."
+    }
+  ],
   "1fD+K4": [
     {
       "type": 0,
@@ -345,6 +357,12 @@
     {
       "type": 0,
       "value": "Is deleted"
+    }
+  ],
+  "2KY/BC": [
+    {
+      "type": 0,
+      "value": "Specify the document type to use for the file uploads when sending them to the Documents API. The direct URL references are replaced with references to the catalogue and document type description."
     }
   ],
   "2Lg8Vc": [
@@ -525,6 +543,12 @@
     {
       "type": 0,
       "value": "CSS class"
+    }
+  ],
+  "3leP68": [
+    {
+      "type": 0,
+      "value": "Document type"
     }
   ],
   "3z1hhJ": [
@@ -1781,6 +1805,12 @@
       "value": "Other options"
     }
   ],
+  "DE7U4q": [
+    {
+      "type": 0,
+      "value": "The RSIN must consist of 9 numbers."
+    }
+  ],
   "DEAqyQ": [
     {
       "type": 0,
@@ -2553,6 +2583,12 @@
     {
       "type": 0,
       "value": "Are you sure you want to delete this item?"
+    }
+  ],
+  "J1zTQz": [
+    {
+      "type": 0,
+      "value": "Document type description"
     }
   ],
   "J5EZDj": [
@@ -4693,6 +4729,12 @@
       "value": "backendName"
     }
   ],
+  "bh2ky5": [
+    {
+      "type": 0,
+      "value": "Catalogus domain"
+    }
+  ],
   "bjIQDR": [
     {
       "type": 0,
@@ -4739,6 +4781,12 @@
     {
       "type": 0,
       "value": "Build a JsonLogic expression using raw JSON."
+    }
+  ],
+  "c770ER": [
+    {
+      "type": 0,
+      "value": "Catalogus RSIN"
     }
   ],
   "cAC5kL": [
@@ -4893,6 +4941,12 @@
       ],
       "type": 8,
       "value": "duplicatedKeys"
+    }
+  ],
+  "ce0Nz4": [
+    {
+      "type": 0,
+      "value": "You must specify a document type description when a catalogue is configured."
     }
   ],
   "ce1N0I": [
@@ -5529,6 +5583,12 @@
     {
       "type": 0,
       "value": "Minimal levels of assurance"
+    }
+  ],
+  "hAc9vQ": [
+    {
+      "type": 0,
+      "value": "Legacy"
     }
   ],
   "hBxKbW": [
@@ -6455,6 +6515,12 @@
       "value": "Which merchant should be used for payments related to this form."
     }
   ],
+  "oiB6Kg": [
+    {
+      "type": 0,
+      "value": "The direct URL configuration is scheduled for removal. If both the URL and the fields above are configured, the new configuration is used."
+    }
+  ],
   "oqv4fM": [
     {
       "type": 0,
@@ -7097,6 +7163,12 @@
       "value": "Derive address"
     }
   ],
+  "tzAOAm": [
+    {
+      "type": 0,
+      "value": "You must specify both domain and RSIN."
+    }
+  ],
   "u+IP17": [
     {
       "type": 0,
@@ -7143,6 +7215,12 @@
     {
       "type": 0,
       "value": "Amount of days successful submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+    }
+  ],
+  "uOtaSP": [
+    {
+      "type": 0,
+      "value": "The document type will be retrieved in the specified catalogue. The version will automatically be selected based on the submission completion timestamp. When used with ZGW APIs, ensure that the document type belongs to the specified case type!"
     }
   ],
   "uUf7cu": [
@@ -7381,6 +7459,12 @@
       "value": "Indication of the level to which extend the dossier of the ZAAK is meant to be public. This is set on the documents created for the ZAAK."
     }
   ],
+  "wqhr+0": [
+    {
+      "type": 0,
+      "value": "Specify either none or all three of the fields below to configure the document type to use."
+    }
+  ],
   "wrdDVu": [
     {
       "type": 0,
@@ -7445,6 +7529,12 @@
     {
       "type": 0,
       "value": "Translation enabled"
+    }
+  ],
+  "xUt2+r": [
+    {
+      "type": 0,
+      "value": "You must specify both domain and RSIN."
     }
   ],
   "xcp+LU": [

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -87,6 +87,12 @@
       "value": "Mark the form step as applicable"
     }
   ],
+  "/MWRm7": [
+    {
+      "type": 0,
+      "value": "There are no file upload components in the form."
+    }
+  ],
   "/XbK4W": [
     {
       "type": 0,
@@ -539,10 +545,22 @@
       "value": "Ask statement of truth"
     }
   ],
+  "3eiHJv": [
+    {
+      "type": 0,
+      "value": "Catalogue RSIN"
+    }
+  ],
   "3h215E": [
     {
       "type": 0,
       "value": "CSS class"
+    }
+  ],
+  "3jd+Cd": [
+    {
+      "type": 0,
+      "value": "Catalogue domain"
     }
   ],
   "3leP68": [
@@ -1757,6 +1775,12 @@
       "value": "Use a variable for the price"
     }
   ],
+  "CpZufh": [
+    {
+      "type": 0,
+      "value": "Check/uncheck all"
+    }
+  ],
   "CtjZFq": [
     {
       "type": 0,
@@ -2141,6 +2165,12 @@
     {
       "type": 0,
       "value": "The co-sign component requires at least one authentication plugin to be enabled."
+    }
+  ],
+  "FJaFwb": [
+    {
+      "type": 0,
+      "value": "Copy"
     }
   ],
   "FNT8nq": [
@@ -2755,6 +2785,20 @@
       "value": "Unfortunately something went wrong!"
     }
   ],
+  "KTmwYn": [
+    {
+      "type": 0,
+      "value": "Update "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": " configuration?"
+    }
+  ],
   "KYTAJZ": [
     {
       "type": 0,
@@ -3105,6 +3149,12 @@
       "value": "A short instruction shown below the signature pad."
     }
   ],
+  "NwBpaW": [
+    {
+      "type": 0,
+      "value": "Document type description"
+    }
+  ],
   "NyyJMK": [
     {
       "type": 0,
@@ -3293,10 +3343,22 @@
       "value": "Include confirmation page content in PDF"
     }
   ],
+  "PbVsAV": [
+    {
+      "type": 0,
+      "value": "File component document types"
+    }
+  ],
   "PdaMqg": [
     {
       "type": 0,
       "value": "Add rule"
+    }
+  ],
+  "PhKHkq": [
+    {
+      "type": 0,
+      "value": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!"
     }
   ],
   "PhN977": [
@@ -4301,6 +4363,12 @@
     {
       "type": 0,
       "value": "Save"
+    }
+  ],
+  "YReu09": [
+    {
+      "type": 0,
+      "value": "Field label"
     }
   ],
   "YSuwK2": [
@@ -6561,6 +6629,12 @@
     {
       "type": 0,
       "value": "Move up"
+    }
+  ],
+  "p0n2wK": [
+    {
+      "type": 0,
+      "value": "The file component changes will be applied immediately. Are you sure you want to continue?"
     }
   ],
   "p5Iv+R": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -129,6 +129,12 @@
       "value": "Geef de knoptekst om een groep te bewaren op."
     }
   ],
+  "/xFb1n": [
+    {
+      "type": 0,
+      "value": "Het 'domein'-attribuut van de Catalogus-entiteit in de Catalogi API."
+    }
+  ],
   "/yDnA3": [
     {
       "type": 0,
@@ -273,6 +279,12 @@
       "value": "Reguliere expressie"
     }
   ],
+  "1andg+": [
+    {
+      "type": 0,
+      "value": "Het 'rsin'-attribuut van de catalogus-entiteit in de Catalogi API."
+    }
+  ],
   "1fD+K4": [
     {
       "type": 0,
@@ -345,6 +357,12 @@
     {
       "type": 0,
       "value": "Verwijderd"
+    }
+  ],
+  "2KY/BC": [
+    {
+      "type": 0,
+      "value": "Selecteer het documenttype voor de geüploade bestanden wanneer ze in de Documenten API opgeslagen worden. De directe URL-referenties zullen vervangen worden met refernties naar de catalogus en omschrijving van het informatieobjecttype."
     }
   ],
   "2Lg8Vc": [
@@ -525,6 +543,12 @@
     {
       "type": 0,
       "value": "Weergavestijl"
+    }
+  ],
+  "3leP68": [
+    {
+      "type": 0,
+      "value": "Documenttype"
     }
   ],
   "3z1hhJ": [
@@ -1768,6 +1792,12 @@
       "value": "Overige instellingen"
     }
   ],
+  "DE7U4q": [
+    {
+      "type": 0,
+      "value": "Het RSIN moet uit 9 getallen bestaan."
+    }
+  ],
   "DEAqyQ": [
     {
       "type": 0,
@@ -2540,6 +2570,12 @@
     {
       "type": 0,
       "value": "Weet u zeker dat u dit item wilt verwijderen?"
+    }
+  ],
+  "J1zTQz": [
+    {
+      "type": 0,
+      "value": "Informatieobjecttype-omschrijving"
     }
   ],
   "J5EZDj": [
@@ -4681,6 +4717,12 @@
       "value": "'"
     }
   ],
+  "bh2ky5": [
+    {
+      "type": 0,
+      "value": "Catalogusdomein"
+    }
+  ],
   "bjIQDR": [
     {
       "type": 0,
@@ -4727,6 +4769,12 @@
     {
       "type": 0,
       "value": "Geef een JSON-logic expressie op in JSON."
+    }
+  ],
+  "c770ER": [
+    {
+      "type": 0,
+      "value": "Catalogus-RSIN"
     }
   ],
   "cAC5kL": [
@@ -4881,6 +4929,12 @@
       ],
       "type": 8,
       "value": "duplicatedKeys"
+    }
+  ],
+  "ce0Nz4": [
+    {
+      "type": 0,
+      "value": "Je moet een omschrijving opgeven wanneer je een catalogus instelt."
     }
   ],
   "ce1N0I": [
@@ -5517,6 +5571,12 @@
     {
       "type": 0,
       "value": "Minimale betrouwbaarheidsniveaus"
+    }
+  ],
+  "hAc9vQ": [
+    {
+      "type": 0,
+      "value": "Veroudered"
     }
   ],
   "hBxKbW": [
@@ -6443,6 +6503,12 @@
       "value": "Welke merchant dient gebruikt te worden voor betalingen voor dit formulier."
     }
   ],
+  "oiB6Kg": [
+    {
+      "type": 0,
+      "value": "De instelling met een URL naar een informatieobjecttype(versie) zal verwijderd worden. Indien je een URL én de bovenstaande velden ingesteld hebt, dan worden de nieuwe instellingen gebruikt."
+    }
+  ],
   "oqv4fM": [
     {
       "type": 0,
@@ -7081,6 +7147,12 @@
       "value": "Adres afleiden"
     }
   ],
+  "tzAOAm": [
+    {
+      "type": 0,
+      "value": "Je moet het domein en RSIN beide instellen."
+    }
+  ],
   "u+IP17": [
     {
       "type": 0,
@@ -7127,6 +7199,12 @@
     {
       "type": 0,
       "value": "Aantal dagen dat een voltooide inzending bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken."
+    }
+  ],
+  "uOtaSP": [
+    {
+      "type": 0,
+      "value": "Het documenttype wordt opgehaald binnen de ingestelde catalogus. De juiste versie van het documenttype wordt automatisch bepaald aan de hand van de inzendingsdatum. Wanneer je via de ZGW-API's registreert, let er dan op dat het documenttype bij het ingestelde zaaktype hoort!"
     }
   ],
   "uUf7cu": [
@@ -7365,6 +7443,12 @@
       "value": "Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de openbaarheid bestemd is. Dit wordt toegepast op de zaakdocumenten die aangemaakt worden."
     }
   ],
+  "wqhr+0": [
+    {
+      "type": 0,
+      "value": "Vul alle drie de onderstaande velden velden in om een documenttype in te stellen, of laat ze allemaal leeg om niets in te stellen."
+    }
+  ],
   "wrdDVu": [
     {
       "type": 0,
@@ -7429,6 +7513,12 @@
     {
       "type": 0,
       "value": "Vertalingen ingeschakeld"
+    }
+  ],
+  "xUt2+r": [
+    {
+      "type": 0,
+      "value": "Je moet het domein en RSIN beide instellen."
     }
   ],
   "xcp+LU": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -90,7 +90,7 @@
   "/MWRm7": [
     {
       "type": 0,
-      "value": "There are no file upload components in the form."
+      "value": "Het formulier bevat geen bestandsuploadvelden."
     }
   ],
   "/XbK4W": [
@@ -548,7 +548,7 @@
   "3eiHJv": [
     {
       "type": 0,
-      "value": "Catalogue RSIN"
+      "value": "Catalogus-RSIN"
     }
   ],
   "3h215E": [
@@ -560,7 +560,7 @@
   "3jd+Cd": [
     {
       "type": 0,
-      "value": "Catalogue domain"
+      "value": "Catalogusdomein"
     }
   ],
   "3leP68": [
@@ -1748,7 +1748,7 @@
   "CpZufh": [
     {
       "type": 0,
-      "value": "Check/uncheck all"
+      "value": "Vink alles aan/uit"
     }
   ],
   "CtjZFq": [
@@ -2157,7 +2157,7 @@
   "FJaFwb": [
     {
       "type": 0,
-      "value": "Copy"
+      "value": "Kopieer"
     }
   ],
   "FNT8nq": [
@@ -2774,16 +2774,12 @@
   ],
   "KTmwYn": [
     {
-      "type": 0,
-      "value": "Update "
-    },
-    {
       "type": 1,
       "value": "label"
     },
     {
       "type": 0,
-      "value": " configuration?"
+      "value": " instellingen bijwerken?"
     }
   ],
   "KYTAJZ": [
@@ -3139,7 +3135,7 @@
   "NwBpaW": [
     {
       "type": 0,
-      "value": "Document type description"
+      "value": "Documenttype-omschrijving"
     }
   ],
   "NyyJMK": [
@@ -3333,7 +3329,7 @@
   "PbVsAV": [
     {
       "type": 0,
-      "value": "File component document types"
+      "value": "Bijlage-documenttypen"
     }
   ],
   "PdaMqg": [
@@ -3345,7 +3341,7 @@
   "PhKHkq": [
     {
       "type": 0,
-      "value": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!"
+      "value": "Je kan de catalogusreferentie en documenttypeomschrijving kopiëren van de plugin-instellingen naar de geselecteerde upload-velden van het formulier. Merk op dat je hiermee bestaande instellingen overschrijft!"
     }
   ],
   "PhN977": [
@@ -4351,7 +4347,7 @@
   "YReu09": [
     {
       "type": 0,
-      "value": "Field label"
+      "value": "Veldlabel"
     }
   ],
   "YSuwK2": [
@@ -6622,7 +6618,7 @@
   "p0n2wK": [
     {
       "type": 0,
-      "value": "The file component changes will be applied immediately. Are you sure you want to continue?"
+      "value": "De bestandsuploadveldinstellingen worden meteen bijgewerkt. Ben je zeker dat je door wil gaan?"
     }
   ],
   "p5Iv+R": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -87,6 +87,12 @@
       "value": "markeer de formulierstap als van toepassing"
     }
   ],
+  "/MWRm7": [
+    {
+      "type": 0,
+      "value": "There are no file upload components in the form."
+    }
+  ],
   "/XbK4W": [
     {
       "type": 0,
@@ -539,10 +545,22 @@
       "value": "Vraag verklaring invullen naar waarheid"
     }
   ],
+  "3eiHJv": [
+    {
+      "type": 0,
+      "value": "Catalogue RSIN"
+    }
+  ],
   "3h215E": [
     {
       "type": 0,
       "value": "Weergavestijl"
+    }
+  ],
+  "3jd+Cd": [
+    {
+      "type": 0,
+      "value": "Catalogue domain"
     }
   ],
   "3leP68": [
@@ -1727,6 +1745,12 @@
       "value": "Gebruik een variabele"
     }
   ],
+  "CpZufh": [
+    {
+      "type": 0,
+      "value": "Check/uncheck all"
+    }
+  ],
   "CtjZFq": [
     {
       "type": 0,
@@ -2128,6 +2152,12 @@
     {
       "type": 0,
       "value": "Er moet minstens één authenticatiemethode ingeschakeld zijn voor de mede-ondertekencomponent."
+    }
+  ],
+  "FJaFwb": [
+    {
+      "type": 0,
+      "value": "Copy"
     }
   ],
   "FNT8nq": [
@@ -2742,6 +2772,20 @@
       "value": "Er ging helaas iets fout!"
     }
   ],
+  "KTmwYn": [
+    {
+      "type": 0,
+      "value": "Update "
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": " configuration?"
+    }
+  ],
   "KYTAJZ": [
     {
       "type": 0,
@@ -3092,6 +3136,12 @@
       "value": "Een korte instructie onder het handtekenvlak."
     }
   ],
+  "NwBpaW": [
+    {
+      "type": 0,
+      "value": "Document type description"
+    }
+  ],
   "NyyJMK": [
     {
       "type": 0,
@@ -3280,10 +3330,22 @@
       "value": "Voeg de inhoud toe aan de PDF"
     }
   ],
+  "PbVsAV": [
+    {
+      "type": 0,
+      "value": "File component document types"
+    }
+  ],
   "PdaMqg": [
     {
       "type": 0,
       "value": "Regel toevoegen"
+    }
+  ],
+  "PhKHkq": [
+    {
+      "type": 0,
+      "value": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!"
     }
   ],
   "PhN977": [
@@ -4284,6 +4346,12 @@
     {
       "type": 0,
       "value": "Opslaan"
+    }
+  ],
+  "YReu09": [
+    {
+      "type": 0,
+      "value": "Field label"
     }
   ],
   "YSuwK2": [
@@ -6549,6 +6617,12 @@
     {
       "type": 0,
       "value": "Omhoog"
+    }
+  ],
+  "p0n2wK": [
+    {
+      "type": 0,
+      "value": "The file component changes will be applied immediately. Are you sure you want to continue?"
     }
   ],
   "p5Iv+R": [

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -22,6 +22,7 @@ const FormContext = React.createContext({
   languages: [],
   translationEnabled: false,
   newLogicEvaluationEnabled: false,
+  updateComponents: () => {},
 });
 FormContext.displayName = 'FormContext';
 

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -5,7 +5,7 @@ import set from 'lodash/set';
 import sortBy from 'lodash/sortBy';
 import zip from 'lodash/zip';
 import PropTypes from 'prop-types';
-import React, {useContext} from 'react';
+import React, {useCallback, useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {TabList, TabPanel, Tabs} from 'react-tabs';
 import useAsync from 'react-use/esm/useAsync';
@@ -779,6 +779,19 @@ function reducer(draft, action) {
     }
 
     /**
+     * Component level actions
+     */
+    case 'UPDATE_COMPONENT_BY_CALLBACK': {
+      const {componentKeys, callback} = action.payload;
+      for (const key of componentKeys) {
+        const component = findComponent(draft.formSteps, c => c.key === key);
+        if (!component) continue;
+        callback(component);
+      }
+      break;
+    }
+
+    /**
      * Submit & validation error handling
      */
     case 'SUBMIT_STARTED': {
@@ -974,6 +987,19 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
   }, [loading]);
 
   const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
+
+  const updateComponents = useCallback(
+    (componentKeys, callback) => {
+      dispatch({
+        type: 'UPDATE_COMPONENT_BY_CALLBACK',
+        payload: {
+          componentKeys,
+          callback,
+        },
+      });
+    },
+    [dispatch]
+  );
 
   /**
    * Functions for handling events
@@ -1244,6 +1270,7 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
           registrationBackends: state.form.registrationBackends,
           selectedAuthPlugins: state.selectedAuthPlugins,
           newLogicEvaluationEnabled: state.form.newLogicEvaluationEnabled,
+          updateComponents: updateComponents,
         }}
       >
         <FormWarnings form={state.form} />

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/LegacyConfigFields.js
@@ -15,7 +15,7 @@ import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {
   AuthAttributePath,
-  DocumentTypesFieldet,
+  DocumentTypesFieldset,
   LegacyDocumentTypesFieldet,
   OrganisationRSIN,
   UpdateExistingObject,
@@ -42,15 +42,6 @@ const onObjectTypeChange = prevValues => ({
 });
 
 const LegacyConfigFields = ({apiGroupChoices}) => {
-  const {
-    values: {
-      objectsApiGroup = null,
-      objecttype = '',
-      objecttypeVersion = null,
-      updateExistingObject = false,
-    },
-  } = useFormikContext();
-
   return (
     <>
       <Fieldset>
@@ -113,7 +104,7 @@ const LegacyConfigFields = ({apiGroupChoices}) => {
           />
         }
       >
-        <DocumentTypesFieldet />
+        <DocumentTypesFieldset />
       </ErrorBoundary>
 
       <LegacyDocumentTypesFieldet />

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/ObjectsApiOptionsFormFields.stories.js
@@ -3,6 +3,7 @@ import {expect, fn, userEvent, waitFor, within} from 'storybook/test';
 
 import {
   FeatureFlagsDecorator,
+  FormDecorator,
   FormModalContentDecorator,
   ValidationErrorsDecorator,
 } from 'components/admin/form_design/story-decorators';
@@ -30,7 +31,12 @@ const render = ({apiGroups, formData}) => (
 
 export default {
   title: 'Form design/Registration/Objects API',
-  decorators: [ValidationErrorsDecorator, FeatureFlagsDecorator, FormModalContentDecorator],
+  decorators: [
+    ValidationErrorsDecorator,
+    FormDecorator,
+    FeatureFlagsDecorator,
+    FormModalContentDecorator,
+  ],
   render,
   args: {
     apiGroups: [
@@ -38,6 +44,24 @@ export default {
       ['group-2', 'Objects API group 2'],
     ],
     formData: {},
+    availableComponents: {
+      textField1: {
+        type: 'textfield',
+        key: 'textField1',
+        label: 'textfield1',
+      },
+      textField2: {
+        type: 'textfield',
+        key: 'textField2',
+        label: 'textfield2',
+      },
+      file: {
+        type: 'file',
+        key: 'file',
+        label: 'attachments',
+      },
+    },
+    updateComponents: fn(),
   },
   parameters: {
     msw: {

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/V2ConfigFields.js
@@ -13,7 +13,7 @@ import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {
   AuthAttributePath,
-  DocumentTypesFieldet,
+  DocumentTypesFieldset,
   LegacyDocumentTypesFieldet,
   OrganisationRSIN,
   UpdateExistingObject,
@@ -136,7 +136,7 @@ const V2ConfigFields = ({apiGroupChoices}) => {
           />
         }
       >
-        <DocumentTypesFieldet />
+        <DocumentTypesFieldset />
       </ErrorBoundary>
 
       <LegacyDocumentTypesFieldet />

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
@@ -9,14 +9,12 @@ import Field from 'components/admin/forms/Field';
 import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
 import {
-  DocumentTypeSelect as GenericDocumentTypeSelect,
-  useGetDocumentTypes,
-} from 'components/admin/forms/zgw';
-import {
   CatalogueSelect,
   CopyDocumentTypesConfig,
+  DocumentTypeSelect as GenericDocumentTypeSelect,
   getCatalogueOption,
   groupAndSortCatalogueOptions,
+  useGetDocumentTypes,
 } from 'components/admin/forms/zgw';
 import {WarningIcon} from 'components/admin/icons';
 import {get} from 'utils/fetch';

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import {useField, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import {useContext, useEffect} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {components} from 'react-select';
 import {useAsync, usePrevious} from 'react-use';
@@ -13,6 +13,7 @@ import FormRow from 'components/admin/forms/FormRow';
 import ReactSelect from 'components/admin/forms/ReactSelect';
 import {
   CatalogueSelect,
+  CopyDocumentTypesConfig,
   getCatalogueOption,
   groupAndSortCatalogueOptions,
 } from 'components/admin/forms/zgw';
@@ -250,6 +251,7 @@ export const DocumentTypesFieldet = () => {
         }
         {...documentTypeProps}
       />
+      <CopyDocumentTypesConfig catalogueField="catalogue" descriptionField="iotAttachment" />
     </Fieldset>
   );
 };

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/DocumentTypes.js
@@ -1,16 +1,17 @@
-import classNames from 'classnames';
 import {useField, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import {useContext, useEffect, useState} from 'react';
+import {useContext, useEffect, useMemo} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import {components} from 'react-select';
 import {useAsync, usePrevious} from 'react-use';
 
 import {FeatureFlagsContext} from 'components/admin/form_design/Context';
 import Field from 'components/admin/forms/Field';
 import Fieldset from 'components/admin/forms/Fieldset';
 import FormRow from 'components/admin/forms/FormRow';
-import ReactSelect from 'components/admin/forms/ReactSelect';
+import {
+  DocumentTypeSelect as GenericDocumentTypeSelect,
+  useGetDocumentTypes,
+} from 'components/admin/forms/zgw';
 import {
   CatalogueSelect,
   CopyDocumentTypesConfig,
@@ -33,51 +34,11 @@ const getCatalogues = async apiGroupID => {
   return groupAndSortCatalogueOptions(response.data);
 };
 
-const getDocumentTypes = async (apiGroupID, catalogueUrl) => {
-  const response = await get(IOT_ENDPOINT, {
-    objects_api_group: apiGroupID,
-    catalogue_url: catalogueUrl,
-  });
-  if (!response.ok) {
-    throw new Error('Loading available document types failed');
-  }
-  const documentTypes = response.data.sort((a, b) => a.description.localeCompare(b.description));
-  return documentTypes.map(({description, isPublished}) => ({
-    value: description,
-    label: description,
-    isPublished: isPublished,
-  }));
-};
-
 // Components
 
-const DocumentTypeSelectOption = props => {
-  const {isPublished, label} = props.data;
-  return (
-    <components.Option {...props}>
-      <span
-        className={classNames('catalogi-type-option', {
-          'catalogi-type-option--draft': !isPublished,
-        })}
-      >
-        <FormattedMessage
-          description="Document type option label"
-          defaultMessage={`{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
-          values={{
-            label,
-            isPublished,
-            draft: chunks => <span className="catalogi-type-option__draft-suffix">{chunks}</span>,
-          }}
-        />
-      </span>
-    </components.Option>
-  );
-};
-
-const DocumentType = ({name, label, loading, options, isDisabled, helpText}) => {
+const DocumentType = ({name, label, loading, documentTypes, isDisabled, helpText}) => {
   const intl = useIntl();
-  const [{value}, , fieldHelpers] = useField(name);
-  const {setValue} = fieldHelpers;
+  const [{value}] = useField(name);
 
   const {ZGW_APIS_INCLUDE_DRAFTS = false} = useContext(FeatureFlagsContext);
 
@@ -85,23 +46,17 @@ const DocumentType = ({name, label, loading, options, isDisabled, helpText}) => 
     !isDisabled &&
     value &&
     !loading &&
-    options.find(option => option.value === value) === undefined;
+    documentTypes.find(option => option.value === value) === undefined;
 
   return (
     <FormRow>
       <Field name={name} label={label} helpText={helpText} disabled={isDisabled} noManageChildProps>
         <>
-          <ReactSelect
+          <GenericDocumentTypeSelect
             name={name}
-            options={options}
-            isLoading={loading}
+            documentTypes={documentTypes}
             isDisabled={isDisabled}
-            onChange={selectedOption => {
-              // unset form key entirely if the selection is cleared
-              setValue(selectedOption ? selectedOption.value : undefined);
-            }}
-            isClearable
-            components={{Option: DocumentTypeSelectOption}}
+            isLoading={loading}
           />
           {showWarning && (
             <WarningIcon
@@ -128,7 +83,7 @@ DocumentType.propTypes = {
   label: PropTypes.node.isRequired,
   loading: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool.isRequired,
-  options: PropTypes.arrayOf(
+  documentTypes: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.string.isRequired,
       label: PropTypes.node.isRequired,
@@ -137,7 +92,7 @@ DocumentType.propTypes = {
   helpText: PropTypes.node,
 };
 
-export const DocumentTypesFieldet = () => {
+export const DocumentTypesFieldset = () => {
   const {values, setValues} = useFormikContext();
   const {objectsApiGroup = null, catalogue = undefined} = values;
 
@@ -174,21 +129,17 @@ export const DocumentTypesFieldet = () => {
     }));
   }, [previousCatalogueUrl, catalogueUrl]);
 
-  const {
-    loading,
-    value: documentTypeOptions = [],
-    error,
-  } = useAsync(async () => {
-    if (!objectsApiGroup) return [];
-    if (!catalogueUrl) return [];
-    return await getDocumentTypes(objectsApiGroup, catalogueUrl);
-  }, [objectsApiGroup, catalogueUrl]);
+  const query = useMemo(
+    () => ({objects_api_group: objectsApiGroup, catalogue_url: catalogueUrl}),
+    [objectsApiGroup, catalogueUrl]
+  );
+  const {loading, documentTypes, error} = useGetDocumentTypes(IOT_ENDPOINT, query);
   if (error) throw error;
 
   const documentTypeProps = {
     isDisabled: !objectsApiGroup || !catalogueUrl,
     loading: loading,
-    options: documentTypeOptions,
+    documentTypes: documentTypes,
   };
 
   return (

--- a/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/index.js
+++ b/src/openforms/js/components/admin/form_design/registrations/objectsapi/fields/index.js
@@ -1,5 +1,5 @@
 export {LegacyDocumentTypesFieldet} from './LegacyDocumentType';
-export {DocumentTypesFieldet} from './DocumentTypes';
+export {DocumentTypesFieldset} from './DocumentTypes';
 export {default as UpdateExistingObject} from './UpdateExistingObject';
 export {default as UploadSubmissionCsv} from './UploadSubmissionCSV';
 export {default as OrganisationRSIN} from './OrganisationRSIN';

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/BasicOptionsFieldset.js
@@ -4,7 +4,7 @@ import {FormattedMessage} from 'react-intl';
 
 import useConfirm from 'components/admin/form_design/useConfirm';
 import Fieldset from 'components/admin/forms/Fieldset';
-import {CatalogueSelectOptions} from 'components/admin/forms/zgw';
+import {CatalogueSelectOptions, CopyDocumentTypesConfig} from 'components/admin/forms/zgw';
 import ErrorBoundary from 'components/errors/ErrorBoundary';
 
 import {CaseTypeSelect, CatalogueSelect, DocumentTypeSelect, ZGWAPIGroup} from './fields';
@@ -54,41 +54,57 @@ const BasicOptionsFieldset = ({
   const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
 
   return (
-    <Fieldset>
-      <ZGWAPIGroup
-        apiGroupChoices={apiGroupChoices}
-        onChangeCheck={async () => {
-          if (!hasAnyFieldConfigured) return true;
-          return openConfirmationModal();
-        }}
-      />
+    <>
+      <Fieldset>
+        <ZGWAPIGroup
+          apiGroupChoices={apiGroupChoices}
+          onChangeCheck={async () => {
+            if (!hasAnyFieldConfigured) return true;
+            return openConfirmationModal();
+          }}
+        />
 
-      <ErrorBoundary
-        errorMessage={
-          <FormattedMessage
-            description="ZGW APIs registrations options: generic error"
-            defaultMessage={`Something went wrong while retrieving the available
+        <ErrorBoundary
+          errorMessage={
+            <FormattedMessage
+              description="ZGW APIs registrations options: generic error"
+              defaultMessage={`Something went wrong while retrieving the available
             catalogues or case/document types defined in the selected catalogue. Please
             check that the services in the selected API group are configured correctly.`}
-          />
-        }
-      >
-        <MaybeThrowError error={cataloguesError} />
-        <CatalogueSelect loading={loadingCatalogues} optionGroups={catalogueOptionGroups} />
-        <CaseTypeSelect catalogueUrl={catalogueUrl} />
-        <DocumentTypeSelect catalogueUrl={catalogueUrl} />
-      </ErrorBoundary>
-      <ConfirmationModal
-        {...confirmationModalProps}
-        message={
-          <FormattedMessage
-            description="ZGW APIs registration options: warning message when changing the api group"
-            defaultMessage="Changing the api group will clear the existing configuration.
+            />
+          }
+        >
+          <MaybeThrowError error={cataloguesError} />
+          <CatalogueSelect loading={loadingCatalogues} optionGroups={catalogueOptionGroups} />
+          <CaseTypeSelect catalogueUrl={catalogueUrl} />
+          <DocumentTypeSelect catalogueUrl={catalogueUrl} />
+        </ErrorBoundary>
+        <ConfirmationModal
+          {...confirmationModalProps}
+          message={
+            <FormattedMessage
+              description="ZGW APIs registration options: warning message when changing the api group"
+              defaultMessage="Changing the api group will clear the existing configuration.
               Are you sure you want to continue?"
+            />
+          }
+        />
+      </Fieldset>
+      <Fieldset
+        title={
+          <FormattedMessage
+            description="ZGw APIs registration: file components document types fieldset title"
+            defaultMessage="File component document types"
           />
         }
-      />
-    </Fieldset>
+        collapsible
+      >
+        <CopyDocumentTypesConfig
+          catalogueField="catalogue"
+          descriptionField="documentTypeDescription"
+        />
+      </Fieldset>
+    </>
   );
 };
 

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -83,12 +83,22 @@ export default {
     formData: {},
     availableComponents: {
       textField1: {
+        type: 'textfield',
+        key: 'textField1',
         label: 'textfield1',
       },
       textField2: {
+        type: 'textfield',
+        key: 'textField2',
         label: 'textfield2',
       },
+      file: {
+        type: 'file',
+        key: 'file',
+        label: 'attachments',
+      },
     },
+    updateComponents: fn(),
   },
   parameters: {
     msw: {

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/fields/DocumentTypeSelect.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/fields/DocumentTypeSelect.js
@@ -1,75 +1,33 @@
-import classNames from 'classnames';
-import {useField, useFormikContext} from 'formik';
+import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
-import React from 'react';
+import {useMemo} from 'react';
 import {FormattedMessage} from 'react-intl';
-import {components} from 'react-select';
-import useAsync from 'react-use/esm/useAsync';
 
 import Field from 'components/admin/forms/Field';
 import FormRow from 'components/admin/forms/FormRow';
-import ReactSelect from 'components/admin/forms/ReactSelect';
-import {get} from 'utils/fetch';
+import {
+  DocumentTypeSelect as GenericDocumentTypeSelect,
+  useGetDocumentTypes,
+} from 'components/admin/forms/zgw';
 
 const DOCUMENT_TYPES_ENDPOINT = '/api/v2/registration/plugins/zgw-api/document-types';
 
-const getAvailableDocumentTypes = async (apiGroupID, catalogueUrl, caseTypeIdentification) => {
-  const response = await get(DOCUMENT_TYPES_ENDPOINT, {
-    zgw_api_group: apiGroupID,
-    catalogue_url: catalogueUrl,
-    case_type_identification: caseTypeIdentification,
-  });
-  if (!response.ok) {
-    throw new Error('Loading available object types failed');
-  }
-  const documentTypes = response.data.sort((a, b) => a.description.localeCompare(b.description));
-  return documentTypes.map(({description, isPublished}) => ({
-    value: description,
-    label: description,
-    isPublished: isPublished,
-  }));
-};
-
 // Components
 
-const DocumentTypeSelectOption = props => {
-  const {isPublished, label} = props.data;
-  return (
-    <components.Option {...props}>
-      <span
-        className={classNames('catalogi-type-option', {
-          'catalogi-type-option--draft': !isPublished,
-        })}
-      >
-        <FormattedMessage
-          description="Document type option label"
-          defaultMessage={`{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
-          values={{
-            label,
-            isPublished,
-            draft: chunks => <span className="catalogi-type-option__draft-suffix">{chunks}</span>,
-          }}
-        />
-      </span>
-    </components.Option>
-  );
-};
-
 const DocumentTypeSelect = ({catalogueUrl = ''}) => {
-  const [, , fieldHelpers] = useField('documentTypeDescription');
   const {
     values: {zgwApiGroup = null, caseTypeIdentification = ''},
   } = useFormikContext();
-  const {setValue} = fieldHelpers;
 
-  const {
-    loading,
-    value: documentTypes = [],
-    error,
-  } = useAsync(async () => {
-    if (!zgwApiGroup || !catalogueUrl || !caseTypeIdentification) return [];
-    return await getAvailableDocumentTypes(zgwApiGroup, catalogueUrl, caseTypeIdentification);
-  }, [zgwApiGroup, catalogueUrl, caseTypeIdentification]);
+  const query = useMemo(
+    () => ({
+      zgw_api_group: zgwApiGroup,
+      catalogue_url: catalogueUrl,
+      case_type_identification: caseTypeIdentification,
+    }),
+    [zgwApiGroup, catalogueUrl, caseTypeIdentification]
+  );
+  const {loading, documentTypes, error} = useGetDocumentTypes(DOCUMENT_TYPES_ENDPOINT, query);
   if (error) throw error;
 
   return (
@@ -94,18 +52,13 @@ const DocumentTypeSelect = ({catalogueUrl = ''}) => {
         }
         noManageChildProps
       >
-        <ReactSelect
+        <GenericDocumentTypeSelect
           name="documentTypeDescription"
-          options={documentTypes}
-          isLoading={loading}
+          documentTypes={documentTypes}
           isDisabled={!zgwApiGroup || !caseTypeIdentification}
           // TODO: make required once legacy config is dropped
-          required={false}
-          isClearable
-          components={{Option: DocumentTypeSelectOption}}
-          onChange={selectedOption => {
-            setValue(selectedOption ? selectedOption.value : undefined);
-          }}
+          isRequired={false}
+          isLoading={loading}
         />
       </Field>
     </FormRow>

--- a/src/openforms/js/components/admin/form_design/story-decorators.js
+++ b/src/openforms/js/components/admin/form_design/story-decorators.js
@@ -97,6 +97,7 @@ export const FormDecorator = (Story, {args}) => (
       ],
       translationEnabled: false,
       newLogicEvaluationEnabled: args.newLogicEvaluationEnabled || false,
+      updateComponents: args.updateComponents ?? (() => {}),
     }}
   >
     <Story />

--- a/src/openforms/js/components/admin/forms/zgw/CopyDocumentTypesConfig.js
+++ b/src/openforms/js/components/admin/forms/zgw/CopyDocumentTypesConfig.js
@@ -1,0 +1,180 @@
+import {useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {FormContext} from 'components/admin/form_design/Context';
+import useConfirm from 'components/admin/form_design/useConfirm';
+import {ChangelistTableWrapper, HeadColumn} from 'components/admin/tables';
+
+const CopyDocumentTypesConfig = ({catalogueField, descriptionField}) => {
+  const intl = useIntl();
+  const {components, updateComponents} = useContext(FormContext);
+  const {getFieldMeta} = useFormikContext();
+  const [selectedComponents, setSelectedComponents] = useState([]);
+  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
+
+  const fileComponents = Object.values(components).filter(component => component.type === 'file');
+  const catalogue = getFieldMeta(catalogueField).value ?? {domain: '', rsin: ''};
+  const description = getFieldMeta(descriptionField).value ?? '';
+
+  if (!fileComponents.length)
+    return (
+      <div className="form-row">
+        <p>
+          <FormattedMessage
+            description="Copy document types config: no file components text"
+            defaultMessage="There are no file upload components in the form."
+          />
+        </p>
+      </div>
+    );
+
+  const componentTableHeadColumns = [
+    <HeadColumn
+      key="checkbox"
+      content={
+        <input
+          type="checkbox"
+          checked={selectedComponents.length === fileComponents.length}
+          onChange={event => {
+            const {checked} = event.target;
+            setSelectedComponents(checked ? fileComponents.map(c => c.key) : []);
+          }}
+          aria-label={intl.formatMessage({
+            description: 'Accessible label for check/uncheck all file components',
+            defaultMessage: 'Check/uncheck all',
+          })}
+        />
+      }
+    />,
+    <HeadColumn
+      key="label"
+      content={
+        <FormattedMessage
+          description="Copy document types config to file components: component label heading"
+          defaultMessage="Field label"
+        />
+      }
+    />,
+    <HeadColumn
+      key="domain"
+      content={
+        <FormattedMessage
+          description="Copy document types config to file components: catalogue domain heading"
+          defaultMessage="Catalogue domain"
+        />
+      }
+    />,
+    <HeadColumn
+      key="rsin"
+      content={
+        <FormattedMessage
+          description="Copy document types config to file components: catalogue RSIN heading"
+          defaultMessage="Catalogue RSIN"
+        />
+      }
+    />,
+    <HeadColumn
+      key="description"
+      content={
+        <FormattedMessage
+          description="Copy document types config to file components: doc type description heading"
+          defaultMessage="Document type description"
+        />
+      }
+    />,
+  ];
+
+  return (
+    <>
+      <div className="description">
+        <FormattedMessage
+          description="Copy document types config: feature description"
+          defaultMessage={`You can copy the catalogue and document type description
+          from the plugin options to the selected file upload fields of the form. Note
+          that this will overwrite existing field-level configuration!`}
+        />
+      </div>
+      <div className="form-row">
+        <ChangelistTableWrapper headColumns={componentTableHeadColumns}>
+          {fileComponents.map(component => (
+            <tr key={component.key}>
+              <td style={{padding: '8px 10px'}}>
+                <input
+                  type="checkbox"
+                  checked={selectedComponents.includes(component.key)}
+                  onChange={event => {
+                    const {key} = component;
+                    const {checked} = event.target;
+                    const updatedSelectedComponents = checked
+                      ? [...selectedComponents, key]
+                      : selectedComponents.filter(k => k !== key);
+                    setSelectedComponents(updatedSelectedComponents);
+                  }}
+                  aria-label={intl.formatMessage(
+                    {
+                      description: 'Accessible label for check/uncheck single file component',
+                      defaultMessage: 'Update {label} configuration?',
+                    },
+                    {label: component.label}
+                  )}
+                />
+              </td>
+              <td>{component.label}</td>
+              <td>{component?.registration?.documentType?.catalogue?.domain ?? '-'}</td>
+              <td>{component?.registration?.documentType?.catalogue?.rsin ?? '-'}</td>
+              <td>{component?.registration?.documentType?.description ?? '-'}</td>
+            </tr>
+          ))}
+        </ChangelistTableWrapper>
+
+        <div style={{textAlign: 'end'}}>
+          <button
+            type="button"
+            className="button"
+            disabled={selectedComponents.length === 0}
+            onClick={async () => {
+              const confirm = await openConfirmationModal();
+              if (!confirm) return;
+              updateComponents(selectedComponents, componentDraft => {
+                if (!componentDraft.registration) {
+                  componentDraft.registration = {};
+                }
+                if (!componentDraft.registration.documentType) {
+                  componentDraft.registration.documentType = {};
+                }
+                componentDraft.registration.documentType.catalogue = catalogue;
+                componentDraft.registration.documentType.description = description;
+                setSelectedComponents([]);
+              });
+            }}
+            style={{paddingInline: '15px', paddingBlock: '10px'}}
+          >
+            <FormattedMessage
+              description="Copy document types config: copy button label"
+              defaultMessage="Copy"
+            />
+          </button>
+        </div>
+      </div>
+
+      <ConfirmationModal
+        {...confirmationModalProps}
+        message={
+          <FormattedMessage
+            description="Copy document type configuration to selected file components confirmation modal content"
+            defaultMessage="The file component changes will be applied immediately. Are you sure you want to continue?"
+          />
+        }
+      />
+    </>
+  );
+};
+
+CopyDocumentTypesConfig.propTypes = {
+  catalogueField: PropTypes.string.isRequired,
+  descriptionField: PropTypes.string.isRequired,
+};
+
+export default CopyDocumentTypesConfig;

--- a/src/openforms/js/components/admin/forms/zgw/DocumentTypeSelect.js
+++ b/src/openforms/js/components/admin/forms/zgw/DocumentTypeSelect.js
@@ -1,0 +1,99 @@
+import classNames from 'classnames';
+import {useField} from 'formik';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+import {components} from 'react-select';
+import useAsync from 'react-use/esm/useAsync';
+
+import ReactSelect from 'components/admin/forms/ReactSelect';
+import {get} from 'utils/fetch';
+
+const getDocumentTypes = async (endpoint, queryParams) => {
+  const response = await get(endpoint, queryParams);
+  if (!response.ok) {
+    throw new Error('Loading available object types failed');
+  }
+  const documentTypes = response.data.sort((a, b) => a.description.localeCompare(b.description));
+  return documentTypes.map(({description, isPublished}) => ({
+    value: description,
+    label: description,
+    isPublished: isPublished,
+  }));
+};
+
+export const useGetDocumentTypes = (endpoint, queryParams) => {
+  const {
+    loading,
+    value: documentTypes = [],
+    error,
+  } = useAsync(async () => {
+    // abort if any query param is empty-ish
+    if (Object.values(queryParams).some(v => !v)) return [];
+    return await getDocumentTypes(endpoint, queryParams);
+  }, [endpoint, queryParams]);
+
+  return {loading, documentTypes, error};
+};
+
+// Components
+
+const DocumentTypeSelectOption = props => {
+  const {isPublished, label} = props.data;
+  return (
+    <components.Option {...props}>
+      <span
+        className={classNames('catalogi-type-option', {
+          'catalogi-type-option--draft': !isPublished,
+        })}
+      >
+        <FormattedMessage
+          description="Document type option label"
+          defaultMessage={`{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}`}
+          values={{
+            label,
+            isPublished,
+            draft: chunks => <span className="catalogi-type-option__draft-suffix">{chunks}</span>,
+          }}
+        />
+      </span>
+    </components.Option>
+  );
+};
+
+export const DocumentTypeSelect = ({
+  name,
+  documentTypes = [],
+  isDisabled = false,
+  isRequired = false,
+  isLoading,
+}) => {
+  const [, , {setValue}] = useField(name);
+  return (
+    <ReactSelect
+      name={name}
+      options={documentTypes}
+      isLoading={isLoading}
+      isDisabled={isDisabled}
+      required={isRequired}
+      isClearable
+      components={{Option: DocumentTypeSelectOption}}
+      onChange={selectedOption => {
+        setValue(selectedOption ? selectedOption.value : undefined);
+      }}
+    />
+  );
+};
+
+DocumentTypeSelect.propTypes = {
+  name: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  documentTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      isPublished: PropTypes.bool.isRequired,
+    })
+  ),
+  isDisabled: PropTypes.bool,
+  isRequired: PropTypes.bool,
+};

--- a/src/openforms/js/components/admin/forms/zgw/index.js
+++ b/src/openforms/js/components/admin/forms/zgw/index.js
@@ -8,3 +8,4 @@ export {
   groupAndSortOptions as groupAndSortCatalogueOptions,
 } from './CatalogueSelect';
 export {default as CopyDocumentTypesConfig} from './CopyDocumentTypesConfig';
+export {DocumentTypeSelect, useGetDocumentTypes} from './DocumentTypeSelect';

--- a/src/openforms/js/components/admin/forms/zgw/index.js
+++ b/src/openforms/js/components/admin/forms/zgw/index.js
@@ -7,3 +7,4 @@ export {
   extractValue as getCatalogueOption,
   groupAndSortOptions as groupAndSortCatalogueOptions,
 } from './CatalogueSelect';
+export {default as CopyDocumentTypesConfig} from './CopyDocumentTypesConfig';

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -44,6 +44,11 @@
     "description": "action type \"step-applicable\" label",
     "originalDefault": "Mark the form step as applicable"
   },
+  "/MWRm7": {
+    "defaultMessage": "There are no file upload components in the form.",
+    "description": "Copy document types config: no file components text",
+    "originalDefault": "There are no file upload components in the form."
+  },
   "/fAEsY": {
     "defaultMessage": "Submission report CSV informatieobjecttype",
     "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
@@ -233,6 +238,16 @@
     "defaultMessage": "Ask statement of truth",
     "description": "Form askStatementOfTruth field label",
     "originalDefault": "Ask statement of truth"
+  },
+  "3eiHJv": {
+    "defaultMessage": "Catalogue RSIN",
+    "description": "Copy document types config to file components: catalogue RSIN heading",
+    "originalDefault": "Catalogue RSIN"
+  },
+  "3jd+Cd": {
+    "defaultMessage": "Catalogue domain",
+    "description": "Copy document types config to file components: catalogue domain heading",
+    "originalDefault": "Catalogue domain"
   },
   "3z1hhJ": {
     "defaultMessage": "Toggle JSON Schema",
@@ -734,6 +749,11 @@
     "description": "variable pricing mode label",
     "originalDefault": "Use a variable for the price"
   },
+  "CpZufh": {
+    "defaultMessage": "Check/uncheck all",
+    "description": "Accessible label for check/uncheck all file components",
+    "originalDefault": "Check/uncheck all"
+  },
   "CtjZFq": {
     "defaultMessage": "Submission allowed",
     "description": "Form submissionAllowed field label",
@@ -923,6 +943,11 @@
     "defaultMessage": "The co-sign component requires at least one authentication plugin to be enabled.",
     "description": "MissingAuthCosignWarning message",
     "originalDefault": "The co-sign component requires at least one authentication plugin to be enabled."
+  },
+  "FJaFwb": {
+    "defaultMessage": "Copy",
+    "description": "Copy document types config: copy button label",
+    "originalDefault": "Copy"
   },
   "FNT8nq": {
     "defaultMessage": "Variable containing email addresses",
@@ -1279,6 +1304,11 @@
     "description": "'Static' source label for fixed metadata variables table",
     "originalDefault": "Static"
   },
+  "KTmwYn": {
+    "defaultMessage": "Update {label} configuration?",
+    "description": "Accessible label for check/uncheck single file component",
+    "originalDefault": "Update {label} configuration?"
+  },
   "KYTAJZ": {
     "defaultMessage": "(checked for every step)",
     "description": "'Trigger from step' information for when unset",
@@ -1489,6 +1519,11 @@
     "description": "ZGW APIs registration options 'document type' label",
     "originalDefault": "Document type"
   },
+  "NwBpaW": {
+    "defaultMessage": "Document type description",
+    "description": "Copy document types config to file components: doc type description heading",
+    "originalDefault": "Document type description"
+  },
   "NyyJMK": {
     "defaultMessage": "The API group specifies which ZGW services to use.",
     "description": "ZGW APIs group field help text",
@@ -1589,10 +1624,20 @@
     "description": "Include confirmation page content in PDF",
     "originalDefault": "Include confirmation page content in PDF"
   },
+  "PbVsAV": {
+    "defaultMessage": "File component document types",
+    "description": "ZGw APIs registration: file components document types fieldset title",
+    "originalDefault": "File component document types"
+  },
   "PdaMqg": {
     "defaultMessage": "Add rule",
     "description": "Add form logic rule button",
     "originalDefault": "Add rule"
+  },
+  "PhKHkq": {
+    "defaultMessage": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!",
+    "description": "Copy document types config: feature description",
+    "originalDefault": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!"
   },
   "PhN977": {
     "defaultMessage": "Plugin configuration: StUF-ZDS",
@@ -2033,6 +2078,11 @@
     "defaultMessage": "Save",
     "description": "Admin save submit button",
     "originalDefault": "Save"
+  },
+  "YReu09": {
+    "defaultMessage": "Field label",
+    "description": "Copy document types config to file components: component label heading",
+    "originalDefault": "Field label"
   },
   "YbnFnL": {
     "defaultMessage": "The component \"{label}\" (with key \"{key}\"{location}) has a problem in the field \"{field}\": {error}",
@@ -3043,6 +3093,11 @@
     "defaultMessage": "No advanced configuration is available for this form.",
     "description": "Form advanced configuration fallback message",
     "originalDefault": "No advanced configuration is available for this form."
+  },
+  "p0n2wK": {
+    "defaultMessage": "The file component changes will be applied immediately. Are you sure you want to continue?",
+    "description": "Copy document type configuration to selected file components confirmation modal content",
+    "originalDefault": "The file component changes will be applied immediately. Are you sure you want to continue?"
   },
   "p5Iv+R": {
     "defaultMessage": "Document type API resource URL in the Catalogi API.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -44,6 +44,11 @@
     "description": "action type \"step-applicable\" label",
     "originalDefault": "Mark the form step as applicable"
   },
+  "/MWRm7": {
+    "defaultMessage": "There are no file upload components in the form.",
+    "description": "Copy document types config: no file components text",
+    "originalDefault": "There are no file upload components in the form."
+  },
   "/fAEsY": {
     "defaultMessage": "Informatieobjecttype CSV-document met inzendingsgegevens",
     "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
@@ -234,6 +239,16 @@
     "defaultMessage": "Vraag verklaring invullen naar waarheid",
     "description": "Form askStatementOfTruth field label",
     "originalDefault": "Ask statement of truth"
+  },
+  "3eiHJv": {
+    "defaultMessage": "Catalogue RSIN",
+    "description": "Copy document types config to file components: catalogue RSIN heading",
+    "originalDefault": "Catalogue RSIN"
+  },
+  "3jd+Cd": {
+    "defaultMessage": "Catalogue domain",
+    "description": "Copy document types config to file components: catalogue domain heading",
+    "originalDefault": "Catalogue domain"
   },
   "3z1hhJ": {
     "defaultMessage": "Toon/verberg JSON Schema",
@@ -742,6 +757,11 @@
     "description": "variable pricing mode label",
     "originalDefault": "Use a variable for the price"
   },
+  "CpZufh": {
+    "defaultMessage": "Check/uncheck all",
+    "description": "Accessible label for check/uncheck all file components",
+    "originalDefault": "Check/uncheck all"
+  },
   "CtjZFq": {
     "defaultMessage": "Inzenden toegestaan",
     "description": "Form submissionAllowed field label",
@@ -935,6 +955,11 @@
     "defaultMessage": "Er moet minstens één authenticatiemethode ingeschakeld zijn voor de mede-ondertekencomponent.",
     "description": "MissingAuthCosignWarning message",
     "originalDefault": "The co-sign component requires at least one authentication plugin to be enabled."
+  },
+  "FJaFwb": {
+    "defaultMessage": "Copy",
+    "description": "Copy document types config: copy button label",
+    "originalDefault": "Copy"
   },
   "FNT8nq": {
     "defaultMessage": "Variabele die adres(sen) bevat",
@@ -1291,6 +1316,11 @@
     "description": "'Static' source label for fixed metadata variables table",
     "originalDefault": "Static"
   },
+  "KTmwYn": {
+    "defaultMessage": "Update {label} configuration?",
+    "description": "Accessible label for check/uncheck single file component",
+    "originalDefault": "Update {label} configuration?"
+  },
   "KYTAJZ": {
     "defaultMessage": "(actief binnen elke stap)",
     "description": "'Trigger from step' information for when unset",
@@ -1502,6 +1532,11 @@
     "description": "ZGW APIs registration options 'document type' label",
     "originalDefault": "Document type"
   },
+  "NwBpaW": {
+    "defaultMessage": "Document type description",
+    "description": "Copy document types config to file components: doc type description heading",
+    "originalDefault": "Document type description"
+  },
   "NyyJMK": {
     "defaultMessage": "De API-groep die bepaalt welke ZGW services gebruikt moeten worden.",
     "description": "ZGW APIs group field help text",
@@ -1606,10 +1641,20 @@
     "description": "Include confirmation page content in PDF",
     "originalDefault": "Include confirmation page content in PDF"
   },
+  "PbVsAV": {
+    "defaultMessage": "File component document types",
+    "description": "ZGw APIs registration: file components document types fieldset title",
+    "originalDefault": "File component document types"
+  },
   "PdaMqg": {
     "defaultMessage": "Regel toevoegen",
     "description": "Add form logic rule button",
     "originalDefault": "Add rule"
+  },
+  "PhKHkq": {
+    "defaultMessage": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!",
+    "description": "Copy document types config: feature description",
+    "originalDefault": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!"
   },
   "PhN977": {
     "defaultMessage": "Plugin-instellingen: StUF-ZDS",
@@ -2053,6 +2098,11 @@
     "defaultMessage": "Opslaan",
     "description": "Admin save submit button",
     "originalDefault": "Save"
+  },
+  "YReu09": {
+    "defaultMessage": "Field label",
+    "description": "Copy document types config to file components: component label heading",
+    "originalDefault": "Field label"
   },
   "YbnFnL": {
     "defaultMessage": "Er is een fout bij de component \"{label}\" (met sleutel \"{key}\"{location}) in het veld \"{field}\": {error}",
@@ -3066,6 +3116,11 @@
     "defaultMessage": "Er zijn geen relevante geavanceerde instellingen.",
     "description": "Form advanced configuration fallback message",
     "originalDefault": "No advanced configuration is available for this form."
+  },
+  "p0n2wK": {
+    "defaultMessage": "The file component changes will be applied immediately. Are you sure you want to continue?",
+    "description": "Copy document type configuration to selected file components confirmation modal content",
+    "originalDefault": "The file component changes will be applied immediately. Are you sure you want to continue?"
   },
   "p5Iv+R": {
     "defaultMessage": "Documenttype-API-resource-URL in de Catalogi-API.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -45,7 +45,7 @@
     "originalDefault": "Mark the form step as applicable"
   },
   "/MWRm7": {
-    "defaultMessage": "There are no file upload components in the form.",
+    "defaultMessage": "Het formulier bevat geen bestandsuploadvelden.",
     "description": "Copy document types config: no file components text",
     "originalDefault": "There are no file upload components in the form."
   },
@@ -241,12 +241,12 @@
     "originalDefault": "Ask statement of truth"
   },
   "3eiHJv": {
-    "defaultMessage": "Catalogue RSIN",
+    "defaultMessage": "Catalogus-RSIN",
     "description": "Copy document types config to file components: catalogue RSIN heading",
     "originalDefault": "Catalogue RSIN"
   },
   "3jd+Cd": {
-    "defaultMessage": "Catalogue domain",
+    "defaultMessage": "Catalogusdomein",
     "description": "Copy document types config to file components: catalogue domain heading",
     "originalDefault": "Catalogue domain"
   },
@@ -758,7 +758,7 @@
     "originalDefault": "Use a variable for the price"
   },
   "CpZufh": {
-    "defaultMessage": "Check/uncheck all",
+    "defaultMessage": "Vink alles aan/uit",
     "description": "Accessible label for check/uncheck all file components",
     "originalDefault": "Check/uncheck all"
   },
@@ -957,7 +957,7 @@
     "originalDefault": "The co-sign component requires at least one authentication plugin to be enabled."
   },
   "FJaFwb": {
-    "defaultMessage": "Copy",
+    "defaultMessage": "Kopieer",
     "description": "Copy document types config: copy button label",
     "originalDefault": "Copy"
   },
@@ -1317,7 +1317,7 @@
     "originalDefault": "Static"
   },
   "KTmwYn": {
-    "defaultMessage": "Update {label} configuration?",
+    "defaultMessage": "{label} instellingen bijwerken?",
     "description": "Accessible label for check/uncheck single file component",
     "originalDefault": "Update {label} configuration?"
   },
@@ -1533,7 +1533,7 @@
     "originalDefault": "Document type"
   },
   "NwBpaW": {
-    "defaultMessage": "Document type description",
+    "defaultMessage": "Documenttype-omschrijving",
     "description": "Copy document types config to file components: doc type description heading",
     "originalDefault": "Document type description"
   },
@@ -1642,7 +1642,7 @@
     "originalDefault": "Include confirmation page content in PDF"
   },
   "PbVsAV": {
-    "defaultMessage": "File component document types",
+    "defaultMessage": "Bijlage-documenttypen",
     "description": "ZGw APIs registration: file components document types fieldset title",
     "originalDefault": "File component document types"
   },
@@ -1652,7 +1652,7 @@
     "originalDefault": "Add rule"
   },
   "PhKHkq": {
-    "defaultMessage": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!",
+    "defaultMessage": "Je kan de catalogusreferentie en documenttypeomschrijving kopiëren van de plugin-instellingen naar de geselecteerde upload-velden van het formulier. Merk op dat je hiermee bestaande instellingen overschrijft!",
     "description": "Copy document types config: feature description",
     "originalDefault": "You can copy the catalogue and document type description from the plugin options to the selected file upload fields of the form. Note that this will overwrite existing field-level configuration!"
   },
@@ -2100,7 +2100,7 @@
     "originalDefault": "Save"
   },
   "YReu09": {
-    "defaultMessage": "Field label",
+    "defaultMessage": "Veldlabel",
     "description": "Copy document types config to file components: component label heading",
     "originalDefault": "Field label"
   },
@@ -3118,7 +3118,7 @@
     "originalDefault": "No advanced configuration is available for this form."
   },
   "p0n2wK": {
-    "defaultMessage": "The file component changes will be applied immediately. Are you sure you want to continue?",
+    "defaultMessage": "De bestandsuploadveldinstellingen worden meteen bijgewerkt. Ben je zeker dat je door wil gaan?",
     "description": "Copy document type configuration to selected file components confirmation modal content",
     "originalDefault": "The file component changes will be applied immediately. Are you sure you want to continue?"
   },

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -214,9 +214,39 @@ def register_submission_attachment(
         document_options["titel"] = title
     if rsin := attachment.bronorganisatie:
         document_options["organisatie_rsin"] = rsin
-    # TODO convert this to catalogue + description mechanism too! See #4267
-    if document_type := attachment.informatieobjecttype:
-        document_options["informatieobjecttype"] = document_type
+
+    # Override the component-specific document type if it's configured
+    if file_component := attachment.component:
+        # default to the legacy URLs, but override with modern configuration if available
+        if document_type := attachment.informatieobjecttype:
+            document_options["informatieobjecttype"] = document_type
+
+        document_type_configuration = file_component.get("registration", {}).get(
+            "documentType", {}
+        )
+        _document_type_description = document_type_configuration.get("description", "")
+        _catalogue = document_type_configuration.get("catalogue", {})
+        if (
+            _document_type_description
+            and (_catalogue_domain := _catalogue.get("domain"))
+            and (_catalogue_rsin := _catalogue.get("rsin"))
+        ):
+            _options: RegistrationOptions = options.copy()
+            _options.update(
+                {
+                    "catalogue": {
+                        "domain": _catalogue_domain,
+                        "rsin": _catalogue_rsin,
+                    },
+                    "iot_attachment": _document_type_description,
+                }
+            )
+            document_options["informatieobjecttype"] = _resolve_documenttype(
+                "attachment",
+                _options,
+                submission,
+                catalogi_client,
+            )
 
     attachment_document = create_attachment_document(
         client=documents_client,

--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -16,7 +16,6 @@ from django.db.models.functions import Coalesce, NullIf
 import structlog
 
 from openforms.contrib.objects_api.clients import (
-    CatalogiClient,
     DocumentenClient,
     get_catalogi_client,
     get_documents_client,
@@ -26,6 +25,7 @@ from openforms.contrib.objects_api.rendering import render_to_json
 from openforms.contrib.objects_api.typing import Record
 from openforms.contrib.zgw.service import (
     DocumentOptions,
+    DocumentTypeResolver,
     create_attachment_document,
     create_csv_document,
     create_report_document,
@@ -67,10 +67,10 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 def _resolve_documenttype(
+    resolver: DocumentTypeResolver,
     field: Literal["submission_report", "submission_csv", "attachment"],
     options: RegistrationOptions,
     submission: Submission,
-    catalogi_client: CatalogiClient,
 ) -> str:
     """
     Given the registration options, resolve the documenttype URL to use.
@@ -106,33 +106,22 @@ def _resolve_documenttype(
     assert submission.completed_on is not None
 
     version_valid_on = datetime_in_amsterdam(submission.completed_on).date()
-    catalogus = catalogi_client.find_catalogus(**catalogue)
-    if catalogus is None:
-        raise RuntimeError(f"Could not resolve catalogue {catalogue}")
-
-    versions = catalogi_client.find_informatieobjecttypen(
-        catalogus=catalogus["url"],
+    version = resolver.resolve(
+        catalogue=catalogue,
         description=description,
-        valid_on=version_valid_on,
+        on_date=version_valid_on,
     )
-    if versions is None:
-        raise RuntimeError(
-            f"Could not find a document type with description '{description}' that is "
-            f"valid on {version_valid_on.isoformat()}."
-        )
-
-    version = versions[0]
     return version["url"]
 
 
 def register_submission_pdf(
+    resolver: DocumentTypeResolver,
     submission: Submission,
     options: RegistrationOptions,
     documents_client: DocumentenClient,
-    catalogi_client: CatalogiClient,
 ) -> str:
     document_type = _resolve_documenttype(
-        "submission_report", options, submission, catalogi_client
+        resolver, "submission_report", options, submission
     )
     if not document_type:
         return ""
@@ -152,16 +141,16 @@ def register_submission_pdf(
 
 
 def register_submission_csv(
+    resolver: DocumentTypeResolver,
     submission: Submission,
     options: RegistrationOptions,
     documents_client: DocumentenClient,
-    catalogi_client: CatalogiClient,
 ) -> str:
     if not options.get("upload_submission_csv", False):
         return ""
 
     document_type = _resolve_documenttype(
-        "submission_csv", options, submission, catalogi_client
+        resolver, "submission_csv", options, submission
     )
     if not document_type:
         return ""
@@ -184,14 +173,14 @@ def register_submission_csv(
 
 
 def register_submission_attachment(
+    resolver: DocumentTypeResolver,
     submission: Submission,
     attachment: SubmissionFileAttachment,
     options: RegistrationOptions,
     documents_client: DocumentenClient,
-    catalogi_client: CatalogiClient,
 ) -> str:
     default_document_type = _resolve_documenttype(
-        "attachment", options, submission, catalogi_client
+        resolver, "attachment", options, submission
     )
     assert default_document_type, "Registration should have been skipped"
 
@@ -242,10 +231,10 @@ def register_submission_attachment(
                 }
             )
             document_options["informatieobjecttype"] = _resolve_documenttype(
+                resolver,
                 "attachment",
                 _options,
                 submission,
-                catalogi_client,
             )
 
     attachment_document = create_attachment_document(
@@ -319,20 +308,21 @@ class ObjectsAPIRegistrationHandler[
             get_catalogi_client(api_group) as catalogi_client,
             save_and_raise(registration_data, submission_attachments),
         ):
+            doc_type_resolver = DocumentTypeResolver(catalogi_client)
             if not registration_data.pdf_url:
                 registration_data.pdf_url = register_submission_pdf(
+                    doc_type_resolver,
                     submission,
                     options,
                     documents_client,
-                    catalogi_client,
                 )
 
             if not registration_data.csv_url:
                 registration_data.csv_url = register_submission_csv(
+                    doc_type_resolver,
                     submission,
                     options,
                     documents_client,
-                    catalogi_client,
                 )
 
             if _is_attachment_document_type_configured:
@@ -346,11 +336,11 @@ class ObjectsAPIRegistrationHandler[
                 for attachment in submission.attachments:
                     if attachment not in existing:
                         document_url = register_submission_attachment(
+                            doc_type_resolver,
                             submission,
                             attachment,
                             options,
                             documents_client,
-                            catalogi_client,
                         )
                         submission_attachments.append(
                             ObjectsAPISubmissionAttachment(

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -1,4 +1,5 @@
 import textwrap
+from datetime import UTC, datetime
 from unittest.mock import patch
 from uuid import UUID
 
@@ -1129,6 +1130,76 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                     "editgrid": "[{'time': '12:34:56'}]",
                 },
             },
+        )
+
+    def test_can_upload_attachments_with_indirect_document_type_reference(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            for_test_docker_compose=True,
+            catalogue_domain="TEST",
+            catalogue_rsin="000000000",
+            organisatie_rsin="000000000",
+        )
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "file",
+                    "key": "file",
+                    "label": "File",
+                    "registration": {
+                        "documentType": {
+                            "catalogue": {
+                                "domain": "TEST",
+                                "rsin": "000000000",
+                            },
+                            "description": "Attachment Informatieobjecttype",
+                        },
+                        "informatieobjecttype": "https://example.com/ignore-me",
+                    },
+                }
+            ],
+            submitted_data={},
+            completed=True,
+            # the version of the document types are valid on this timestamp
+            completed_on=datetime(2024, 7, 1, 12, 0, 0).replace(tzinfo=UTC),
+        )
+        attachment = SubmissionFileAttachmentFactory.create(
+            submission_step=submission.steps[0],
+            content_type="image/png",
+            form_key="file",
+            _component_configuration_path="components.0",
+        )
+        options: RegistrationOptionsV1 = {
+            "version": 1,
+            "objects_api_group": objects_api_group,
+            "objecttype": UUID("8e46e0a5-b1b4-449b-b9e9-fa3cea655f48"),
+            "objecttype_version": 3,
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            # a default is required to register file component attachments, aparently
+            "iot_attachment": "PDF Informatieobjecttype",
+            "upload_submission_csv": False,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+        }
+
+        plugin = ObjectsAPIRegistration(PLUGIN_IDENTIFIER)
+
+        # Run the registration
+        plugin.register_submission(submission, options)
+
+        submission.refresh_from_db()
+        assert submission.registration_result
+
+        with get_documents_client(objects_api_group) as documents_client:
+            attachment_document = documents_client.get(
+                ObjectsAPISubmissionAttachment.objects.get(
+                    submission_file_attachment=attachment
+                ).document_url
+            ).json()
+
+        self.assertEqual(
+            attachment_document["informatieobjecttype"],
+            "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
         )
 
 

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -15,6 +15,7 @@ from openforms.config.constants import FamilyMembersDataAPIChoices
 from openforms.config.models import GlobalConfiguration
 from openforms.contrib.haal_centraal.constants import BRPVersions
 from openforms.contrib.haal_centraal.models import HaalCentraalConfig
+from openforms.contrib.objects_api.clients import get_documents_client
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.formio.tests.factories import SubmittedFileFactory
 from openforms.forms.tests.factories import FormVariableFactory
@@ -35,7 +36,11 @@ from openforms.utils.tests.vcr import OFVCRMixin
 from ....constants import RegistrationAttribute
 from ..config import ObjectsAPIOptionsSerializer
 from ..constants import PLUGIN_IDENTIFIER
-from ..models import ObjectsAPIConfig, ObjectsAPIRegistrationData
+from ..models import (
+    ObjectsAPIConfig,
+    ObjectsAPIRegistrationData,
+    ObjectsAPISubmissionAttachment,
+)
 from ..plugin import ObjectsAPIRegistration
 from ..submission_registration import ObjectsAPIV2Handler
 from ..typing import RegistrationOptionsV2
@@ -1477,4 +1482,82 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                 "textfield": "",
                 "nestedTextfield": "",
             },
+        )
+
+    def test_can_upload_attachments_with_indirect_document_type_reference(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            for_test_docker_compose=True,
+            catalogue_domain="TEST",
+            catalogue_rsin="000000000",
+            organisatie_rsin="000000000",
+        )
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "file",
+                    "key": "file",
+                    "label": "File",
+                    "registration": {
+                        "documentType": {
+                            "catalogue": {
+                                "domain": "TEST",
+                                "rsin": "000000000",
+                            },
+                            "description": "Attachment Informatieobjecttype",
+                        },
+                        "informatieobjecttype": "https://example.com/ignore-me",
+                    },
+                }
+            ],
+            submitted_data={},
+            completed=True,
+            # the version of the document types are valid on this timestamp
+            completed_on=datetime(2024, 7, 1, 12, 0, 0).replace(tzinfo=UTC),
+        )
+        attachment = SubmissionFileAttachmentFactory.create(
+            submission_step=submission.steps[0],
+            content_type="image/png",
+            form_key="file",
+            _component_configuration_path="components.0",
+        )
+        options: RegistrationOptionsV2 = {
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            # See the docker compose fixtures for more info on these values:
+            "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
+            "objecttype_version": 1,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "variables_mapping": [
+                {
+                    "variable_key": "environment",
+                    "target_path": ["environment"],
+                },
+            ],
+            "transform_to_list": [],
+            "iot_attachment": "PDF Informatieobjecttype",
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            # a default is required to register file component attachments, aparently
+            "upload_submission_csv": False,
+        }
+
+        plugin = ObjectsAPIRegistration(PLUGIN_IDENTIFIER)
+
+        # Run the registration
+        plugin.register_submission(submission, options)
+
+        submission.refresh_from_db()
+        assert submission.registration_result
+
+        with get_documents_client(objects_api_group) as documents_client:
+            attachment_document = documents_client.get(
+                ObjectsAPISubmissionAttachment.objects.get(
+                    submission_file_attachment=attachment
+                ).document_url
+            ).json()
+
+        self.assertEqual(
+            attachment_document["informatieobjecttype"],
+            "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
         )

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v1/ObjectsAPIBackendV1Tests/test_can_upload_attachments_with_indirect_document_type_reference.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v1/ObjectsAPIBackendV1Tests/test_can_upload_attachments_with_indirect_document_type_reference.yaml
@@ -1,0 +1,356 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=PDF+Informatieobjecttype&datumGeldigheid=2024-07-01
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '850'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=Attachment+Informatieobjecttype&datumGeldigheid=2024-07-01
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774"],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
+      "bronorganisatie": "000000000", "creatiedatum": "2026-05-08", "titel": "Form
+      000", "auteur": "Aanvrager", "taal": "nld", "formaat": "image/png", "inhoud":
+      "Y29udGVudA==", "status": "definitief", "bestandsnaam": "add.mov", "ontvangstdatum":
+      "2024-07-01", "beschrijving": "Bijgevoegd document", "indicatieGebruiksrecht":
+      false, "bestandsomvang": 7}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '471'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322","identificatie":"DOCUMENT-2026-0000000061","bronorganisatie":"000000000","creatiedatum":"2026-05-08","titel":"Form
+        000","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"image/png","taal":"nld","versie":1,"beginRegistratie":"2026-05-08T14:29:03.214677Z","bestandsnaam":"add.mov","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-07-01","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1027'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","uuid":"8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","name":"Person","namePlural":"Persons","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2023-10-24","modifiedAt":"2024-11-25","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/1","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/2","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/4","http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48/versions/3"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '887'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 08 May 2026 14:29:03 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.7
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+      "record": {"typeVersion": 3, "data": {"bron": {"naam": "Open Formulieren", "kenmerk":
+      "6db972f3-769a-4f16-967b-c760165b822d"}, "type": "terugbelnotitie", "aanvraaggegevens":
+      {"fd-0": {"file": null}}, "taal": "nl", "betrokkenen": [{"inpBsn": "", "rolOmschrijvingGeneriek":
+      "initiator"}], "pdf": "", "csv": "", "bijlagen": ["http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322"],
+      "payment": {"completed": false, "amount": 0, "public_order_ids": [], "payment_ids":
+      []}}, "startAt": "2026-05-08"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '644'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/e4f521e3-6c5a-46a2-b2ca-b439094afaae","uuid":"e4f521e3-6c5a-46a2-b2ca-b439094afaae","type":"http://objecttypes-web:8000/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bron":{"naam":"Open
+        Formulieren","kenmerk":"6db972f3-769a-4f16-967b-c760165b822d"},"type":"terugbelnotitie","aanvraaggegevens":{"fd-0":{"file":null}},"taal":"nl","betrokkenen":[{"inpBsn":"","rolOmschrijvingGeneriek":"initiator"}],"pdf":"","csv":"","bijlagen":["http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322"],"payment":{"completed":false,"amount":0,"public_order_ids":[],"payment_ids":[]}},"geometry":null,"startAt":"2026-05-08","endAt":null,"registrationAt":"2026-05-08","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '843'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 08 May 2026 14:29:03 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/e4f521e3-6c5a-46a2-b2ca-b439094afaae
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.7
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322","identificatie":"DOCUMENT-2026-0000000061","bronorganisatie":"000000000","creatiedatum":"2026-05-08","titel":"Form
+        000","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"image/png","taal":"nld","versie":1,"beginRegistratie":"2026-05-08T14:29:03.214677Z","bestandsnaam":"add.mov","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/239dd9a7-a46a-4a95-a569-df5964164322/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-07-01","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1017'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"22547e2b8af384295adae7e487b51bd9"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_can_upload_attachments_with_indirect_document_type_reference.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_can_upload_attachments_with_indirect_document_type_reference.yaml
@@ -1,0 +1,352 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=PDF+Informatieobjecttype&datumGeldigheid=2024-07-01
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":[],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '850'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=Attachment+Informatieobjecttype&datumGeldigheid=2024-07-01
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-03-19","eindeGeldigheid":"2024-07-10","concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774"],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1117'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
+      "bronorganisatie": "000000000", "creatiedatum": "2024-03-19", "titel": "Form
+      001", "auteur": "Aanvrager", "taal": "nld", "formaat": "image/png", "inhoud":
+      "Y29udGVudA==", "status": "definitief", "bestandsnaam": "wind.gif", "ontvangstdatum":
+      "2024-07-01", "beschrijving": "Bijgevoegd document", "indicatieGebruiksrecht":
+      false, "bestandsomvang": 7}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '472'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b482f78b-0ca6-461f-a840-1adbda94b9a6","identificatie":"DOCUMENT-2024-0000000003","bronorganisatie":"000000000","creatiedatum":"2024-03-19","titel":"Form
+        001","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"image/png","taal":"nld","versie":1,"beginRegistratie":"2026-05-08T14:29:04.047176Z","bestandsnaam":"wind.gif","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b482f78b-0ca6-461f-a840-1adbda94b9a6/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-07-01","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1028'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b482f78b-0ca6-461f-a840-1adbda94b9a6
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+        everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '619'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 08 May 2026 14:29:04 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.7
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e",
+      "record": {"typeVersion": 1, "data": {"environment": "development"}, "startAt":
+      "2024-03-19"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '190'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/27500bf5-fb6b-4416-ac4f-6d6aab87bae2","uuid":"27500bf5-fb6b-4416-ac4f-6d6aab87bae2","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"environment":"development"},"geometry":null,"startAt":"2024-03-19","endAt":null,"registrationAt":"2026-05-08","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '420'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Fri, 08 May 2026 14:29:04 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/27500bf5-fb6b-4416-ac4f-6d6aab87bae2
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.7
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b482f78b-0ca6-461f-a840-1adbda94b9a6
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b482f78b-0ca6-461f-a840-1adbda94b9a6","identificatie":"DOCUMENT-2024-0000000003","bronorganisatie":"000000000","creatiedatum":"2024-03-19","titel":"Form
+        001","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"image/png","taal":"nld","versie":1,"beginRegistratie":"2026-05-08T14:29:04.047176Z","bestandsnaam":"wind.gif","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/b482f78b-0ca6-461f-a840-1adbda94b9a6/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-07-01","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","locked":false,"bestandsdelen":[],"trefwoorden":[]}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1018'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"005c8a359b3f6932022046ed5c43ab98"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -627,7 +627,7 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
                     )
                     _catalogue = document_type_configuration.get("catalogue", {})
                     if (
-                        document_type_description
+                        _document_type_description
                         and (_catalogue_domain := _catalogue.get("domain"))
                         and (_catalogue_rsin := _catalogue.get("rsin"))
                     ):

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -134,6 +134,7 @@ def _resolve_case_type(
     return version["url"]
 
 
+# TODO: cache lookups
 def _resolve_document_type(
     catalogi_client: CatalogiClient,
     catalogue: CatalogueOption,
@@ -611,9 +612,36 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
 
             # TODO: threading? asyncio?
             for attachment in submission.attachments:
+                # default/legacy behaviour, but override it with specific catalogue +
+                # description configuration when available
+                iot = attachment.informatieobjecttype or informatieobjecttype_url
                 # collect attributes of the attachment and add them to the configuration
                 # attribute names conform to the Documenten API specification
-                iot = attachment.informatieobjecttype or informatieobjecttype_url
+                file_component = attachment.component
+                if file_component is not None:
+                    document_type_configuration = file_component.get(
+                        "registration", {}
+                    ).get("documentType", {})
+                    _document_type_description = document_type_configuration.get(
+                        "description", ""
+                    )
+                    _catalogue = document_type_configuration.get("catalogue", {})
+                    if (
+                        document_type_description
+                        and (_catalogue_domain := _catalogue.get("domain"))
+                        and (_catalogue_rsin := _catalogue.get("rsin"))
+                    ):
+                        iot = _resolve_document_type(
+                            catalogi_client,
+                            catalogue={
+                                "domain": _catalogue_domain,
+                                "rsin": _catalogue_rsin,
+                            },
+                            zaaktype_url=zaak["zaaktype"],
+                            description=_document_type_description,
+                            submission_completed=submission.completed_on,
+                        )
+
                 bronorganisatie = (
                     attachment.bronorganisatie or options["organisatie_rsin"]
                 )

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -25,6 +25,7 @@ from openforms.contrib.zgw.clients.catalogi import (
 )
 from openforms.contrib.zgw.service import (
     DocumentOptions,
+    DocumentTypeResolver,
     create_attachment_document,
     create_report_document,
 )
@@ -134,35 +135,19 @@ def _resolve_case_type(
     return version["url"]
 
 
-# TODO: cache lookups
 def _resolve_document_type(
-    catalogi_client: CatalogiClient,
+    resolver: DocumentTypeResolver,
     catalogue: CatalogueOption,
     zaaktype_url: str,
     description: str,
     submission_completed: datetime,
-):
-    version_valid_on = datetime_in_amsterdam(submission_completed).date()
-
-    catalogus = catalogi_client.find_catalogus(**catalogue)
-    if catalogus is None:
-        raise RuntimeError(f"Could not resolve catalogue {catalogue}")
-    versions = catalogi_client.find_informatieobjecttypen(
-        catalogus=catalogus["url"],
+) -> str:
+    version = resolver.resolve(
+        catalogue=catalogue,
         description=description,
-        valid_on=version_valid_on,
+        on_date=datetime_in_amsterdam(submission_completed).date(),
         within_casetype=zaaktype_url,
     )
-    if versions is None:
-        raise RuntimeError(
-            "Could not find a document type with description "
-            f"'{description}' in the case type that is valid on "
-            f"{version_valid_on.isoformat()}."
-        )
-
-    # the client enforces there's a single version returned when a valid_on date is
-    # passed.
-    version = versions[0]
     return version["url"]
 
 
@@ -413,12 +398,14 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
             get_zaken_client(zgw) as zaken_client,
             get_catalogi_client(zgw) as catalogi_client,
         ):
+            doc_type_resolver = DocumentTypeResolver(catalogi_client)
+
             # resolve (default) document type to use
             if document_type_description := options["document_type_description"]:
                 catalogue = options.get("catalogue")
                 assert catalogue is not None  # enforced by validation
                 informatieobjecttype_url = _resolve_document_type(
-                    catalogi_client,
+                    doc_type_resolver,
                     catalogue=catalogue,
                     zaaktype_url=zaak["zaaktype"],
                     description=document_type_description,
@@ -632,7 +619,7 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
                         and (_catalogue_rsin := _catalogue.get("rsin"))
                     ):
                         iot = _resolve_document_type(
-                            catalogi_client,
+                            doc_type_resolver,
                             catalogue={
                                 "domain": _catalogue_domain,
                                 "rsin": _catalogue_rsin,

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -2989,3 +2989,75 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
 
         self.assertEqual(zaak_data["omschrijving"], "Some form")
         self.assertEqual(zaak_data["toelichting"], "")
+
+    def test_can_upload_attachments_with_indirect_document_type_reference(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "file",
+                    "key": "file",
+                    "label": "File",
+                    "registration": {
+                        "documentType": {
+                            "catalogue": {
+                                "domain": "TEST",
+                                "rsin": "000000000",
+                            },
+                            "description": "Attachment Informatieobjecttype",
+                        },
+                        "informatieobjecttype": "https://example.com/ignore-me",
+                    },
+                }
+            ],
+            form__name="Public form name",
+            form__internal_name="Internal form name",
+            form__registration_backend="zgw-create-zaak",
+            bsn="111222333",
+            completed=True,
+            # Pin to a known case & document type version
+            completed_on=datetime(2024, 11, 9, 15, 30, 0).replace(tzinfo=UTC),
+        )
+        attachment = SubmissionFileAttachmentFactory.create(
+            submission_step=submission.steps[0],
+            content_type="image/png",
+            form_key="file",
+            _component_configuration_path="components.0",
+        )
+        options: RegistrationOptions = {
+            "zgw_api_group": self.zgw_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "ZT-001",
+            "document_type_description": "PDF Informatieobjecttype",
+            "zaaktype": "",
+            "informatieobjecttype": "",
+            "organisatie_rsin": "000000000",
+            # empty value should be ignored, use the VA from the zaaktype
+            "zaak_vertrouwelijkheidaanduiding": "",
+            "objects_api_group": None,
+            "product_url": "",
+            "partners_roltype": "",
+            "partners_description": "",
+            "children_roltype": "",
+            "children_description": "",
+            # empty-ish value should fall back to default
+            "auteur": "",
+        }
+        plugin = ZGWRegistration("zgw")
+        _run_preregistration(submission, plugin, options)
+
+        plugin.register_submission(submission, options)
+
+        submission.refresh_from_db()
+        assert submission.registration_result
+
+        document_results = submission.registration_result["intermediate"]["documents"]
+        resolved_document_type = document_results[str(attachment.pk)]["document"][
+            "informatieobjecttype"
+        ]
+        # UUID copied from Open Zaak admin based on fixture data
+        self.assertTrue(
+            resolved_document_type.endswith("/7755ab0f-9e37-4834-8bbf-158f9f2da38e")
+        )

--- a/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_can_upload_attachments_with_indirect_document_type_reference.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/ZGWBackendVCRTests/test_can_upload_attachments_with_indirect_document_type_reference.yaml
@@ -1,0 +1,744 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&identificatie=ZT-001&datumGeldigheid=2024-11-09
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost:81/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555","http://localhost:8003/catalogi/api/v1/eigenschappen/f376c43d-97f6-423c-a25c-9264142db235"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '2325'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaaktype": "http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774",
+      "bronorganisatie": "000000000", "verantwoordelijkeOrganisatie": "000000000",
+      "registratiedatum": "2026-05-08", "startdatum": "2026-05-08", "productenOfDiensten":
+      [], "omschrijving": "Public form name", "toelichting": "Aangemaakt door Open
+      Formulieren", "betalingsindicatie": "nvt"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Crs:
+      - EPSG:4326
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '382'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaken
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab","uuid":"39922637-041d-481b-966b-2d984273afab","identificatie":"ZAAK-2026-0000000045","bronorganisatie":"000000000","omschrijving":"Public
+        form name","toelichting":"Aangemaakt door Open Formulieren","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","registratiedatum":"2026-05-08","verantwoordelijkeOrganisatie":"000000000","startdatum":"2026-05-08","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"intern","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+        is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '1397'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=PDF+Informatieobjecttype&datumGeldigheid=2024-11-09
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"PDF
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-11","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774"],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '928'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost:81/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555","http://localhost:8003/catalogi/api/v1/eigenschappen/f376c43d-97f6-423c-a25c-9264142db235"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '2273'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"14cb0d757ba364562edbb66412778d30"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71",
+      "bronorganisatie": "000000000", "creatiedatum": "2026-05-08", "titel": "Public
+      form name", "auteur": "Aanvrager", "taal": "nld", "formaat": "application/pdf",
+      "inhoud": "", "status": "definitief", "bestandsnaam": "open-forms-Public form
+      name.pdf", "ontvangstdatum": null, "beschrijving": "Ingezonden formulier", "indicatieGebruiksrecht":
+      false, "bestandsomvang": 0}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '490'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/3b743dad-a222-4558-9308-a761a39cc67c","identificatie":"DOCUMENT-2026-0000000057","bronorganisatie":"000000000","creatiedatum":"2026-05-08","titel":"Public
+        form name","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"application/pdf","taal":"nld","versie":1,"beginRegistratie":"2026-05-08T12:57:16.938567Z","bestandsnaam":"open-forms-Public
+        form name.pdf","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/3b743dad-a222-4558-9308-a761a39cc67c/download?versie=1","bestandsomvang":0,"link":"","beschrijving":"Ingezonden
+        formulier","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1058'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/3b743dad-a222-4558-9308-a761a39cc67c
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab",
+      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/3b743dad-a222-4558-9308-a761a39cc67c"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '219'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaakinformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/565183d4-b981-43c9-a975-979fd9a836fc","uuid":"565183d4-b981-43c9-a975-979fd9a836fc","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/3b743dad-a222-4558-9308-a761a39cc67c","zaak":"http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab","aardRelatieWeergave":"Hoort
+        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2026-05-08T12:57:17.089929Z","vernietigingsdatum":null,"status":null}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '534'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/565183d4-b981-43c9-a975-979fd9a836fc
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Ff609b6fe-449a-46dc-a0af-de55dc5f6774&omschrijvingGeneriek=initiator
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","zaaktypeIdentificatie":"ZT-001","omschrijving":"Initiator","omschrijvingGeneriek":"initiator","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","beginGeldigheid":null,"eindeGeldigheid":null,"beginObject":null,"eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '524'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab",
+      "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8",
+      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      {"inpBsn": "111222333", "vestigingsNummer": ""}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/rollen
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/a16d3c3b-326c-4a5f-b519-8c701d34b537","uuid":"a16d3c3b-326c-4a5f-b519-8c701d34b537","zaak":"http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","omschrijving":"Initiator","omschrijvingGeneriek":"initiator","roltoelichting":"inzender
+        formulier","registratiedatum":"2026-05-08T12:57:17.288652Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"111222333","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '935'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/rollen/a16d3c3b-326c-4a5f-b519-8c701d34b537
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/statustypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Ff609b6fe-449a-46dc-a0af-de55dc5f6774
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47","omschrijving":"Ontvangen","omschrijvingGeneriek":"","statustekst":"","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","zaaktypeIdentificatie":"ZT-001","volgnummer":1,"isEindstatus":false,"informeren":false,"doorlooptijd":null,"toelichting":null,"checklistitemStatustype":[],"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","eigenschappen":[],"zaakobjecttypen":[],"beginGeldigheid":null,"eindeGeldigheid":null,"beginObject":null,"eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","omschrijving":"Afgerond","omschrijvingGeneriek":"","statustekst":"","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","zaaktypeIdentificatie":"ZT-001","volgnummer":2,"isEindstatus":true,"informeren":false,"doorlooptijd":null,"toelichting":null,"checklistitemStatustype":[],"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","eigenschappen":[],"zaakobjecttypen":[],"beginGeldigheid":null,"eindeGeldigheid":null,"beginObject":null,"eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1343'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab",
+      "statustype": "http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47",
+      "datumStatusGezet": "2026-05-08T12:57:17.405993+00:00", "statustoelichting":
+      ""}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/statussen
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/af61e7f5-4293-4f8d-af77-7ce6ebf34dd2","uuid":"af61e7f5-4293-4f8d-af77-7ce6ebf34dd2","zaak":"http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47","datumStatusGezet":"2026-05-08T12:57:17.405993Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '479'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/statussen/af61e7f5-4293-4f8d-af77-7ce6ebf34dd2
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=Attachment+Informatieobjecttype&datumGeldigheid=2024-11-09
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-10","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1022'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost:81/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555","http://localhost:8003/catalogi/api/v1/eigenschappen/f376c43d-97f6-423c-a25c-9264142db235"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '2273'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"14cb0d757ba364562edbb66412778d30"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e",
+      "bronorganisatie": "000000000", "creatiedatum": "2026-05-08", "titel": "window.wav",
+      "auteur": "Aanvrager", "taal": "nld", "formaat": "image/png", "inhoud": "Y29udGVudA==",
+      "status": "definitief", "bestandsnaam": "window.wav", "ontvangstdatum": "2024-11-09",
+      "beschrijving": "Bijgevoegd document", "indicatieGebruiksrecht": false, "bestandsomvang":
+      7}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '476'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c2129780-5a3a-4977-829d-3dfc31b874c1","identificatie":"DOCUMENT-2026-0000000058","bronorganisatie":"000000000","creatiedatum":"2026-05-08","titel":"window.wav","vertrouwelijkheidaanduiding":"openbaar","auteur":"Aanvrager","status":"definitief","formaat":"image/png","taal":"nld","versie":1,"beginRegistratie":"2026-05-08T12:57:17.801528Z","bestandsnaam":"window.wav","inhoud":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c2129780-5a3a-4977-829d-3dfc31b874c1/download?versie=1","bestandsomvang":7,"link":"","beschrijving":"Bijgevoegd
+        document","ontvangstdatum":"2024-11-09","verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e","locked":false,"bestandsdelen":[],"trefwoorden":[],"lock":""}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1032'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c2129780-5a3a-4977-829d-3dfc31b874c1
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab",
+      "informatieobject": "http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c2129780-5a3a-4977-829d-3dfc31b874c1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '219'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaakinformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/b60cf665-0161-4d62-b2d9-a31c8c5f1834","uuid":"b60cf665-0161-4d62-b2d9-a31c8c5f1834","informatieobject":"http://localhost:8003/documenten/api/v1/enkelvoudiginformatieobjecten/c2129780-5a3a-4977-829d-3dfc31b874c1","zaak":"http://localhost:8003/zaken/api/v1/zaken/39922637-041d-481b-966b-2d984273afab","aardRelatieWeergave":"Hoort
+        bij, omgekeerd: kent","titel":"","beschrijving":"","registratiedatum":"2026-05-08T12:57:17.962319Z","vernietigingsdatum":null,"status":null}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '534'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaakinformatieobjecten/b60cf665-0161-4d62-b2d9-a31c8c5f1834
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/src/openforms/submissions/models/submission_files.py
+++ b/src/openforms/submissions/models/submission_files.py
@@ -11,12 +11,14 @@ from typing import TYPE_CHECKING, ClassVar
 from django.core.files.base import File
 from django.db import models
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 import structlog
 from glom import glom
 from privates.fields import PrivateMediaFileField
 
+from openforms.formio.typing import FileComponent
 from openforms.typing import JSONValue
 from openforms.utils.files import DeleteFileFieldFilesMixin, DeleteFilesQuerySetMixin
 
@@ -234,18 +236,30 @@ class SubmissionFileAttachment(DeleteFileFieldFilesMixin, models.Model):
                 sha256.update(chunk)
         return sha256.hexdigest()
 
+    @cached_property
+    def component(self) -> FileComponent | None:
+        """
+        Resolve the formio component definition that produced this attachment.
+
+        .. todo:: Clean up upload processing so that ``None`` can never happen. See
+            https://github.com/open-formulieren/open-forms/issues/2713
+
+        :return: Component dict or ``None`` if it could not be resolved.
+        """
+        wrapper = self.submission_step.form_step.form_definition.configuration_wrapper
+        component = wrapper.flattened_by_path.get(self._component_configuration_path)
+        return component
+
     def _get_formio_config_property(
         self, lookup: str, default: JSONValue = ""
     ) -> str | None:
         """
         Derive a property from the attached formio configuration.
         """
-        wrapper = self.submission_step.form_step.form_definition.configuration_wrapper
-        component = wrapper.flattened_by_path.get(self._component_configuration_path)
-        if not component:
+        if not self.component:
             return None
 
-        if value := glom(component, lookup, default=default):
+        if value := glom(self.component, lookup, default=default):
             assert isinstance(value, str)
             return value
 


### PR DESCRIPTION
Closes #6269

**Changes**

The `file` component now supports registration configuration where the catalogue identifier and document type descrition are specified. This is paired against the configured API group's catalogi API service and resolves into the correct version of a document type for a given submission.

Additionally, I've added some optimization to avoid looking up the same catalogue and/or document types over and over if multiple similar configurations are provided.

Finally, the file component configuration is quite cumbersome, so I added an option to copy registration plugin options into the components which we can do in JS quite easily, that should reduce the impact for form builders.

Problem detection with mis-matched configuration is deferred and will be implemented as part of #6262

I verified that uploads inside repeating groups are also properly picked up in the component table.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
