### PR TITLE
Implement upgrade check for legacy ZGW APIs fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,8 +374,7 @@ jobs:
     strategy:
       matrix:
         start:
-          - '3.3.1'
-          - '3.3.9'
+          - '3.5.2'
 
     steps:
       - uses: actions/checkout@v6
@@ -402,7 +401,7 @@ jobs:
           docker compose run -e RELEASE=${RELEASE} web \
             /app/bin/test_fix_scripts.sh
         env:
-          RELEASE: '3.5.0'
+          RELEASE: '4.0.0'
           # ensure local image gets used
           TAG: ${{ needs.setup.outputs.version }}
 

--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -16,7 +16,7 @@ from log_outgoing_requests.datastructures import ContentType
 from log_outgoing_requests.structlog import ExtractRequestAndResponseDetails
 from maykin_common.config import config
 from maykin_common.health_checks import default_health_check_apps
-from upgrade_check import UpgradeCheck, VersionRange
+from upgrade_check import CommandCheck, UpgradeCheck, VersionRange
 from upgrade_check.constraints import UpgradePaths
 
 from csp_post_processor.constants import NONCE_HTTP_HEADER
@@ -1320,8 +1320,12 @@ SETUP_CONFIGURATION_STEPS = [
 # DJANGO-UPGRADE-CHECK
 #
 UPGRADE_CHECK_PATHS: UpgradePaths = {
-    "3.5.0": UpgradeCheck(
-        VersionRange(minimum="3.3.1"),
+    "4.0.0": UpgradeCheck(
+        # 3.5.3 will provide the necessary migration tooling, update when it's released
+        VersionRange(minimum="3.5.2"),
+        code_checks=[
+            CommandCheck("check_legacy_catalogi_api_urls"),
+        ],
     ),
 }
 UPGRADE_CHECK_STRICT = False

--- a/src/openforms/forms/management/commands/check_legacy_catalogi_api_urls.py
+++ b/src/openforms/forms/management/commands/check_legacy_catalogi_api_urls.py
@@ -1,0 +1,9 @@
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Check for legacy Catalogi API URL usage."
+
+    def handle(self, **options):
+        # raise CommandError("Legacy Catalogi API URL usage detected.")
+        pass

--- a/src/openforms/forms/management/commands/check_legacy_catalogi_api_urls.py
+++ b/src/openforms/forms/management/commands/check_legacy_catalogi_api_urls.py
@@ -1,9 +1,23 @@
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
+
+from openforms.zgw_urls_migrator import Migrator
 
 
 class Command(BaseCommand):
     help = "Check for legacy Catalogi API URL usage."
 
     def handle(self, **options):
-        # raise CommandError("Legacy Catalogi API URL usage detected.")
-        pass
+        migrator = Migrator(outfile=self.stdout)
+        self.stdout.write("Checking for legacy ZGW API URL usages...")
+
+        check_passes = migrator.check()
+        if not check_passes:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Did you forget to run the 'migrate_catalogi_api_urls --no-dry-run'"
+                    " migration tool on 3.5?"
+                )
+            )
+            raise CommandError("Legacy Catalogi API URL usage detected.")
+
+        self.stdout.write("Ok, all set!")

--- a/src/openforms/upgrades/tests/test_legacy_catalogi_url_usage_check.py
+++ b/src/openforms/upgrades/tests/test_legacy_catalogi_url_usage_check.py
@@ -379,6 +379,99 @@ class LegacyCatalogiUsageCheckTests(TestCase):
 
         self.assertFalse(result)
 
+    def test_not_ok_for_partially_or_unmigrated_objects_api_registration_backends_2(
+        self,
+    ):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
+        objects_options: ObjectsRegistrationOptionsV2 = {
+            "informatieobjecttype_submission_report": "",
+            "informatieobjecttype_submission_csv": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "b2d83b94-9b9b-4e80-a82f-73ff993c62f3"
+            ),
+            "informatieobjecttype_attachment": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            # note the absence of a catalogue here. The 3.5 migration tool will result
+            # in it being set on the backend options.
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            "iot_attachment": "",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": True,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options).data,
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
+    def test_not_ok_for_partially_or_unmigrated_objects_api_registration_backends_3(
+        self,
+    ):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
+        objects_options: ObjectsRegistrationOptionsV2 = {
+            "informatieobjecttype_submission_report": "",
+            "informatieobjecttype_submission_csv": "",
+            "informatieobjecttype_attachment": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            # note the absence of a catalogue here. The 3.5 migration tool will result
+            # in it being set on the backend options.
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            "iot_attachment": "",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": True,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options).data,
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
     def test_ok_for_migrated_registration_backends(self):
         api_group = ZGWApiGroupConfigFactory.create(
             catalogue_domain="", catalogue_rsin=""
@@ -426,6 +519,42 @@ class LegacyCatalogiUsageCheckTests(TestCase):
                 "rsin": "000000000",
             },
             "case_type_identification": "ZT-001",
+            "document_type_description": "",
+            "product_url": "",
+            "zaaktype": (
+                "http://localhost:8003/catalogi/api/v1/zaaktypen/"
+                "1f41885e-23fc-4462-bbc8-80be4ae484dc"
+            ),
+            "informatieobjecttype": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            "partners_roltype": "",
+            "partners_description": "",
+            "children_roltype": "",
+            "children_description": "",
+            "objects_api_group": None,
+        }
+        FormRegistrationBackendFactory.create(
+            backend="zgw-create-zaak",
+            options=ZaakOptionsSerializer(instance=zgw_options_1).data,
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
+    def test_not_ok_for_partially_or_unmigrated_zgw_registration_backends_2(self):
+        api_group = ZGWApiGroupConfigFactory.create(
+            catalogue_domain="", catalogue_rsin=""
+        )
+        zgw_options_1: ZGWRegistrationOptions = {
+            "zgw_api_group": api_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "",
             "document_type_description": "",
             "product_url": "",
             "zaaktype": (

--- a/src/openforms/upgrades/tests/test_legacy_catalogi_url_usage_check.py
+++ b/src/openforms/upgrades/tests/test_legacy_catalogi_url_usage_check.py
@@ -1,0 +1,452 @@
+from io import StringIO
+from uuid import uuid4
+
+from django.test import TestCase
+
+from upgrade_check import CommandCheck
+
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
+from openforms.forms.tests.factories import (
+    FormDefinitionFactory,
+    FormFactory,
+    FormRegistrationBackendFactory,
+)
+from openforms.registrations.contrib.objects_api.config import (
+    ObjectsAPIOptionsSerializer,
+)
+from openforms.registrations.contrib.objects_api.constants import (
+    PLUGIN_IDENTIFIER as OBJECTS_PLUGIN_IDENTIFIER,
+)
+from openforms.registrations.contrib.objects_api.typing import (
+    RegistrationOptionsV2 as ObjectsRegistrationOptionsV2,
+)
+from openforms.registrations.contrib.zgw_apis.options import ZaakOptionsSerializer
+from openforms.registrations.contrib.zgw_apis.tests.factories import (
+    ZGWApiGroupConfigFactory,
+)
+from openforms.registrations.contrib.zgw_apis.typing import (
+    RegistrationOptions as ZGWRegistrationOptions,
+)
+
+check = CommandCheck(
+    "check_legacy_catalogi_api_urls",
+    options={
+        "stdout": StringIO(),
+        "stderr": StringIO(),
+    },
+)
+
+
+class LegacyCatalogiUsageCheckTests(TestCase):
+    def test_ok_when_no_data_in_environment(self):
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_ok_for_forms_defs_without_file_components(self):
+        FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "ignoreMe",
+                        "label": "Ignore me",
+                    },
+                ]
+            },
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_ok_for_unused_form_definitions_with_legacy_config(self):
+        # this doesn't impact runtime because the form definitions aren't used anywhere
+        # and rely on form validation to catch these legacy configs if they do get added
+        # eventually
+        FormDefinitionFactory.create(
+            configuration={
+                "components": [
+                    {
+                        "type": "file",
+                        "key": "file",
+                        "label": "file",
+                        "registration": {
+                            "informatieobjecttype": "https://example.com",
+                        },
+                    }
+                ]
+            }
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_ok_for_form_with_file_component_with_migrated_config(self):
+        FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "label": "fieldset",
+                        "components": [
+                            {
+                                "type": "file",
+                                "key": "file",
+                                "label": "file",
+                                "registration": {
+                                    "documentType": {
+                                        "catalogue": {
+                                            "domain": "TEST",
+                                            "rsin": "000000000",
+                                        },
+                                        "description": "Attachment",
+                                    },
+                                    "informatieobjecttype": "https://example.com",
+                                },
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_not_ok_for_form_with_file_component_with_legacy_config(self):
+        FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "editgrid",
+                        "key": "editgrid",
+                        "label": "editgrid",
+                        "components": [
+                            {
+                                "type": "file",
+                                "key": "file",
+                                "label": "file",
+                                "registration": {
+                                    "informatieobjecttype": "https://example.com",
+                                },
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
+    def test_ok_for_migrated_or_empty_objects_api_groups(self):
+        ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="TEST",
+            catalogue_rsin="000000000",
+            iot_submission_report="PDF",
+            iot_submission_csv="CSV",
+            iot_attachment="Attachment",
+            informatieobjecttype_submission_report="https://example.com",
+            informatieobjecttype_submission_csv="https://example.com",
+            informatieobjecttype_attachment="https://example.com",
+        )
+        ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_not_ok_for_unmigrated_objects_api_groups(self):
+        ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="https://example.com",
+            informatieobjecttype_submission_csv="https://example.com",
+            informatieobjecttype_attachment="https://example.com",
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
+    def test_not_ok_for_partially_migrated_objects_api_groups(self):
+        ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="TEST",
+            catalogue_rsin="000000000",
+            iot_submission_report="PDF",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="https://example.com",
+            informatieobjecttype_submission_csv="https://example.com",
+            informatieobjecttype_attachment="https://example.com",
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
+    def test_ok_for_empty_zgw_api_group_or_api_group_with_catalogue(self):
+        ZGWApiGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+        )
+        ZGWApiGroupConfigFactory.create(
+            catalogue_domain="TEST",
+            catalogue_rsin="000000000",
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_ok_for_migrated_or_empty_objects_api_registration_backends(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
+        objects_options_1: ObjectsRegistrationOptionsV2 = {
+            "informatieobjecttype_submission_report": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "7a474713-0833-402a-8441-e467c08ac55b"
+            ),
+            "informatieobjecttype_submission_csv": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "b2d83b94-9b9b-4e80-a82f-73ff993c62f3"
+            ),
+            "informatieobjecttype_attachment": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "iot_submission_report": "PDF",
+            "iot_submission_csv": "CSV",
+            "iot_attachment": "Attachment",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": True,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options_1).data,
+        )
+        objects_options_2: ObjectsRegistrationOptionsV2 = {
+            "informatieobjecttype_submission_report": "",
+            "informatieobjecttype_submission_csv": "",
+            "informatieobjecttype_attachment": "",
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            "iot_attachment": "",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": True,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options_2).data,
+        )
+        objects_options_3: ObjectsRegistrationOptionsV2 = {
+            "informatieobjecttype_submission_report": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "7a474713-0833-402a-8441-e467c08ac55b"
+            ),
+            # may not trip up detection, because a catalogue is specified, you opt
+            # into the new behaviour! This effectively means there's no document type
+            # configured for CSV and the file will not be created.
+            "informatieobjecttype_submission_csv": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "b2d83b94-9b9b-4e80-a82f-73ff993c62f3"
+            ),
+            "informatieobjecttype_attachment": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "iot_submission_report": "PDF",
+            "iot_submission_csv": "",
+            "iot_attachment": "Attachment",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": False,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options_3).data,
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_not_ok_for_partially_or_unmigrated_objects_api_registration_backends(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
+        objects_options: ObjectsRegistrationOptionsV2 = {
+            "informatieobjecttype_submission_report": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "7a474713-0833-402a-8441-e467c08ac55b"
+            ),
+            "informatieobjecttype_submission_csv": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "b2d83b94-9b9b-4e80-a82f-73ff993c62f3"
+            ),
+            "informatieobjecttype_attachment": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            # note the absence of a catalogue here. The 3.5 migration tool will result
+            # in it being set on the backend options.
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            "iot_attachment": "",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": True,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options).data,
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)
+
+    def test_ok_for_migrated_registration_backends(self):
+        api_group = ZGWApiGroupConfigFactory.create(
+            catalogue_domain="", catalogue_rsin=""
+        )
+        zgw_options_1: ZGWRegistrationOptions = {
+            "zgw_api_group": api_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "ZT-001",
+            "document_type_description": "Attachment",
+            "product_url": "",
+            "zaaktype": (
+                "http://localhost:8003/catalogi/api/v1/zaaktypen/"
+                "1f41885e-23fc-4462-bbc8-80be4ae484dc"
+            ),
+            "informatieobjecttype": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            "partners_roltype": "",
+            "partners_description": "",
+            "children_roltype": "",
+            "children_description": "",
+            "objects_api_group": None,
+        }
+        FormRegistrationBackendFactory.create(
+            backend="zgw-create-zaak",
+            options=ZaakOptionsSerializer(instance=zgw_options_1).data,
+        )
+
+        result = check.execute()
+
+        self.assertTrue(result)
+
+    def test_not_ok_for_partially_or_unmigrated_zgw_registration_backends(self):
+        api_group = ZGWApiGroupConfigFactory.create(
+            catalogue_domain="", catalogue_rsin=""
+        )
+        zgw_options_1: ZGWRegistrationOptions = {
+            "zgw_api_group": api_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "ZT-001",
+            "document_type_description": "",
+            "product_url": "",
+            "zaaktype": (
+                "http://localhost:8003/catalogi/api/v1/zaaktypen/"
+                "1f41885e-23fc-4462-bbc8-80be4ae484dc"
+            ),
+            "informatieobjecttype": (
+                "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/"
+                "531f6c1a-97f7-478c-85f0-67d2f23661c7"
+            ),
+            "partners_roltype": "",
+            "partners_description": "",
+            "children_roltype": "",
+            "children_description": "",
+            "objects_api_group": None,
+        }
+        FormRegistrationBackendFactory.create(
+            backend="zgw-create-zaak",
+            options=ZaakOptionsSerializer(instance=zgw_options_1).data,
+        )
+
+        result = check.execute()
+
+        self.assertFalse(result)

--- a/src/openforms/zgw_urls_migrator.py
+++ b/src/openforms/zgw_urls_migrator.py
@@ -9,7 +9,11 @@ the URLs at runtime. The migration from legacy to new pattern needs to be done b
 
 import functools
 from collections.abc import Collection, Iterator, Mapping
+from dataclasses import dataclass
 from io import TextIOBase
+from itertools import groupby
+
+from django.db.models import Prefetch
 
 from rest_framework import serializers
 from tabulate import tabulate
@@ -46,6 +50,26 @@ class MigrationProblem(Exception):
         super().__init__(message, *args, **kwargs)
 
 
+@dataclass
+class ComponentProblem:
+    form: str
+    step: str
+    component: str
+
+
+@dataclass
+class APIGroupProblem:
+    group: str
+    type: str
+
+
+@dataclass
+class RegistrationBackendProblem:
+    form: str
+    backend: str
+    backend_type: str
+
+
 class Migrator:
     def __init__(self, outfile: TextIOBase):
         self.outfile = outfile
@@ -66,6 +90,108 @@ class Migrator:
             raise MigrationProblem(
                 "There are automatic migration problems, please analyze the output."
             )
+
+    def check(self) -> bool:
+        """
+        Run in check mode, making no changes but only reporting detected problems.
+
+        :returns: ``False`` if problems are detected.
+        """
+        formio_config_migrator = FormioConfigurationMigrator(outfile=self.outfile)
+        registration_backend_migrator = RegistrationBackendMigrator(
+            outfile=self.outfile
+        )
+        component_problems = formio_config_migrator.check()
+        registration_backend_problems, api_group_problems = (
+            registration_backend_migrator.check()
+        )
+
+        # display detected problems
+        if component_problems:
+            self.outfile.write("🚨 Component problems detected.")
+            self.outfile.write("")
+            self.outfile.write(
+                "   The Legacy `registration.informatieobjecttype` is not yet "
+                "migrated to `registration.documentType`."
+            )
+            self.outfile.write("")
+            component_problems = sorted(
+                component_problems, key=lambda p: (p.form, p.step)
+            )
+
+            def report_component_problems() -> Iterator[tuple[str, str, str]]:
+                for form, steps in groupby(component_problems, key=lambda p: p.form):
+                    _form_repr = form
+                    for step, problems in groupby(steps, key=lambda s: s.step):
+                        _step_repr = step
+                        for problem in problems:
+                            yield (
+                                _form_repr,
+                                _step_repr,
+                                problem.component,
+                            )
+                            _step_repr = ""
+                            _form_repr = ""
+
+            self.outfile.write(
+                tabulate(
+                    report_component_problems(),
+                    headers=("Form", "Step", "Component"),
+                    maxcolwidths=[50, 50, 100],
+                )
+            )
+            self.outfile.write("")
+
+        if api_group_problems:
+            self.outfile.write("🚨 API group problems detected.")
+            self.outfile.write("")
+            self.outfile.write(
+                "   The listed API groups still (partially) use legacy URLs."
+            )
+            self.outfile.write("")
+            self.outfile.write(
+                tabulate(
+                    ((problem.group, problem.type) for problem in api_group_problems),
+                    headers=("Group", "Type"),
+                    maxcolwidths=[75, 50],
+                )
+            )
+
+        if registration_backend_problems:
+            self.outfile.write("🚨 Registration backend problems detected.")
+            self.outfile.write("")
+            self.outfile.write(
+                "   The listed backends still (partially) use legacy URLs."
+            )
+            self.outfile.write("")
+            registration_backend_problems = sorted(
+                registration_backend_problems, key=lambda p: (p.form, p.backend)
+            )
+
+            def report_backend_problems() -> Iterator[tuple[str, str, str]]:
+                for form, problems in groupby(
+                    registration_backend_problems, key=lambda p: p.form
+                ):
+                    _form_repr = form
+                    for problem in problems:
+                        yield (_form_repr, problem.backend, problem.backend_type)
+                        _form_repr = ""
+
+            self.outfile.write(
+                tabulate(
+                    report_backend_problems(),
+                    headers=("Form", "Backend", "Type"),
+                    maxcolwidths=[75, 75, 50],
+                )
+            )
+            self.outfile.write("")
+
+        has_problems = (
+            len(component_problems)
+            + len(registration_backend_problems)
+            + len(api_group_problems)
+        ) > 0
+        return not has_problems
 
 
 @functools.lru_cache(maxsize=100)
@@ -122,18 +248,23 @@ def look_up_case_type(url: str) -> tuple[tuple[str, str], str]:
     return ((catalogus["domein"], catalogus["rsin"]), zt["identificatie"])
 
 
+def _get_form_repr(form: Form) -> str:
+    return f"{form.admin_name} (ID:  {form.pk})"
+
+
 class FormioConfigurationMigrator:
     processed_fds: set[int] = set()
     has_errors: bool = False
 
     def __init__(self, outfile: TextIOBase):
         self.outfile = outfile
+        self.forms_queryset = Form.objects.all()
 
     def migrate(self) -> None:
         """
         Migrate all forms in the environment.
         """
-        qs = Form.objects.all()
+        qs = self.forms_queryset
         if not qs.exists():
             return
 
@@ -142,7 +273,7 @@ class FormioConfigurationMigrator:
                 yield from _run_for_form(form)
 
         def _run_for_form(form: Form) -> Iterator[tuple[str, str, str]]:
-            form_repr = f"{form.admin_name} (ID:  {form.pk})"
+            form_repr = _get_form_repr(form)
             step_details = self.migrate_form(form)
             if not step_details:
                 yield (form_repr, "-", "-")
@@ -168,19 +299,41 @@ class FormioConfigurationMigrator:
             )
         )
 
+    def _iter_form_defs(self, form: Form) -> Iterator[tuple[FormDefinition, str]]:
+        for form_definition in FormDefinition.objects.filter(formstep__form=form):
+            if form_definition.pk in self.processed_fds:
+                continue
+            step_repr = f"{form_definition.admin_name} (ID: {form_definition.pk})"
+            yield form_definition, step_repr
+            self.processed_fds.add(form_definition.pk)
+
+    @staticmethod
+    def _iter_form_def_file_components(
+        form_definition: FormDefinition,
+    ) -> Iterator[FileComponent]:
+        config_wrapper = form_definition.configuration_wrapper
+        # loop over all components in the form definition and yield only the file
+        # components
+        for component in config_wrapper:
+            match component["type"]:
+                case "file":
+                    yield component  # pyright: ignore[reportReturnType]
+                case "editgrid":
+                    # no special treatment needed, the child components are included in
+                    # the config_wrapper already.
+                    continue
+                case _:
+                    continue
+
     def migrate_form(self, form: Form) -> Mapping[str, Mapping[str, str]]:
         """
         Process all the form definitions used in a given form.
         """
         # track component details per step
         step_details: dict[str, Mapping[str, str]] = {}
-        for form_definition in FormDefinition.objects.filter(formstep__form=form):
-            if form_definition.pk in self.processed_fds:
-                continue
-            step_repr = f"{form_definition.admin_name} (ID: {form_definition.pk})"
+        for form_definition, step_repr in self._iter_form_defs(form):
             component_details = self.migrate_form_definition(form_definition)
             step_details[step_repr] = component_details
-            self.processed_fds.add(form_definition.pk)
         return step_details
 
     def migrate_form_definition(
@@ -196,27 +349,16 @@ class FormioConfigurationMigrator:
         """
         # key: component key, value: detailed reporting information for the component
         component_details: dict[str, str] = {}
-        config_wrapper = form_definition.configuration_wrapper
         # loop over all components in the form definition and process the file
         # components
         needs_save = False
-        for component in config_wrapper:
-            match component["type"]:
-                case "file":
-                    try:
-                        changed = self.process_file_component(component)  # pyright: ignore[reportArgumentType]
-                    except MigrationProblem as exc:
-                        self.has_errors = True
-                        component_details[component["key"]] = exc.message
-                        continue
-                case "editgrid":
-                    # no special treatment needed, the child components are included in
-                    # the config_wrapper already.
-                    # TODO: validate/confirm this with a unit test!
-                    continue
-                case _:
-                    continue
-
+        for component in self._iter_form_def_file_components(form_definition):
+            try:
+                changed = self.process_file_component(component)
+            except MigrationProblem as exc:
+                self.has_errors = True
+                component_details[component["key"]] = exc.message
+                continue
             if changed:
                 needs_save = True
                 component_details[component["key"]] = "Configuration update ok."
@@ -227,13 +369,16 @@ class FormioConfigurationMigrator:
         return component_details
 
     @staticmethod
-    def process_file_component(component: FileComponent) -> bool:
+    def check_file_component(component: FileComponent) -> bool:
+        """
+        Check whether the component needs a migration or not.
+        """
         # no registration configuration at all - nothing to do
         if not (registration := component.get("registration")):
             return False
 
         # no legacy URL configured, do nothing
-        if not (legacy_url := registration.get("informatieobjecttype")):
+        if not registration.get("informatieobjecttype"):
             return False
 
         # new format is already configured, do nothing
@@ -245,7 +390,17 @@ class FormioConfigurationMigrator:
             and catalogue.get("rsin")
         ):
             return False
+        return True
 
+    @classmethod
+    def process_file_component(cls, component: FileComponent) -> bool:
+        needs_update = cls.check_file_component(component)
+        if not needs_update:
+            return False
+
+        assert "registration" in component
+        assert "informatieobjecttype" in component["registration"]
+        legacy_url = component["registration"]["informatieobjecttype"]
         # look up the document type and fill out the catalogue + description
         ((domain, rsin), description) = look_up_document_type(legacy_url)
 
@@ -259,6 +414,35 @@ class FormioConfigurationMigrator:
         }
 
         return True
+
+    def check(self) -> Collection[ComponentProblem]:
+        """
+        Scan the (used) form definitions for file components with unmigrated URLs.
+        """
+        qs = self.forms_queryset
+        problems: list[ComponentProblem] = []
+
+        for form in qs.iterator():
+            form_repr = _get_form_repr(form)
+            for form_definition, step_repr in self._iter_form_defs(form):
+                for component in self._iter_form_def_file_components(form_definition):
+                    key = component["key"]
+                    component_label = component.get("label", "")
+                    component_repr = (
+                        f"{component_label} ({key})" if component_label else key
+                    )
+                    needs_update = self.check_file_component(component)
+                    if not needs_update:
+                        continue
+                    problems.append(
+                        ComponentProblem(
+                            form=form_repr,
+                            step=step_repr,
+                            component=component_repr,
+                        )
+                    )
+
+        return problems
 
 
 REGISTRATION_PLUGIN_IDS = (
@@ -279,20 +463,37 @@ class RegistrationBackendMigrator:
 
     def __init__(self, outfile: TextIOBase):
         self.outfile = outfile
+        self.forms_queryset = (
+            Form.objects.filter(
+                registration_backends__backend__in=REGISTRATION_PLUGIN_IDS
+            )
+            .prefetch_related(
+                Prefetch(
+                    "registration_backends",
+                    queryset=FormRegistrationBackend.objects.filter(
+                        backend__in=REGISTRATION_PLUGIN_IDS
+                    ),
+                )
+            )
+            .distinct()
+        )
+        self.objects_api_groups_queryset = ObjectsAPIGroupConfig.objects.exclude(
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
 
     def migrate(self):
         self.migrate_zgw_api_groups()
         self.migrate_objects_api_groups()
 
-        forms = Form.objects.filter(
-            registration_backends__backend__in=REGISTRATION_PLUGIN_IDS
-        ).distinct()
+        forms = self.forms_queryset
         if not forms.exists():
             return
 
         def _run() -> Iterator[tuple[str, str, str]]:
-            for form in forms.iterator():
-                form_repr = f"{form.admin_name} (ID:  {form.pk})"
+            for form in forms.iterator(chunk_size=25):
+                form_repr = _get_form_repr(form)
                 backends_output = self.migrate_form_registration_backends(form)
                 assert backends_output, (
                     "Only forms with eligible backends should be processed"
@@ -319,11 +520,7 @@ class RegistrationBackendMigrator:
         pass
 
     def migrate_objects_api_groups(self):
-        groups = ObjectsAPIGroupConfig.objects.exclude(
-            informatieobjecttype_submission_report="",
-            informatieobjecttype_submission_csv="",
-            informatieobjecttype_attachment="",
-        )
+        groups = self.objects_api_groups_queryset
         if not groups.exists():
             return
 
@@ -429,9 +626,8 @@ class RegistrationBackendMigrator:
         self, form: Form
     ) -> Mapping[str, Collection[str]]:
         summary: dict[str, Collection[str]] = {}
-        for backend in form.registration_backends.filter(
-            backend__in=REGISTRATION_PLUGIN_IDS
-        ):
+        # only matching backends should have been prefetched
+        for backend in form.registration_backends.all():
             backend_details: list[str] = []
 
             try:
@@ -462,6 +658,56 @@ class RegistrationBackendMigrator:
             summary[backend.name] = backend_details
 
         return summary
+
+    @staticmethod
+    def check_backend_needs_migration(backend: FormRegistrationBackend) -> bool:
+        options = backend.options
+        # we ignore invalid serializer data for the options - 4.0 can't be
+        # blamed for broken upgrades if the configuration is already broken to begin
+        # with
+        match backend.backend:
+            case "zgw-create-zaak":
+                legacy_zaaktype_url = options.get("zaaktype")
+                legacy_documenttype_url = options.get("informatieobjecttype")
+                case_type_identification = options.get("case_type_identification")
+                document_type_description = options.get("document_type_description")
+                if legacy_zaaktype_url and not case_type_identification:
+                    return True
+                if legacy_documenttype_url and not document_type_description:
+                    return True
+                return False
+            case "objects_api":
+                catalogue = options.get("catalogue")
+                informatieobjecttype_submission_report = options.get(
+                    "informatieobjecttype_submission_report"
+                )
+                informatieobjecttype_submission_csv = options.get(
+                    "informatieobjecttype_submission_csv"
+                )
+                informatieobjecttype_attachment = options.get(
+                    "informatieobjecttype_attachment"
+                )
+                iot_submission_report = options.get("iot_submission_report")
+                iot_submission_csv = options.get("iot_submission_csv")
+                iot_attachment = options.get("iot_attachment")
+
+                # as soon as a catalogue is specified in the options, it enables the
+                # new document types, ignoring any legacy URLs configured
+                if catalogue:
+                    return False
+
+                # otherwise, all fields are optional, so only complain if there are
+                # legacy URLs present
+                if informatieobjecttype_submission_report and not iot_submission_report:
+                    return True
+                if informatieobjecttype_submission_csv and not iot_submission_csv:
+                    return True
+                if informatieobjecttype_attachment and not iot_attachment:
+                    return True
+
+                return False
+            case _:  # pragma: no cover
+                return False
 
     def migrate_zgw_backend(self, backend: FormRegistrationBackend) -> bool:
         # XXX: object types integration is out of scope for 4.0, we can do something for
@@ -671,3 +917,47 @@ class RegistrationBackendMigrator:
         backend.save()
 
         return True
+
+    def check_api_groups(self) -> Collection[APIGroupProblem]:
+        # we don't need to check ZGW API groups at all as there are no URLs configured
+        # in there
+        problems: list[APIGroupProblem] = []
+
+        for group in self.objects_api_groups_queryset:
+            submission_report_ok = (
+                group.iot_submission_report
+                or not group.informatieobjecttype_submission_report
+            )
+            submission_csv_ok = (
+                group.iot_submission_csv
+                or not group.informatieobjecttype_submission_csv
+            )
+            attachment_ok = (
+                group.iot_attachment or not group.informatieobjecttype_attachment
+            )
+            if submission_report_ok and submission_csv_ok and attachment_ok:
+                continue
+            problems.append(APIGroupProblem(group=group.name, type="Objects API"))
+
+        return problems
+
+    def check(
+        self,
+    ) -> tuple[Collection[RegistrationBackendProblem], Collection[APIGroupProblem]]:
+        api_group_problems = self.check_api_groups()
+        backend_problems: list[RegistrationBackendProblem] = []
+        for form in self.forms_queryset:
+            form_repr = _get_form_repr(form)
+            for backend in form.registration_backends.all():
+                needs_migration = self.check_backend_needs_migration(backend)
+                if not needs_migration:
+                    continue
+                backend_problems.append(
+                    RegistrationBackendProblem(
+                        form=form_repr,
+                        backend=backend.name,
+                        backend_type=backend.backend,
+                    )
+                )
+
+        return (backend_problems, api_group_problems)


### PR DESCRIPTION
Closes #4939 (partly)

[skip: e2e]

**Changes**

* Adapted the migrator to run checks without making changes
* Added management command and upgrade check

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
