### PR TITLE
[#6289] Fix `AttributeError` while extracting variables from template

### DIFF
--- a/src/openforms/template/__init__.py
+++ b/src/openforms/template/__init__.py
@@ -104,6 +104,11 @@ def _iter_variables_from_node(node: Node) -> Iterator[str]:
             # iterating over the complete node list
             for condition, _ in node.conditions_nodelists:
                 # Example: {% if someVar %} -> someVar
+                # condition is None for {% else %} branches (see django.template.defaulttags
+                # and specifically the do_if function)
+                if condition is None:
+                    continue
+
                 if (
                     isinstance(condition, TemplateLiteral)
                     and isinstance(condition.value, FilterExpression)

--- a/src/openforms/template/tests/test_extract_variables.py
+++ b/src/openforms/template/tests/test_extract_variables.py
@@ -68,3 +68,39 @@ class ExtractVariablesTests(SimpleTestCase):
                 "reallyLastVarIPromise",
             },
         )
+
+    def test_var_in_if_else_blocks(self):
+        source = """
+            <p>This is a request for the form "{{ form_name }}" to co-sign.</p>\r\n
+            <p>
+                {% if some_var %}
+                    {{contact1_voornamen}}
+                    {% if contact1_voorvoegsel %}
+                        {{contact1_voorvoegsel}}
+                    {% endif %}
+                    {{contact1_achternaam}},
+                {% else %}
+                    {{voornaam}}
+                    {% if tussenvoegsel %}
+                        {{tussenvoegsel}}
+                    {% endif %}
+                    {{achternaam}},
+                {% endif %}
+                has completed the form.
+            </p>
+            """
+        variable_names = set(extract_variables_used(source))
+
+        self.assertEqual(
+            variable_names,
+            {
+                "form_name",
+                "some_var",
+                "contact1_voornamen",
+                "contact1_voorvoegsel",
+                "contact1_achternaam",
+                "voornaam",
+                "tussenvoegsel",
+                "achternaam",
+            },
+        )


### PR DESCRIPTION
Closes #6289

**Changes**

- The `{% else %}` statement is not properly handled in extracting the variables from a template.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
