### PR TITLE
Create digital address for betrokkene in Customer Interactions API

### DIFF
--- a/docs/configuration/prefill/communication_preferences.rst
+++ b/docs/configuration/prefill/communication_preferences.rst
@@ -94,14 +94,20 @@ The communication preferences prefill configuration is also used to update commu
 Customer Interactions API. To enable it you need to check "Open Forms should update customer data after submission"
 in the "Profile" component configuration.
 
-When the form is submitted Open Forms records following data in the Customer Interactions API:
+When the form is submitted, Open Forms records the following data in the Customer Interactions API:
 
-* klantcontact
-* betrokkene
-* onderwerpobject, where a public reference of the submission is stored
-* digitaleadressen, where new communication preferences are stored if user has chosen "Sla mijn gegevens op
-  voor de volgende keer." while filling the form.
-* partij, if user is authenticated in the form, but unknown in the Customer Interactions API.
+* ``klantcontact``
+* ``betrokkene``
+* ``onderwerpobject``, where a public reference of the submission is stored
+* ``digitaleadressen``:
+
+    The new and updated digital addresses for this interaction. The digital addresses are either linked to:
+
+    * ``betrokkene`` if the user is not authenticated or the selected address already exists for this ``partij``
+    * ``partij`` if the user is authenticated and they use the new address and choose "Sla mijn gegevens op
+      voor de volgende keer." while filling the form.
+
+* ``partij``, if user is authenticated in the form, but unknown in the Customer Interactions API.
 
 Technical
 =========

--- a/docs/developers/backend/modules/authentication.rst
+++ b/docs/developers/backend/modules/authentication.rst
@@ -95,7 +95,7 @@ details.
 Requesting attributes using the condiscon system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`Condiscon <https://docs.yivi.app/condiscon/>`_ is a Yivi-specific way of defining the
+`Condiscon <https://docs.yivi.app/session-requests/>`_ is a Yivi-specific way of defining the
 authentication attributes to request from users. With condiscon you define a multi-layer
 conditional data structure, which provides users more control over which attributes they
 do and don't provide.
@@ -116,7 +116,7 @@ scope standard.
 
    - For the Yivi authentication to be successful, at least *one* attribute needs to be
      disclosed.
-   - The order of `optional disjunction <https://docs.yivi.app/condiscon/#other-features>`_
+   - The order of `optional disjunction <https://docs.yivi.app/session-requests/#optional-disjunctions>`_
      matters. Make sure that the "empty" option is the last item in the disjunction list.
 
      Example of a valid optional disjunction:

--- a/pyright.pyproject.toml
+++ b/pyright.pyproject.toml
@@ -112,7 +112,6 @@ exclude = [
     "src/openforms/authentication/contrib/digid/tests/test_auth_procedure.py",
     "src/openforms/authentication/contrib/digid/tests/test_signicat_integration.py",
     "src/openforms/authentication/contrib/eherkenning/tests/test_signicat_integration.py",
-    "src/openforms/contrib/customer_interactions/tests/",
     "src/openforms/contrib/objects_api/tests/",
     "src/openforms/contrib/objects_api/json_schema.py",
     "src/openforms/formio/formatters/tests/",

--- a/src/openforms/contrib/customer_interactions/tests/factories.py
+++ b/src/openforms/contrib/customer_interactions/tests/factories.py
@@ -12,7 +12,7 @@ class CustomerInteractionsAPIGroupConfigFactory(factory.django.DjangoModelFactor
         "zgw_consumers.test.factories.ServiceFactory", api_type=APITypes.kc
     )
 
-    class Meta:
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = CustomerInteractionsAPIGroupConfig
 
     class Params:

--- a/src/openforms/contrib/customer_interactions/tests/mixins.py
+++ b/src/openforms/contrib/customer_interactions/tests/mixins.py
@@ -9,7 +9,7 @@ class CustomerInteractionsMixin:
 
     @classmethod
     def setUpTestData(cls):
-        super().setUpTestData()
+        super().setUpTestData()  # pyright: ignore[reportAttributeAccessIssue]
 
         cls.config = CustomerInteractionsAPIGroupConfigFactory.create(
             for_test_docker_compose=True
@@ -20,6 +20,6 @@ class CustomerInteractionsMixin:
         found_address = next((da for da in results if da["adres"] == adres), None)
         assert found_address is not None
         for property, expected_value in expected_address.items():
-            self.assertEqual(
+            self.assertEqual(  # pyright: ignore[reportAttributeAccessIssue]
                 expected_value, found_address[property], f"for address {adres}"
             )

--- a/src/openforms/contrib/customer_interactions/tests/test_update_customer_interaction_data.py
+++ b/src/openforms/contrib/customer_interactions/tests/test_update_customer_interaction_data.py
@@ -330,11 +330,11 @@ class UpdateCustomerInteractionDataTests(
         # both addresses are known in the Open Klant
         profile_data: list[DigitalAddress] = [
             {
-                "address": "someemail@example.org",
+                "address": "someemail@example.org",  # not default
                 "type": "email",
             },
             {
-                "address": "0687654321",
+                "address": "0612345678",  # default
                 "type": "phoneNumber",
             },
         ]
@@ -401,8 +401,19 @@ class UpdateCustomerInteractionDataTests(
             {"url": party["url"], "uuid": partij_uuid},
         )
 
-        # no new address is added
-        self.assertEqual(digital_addresses["created"], [])
+        # not default address is created for betrokkene
+        self.assertEqual(len(digital_addresses["created"]), 1)
+        expected_address: ExpectedDigitalAddress = {
+            "adres": "someemail@example.org",
+            "soortDigitaalAdres": "email",
+            "isStandaardAdres": False,
+            "verstrektDoorPartij": None,
+            "verstrektDoorBetrokkene": {
+                "url": betrokkene["url"],
+                "uuid": betrokkene["uuid"],
+            },
+        }
+        self.assertAddressPresent(digital_addresses["created"], expected_address)
         self.assertEqual(digital_addresses["updated"], [])
 
     def test_auth_with_bsn_user_known_in_openklant_known_addresses_with_different_preference(

--- a/src/openforms/contrib/customer_interactions/tests/test_update_customer_interaction_data.py
+++ b/src/openforms/contrib/customer_interactions/tests/test_update_customer_interaction_data.py
@@ -52,6 +52,7 @@ class UpdateCustomerInteractionDataTests(
         )
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -151,6 +152,7 @@ class UpdateCustomerInteractionDataTests(
         )
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -162,6 +164,7 @@ class UpdateCustomerInteractionDataTests(
             party = client.find_party_for_bsn("108915864")
 
         # check that party is linked to the user
+        assert party is not None
         self.assertEqual(party["uuid"], partij_uuid)
         self.assertEqual(klantcontact["kanaal"], "Webformulier")
         self.assertEqual(klantcontact["onderwerp"], "With profile")
@@ -256,6 +259,7 @@ class UpdateCustomerInteractionDataTests(
         prefill_variables(submission=submission)
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -266,6 +270,7 @@ class UpdateCustomerInteractionDataTests(
         with get_customer_interactions_client(self.config) as client:
             party = client.find_party_for_bsn("123456782")
 
+        assert party is not None
         self.assertEqual(party["uuid"], partij_uuid)
         self.assertEqual(klantcontact["kanaal"], "Webformulier")
         self.assertEqual(klantcontact["onderwerp"], "With profile")
@@ -364,6 +369,7 @@ class UpdateCustomerInteractionDataTests(
         prefill_variables(submission=submission)
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -374,6 +380,7 @@ class UpdateCustomerInteractionDataTests(
         with get_customer_interactions_client(self.config) as client:
             party = client.find_party_for_bsn("123456782")
 
+        assert party is not None
         self.assertEqual(party["uuid"], partij_uuid)
         self.assertEqual(klantcontact["kanaal"], "Webformulier")
         self.assertEqual(klantcontact["onderwerp"], "With profile")
@@ -449,6 +456,7 @@ class UpdateCustomerInteractionDataTests(
         prefill_variables(submission=submission)
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -459,6 +467,7 @@ class UpdateCustomerInteractionDataTests(
         with get_customer_interactions_client(self.config) as client:
             party = client.find_party_for_bsn("123456782")
 
+        assert party is not None
         self.assertEqual(party["uuid"], partij_uuid)
         self.assertEqual(klantcontact["kanaal"], "Webformulier")
         self.assertEqual(klantcontact["onderwerp"], "With profile")
@@ -553,6 +562,7 @@ class UpdateCustomerInteractionDataTests(
         )
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -564,6 +574,7 @@ class UpdateCustomerInteractionDataTests(
             party = client.find_party_for_kvk("11122233")
 
         # check that party is linked to the organization
+        assert party is not None
         self.assertEqual(party["uuid"], partij_uuid)
         self.assertEqual(klantcontact["kanaal"], "Webformulier")
         self.assertEqual(klantcontact["onderwerp"], "With profile")
@@ -658,6 +669,7 @@ class UpdateCustomerInteractionDataTests(
         prefill_variables(submission=submission)
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]
@@ -668,6 +680,7 @@ class UpdateCustomerInteractionDataTests(
         with get_customer_interactions_client(self.config) as client:
             party = client.find_party_for_kvk("12345678")
 
+        assert party is not None
         self.assertEqual(party["uuid"], partij_uuid)
         self.assertEqual(klantcontact["kanaal"], "Webformulier")
         self.assertEqual(klantcontact["onderwerp"], "With profile")
@@ -785,6 +798,7 @@ class UpdateCustomerInteractionDataTests(
         )
 
         result = update_customer_interaction_data(submission, "profile")
+        assert result is not None
 
         klantcontact = result["klantcontact"]
         betrokkene = result["betrokkene"]

--- a/src/openforms/contrib/customer_interactions/tests/vcr_cassettes/test_update_customer_interaction_data/UpdateCustomerInteractionDataTests/test_auth_with_bsn_user_known_in_openklant_known_addresses.yaml
+++ b/src/openforms/contrib/customer_interactions/tests/vcr_cassettes/test_update_customer_interaction_data/UpdateCustomerInteractionDataTests/test_auth_with_bsn_user_known_in_openklant_known_addresses.yaml
@@ -15,10 +15,11 @@ interactions:
       Content-Length:
       - '2616'
       Content-Security-Policy:
-      - 'frame-src ''self''; font-src ''self'' fonts.gstatic.com; worker-src ''self''
-        blob:; object-src ''none''; form-action ''self''; default-src ''self''; base-uri
-        ''self''; img-src ''self'' data: cdn.redoc.ly; script-src ''self'' ''unsafe-inline'';
-        frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; frame-src ''self''; object-src ''none''; font-src
+        ''self'' fonts.gstatic.com; form-action ''self''; default-src ''self''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; base-uri
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -41,7 +42,7 @@ interactions:
     uri: http://localhost:8005/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9","nummer":"0000000001","interneNotitie":"","betrokkenen":[],"categorieRelaties":[],"digitaleAdressen":[{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},{"uuid":"1a7308a4-f52b-4e3c-9bcf-2f402617422c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1a7308a4-f52b-4e3c-9bcf-2f402617422c"},{"uuid":"3d8d396f-7af5-4ab4-b414-60b1a1bcd341","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/3d8d396f-7af5-4ab4-b414-60b1a1bcd341"},{"uuid":"9cc8ef7a-ceea-4e92-adc4-4486958d38ca","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/9cc8ef7a-ceea-4e92-adc4-4486958d38ca"},{"uuid":"1817f1d5-2e3f-4569-9a8c-8b224a7f388c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1817f1d5-2e3f-4569-9a8c-8b224a7f388c"}],"voorkeursDigitaalAdres":{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"50eea111-6836-4f0b-877e-c0b0ed577d8b","url":"http://localhost:8005/klantinteracties/api/v1/partij-identificatoren/50eea111-6836-4f0b-877e-c0b0ed577d8b","identificeerdePartij":{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":null,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"J","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"31801874-914e-4e6a-b87b-9a76d287a621","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/31801874-914e-4e6a-b87b-9a76d287a621"},{"uuid":"9b7d54b6-db34-43c0-b4e4-64edf698f282","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/9b7d54b6-db34-43c0-b4e4-64edf698f282"},{"uuid":"ec952c77-322c-466e-9292-2a227ca80d01","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/ec952c77-322c-466e-9292-2a227ca80d01"},{"uuid":"24f6cd9c-af17-401b-a17e-bc4f49a9ab92","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/24f6cd9c-af17-401b-a17e-bc4f49a9ab92"},{"uuid":"7c614e26-575d-48e7-b10a-4b0b31ccbcf0","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/7c614e26-575d-48e7-b10a-4b0b31ccbcf0"},{"uuid":"be7ba874-3728-49cc-b185-65e99165a794","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/be7ba874-3728-49cc-b185-65e99165a794"}],"categorieRelaties":[],"digitaleAdressen":[{"uuid":"3d8d396f-7af5-4ab4-b414-60b1a1bcd341","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/3d8d396f-7af5-4ab4-b414-60b1a1bcd341"},{"uuid":"1817f1d5-2e3f-4569-9a8c-8b224a7f388c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1817f1d5-2e3f-4569-9a8c-8b224a7f388c"},{"uuid":"1a7308a4-f52b-4e3c-9bcf-2f402617422c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1a7308a4-f52b-4e3c-9bcf-2f402617422c"},{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},{"uuid":"9cc8ef7a-ceea-4e92-adc4-4486958d38ca","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/9cc8ef7a-ceea-4e92-adc4-4486958d38ca"}],"voorkeursDigitaalAdres":{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"50eea111-6836-4f0b-877e-c0b0ed577d8b","url":"http://localhost:8005/klantinteracties/api/v1/partij-identificatoren/50eea111-6836-4f0b-877e-c0b0ed577d8b","identificeerdePartij":{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":null,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"J","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"John
         Smith"},"_expand":{}}]}'
     headers:
       API-version:
@@ -49,12 +50,13 @@ interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '2532'
+      - '3437'
       Content-Security-Policy:
-      - 'frame-src ''self''; font-src ''self'' fonts.gstatic.com; worker-src ''self''
-        blob:; object-src ''none''; form-action ''self''; default-src ''self''; base-uri
-        ''self''; img-src ''self'' data: cdn.redoc.ly; script-src ''self'' ''unsafe-inline'';
-        frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; frame-src ''self''; object-src ''none''; font-src
+        ''self'' fonts.gstatic.com; form-action ''self''; default-src ''self''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; base-uri
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
@@ -86,8 +88,8 @@ interactions:
     uri: http://localhost:8005/klantinteracties/api/v1/maak-klantcontact
   response:
     body:
-      string: '{"klantcontact":{"uuid":"fe1dacc9-4631-4c4c-adae-f15c11b6af46","url":"http://localhost:8005/klantinteracties/api/v1/klantcontacten/fe1dacc9-4631-4c4c-adae-f15c11b6af46","gingOverOnderwerpobjecten":[{"uuid":"97213307-48b8-4792-b7be-c19bffe46509","url":"http://localhost:8005/klantinteracties/api/v1/onderwerpobjecten/97213307-48b8-4792-b7be-c19bffe46509"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"31801874-914e-4e6a-b87b-9a76d287a621","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/31801874-914e-4e6a-b87b-9a76d287a621"}],"leiddeTotInterneTaken":[],"nummer":"0000000001","kanaal":"Webformulier","onderwerp":"With
-        profile","inhoud":"","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":true,"plaatsgevondenOp":"2026-03-25T15:53:43.810002Z"},"betrokkene":{"uuid":"31801874-914e-4e6a-b87b-9a76d287a621","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/31801874-914e-4e6a-b87b-9a76d287a621","wasPartij":{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9"},"hadKlantcontact":{"uuid":"fe1dacc9-4631-4c4c-adae-f15c11b6af46","url":"http://localhost:8005/klantinteracties/api/v1/klantcontacten/fe1dacc9-4631-4c4c-adae-f15c11b6af46"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"","initiator":true},"onderwerpobject":{"uuid":"97213307-48b8-4792-b7be-c19bffe46509","url":"http://localhost:8005/klantinteracties/api/v1/onderwerpobjecten/97213307-48b8-4792-b7be-c19bffe46509","klantcontact":{"uuid":"fe1dacc9-4631-4c4c-adae-f15c11b6af46","url":"http://localhost:8005/klantinteracties/api/v1/klantcontacten/fe1dacc9-4631-4c4c-adae-f15c11b6af46"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"OF-12346","codeObjecttype":"formulierinzending","codeRegister":"Open
+      string: '{"klantcontact":{"uuid":"7ef38d94-e8ea-4882-b74f-4e072aa0a35f","url":"http://localhost:8005/klantinteracties/api/v1/klantcontacten/7ef38d94-e8ea-4882-b74f-4e072aa0a35f","gingOverOnderwerpobjecten":[{"uuid":"df1b9c22-cc35-4ed1-8d91-1f4ffea670b4","url":"http://localhost:8005/klantinteracties/api/v1/onderwerpobjecten/df1b9c22-cc35-4ed1-8d91-1f4ffea670b4"}],"hadBetrokkenActoren":[],"omvatteBijlagen":[],"hadBetrokkenen":[{"uuid":"04171b95-eb06-4b0e-9327-28fdbb0576a9","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/04171b95-eb06-4b0e-9327-28fdbb0576a9"}],"leiddeTotInterneTaken":[],"nummer":"0000000012","kanaal":"Webformulier","onderwerp":"With
+        profile","inhoud":"","indicatieContactGelukt":null,"taal":"nld","vertrouwelijk":true,"plaatsgevondenOp":"2026-05-11T14:50:52.831519Z"},"betrokkene":{"uuid":"04171b95-eb06-4b0e-9327-28fdbb0576a9","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/04171b95-eb06-4b0e-9327-28fdbb0576a9","wasPartij":{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9"},"hadKlantcontact":{"uuid":"7ef38d94-e8ea-4882-b74f-4e072aa0a35f","url":"http://localhost:8005/klantinteracties/api/v1/klantcontacten/7ef38d94-e8ea-4882-b74f-4e072aa0a35f"},"digitaleAdressen":[],"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"contactnaam":{"voorletters":"","voornaam":"","voorvoegselAchternaam":"","achternaam":""},"volledigeNaam":"","rol":"klant","organisatienaam":"","initiator":true},"onderwerpobject":{"uuid":"df1b9c22-cc35-4ed1-8d91-1f4ffea670b4","url":"http://localhost:8005/klantinteracties/api/v1/onderwerpobjecten/df1b9c22-cc35-4ed1-8d91-1f4ffea670b4","klantcontact":{"uuid":"7ef38d94-e8ea-4882-b74f-4e072aa0a35f","url":"http://localhost:8005/klantinteracties/api/v1/klantcontacten/7ef38d94-e8ea-4882-b74f-4e072aa0a35f"},"wasKlantcontact":null,"onderwerpobjectidentificator":{"objectId":"OF-12346","codeObjecttype":"formulierinzending","codeRegister":"Open
         Formulieren","codeSoortObjectId":"public_registration_reference"}}}'
     headers:
       API-version:
@@ -97,14 +99,59 @@ interactions:
       Content-Length:
       - '2402'
       Content-Security-Policy:
-      - 'frame-src ''self''; font-src ''self'' fonts.gstatic.com; worker-src ''self''
-        blob:; object-src ''none''; form-action ''self''; default-src ''self''; base-uri
-        ''self''; img-src ''self'' data: cdn.redoc.ly; script-src ''self'' ''unsafe-inline'';
-        frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; frame-src ''self''; object-src ''none''; font-src
+        ''self'' fonts.gstatic.com; form-action ''self''; default-src ''self''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; base-uri
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"adres": "someemail@example.org", "soortDigitaalAdres": "email", "isStandaardAdres":
+      false, "verstrektDoorBetrokkene": {"uuid": "04171b95-eb06-4b0e-9327-28fdbb0576a9"},
+      "verstrektDoorPartij": null, "omschrijving": ""}'
+    headers:
+      Content-Length:
+      - '218'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8005/klantinteracties/api/v1/digitaleadressen
+  response:
+    body:
+      string: '{"uuid":"0e087daa-3f4a-4da6-a398-92350ec08efa","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/0e087daa-3f4a-4da6-a398-92350ec08efa","verstrektDoorBetrokkene":{"uuid":"04171b95-eb06-4b0e-9327-28fdbb0576a9","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/04171b95-eb06-4b0e-9327-28fdbb0576a9"},"verstrektDoorPartij":null,"adres":"someemail@example.org","soortDigitaalAdres":"email","isStandaardAdres":false,"omschrijving":"","referentie":"","verificatieDatum":null}'
+    headers:
+      API-version:
+      - 0.4.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '503'
+      Content-Security-Policy:
+      - 'img-src ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; frame-src ''self''; object-src ''none''; font-src
+        ''self'' fonts.gstatic.com; form-action ''self''; default-src ''self''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; base-uri
+        ''self'''
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8005/klantinteracties/api/v1/digitaleadressen/0e087daa-3f4a-4da6-a398-92350ec08efa
       Referrer-Policy:
       - same-origin
       Vary:
@@ -123,7 +170,7 @@ interactions:
     uri: http://localhost:8005/klantinteracties/api/v1/partijen?partijIdentificator__codeSoortObjectId=bsn&partijIdentificator__codeRegister=brp&partijIdentificator__codeObjecttype=natuurlijk_persoon&partijIdentificator__objectId=123456782
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"31801874-914e-4e6a-b87b-9a76d287a621","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/31801874-914e-4e6a-b87b-9a76d287a621"}],"categorieRelaties":[],"digitaleAdressen":[{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},{"uuid":"1a7308a4-f52b-4e3c-9bcf-2f402617422c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1a7308a4-f52b-4e3c-9bcf-2f402617422c"},{"uuid":"3d8d396f-7af5-4ab4-b414-60b1a1bcd341","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/3d8d396f-7af5-4ab4-b414-60b1a1bcd341"},{"uuid":"9cc8ef7a-ceea-4e92-adc4-4486958d38ca","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/9cc8ef7a-ceea-4e92-adc4-4486958d38ca"},{"uuid":"1817f1d5-2e3f-4569-9a8c-8b224a7f388c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1817f1d5-2e3f-4569-9a8c-8b224a7f388c"}],"voorkeursDigitaalAdres":{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"50eea111-6836-4f0b-877e-c0b0ed577d8b","url":"http://localhost:8005/klantinteracties/api/v1/partij-identificatoren/50eea111-6836-4f0b-877e-c0b0ed577d8b","identificeerdePartij":{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":null,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"J","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"John
+      string: '{"count":1,"next":null,"previous":null,"results":[{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9","nummer":"0000000001","interneNotitie":"","betrokkenen":[{"uuid":"31801874-914e-4e6a-b87b-9a76d287a621","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/31801874-914e-4e6a-b87b-9a76d287a621"},{"uuid":"9b7d54b6-db34-43c0-b4e4-64edf698f282","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/9b7d54b6-db34-43c0-b4e4-64edf698f282"},{"uuid":"ec952c77-322c-466e-9292-2a227ca80d01","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/ec952c77-322c-466e-9292-2a227ca80d01"},{"uuid":"24f6cd9c-af17-401b-a17e-bc4f49a9ab92","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/24f6cd9c-af17-401b-a17e-bc4f49a9ab92"},{"uuid":"7c614e26-575d-48e7-b10a-4b0b31ccbcf0","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/7c614e26-575d-48e7-b10a-4b0b31ccbcf0"},{"uuid":"be7ba874-3728-49cc-b185-65e99165a794","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/be7ba874-3728-49cc-b185-65e99165a794"},{"uuid":"04171b95-eb06-4b0e-9327-28fdbb0576a9","url":"http://localhost:8005/klantinteracties/api/v1/betrokkenen/04171b95-eb06-4b0e-9327-28fdbb0576a9"}],"categorieRelaties":[],"digitaleAdressen":[{"uuid":"3d8d396f-7af5-4ab4-b414-60b1a1bcd341","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/3d8d396f-7af5-4ab4-b414-60b1a1bcd341"},{"uuid":"1817f1d5-2e3f-4569-9a8c-8b224a7f388c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1817f1d5-2e3f-4569-9a8c-8b224a7f388c"},{"uuid":"1a7308a4-f52b-4e3c-9bcf-2f402617422c","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/1a7308a4-f52b-4e3c-9bcf-2f402617422c"},{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},{"uuid":"9cc8ef7a-ceea-4e92-adc4-4486958d38ca","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/9cc8ef7a-ceea-4e92-adc4-4486958d38ca"}],"voorkeursDigitaalAdres":{"uuid":"e5455329-526c-4614-9687-ad3f87d156f3","url":"http://localhost:8005/klantinteracties/api/v1/digitaleadressen/e5455329-526c-4614-9687-ad3f87d156f3"},"vertegenwoordigden":[],"rekeningnummers":[],"voorkeursRekeningnummer":null,"partijIdentificatoren":[{"uuid":"50eea111-6836-4f0b-877e-c0b0ed577d8b","url":"http://localhost:8005/klantinteracties/api/v1/partij-identificatoren/50eea111-6836-4f0b-877e-c0b0ed577d8b","identificeerdePartij":{"uuid":"4bf35628-d6fd-4815-9a76-e55c275986b9","url":"http://localhost:8005/klantinteracties/api/v1/partijen/4bf35628-d6fd-4815-9a76-e55c275986b9"},"anderePartijIdentificator":"","partijIdentificator":{"codeObjecttype":"natuurlijk_persoon","codeSoortObjectId":"bsn","objectId":"123456782","codeRegister":"brp"},"subIdentificatorVan":null}],"soortPartij":"persoon","indicatieGeheimhouding":null,"voorkeurstaal":"nld","indicatieActief":true,"bezoekadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"correspondentieadres":{"nummeraanduidingId":"","straatnaam":"","huisnummer":null,"huisnummertoevoeging":"","postcode":"","stad":"","adresregel1":"","adresregel2":"","adresregel3":"","land":""},"partijIdentificatie":{"contactnaam":{"voorletters":"J","voornaam":"John","voorvoegselAchternaam":"","achternaam":"Smith"},"volledigeNaam":"John
         Smith"},"_expand":{}}]}'
     headers:
       API-version:
@@ -131,12 +178,13 @@ interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '2682'
+      - '3588'
       Content-Security-Policy:
-      - 'frame-src ''self''; font-src ''self'' fonts.gstatic.com; worker-src ''self''
-        blob:; object-src ''none''; form-action ''self''; default-src ''self''; base-uri
-        ''self''; img-src ''self'' data: cdn.redoc.ly; script-src ''self'' ''unsafe-inline'';
-        frame-ancestors ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com'
+      - 'img-src ''self'' data: cdn.redoc.ly; worker-src ''self'' blob:; script-src
+        ''self'' ''unsafe-inline''; frame-src ''self''; object-src ''none''; font-src
+        ''self'' fonts.gstatic.com; form-action ''self''; default-src ''self''; frame-ancestors
+        ''none''; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; base-uri
+        ''self'''
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:

--- a/src/openforms/contrib/customer_interactions/update.py
+++ b/src/openforms/contrib/customer_interactions/update.py
@@ -139,9 +139,10 @@ def update_customer_interaction_data(
                 continue
 
             address_channel: SupportedChannels = digital_address["type"]
-            is_address_new_preferred: bool = bool(
+            is_address_new_preferred = (
                 digital_address.get("preferenceUpdate") == "isNewPreferred"
             )
+
             # prefill values
             prefill_communication_channel: CommunicationChannel | None = next(
                 (value for value in prefill_value if value["type"] == address_channel),
@@ -157,19 +158,22 @@ def update_customer_interaction_data(
                 if prefill_communication_channel
                 else None
             )
+            is_preferred_address: bool = bool(address_value == prefill_preferred)
+
+            # if address is already a default - we don't create/update digital addresses
+            if is_preferred_address:
+                continue
 
             if address_value in prefill_channel_options:
                 # flow 5. we update it only if it's marked as "isNewPreferred"
-                if is_address_new_preferred and address_value != prefill_preferred:
+                if is_address_new_preferred:
                     updated_address = client.update_digital_address_for_party(
                         address=address_value, party_uuid=party_uuid, is_preferred=True
                     )
                     updated_addresses.append(updated_address)
 
                 # flow 3. we create a new address and link it to betrokkene
-                elif (
-                    not is_address_new_preferred and address_value != prefill_preferred
-                ):
+                else:
                     created_address = client.create_digital_address(
                         address=address_value,
                         address_type=channels_to_address_types[address_channel],

--- a/src/openforms/contrib/customer_interactions/update.py
+++ b/src/openforms/contrib/customer_interactions/update.py
@@ -48,7 +48,7 @@ def update_customer_interaction_data(
     There are several flows how the information is updated depending on if the user and
     their digital addresses are known in the Customer Interactions API
 
-    1. User is not authenticated (implemented):
+    1. User is not authenticated:
 
       * create ``contactMoment``, ``betrokkene`` and ``onderwerpObject``
       * create ``digitaalAdres`` records linked to the created ``betrokkene``
@@ -66,6 +66,7 @@ def update_customer_interaction_data(
       * find ``partij`` for the user
       * create ``contactMoment``, ``betrokkene`` and ``onderwerpObject`` and link ``betrokkene``
         to the found ``partij``
+      * create ``digitaalAdres`` records linked to the created ``betrokkene`` if the used address is not default
 
     4. User is authenticated, known in the API and submits new addresses:
 
@@ -118,7 +119,7 @@ def update_customer_interaction_data(
             auth_attribute: AuthAttribute = submission.auth_info.attribute
 
             # link authenticated user to the party
-            party, created = client.get_or_create_party(auth_attribute, auth_value)
+            party, _ = client.get_or_create_party(auth_attribute, auth_value)
             party_uuid = party["uuid"]
         else:
             party_uuid = ""
@@ -158,14 +159,28 @@ def update_customer_interaction_data(
             )
 
             if address_value in prefill_channel_options:
-                # we update it only if it's marked as "isNewPreferred"
+                # flow 5. we update it only if it's marked as "isNewPreferred"
                 if is_address_new_preferred and address_value != prefill_preferred:
                     updated_address = client.update_digital_address_for_party(
                         address=address_value, party_uuid=party_uuid, is_preferred=True
                     )
                     updated_addresses.append(updated_address)
 
+                # flow 3. we create a new address and link it to betrokkene
+                elif (
+                    not is_address_new_preferred and address_value != prefill_preferred
+                ):
+                    created_address = client.create_digital_address(
+                        address=address_value,
+                        address_type=channels_to_address_types[address_channel],
+                        betrokkene_uuid=customer_contact["betrokkene"]["uuid"],
+                        is_preferred=False,
+                    )
+                    created_addresses.append(created_address)
+
             else:
+                # flows 1,2 4: we create a new address and link it to betrokkene
+                # flows 2,4: we link a new address to partij if it's marked as "isNewPreferred"
                 created_address = client.create_digital_address(
                     address=address_value,
                     address_type=channels_to_address_types[address_channel],

--- a/src/openforms/prefill/contrib/customer_interactions/typing.py
+++ b/src/openforms/prefill/contrib/customer_interactions/typing.py
@@ -15,4 +15,4 @@ class CommunicationPreferencesOptions(TypedDict):
 class CommunicationChannel(TypedDict):
     type: SupportedChannels
     options: Sequence[str]
-    preferred: str | None
+    preferred: str | None  # The preferred address in this channel


### PR DESCRIPTION
Closes #6082

**Changes**

* create a new digital address linked to "betrokkene" in Open Klant when
    * user selects existing address from dropdown
    * this is not a default address
    * they don't change the default preference (don't select "Sla mijn gegevens op
      voor de volgende keer.")

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
