### PR TITLE
Add tests for a particular use case of DH

### DIFF
--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime
 from decimal import Decimal
-from unittest import expectedFailure
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -1567,7 +1566,6 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         )
 
     @tag("dh-864")
-    @expectedFailure
     def test_conditional_fieldset_inside_repeating_group(self):
         objects_api_group = ObjectsAPIGroupConfigFactory.create(
             for_test_docker_compose=True,
@@ -1602,7 +1600,7 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
                             "components": [
                                 {
                                     "type": "textfield",
-                                    "key": "nestedTextfield",
+                                    "key": "container.nestedTextfield",
                                     "label": "Nested text field",
                                 },
                             ],
@@ -1659,20 +1657,21 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         assert result is not None
 
         record_data = result["record"]["data"]
-        # fails because we also emit the *unsaved* variables because of commit
-        # 46c64bc7f7 (issue #6007) which was reported to be missing the variables for
-        # hidden fields, and a follow up enhancement was created in
-        # https://github.com/open-formulieren/open-forms/issues/6012 to make this a
-        # backend option.
         self.assertEqual(
             record_data,
             {
                 "fieldsetShown": False,
                 "repeatingGroupItems": [
-                    # this is what DH *expects*, but they *get* also the key
-                    # nestedTextfield from the hidden text field.
                     {
                         "editgridTextfield": "foo",
+                        # the component key structure is used in the output of the mapped
+                        # item of the edit grid.
+                        # Note that DH would expect this parent key and child not to be
+                        # present at all, however because of #6007 we can't do that,
+                        # unless #6012 gets implemented.
+                        "container": {
+                            "nestedTextfield": "",
+                        },
                     },
                 ],
             },

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v2.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from decimal import Decimal
+from unittest import expectedFailure
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -1563,4 +1564,116 @@ class ObjectsAPIBackendV2Tests(OFVCRMixin, TestCase):
         self.assertEqual(
             attachment_document["informatieobjecttype"],
             "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7",
+        )
+
+    @tag("dh-864")
+    @expectedFailure
+    def test_conditional_fieldset_inside_repeating_group(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            for_test_docker_compose=True,
+            organisatie_rsin="000000000",
+        )
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "checkbox",
+                    "key": "showNestedFieldset",
+                    "label": "Show nested fieldset",
+                },
+                {
+                    "type": "editgrid",
+                    "key": "repeatingGroup",
+                    "label": "Repeating group",
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "editgridTextfield",
+                            "label": "Edit grid text field",
+                        },
+                        {
+                            "type": "fieldset",
+                            "key": "editgridFieldset",
+                            "label": "Edit grid fieldset",
+                            "conditional": {
+                                "show": True,
+                                "when": "showNestedFieldset",
+                                "eq": True,
+                            },
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "nestedTextfield",
+                                    "label": "Nested text field",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            submitted_data={
+                # leads to no submission data for the fields inside the fieldset,
+                # because they aren't visible
+                "showNestedFieldset": False,
+                "repeatingGroup": [
+                    {
+                        "editgridTextfield": "foo",
+                    }
+                ],
+            },
+            completed=True,
+            # the version of the document types are valid on this timestamp
+            completed_on=datetime(2024, 7, 1, 12, 0, 0).replace(tzinfo=UTC),
+        )
+        options: RegistrationOptionsV2 = {
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            # See the docker compose fixtures for more info on these values:
+            "objecttype": UUID("8faed0fa-7864-4409-aa6d-533a37616a9e"),
+            "objecttype_version": 1,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "variables_mapping": [
+                {
+                    "variable_key": "showNestedFieldset",
+                    "target_path": ["fieldsetShown"],
+                },
+                {
+                    "variable_key": "repeatingGroup",
+                    "target_path": ["repeatingGroupItems"],
+                },
+            ],
+            "transform_to_list": [],
+            "iot_attachment": "",
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            "upload_submission_csv": False,
+        }
+        plugin = ObjectsAPIRegistration(PLUGIN_IDENTIFIER)
+
+        # Run the registration
+        result = plugin.register_submission(submission, options)
+        assert result is not None
+
+        record_data = result["record"]["data"]
+        # fails because we also emit the *unsaved* variables because of commit
+        # 46c64bc7f7 (issue #6007) which was reported to be missing the variables for
+        # hidden fields, and a follow up enhancement was created in
+        # https://github.com/open-formulieren/open-forms/issues/6012 to make this a
+        # backend option.
+        self.assertEqual(
+            record_data,
+            {
+                "fieldsetShown": False,
+                "repeatingGroupItems": [
+                    # this is what DH *expects*, but they *get* also the key
+                    # nestedTextfield from the hidden text field.
+                    {
+                        "editgridTextfield": "foo",
+                    },
+                ],
+            },
         )

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_conditional_fieldset_inside_repeating_group.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_conditional_fieldset_inside_repeating_group.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8001/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e
+  response:
+    body:
+      string: '{"url":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","uuid":"8faed0fa-7864-4409-aa6d-533a37616a9e","name":"Accepts
+        everything","namePlural":"Accepts everything","description":"","dataClassification":"open","maintainerOrganization":"","maintainerDepartment":"","contactPerson":"","contactEmail":"","source":"","updateFrequency":"unknown","providerOrganization":"","documentationUrl":"","labels":{},"createdAt":"2024-07-22","modifiedAt":"2024-07-22","allowGeometry":true,"versions":["http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e/versions/1"]}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '619'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 21 May 2026 12:57:35 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.7
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e",
+      "record": {"typeVersion": 1, "data": {"fieldsetShown": false, "repeatingGroupItems":
+      [{"editgridTextfield": "foo", "nestedTextfield": ""}]}, "startAt": "2024-03-19"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8002/api/v2/objects
+  response:
+    body:
+      string: '{"url":"http://objects-web:8000/api/v2/objects/be43c61b-fa4c-4998-97da-bc897c5a9e15","uuid":"be43c61b-fa4c-4998-97da-bc897c5a9e15","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"fieldsetShown":false,"repeatingGroupItems":[{"editgridTextfield":"foo","nestedTextfield":""}]},"geometry":null,"startAt":"2024-03-19","endAt":null,"registrationAt":"2026-05-21","correctionFor":null,"correctedBy":null}}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '487'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 21 May 2026 12:57:36 GMT
+      Location:
+      - http://localhost:8002/api/v2/objects/be43c61b-fa4c-4998-97da-bc897c5a9e15
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.29.7
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_conditional_fieldset_inside_repeating_group.yaml
+++ b/src/openforms/registrations/contrib/objects_api/tests/vcr_cassettes/test_backend_v2/ObjectsAPIBackendV2Tests/test_conditional_fieldset_inside_repeating_group.yaml
@@ -28,7 +28,7 @@ interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Thu, 21 May 2026 12:57:35 GMT
+      - Thu, 21 May 2026 13:07:44 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -45,7 +45,8 @@ interactions:
 - request:
     body: '{"type": "http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e",
       "record": {"typeVersion": 1, "data": {"fieldsetShown": false, "repeatingGroupItems":
-      [{"editgridTextfield": "foo", "nestedTextfield": ""}]}, "startAt": "2024-03-19"}}'
+      [{"editgridTextfield": "foo", "container": {"nestedTextfield": ""}}]}, "startAt":
+      "2024-03-19"}}'
     headers:
       Accept:
       - '*/*'
@@ -56,7 +57,7 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '262'
+      - '277'
       Content-Type:
       - application/json
       User-Agent:
@@ -65,7 +66,7 @@ interactions:
     uri: http://localhost:8002/api/v2/objects
   response:
     body:
-      string: '{"url":"http://objects-web:8000/api/v2/objects/be43c61b-fa4c-4998-97da-bc897c5a9e15","uuid":"be43c61b-fa4c-4998-97da-bc897c5a9e15","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"fieldsetShown":false,"repeatingGroupItems":[{"editgridTextfield":"foo","nestedTextfield":""}]},"geometry":null,"startAt":"2024-03-19","endAt":null,"registrationAt":"2026-05-21","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://objects-web:8000/api/v2/objects/9e805388-6605-4ec8-9ff8-2b5c8b328ab0","uuid":"9e805388-6605-4ec8-9ff8-2b5c8b328ab0","type":"http://objecttypes-web:8000/api/v2/objecttypes/8faed0fa-7864-4409-aa6d-533a37616a9e","record":{"index":1,"typeVersion":1,"data":{"fieldsetShown":false,"repeatingGroupItems":[{"editgridTextfield":"foo","container":{"nestedTextfield":""}}]},"geometry":null,"startAt":"2024-03-19","endAt":null,"registrationAt":"2026-05-21","correctionFor":null,"correctedBy":null}}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
@@ -74,15 +75,15 @@ interactions:
       Content-Crs:
       - EPSG:4326
       Content-Length:
-      - '487'
+      - '501'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Thu, 21 May 2026 12:57:36 GMT
+      - Thu, 21 May 2026 13:07:45 GMT
       Location:
-      - http://localhost:8002/api/v2/objects/be43c61b-fa4c-4998-97da-bc897c5a9e15
+      - http://localhost:8002/api/v2/objects/9e805388-6605-4ec8-9ff8-2b5c8b328ab0
       Referrer-Policy:
       - same-origin
       Server:


### PR DESCRIPTION
Taiga DH 864

**Changes**

* Added test with configuration and wrong expectations (expected failure)
* Updated test with workaround to prevent the schema validation issue

I've also checked out the wrong expectation situation and reverted the #6007 fix locally, which produced a passing test:

```diff
diff --git a/src/openforms/registrations/contrib/objects_api/submission_registration.py b/src/openforms/registrations/contrib/objects_api/submission_registration.py
index d6129fd8e..9afc8d15c 100644
--- a/src/openforms/registrations/contrib/objects_api/submission_registration.py
+++ b/src/openforms/registrations/contrib/objects_api/submission_registration.py
@@ -474,7 +474,7 @@ class ObjectsAPIV2Handler(ObjectsAPIRegistrationHandler[RegistrationOptionsV2]):
 
         all_values = state.get_data(
             include_static_variables=True,
-            include_unsaved=True,
+            include_unsaved=False,
         )
         # update with the registration static values - a special subtype of static
         # variables. They're possibly derived from user input.

```

```
(open-forms) ➜  open-forms git:(06fd4fd92) ✗ runtests src -k test_conditional_fieldset_inside_repeating_group                                                                                                     
Found 1 test(s).
Using existing test database for alias 'default'...
System check identified no issues (0 silenced).
u
======================================================================
UNEXPECTED SUCCESS: test_conditional_fieldset_inside_repeating_group (openforms.registrations.contrib.objects_api.tests.test_backend_v2.ObjectsAPIBackendV2Tests.test_conditional_fieldset_inside_repeating_group)
----------------------------------------------------------------------
Ran 1 test in 0.659s

FAILED (unexpected successes=1)
Preserving test database for alias 'default'...
```

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes

[skip: e2e]