### PR TITLE
Remove pip in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         # weasyprint deps, see https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#debian-11
         libpango-1.0-0 \
         libpangoft2-1.0-0 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && pip uninstall --yes --root-user-action ignore pip
 
 WORKDIR /app
 COPY ./bin/docker_start.sh /start.sh


### PR DESCRIPTION
Extra security/hardening of the docker image: remove the pip python package manager. Sometimes it shows up in image scanning results with known vulnerabilities. Even though pip is not reachable (or supposed to be) from the application, we can be better safe than sorry by just not making it available at all.

We do not need pip in the production image, and the default unprivileged container user doesn't even have permissions to write to the site- packages directory, so having it present has no use.

[skip: e2e]